### PR TITLE
Only run RISCV formal test on relevant changes

### DIFF
--- a/.github/scripts/has_riscv_changes.sh
+++ b/.github/scripts/has_riscv_changes.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Exits with 0 if changes were made to files relevant to the RISCV formal
+# checks. E.g., CI configuration, formal check configuration, RTL, ...
+#
+
+# If script is not run from a PR, we compare HEAD and HEAD~1. This works
+# because we only use squash and merge as merge strategies, not rebase.
+head_ref=${GITHUB_HEAD_REF:-HEAD}
+base_ref=${GITHUB_BASE_REF:-HEAD~1}
+
+git diff \
+  --exit-code --quiet "${base_ref}".."${head_ref}" \
+  .github/ contranomy/ riscv-formal-config/ riscv-formal/
+
+[ $? -ne 0 ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,9 @@ jobs:
 
       - name: Verify ${{ matrix.check }}
         run: |
-          .github/scripts/run_riscv_formal_check.sh ${{ matrix.check }}
+          if .github/scripts/has_riscv_changes.sh; then
+            .github/scripts/run_riscv_formal_check.sh ${{ matrix.check }}
+          fi
 
       - name: Verification failed, uploading results
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
The catch-all job gets in the way a bit here, but this should remove ~95% of wasted resources.