### PR TITLE
Calendar implementation with wishbone support

### DIFF
--- a/bittide/src/Bittide/SharedTypes.hs
+++ b/bittide/src/Bittide/SharedTypes.hs
@@ -26,7 +26,6 @@ type LessThan a b = (KnownNat a, KnownNat b, a <= b)
 type NatFitsInBits n bits = NatRequiredBits n <= bits
 type NatRequiredBits n = CLog 2 (n + 1)
 type Paddable a = (BitPack a, NFDataX a, 1 <= BitSize a)
-type TypeRequiredRegisters t regSize = DivRU (BitSize t) regSize
 type WriteAny maxIndex writeData = Maybe (Index maxIndex, writeData)
 
 type Pad a bw  = (Regs a bw * bw) - BitSize a


### PR DESCRIPTION
This PR finalizes the calendar with wishbone support. It adds the calendar's wishbone transmit module `wbCalTX` and changes the testsuite to make use of the new calendar implementation. 

Testsuite changes:
* All tests now use `calendarWB`
* All tests now use a new generated that generates calendars with an arbitrarily sized entries.
* A new test was added to test reading the shadow calendar.