### PR TITLE
Initial instruction memory element

### DIFF
--- a/bittide/src/Bittide/Calendar.hs
+++ b/bittide/src/Bittide/Calendar.hs
@@ -89,7 +89,7 @@ mkCalendar (CalendarConfig maxCalDepth bsActive bsShadow) =
 data CalendarState maxCalDepth = CalendarState
   { firstCycle      :: Bool
     -- ^ is True after reset, becomes false after first cycle.
-  , selectedBuffer  :: SelectedBuffer
+  , selectedBuffer  :: AorB
     -- ^ Indicates if buffer A or B is active.
   , entryTracker    :: Index maxCalDepth
     -- ^ Read point for the active calendar.
@@ -194,7 +194,7 @@ calendar SNat bootstrapActive bootstrapShadow wbIn =
     (calState, (bufCtrl1, calOut1))
    where
     selectedBuffer1
-      | swapCalendars && lastCycle = flipBuffer selectedBuffer
+      | swapCalendars && lastCycle = swapAorB selectedBuffer
       | otherwise = selectedBuffer
     lastCycle = entryTracker == activeDepth
 

--- a/bittide/src/Bittide/DoubleBufferedRam.hs
+++ b/bittide/src/Bittide/DoubleBufferedRam.hs
@@ -7,6 +7,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE GADTs #-}
 
 module Bittide.DoubleBufferedRam where
 
@@ -18,7 +19,10 @@ import Protocols.Wishbone
 import Bittide.SharedTypes
 import Data.Bifunctor
 
-data InitialContent n a = Reloadable (Vec n a) | NonReloadable (Vec n a) | Undefined
+data InitialContent n a where
+  NonReloadable :: Vec n a -> InitialContent n a
+  Reloadable :: Vec n a -> InitialContent n a
+  Undefined :: (1 <= n, KnownNat n) => InitialContent n a
 
 getContent :: InitialContent n a -> Vec n a
 getContent (Reloadable v) = v

--- a/bittide/src/Bittide/DoubleBufferedRam.hs
+++ b/bittide/src/Bittide/DoubleBufferedRam.hs
@@ -13,12 +13,12 @@ module Bittide.DoubleBufferedRam where
 
 import Clash.Prelude
 
+import Data.Bifunctor
 import Data.Maybe
+import Protocols (Circuit (Circuit))
 import Protocols.Wishbone
 
 import Bittide.SharedTypes hiding (delayControls)
-import Data.Bifunctor
-import Protocols (Circuit (Circuit))
 
 data InitialContent n a where
   NonReloadable :: Vec n a -> InitialContent n a
@@ -78,6 +78,8 @@ wbStorageDP d@SNat initial aM2S bM2S = (aS2M, bS2M)
   noWrite wb = wb{writeEnable = False}
   writeIsErr wb write = wb{err = err wb || write}
 
+-- | Wishbone storage element with 'Circuit' interface from 'Protocols.Wishbone' that
+-- allows for half-word aligned reads and writes.
 wbStorage ::
   forall dom depth initDepth aw .
   ( HiddenClockResetEnable dom
@@ -92,7 +94,7 @@ wbStorage d initContent = Circuit $ \(m2s, ()) ->
   (wbStorage' d initContent m2s, ())
 
 -- | Storage element with a single wishbone port, it is half word addressable to work with
--- RISC-V's C extension.
+-- RISC-V's C extension. This storage element allows for half-word aligned accesses.
 wbStorage' ::
   forall dom depth initDepth aw .
   ( HiddenClockResetEnable dom

--- a/bittide/src/Bittide/DoubleBufferedRam.hs
+++ b/bittide/src/Bittide/DoubleBufferedRam.hs
@@ -163,9 +163,9 @@ wbStorage SNat initContent wbIn = delayControls wbOut
       | otherwise = (byteSelectB0, byteSelectA0)
 
   splitWrite ::
-    KnownNat a =>
-    Maybe (Located n (BitVector (2*a))) ->
-    (Maybe (Located n (BitVector a)), Maybe (Located n (BitVector a)))
+    KnownNat bits =>
+    Maybe (LocatedBits n (2*bits)) ->
+    (Maybe (LocatedBits n bits), Maybe (LocatedBits n bits))
   splitWrite (Just (i, a)) = (Just (i,upper), Just (i, lower))
    where
     (upper,lower) = split a

--- a/bittide/src/Bittide/DoubleBufferedRam.hs
+++ b/bittide/src/Bittide/DoubleBufferedRam.hs
@@ -18,6 +18,31 @@ import Protocols.Wishbone
 import Bittide.SharedTypes
 import Data.Bifunctor
 
+data InitialContent n a = Reloadable (Vec n a) | NonReloadable (Vec n a) | Undefined
+
+getContent :: InitialContent n a -> Vec n a
+getContent (Reloadable v) = v
+getContent (NonReloadable v) = v
+getContent (Undefined) = error "getContent: Content is Undefined."
+
+contentGenerator ::
+  forall dom romSize targetSize a .
+  ( HiddenClockResetEnable dom
+  , KnownNat targetSize,  1 <= targetSize
+  , KnownNat romSize, romSize <= targetSize
+  , NFDataX a) =>
+  Vec romSize a ->
+  (Signal dom (Maybe (Located targetSize a)), Signal dom Bool)
+contentGenerator Nil = (pure Nothing, pure True)
+contentGenerator content@(Cons _ _) = (mux (running .&&. not <$> done) writeOp (pure Nothing), done)
+ where
+  running = register False $ pure True
+  writeOp = curry Just . resize <$> romAddr0 <*> element
+  done = register False (done .||. (running .&&. romAddr0 .==. pure maxBound))
+  romAddr0 = register (maxBound :: Index romSize) romAddr1
+  romAddr1 = satSucc SatWrap <$> romAddr0
+  element = rom content (bitCoerce <$> romAddr1)
+
 -- | Dual-ported Wishbone storage element, essentially a wrapper for the single-ported version
 -- which priorities port B over port A. While port B is making a transaction, port A will be ignored.
 wbStorageDP ::

--- a/bittide/src/Bittide/ScatterGather.hs
+++ b/bittide/src/Bittide/ScatterGather.hs
@@ -77,7 +77,7 @@ scatterUnit calConfig wbIn linkIn readAddr = (readOut, wbOut)
   writeOp = (\a b -> (a,) <$> b) <$> writeAddr <*> linkIn
   readOut = doubleBufferedRamU bufSelect0 readAddr writeOp
   bufSelect0 = register A bufSelect1
-  bufSelect1 = mux metaCycle (flipBuffer <$> bufSelect0) bufSelect0
+  bufSelect1 = mux metaCycle (swapAorB <$> bufSelect0) bufSelect0
 
 -- | Double buffered memory component that can be written to by a generic write operation. The
 -- write address of the incoming frame is determined by the incorporated 'calendar'. The
@@ -106,7 +106,7 @@ gatherUnit calConfig wbIn writeOp byteEnables= (linkOut, wbOut)
   bramOut = doubleBufferedRamByteAddressableU
     (bitCoerce <$> bufSelect0) readAddr writeOp byteEnables
   bufSelect0 = register A bufSelect1
-  bufSelect1 = mux metaCycle (flipBuffer <$> bufSelect0) bufSelect0
+  bufSelect1 = mux metaCycle (swapAorB <$> bufSelect0) bufSelect0
 
 -- | Wishbone interface for the 'scatterUnit' and 'gatherUnit'. It makes the scatter and gather
 -- unit, which operate on 64 bit frames, addressable via a 32 bit wishbone bus.

--- a/bittide/src/Bittide/SharedTypes.hs
+++ b/bittide/src/Bittide/SharedTypes.hs
@@ -22,6 +22,14 @@ import Data.Proxy
 import Data.Type.Equality ((:~:)(Refl))
 import Protocols.Wishbone
 
+-- | To be used when there are two options.
+data AorB = A | B deriving (Eq, Generic, BitPack, Show, NFDataX)
+
+-- | If we receive 'A', return 'B'. If we receive 'B', return 'A'
+swapAorB :: AorB -> AorB
+swapAorB A = B
+swapAorB B = A
+
 -- | A single byte.
 type Byte = BitVector 8
 -- | BitVector of _n_ bytes.

--- a/bittide/tests/Tests/DoubleBufferedRam.hs
+++ b/bittide/tests/Tests/DoubleBufferedRam.hs
@@ -60,6 +60,8 @@ ramGroup = testGroup "DoubleBufferedRam group"
       "registerWbSigToWb" registerWbSigToWb
   , testPropertyNamed "registerWb write conflict resolution matches set priorities"
       "registerWbWriteCollisions" registerWbWriteCollisions
+  , testPropertyNamed "Simulate the contentGenerator for an arbitrary vector."
+      "testContentGen" testContentGen
   ]
 
 genRamContents :: (MonadGen m, Integral i) => i -> m a -> m (SomeVec 1 a)

--- a/bittide/tests/Tests/DoubleBufferedRam.hs
+++ b/bittide/tests/Tests/DoubleBufferedRam.hs
@@ -622,6 +622,30 @@ testContentGen = property $ do
         (bundle $ contentGenerator @_ @v @(v +1) content)
       expectedDones
         | l == 0 = L.repeat True
-        | otherwise = (L.replicate (l + 2) False) <> (L.repeat True)
-    dones === (L.take simLength expectedDones)
+        | otherwise = L.replicate (l + 2) False <> L.repeat True
+    dones === L.take simLength expectedDones
     catMaybes writes === toList (zip (iterateI succ 0) content)
+
+-- testWbStorage :: Property
+-- testWbStorage = property $ do
+--   nat <- forAll $ Gen.enum 1 100
+--   case TN.someNatVal (nat - 1) of
+--     SomeNat (succSNat . snatProxy -> n) -> go n
+--  where
+--   go :: forall v m . (KnownNat v, 1 <= v, Monad m) => SNat v -> PropertyT m ()
+--   go SNat = do
+--     content <- forAll $ genNonEmptyVec @_ @v (pack <$> genUnsigned @_ @32 Range.constantBounded)
+--     let
+--       l = length content
+--       simLength = 2 + l * 2
+--       topEntity wbIn = bundle (undef, reload, nonReload)
+--        where
+--         undef = wcre $ wbStorage @System @v @v @32 SNat Undefined wbIn
+--         reload = wcre $ wbStorage @System @v @v @32 SNat (Reloadable content) wbIn
+--         nonReload = wcre $ wbStorage @System @v @v @32 SNat (NonReloadable content) wbIn
+--       (undefOut, reloadOut, nonReloadOut) = L.unzip3 $ simulateN
+
+--     True === True
+
+-- wcre :: KnownDomain dom => (HiddenClockResetEnable dom => r) -> r
+-- wcre = withClockResetEnable clockGen resetGen enableGen

--- a/bittide/tests/Tests/DoubleBufferedRam.hs
+++ b/bittide/tests/Tests/DoubleBufferedRam.hs
@@ -549,12 +549,12 @@ byteAddressableDoubleBufferedRamBehavior :: forall bits memDepth nBytes .
  , nBytes ~ Regs (BitVector bits) 8
  , KnownNat bits
  , 1 <= bits) =>
- ((SelectedBuffer, Index memDepth, Maybe (LocatedBits memDepth bits), BitVector nBytes)
+ ((AorB, Index memDepth, Maybe (LocatedBits memDepth bits), BitVector nBytes)
  , Vec memDepth (BitVector bits), Vec memDepth (BitVector bits))->
 
- (SelectedBuffer, Index memDepth, Maybe (LocatedBits memDepth bits), BitVector nBytes) ->
+ (AorB, Index memDepth, Maybe (LocatedBits memDepth bits), BitVector nBytes) ->
 
- (((SelectedBuffer, Index memDepth, Maybe (LocatedBits memDepth bits), BitVector nBytes)
+ (((AorB, Index memDepth, Maybe (LocatedBits memDepth bits), BitVector nBytes)
  , Vec memDepth (BitVector bits)
  , Vec memDepth (BitVector bits))
  , BitVector bits)
@@ -701,12 +701,12 @@ wbStorageBehavior = property $ do
       goldenTransactions = ramOpToTransaction goldenInput $ L.tail simGolden
       simTransactions = wbToTransaction topEntityInput simOut
 
-    footnote . fromString $ "goldenTransactions" <> showX goldenTransactions
-    footnote . fromString $ "simTransactions" <> showX simTransactions
-    footnote . fromString $ "simGolden" <> showX simGolden
-    footnote . fromString $ "simOut" <> showX simOut
-    footnote . fromString $ "goldenInput" <> showX goldenInput
-    footnote . fromString $ "topEntityInput" <> showX topEntityInput
+    footnote $ "goldenTransactions" <> showX goldenTransactions
+    footnote $ "simTransactions" <> showX simTransactions
+    footnote $ "simGolden" <> showX simGolden
+    footnote $ "simOut" <> showX simOut
+    footnote $ "goldenInput" <> showX goldenInput
+    footnote $ "topEntityInput" <> showX topEntityInput
 
     simTransactions === goldenTransactions
 


### PR DESCRIPTION
Initial implementation for the dual ported instruction storage.
This implements a wrapper for the ```wishboneStorage``` that can connect two wishbone ports, port A and port B.
Port A can only be used for reading and write attempts will set the wishbone's error signal (and nothing will be written).
Port B can be used for both reading and writing. When both ports are interacting with this component, port B will be prioritized.
Port A will be ignored untill the transaction with port B is done. 

TODO:
- [x] Implement wrapper for ```wishoneStorage``` that connects two busses.
- [x] Write tests
- [x] Documentation