### PR TITLE
firmware ELF loader now handles bigger memsz properly

### DIFF
--- a/firmware/bittide-sys/Cargo.toml
+++ b/firmware/bittide-sys/Cargo.toml
@@ -13,3 +13,4 @@ proptest = "1.0"
 object = { version = "0.28", features = ["write"] }
 libc = "0.2"
 test-strategy = "0.2.0"
+rand = "0.8"

--- a/firmware/bittide-sys/src/elf_loading/mod.rs
+++ b/firmware/bittide-sys/src/elf_loading/mod.rs
@@ -27,6 +27,18 @@ pub unsafe fn load_elf_file(valid_elf: &ValidatedElfFile<'_>) {
 
         // write the segment to its desired memory location
         core::ptr::copy_nonoverlapping(data.as_ptr(), addr_ptr, data.len());
+
+        // the size in memory can be bigger than the data provided in the ELF file,
+        // the remaining bytes should be filled with zeroes.
+        let zero_padding = (p.memsz() as usize).saturating_sub(data.len());
+        if zero_padding > 0 {
+            // SAFETY: - `addr_ptr.add(data.len())` is valid since it points at
+            //           most one byte after a valid allocation
+            //         - the call to `write_bytes` is valid as the memory/buffer
+            //           size was validated to be big enough to hold the full
+            //           data + padding.
+            core::ptr::write_bytes(addr_ptr.add(data.len()), 0, zero_padding);
+        }
     }
 }
 

--- a/firmware/bittide-sys/tests/elf_common.rs
+++ b/firmware/bittide-sys/tests/elf_common.rs
@@ -6,6 +6,7 @@ use object::{
     write::elf::{FileHeader, ProgramHeader, Writer},
 };
 use proptest::{collection, prelude::*};
+use rand::Fill;
 use std::panic::AssertUnwindSafe;
 
 type Addr = u64;
@@ -22,6 +23,7 @@ pub struct Segment {
     pub addr: Addr,
     pub ty: SegmentType,
     pub data: Vec<u8>,
+    pub zero_padding: u64,
     pub load: bool,
 }
 
@@ -94,7 +96,7 @@ pub fn create_elf_file(info: &ElfCreateInfo) -> Vec<u8> {
             p_vaddr: seg.addr,
             p_paddr: seg.addr,
             p_filesz: if seg.load { seg.data.len() as u64 } else { 0 },
-            p_memsz: seg.data.len() as u64,
+            p_memsz: seg.data.len() as u64 + seg.zero_padding,
             p_align: 64,
         });
     }
@@ -112,6 +114,9 @@ pub fn create_elf_file(info: &ElfCreateInfo) -> Vec<u8> {
 }
 
 /// Run a function with an allocated buffer within the 32bit address space.
+///
+/// To aid with testing, instead of returning a zeroed out buffer, the buffer
+/// gets filled with random values.
 ///
 /// # Safety
 ///
@@ -163,6 +168,8 @@ pub unsafe fn with_32bit_addr_buffer<R: 'static>(size: u32, f: impl FnOnce(&mut 
         std::slice::from_raw_parts_mut(mem_bytes, size as usize)
     };
 
+    buf.try_fill(&mut rand::thread_rng()).unwrap();
+
     let res = std::panic::catch_unwind(AssertUnwindSafe(|| f(buf)));
 
     // SAFETY: the pointer `mem` was previously allocated by mmap, `size` is the size of
@@ -196,7 +203,7 @@ pub fn elf_config_from_segs(segs: &[Segment]) -> ElfConfig {
                 config.instruction_memory_address.end = config
                     .instruction_memory_address
                     .end
-                    .max(seg.addr as usize + seg.data.len());
+                    .max(seg.addr as usize + seg.data.len() + seg.zero_padding as usize);
             }
             SegmentType::Data | SegmentType::RoData => {
                 config.data_memory_address.start =
@@ -204,7 +211,7 @@ pub fn elf_config_from_segs(segs: &[Segment]) -> ElfConfig {
                 config.data_memory_address.end = config
                     .data_memory_address
                     .end
-                    .max(seg.addr as usize + seg.data.len());
+                    .max(seg.addr as usize + seg.data.len() + seg.zero_padding as usize);
             }
         }
     }
@@ -243,55 +250,63 @@ pub fn gen_segments(
 ) -> impl Strategy<Value = Vec<Segment>> {
     let text_lower_bound = if text_can_be_empty { 0 } else { 1 };
     let texts = (0..n_text)
-        .map(|_| collection::vec(any::<u8>(), text_lower_bound..1000))
+        .map(|_| {
+            (
+                collection::vec(any::<u8>(), text_lower_bound..1000),
+                (0..1000u64),
+            )
+        })
         .collect::<Vec<_>>();
 
     let data = (0..n_data)
-        .map(|_| collection::vec(any::<u8>(), 0..1000))
+        .map(|_| (collection::vec(any::<u8>(), 0..1000), (0..1000u64)))
         .collect::<Vec<_>>();
 
     let rodata = (0..n_rodata)
-        .map(|_| collection::vec(any::<u8>(), 0..1000))
+        .map(|_| (collection::vec(any::<u8>(), 0..1000), (0..1000u64)))
         .collect::<Vec<_>>();
 
     (texts, data, rodata).prop_map(|(texts, data, rodata)| {
         let mut offset = 0;
 
         let mut v = vec![];
-        for d in texts {
+        for (d, padding) in texts {
             let data_len = d.len() as u64;
             v.push(Segment {
                 addr: offset,
                 ty: SegmentType::Text,
+                zero_padding: padding,
                 data: d,
                 load: true,
             });
 
-            offset += data_len;
+            offset += data_len + padding;
         }
 
-        for d in data {
+        for (d, padding) in data {
             let data_len = d.len() as u64;
             v.push(Segment {
                 addr: offset,
                 ty: SegmentType::Data,
+                zero_padding: padding,
                 data: d,
                 load: true,
             });
 
-            offset += data_len;
+            offset += data_len + padding;
         }
 
-        for d in rodata {
+        for (d, padding) in rodata {
             let data_len = d.len() as u64;
             v.push(Segment {
                 addr: offset,
                 ty: SegmentType::RoData,
+                zero_padding: padding,
                 data: d,
                 load: true,
             });
 
-            offset += data_len;
+            offset += data_len + padding;
         }
 
         v

--- a/firmware/bittide-sys/tests/elf_loading.rs
+++ b/firmware/bittide-sys/tests/elf_loading.rs
@@ -12,7 +12,7 @@ mod elf_common;
 
 // Generate valid ELF files and make sure segments are loaded into the buffer
 // properly.
-#[proptest(ProptestConfig { cases: 1000, ..ProptestConfig::default() })]
+#[proptest(ProptestConfig { cases: 100, max_shrink_iters: 100000, ..ProptestConfig::default() })]
 fn all_loaded_sections_copied(#[strategy(gen_valid_elf_file())] mut info: ElfCreateInfo) {
     let buffer_size = elf_loaded_buffer_size(&info);
     unsafe {
@@ -32,7 +32,9 @@ fn all_loaded_sections_copied(#[strategy(gen_valid_elf_file())] mut info: ElfCre
             for seg in &info.segments {
                 let start = (seg.addr - base_addr) as usize;
                 let end = start as usize + seg.data.len();
+                let padding_end = end + seg.zero_padding as usize;
                 assert_eq!(&buf[start..end], &seg.data);
+                assert!(buf[end..padding_end].iter().all(|b| *b == 0));
             }
         });
     }


### PR DESCRIPTION
The ELF loader did not inspect the `memsz` attribute of Program/Segment headers and only loaded the given data from the ELF file (with length `filesz`).

The expected behaviour is to fill remaining bytes (`memsz - filesz`) with `0`. The loader was changed to implement this behaviour and the prop-tests were modified to test for this properly.