### PR TITLE
Up hedgehog test amount

### DIFF
--- a/bittide/tests/UnitTests.hs
+++ b/bittide/tests/UnitTests.hs
@@ -6,6 +6,7 @@ Maintainer:          devops@qbaylogic.com
 module Main where
 
 import Test.Tasty
+import Test.Tasty.Hedgehog
 
 import Tests.Calendar
 import Tests.DoubleBufferedRAM
@@ -16,5 +17,11 @@ tests :: TestTree
 tests = testGroup "Unittests"
   [calGroup, sgGroup, switchGroup, ramGroup]
 
+setDefaultHedgehogTestLimit :: HedgehogTestLimit -> HedgehogTestLimit
+setDefaultHedgehogTestLimit (HedgehogTestLimit Nothing) = HedgehogTestLimit (Just 10000)
+setDefaultHedgehogTestLimit opt = opt
+
 main :: IO ()
-main = defaultMain tests
+main = defaultMain $
+  adjustOption setDefaultHedgehogTestLimit
+  tests


### PR DESCRIPTION
A failing test was encountered on a CI job, lets up the amount of hedgehog tests to catch problems earlier.