### PR TITLE
Switch remove reorder buffers and add rxUnits + txUnits

### DIFF
--- a/bittide/src/Bittide/Calendar.hs
+++ b/bittide/src/Bittide/Calendar.hs
@@ -25,7 +25,6 @@ import Clash.Prelude
 import Data.Maybe
 import Protocols.Wishbone
 
-import Bittide.DoubleBufferedRam
 import Bittide.SharedTypes
 
 

--- a/bittide/src/Bittide/Link.hs
+++ b/bittide/src/Bittide/Link.hs
@@ -205,3 +205,6 @@ setLowerSlice ::
   BitVector bv ->
   BitVector bv
 setLowerSlice = setSlice @_ @_ @(bv - slice) (SNat @(slice -1)) d0
+
+sequenceCounter :: HiddenClockResetEnable dom => Signal dom (Unsigned 64)
+sequenceCounter = register 0 $ satSucc SatError <$> sequenceCounter

--- a/bittide/src/Bittide/Link.hs
+++ b/bittide/src/Bittide/Link.hs
@@ -206,5 +206,7 @@ setLowerSlice ::
   BitVector bv
 setLowerSlice = setSlice @_ @_ @(bv - slice) (SNat @(slice -1)) d0
 
+-- | Counts the number of cycles since the last reset. Initially Unsigned 64 has been
+--  picked because it's unlikely to overflow in the lifetime of a Bittide system.
 sequenceCounter :: HiddenClockResetEnable dom => Signal dom (Unsigned 64)
 sequenceCounter = register 0 $ satSucc SatError <$> sequenceCounter

--- a/bittide/src/Bittide/Switch.hs
+++ b/bittide/src/Bittide/Switch.hs
@@ -29,7 +29,8 @@ data SwitchConfig links nBytes addrW where
 
 deriving instance Show (SwitchConfig links nBytes addrW)
 
--- | Creates a 'switch' from a 'SwitchConfig'.
+-- | Creates a 'switch' from a 'SwitchConfig'. This wrapper functions hides the preambleWidth
+-- type variable from the rest of the implementation.
 mkswitch ::
   ( HiddenClockResetEnable dom
   , KnownNat links

--- a/bittide/src/Bittide/Switch.hs
+++ b/bittide/src/Bittide/Switch.hs
@@ -31,7 +31,7 @@ data SwitchConfig links nBytes addrW where
 
 deriving instance Show (SwitchConfig links nBytes addrW)
 
--- | Creates a 'switch' from a 'SwitchConfig'. This wrapper functions hides the preambleWidth
+-- | Creates a 'switch' from a 'SwitchConfig'. This wrapper functions hides the @preambleWidth@
 -- type variable from the rest of the implementation.
 mkSwitch ::
   ( HiddenClockResetEnable dom
@@ -48,13 +48,13 @@ mkSwitch ::
 mkSwitch SwitchConfig{..} = switch preamble calendarConfig
 
 {-# NOINLINE switch #-}
--- | The Bittide Switch routes data from incoming links to outgoing links based on a calendar.
--- The switch consists of a crossbar, a calendar and the receiver and transmitter logic per link.
--- For each incoming link, the switch has a 'rxUnit' and a receive register (single depth
--- scatter unit). For each outgoing link the switch has a transmit register (single depth
--- gather unit) and a 'txUnit'. The crossbar selects one of the receive register's output
--- for each transmit register. Index 0 selects a null frame (Nothing) and k selects
--- receive register (k - 1).
+-- | The Bittide Switch routes data from incoming links to outgoing links based on a 'Calendar'.
+-- The switch consists of a 'crossbar', a 'calendar' and receiver and transmitter logic per link.
+-- The receive logic consists of a 'rxUnit' and a receive register (single depth
+-- 'Bittide.ScatterGather.scatterUnit'). The transmit logic consists of a transmit register
+-- (single depth 'Bittide.ScatterGather.gatherUnit') and a 'txUnit'. The 'crossbar' selects
+-- one of the receive register's output for each transmit register. Index @0@ selects a
+-- null frame @Nothing@ and @k@ selects receive register @(k - 1)@.
 switch ::
   forall dom nBytes addrW links frameWidth preambleWidth .
   ( HiddenClockResetEnable dom
@@ -87,8 +87,8 @@ switch preamble calConfig m2ss streamsIn = (streamsOut,calS2M :> (rxS2Ms ++ txS2
   (txS2Ms, streamsOut) = unzip $ txUnit preamble sc <$> gatherFrames <*> txM2Ss
 
 {-# NOINLINE crossBar #-}
--- | The crossbar receives a vector of indices and a vector of incoming frames.
--- For each outgoing link it will select a data source. 0 selects a null frame (Nothing),
+-- | The 'crossbar' receives a vector of indices and a vector of incoming frames.
+-- For each outgoing link it will select a data source. @0@ selects a null frame @Nothing@,
 -- therefore indexing of incoming links starts at 1 (index 1 selects incoming frame 0).
 -- Source: bittide hardware, switch logic.
 crossBar ::

--- a/bittide/src/Bittide/Switch.hs
+++ b/bittide/src/Bittide/Switch.hs
@@ -2,6 +2,7 @@
 --
 -- SPDX-License-Identifier: Apache-2.0
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE RecordWildCards #-}
 
 module Bittide.Switch where
 
@@ -23,9 +24,10 @@ type CalendarEntry links = Vec links (CrossbarIndex links)
 data SwitchConfig links nBytes addrW where
   SwitchConfig ::
     (KnownNat preambleWidth, 1 <= preambleWidth) =>
-    BitVector preambleWidth ->
-    CalendarConfig nBytes addrW (CalendarEntry links) ->
-    SwitchConfig links nBytes addrW
+    { preamble :: BitVector preambleWidth
+    , calendarConfig :: CalendarConfig nBytes addrW (CalendarEntry links)
+    }
+    -> SwitchConfig links nBytes addrW
 
 deriving instance Show (SwitchConfig links nBytes addrW)
 
@@ -43,7 +45,7 @@ mkSwitch ::
   ( Vec links (Signal dom (DataLink frameWidth))
   , Vec (1 + (links * 2)) (Signal dom (WishboneS2M (Bytes nBytes))))
 
-mkSwitch (SwitchConfig preamble calConfig) = switch preamble calConfig
+mkSwitch SwitchConfig{..} = switch preamble calendarConfig
 
 {-# NOINLINE switch #-}
 -- | The Bittide Switch routes data from incoming links to outgoing links based on a calendar.

--- a/bittide/src/Bittide/Switch.hs
+++ b/bittide/src/Bittide/Switch.hs
@@ -31,7 +31,7 @@ deriving instance Show (SwitchConfig links nBytes addrW)
 
 -- | Creates a 'switch' from a 'SwitchConfig'. This wrapper functions hides the preambleWidth
 -- type variable from the rest of the implementation.
-mkswitch ::
+mkSwitch ::
   ( HiddenClockResetEnable dom
   , KnownNat links
   , KnownNat frameWidth, 1 <= frameWidth
@@ -43,7 +43,7 @@ mkswitch ::
   ( Vec links (Signal dom (DataLink frameWidth))
   , Vec (1 + (links * 2)) (Signal dom (WishboneS2M (Bytes nBytes))))
 
-mkswitch (SwitchConfig preamble calConfig) = switch preamble calConfig
+mkSwitch (SwitchConfig preamble calConfig) = switch preamble calConfig
 
 {-# NOINLINE switch #-}
 -- | The Bittide Switch routes data from incoming links to outgoing links based on a calendar.

--- a/bittide/src/Bittide/Switch.hs
+++ b/bittide/src/Bittide/Switch.hs
@@ -23,7 +23,7 @@ type CalendarEntry links = Vec links (CrossbarIndex links)
 
 data SwitchConfig links nBytes addrW where
   SwitchConfig ::
-    (KnownNat preambleWidth, 1 <= preambleWidth) =>
+    (KnownNat preambleWidth, 1 <= preambleWidth, 1 <= nBytes, 2 <= addrW) =>
     { preamble :: BitVector preambleWidth
     , calendarConfig :: CalendarConfig nBytes addrW (CalendarEntry links)
     }

--- a/bittide/src/Bittide/Switch.hs
+++ b/bittide/src/Bittide/Switch.hs
@@ -10,7 +10,6 @@ import Clash.Prelude
 import Protocols.Wishbone
 
 import Bittide.Calendar
-import Bittide.Extra.Wishbone
 import Bittide.Link
 import Bittide.SharedTypes
 
@@ -28,6 +27,8 @@ data SwitchConfig links nBytes addrW where
     CalendarConfig nBytes addrW (CalendarEntry links) ->
     SwitchConfig links nBytes addrW
 
+deriving instance Show (SwitchConfig links nBytes addrW)
+
 -- | Creates a 'switch' from a 'SwitchConfig'.
 mkswitch ::
   ( HiddenClockResetEnable dom
@@ -36,10 +37,10 @@ mkswitch ::
   , KnownNat nBytes, 1 <= nBytes
   , KnownNat addrW, 2 <= addrW) =>
   SwitchConfig links nBytes addrW ->
-  Vec (1 + (2 * links)) (Signal dom (WishboneM2S nBytes addrW)) ->
+  Vec (1 + (2 * links)) (Signal dom (WishboneM2S addrW nBytes (Bytes nBytes))) ->
   Vec links (Signal dom (DataLink frameWidth)) ->
   ( Vec links (Signal dom (DataLink frameWidth))
-  , Vec (1 + (links * 2)) (Signal dom (WishboneS2M nBytes)))
+  , Vec (1 + (links * 2)) (Signal dom (WishboneS2M (Bytes nBytes))))
 
 mkswitch (SwitchConfig preamble calConfig) = switch preamble calConfig
 

--- a/bittide/src/Bittide/Switch.hs
+++ b/bittide/src/Bittide/Switch.hs
@@ -18,8 +18,6 @@ type CrossbarIndex links = Index (links+1)
 -- memory and a crossbar index to select the outgoing frame.
 type CalendarEntry links = Vec links (CrossbarIndex links)
 
--- TODO: Remove Bittide.ScatterEngine and its tests before merging #71
-
 {-# NOINLINE switch #-}
 -- | The Bittide Switch routes data from incoming to outgoing links based on a calendar.
 -- The switch consists of a crossbar, a calendar and a scatter engine for all incoming links.

--- a/bittide/tests/Tests/Switch.hs
+++ b/bittide/tests/Tests/Switch.hs
@@ -63,9 +63,9 @@ genSwitchCalendar links calDepth = do
   case TN.someNatVal links of
     (SomeNat (snatProxy -> l)) -> do
       testCal <- genCalendarConfig calDepth $ genSwitchEntry l
-      preamble <- genDefinedBitVector @64
-      let
-      return $ SwitchTestConfig (SwitchConfig preamble testCal)
+      return $ SwitchTestConfig (SwitchConfig
+        { preamble = errorX "preamble Undefined" :: BitVector 64
+        , calendarConfig = testCal})
 
 -- | This test checks that for any switch calendar all outputs select the correct frame.
 switchFrameRoutingWorks :: Property
@@ -74,7 +74,7 @@ switchFrameRoutingWorks = property $ do
   calDepth <- forAll $ Gen.enum 1 8
   switchCal <- forAll $ genSwitchCalendar @4 @32 (fromIntegral links) calDepth
   case switchCal of
-    SwitchTestConfig (SwitchConfig preamble calConfig@(CalendarConfig _ (toList -> cal) _)) -> do
+    SwitchTestConfig (SwitchConfig{preamble, calendarConfig@(CalendarConfig _ (toList -> cal) _)}) -> do
       simLength <- forAll $ Gen.enum 1 (3 * fromIntegral calDepth)
       preamble <- forAll (genDefinedBitVector @64)
       let

--- a/bittide/tests/Tests/Switch.hs
+++ b/bittide/tests/Tests/Switch.hs
@@ -35,13 +35,13 @@ switchGroup :: TestTree
 switchGroup = testGroup "Switch group"
   [testPropertyNamed "Routing works" "switchFrameRoutingWorks" switchFrameRoutingWorks]
 
-data SwitchConfig  nBytes addrW where
-  SwitchConfig ::
+data SwitchTestConfig  nBytes addrW where
+  SwitchTestConfig ::
     SNat links ->
     CalendarConfig nBytes addrW (CalendarEntry links) ->
-    SwitchConfig nBytes addrW
+    SwitchTestConfig nBytes addrW
 
-deriving instance Show (SwitchConfig nBytes addrW)
+deriving instance Show (SwitchTestConfig nBytes addrW)
 
 -- This generator can generate a calendar entry for a switch given the amount of links.
 genSwitchEntry ::
@@ -58,12 +58,12 @@ genSwitchCalendar ::
   (KnownNat nBytes, 1 <= nBytes, KnownNat addrW) =>
   Natural ->
   Natural ->
-  Gen (SwitchConfig nBytes addrW)
+  Gen (SwitchTestConfig nBytes addrW)
 genSwitchCalendar links calDepth = do
   case TN.someNatVal links of
     (SomeNat (snatProxy -> l)) -> do
       testCal <- genCalendarConfig calDepth $ genSwitchEntry l
-      return $ SwitchConfig l testCal
+      return $ SwitchTestConfig l testCal
 
 -- | This test checks that for any switch calendar all outputs select the correct frame.
 switchFrameRoutingWorks :: Property
@@ -72,7 +72,7 @@ switchFrameRoutingWorks = property $ do
   calDepth <- forAll $ Gen.enum 1 8
   switchCal <- forAll $ genSwitchCalendar @4 @32 (fromIntegral links) calDepth
   case switchCal of
-    SwitchConfig (SNat :: SNat links) calConfig@(CalendarConfig _ (toList -> cal) _) -> do
+    SwitchTestConfig (SNat :: SNat links) calConfig@(CalendarConfig _ (toList -> cal) _) -> do
       simLength <- forAll $ Gen.enum 1 (3 * fromIntegral calDepth)
       preamble <- forAll (genDefinedBitVector @64)
       let

--- a/bittide/tests/Tests/Switch.hs
+++ b/bittide/tests/Tests/Switch.hs
@@ -6,7 +6,6 @@
 
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE FlexibleContexts #-}
 module Tests.Switch(switchGroup) where
 
 import Clash.Prelude
@@ -38,88 +37,66 @@ switchGroup = testGroup "Switch group"
 
 data SwitchConfig  nBytes addrW where
   SwitchConfig ::
-    1 <= memDepth =>
     SNat links ->
-    SNat memDepth ->
-    CalendarConfig nBytes addrW (CalendarEntry links memDepth) ->
+    CalendarConfig nBytes addrW (CalendarEntry links) ->
     SwitchConfig nBytes addrW
 
 deriving instance Show (SwitchConfig nBytes addrW)
 
--- This generator can generate a calendar entry for a switch given the amount of links and
--- memory depth.
+-- This generator can generate a calendar entry for a switch given the amount of links.
 genSwitchEntry ::
-  forall links scatterDepth .
-  1 <= scatterDepth =>
+  forall links .
   SNat links ->
-  SNat scatterDepth ->
-  Gen (CalendarEntry links scatterDepth)
-genSwitchEntry SNat SNat = genVec elemGen
- where
-  genScatterEntry = genIndex Range.constantBounded
-  genLinkEntry = genIndex Range.constantBounded
-  elemGen = (,) <$> genScatterEntry <*> genLinkEntry
+  Gen (CalendarEntry links)
+genSwitchEntry SNat = genVec (genIndex Range.constantBounded)
 
--- | This generator can generate a any calendar for the bittide switch, knowing the
--- amount of bytes and address width of the wishbone bus, and given the amount of links,
--- memory depth of the scatter engine and calendar depth of the switch.
+-- | This generator can generate a calendar for the bittide switch, knowing the
+-- amount of bytes and address width of the wishbone bus, and given the amount of links and
+-- calendar depth of the switch.
 genSwitchCalendar ::
   forall nBytes addrW .
   (KnownNat nBytes, 1 <= nBytes, KnownNat addrW) =>
   Natural ->
   Natural ->
-  Natural ->
   Gen (SwitchConfig nBytes addrW)
-genSwitchCalendar links memDepth calDepth = do
-  case (TN.someNatVal links, TN.someNatVal (memDepth - 1)) of
-    (SomeNat (snatProxy -> l), SomeNat (succSNat . snatProxy -> d)) -> do
-      testCal <- genCalendarConfig calDepth $ genSwitchEntry l d
-      return $ SwitchConfig l d testCal
+genSwitchCalendar links calDepth = do
+  case TN.someNatVal links of
+    (SomeNat (snatProxy -> l)) -> do
+      testCal <- genCalendarConfig calDepth $ genSwitchEntry l
+      return $ SwitchConfig l testCal
 
--- | This test checks that for any switch calendar with memory depth 1 and calendar depth 1
---, all outputs select the correct frame.
+-- | This test checks that for any switch calendar all outputs select the correct frame.
 switchFrameRoutingWorks :: Property
 switchFrameRoutingWorks = property $ do
-  links <- forAll $ Gen.enum 1 15
-  let
-    calDepth = 1
-    memDepth = 1
-  switchCal <- forAll $ genSwitchCalendar @4 @32 links memDepth calDepth
+  links <- forAll $ Gen.int (Range.constant 1 15)
+  calDepth <- forAll $ Gen.enum 1 8
+  switchCal <- forAll $ genSwitchCalendar @4 @32 (fromIntegral links) calDepth
   case switchCal of
-    SwitchConfig SNat SNat calConfig@(CalendarConfig _ (toList -> cal) _) -> do
-      let
-        links0 = fromIntegral links
-        latency = fromIntegral memDepth + 1
-
-      simLength <- forAll $ Gen.enum latency 100
+    SwitchConfig (SNat :: SNat links) calConfig@(CalendarConfig _ (toList -> cal) _) -> do
+      simLength <- forAll $ Gen.enum 1 (3 * fromIntegral calDepth)
       let
         genFrame = Just <$> genDefinedBitVector @64
-        allLinks = Gen.list (Range.singleton links0) genFrame
+        allLinks = Gen.list (Range.singleton links) genFrame
       topEntityInput <- forAll $ Gen.list (Range.singleton simLength) allLinks
-
       let
         topEntity streamsIn = withClockResetEnable clockGen resetGen enableGen $
          fst (switch calConfig (pure emptyWishboneM2S) streamsIn)
         simOut = simulateN @System simLength topEntity $ fmap unsafeFromList topEntityInput
-        simOut1 = P.drop latency $ fmap toList simOut
-
       let
-        expectedFrames = P.take simLength
-          (P.replicate links0 Nothing : P.replicate links0 Nothing : topEntityInput)
-        expectedOutput = P.drop latency . P.take simLength $
+        expectedFrames = P.replicate links Nothing : topEntityInput
+        expectedOutput = P.take simLength $ P.replicate links Nothing :
           P.zipWith selectAllOutputs expectedFrames (cycle $ fmap toList cal)
       footnote . fromString $ "expected:" <> showX expectedOutput
-      footnote . fromString $ "simOut1: " <> showX simOut1
       footnote . fromString $ "simOut: " <> showX simOut
       footnote . fromString $ "input: " <> showX topEntityInput
-      simOut1 === expectedOutput
+      fmap toList simOut === expectedOutput
 
 selectAllOutputs ::
-  (KnownNat l, KnownNat d) =>
+  (KnownNat l) =>
   [Maybe a] ->
-  [(Index d, Index (l+1))] ->
+  [Index (l+1)] ->
   [Maybe a]
-selectAllOutputs incomingFrames = fmap (selectionFunc . fromEnum . snd)
+selectAllOutputs incomingFrames = fmap (selectionFunc . fromEnum)
  where
   allFrames = Nothing Seq.<| Seq.fromList incomingFrames
   selectionFunc = (allFrames `Seq.index`)

--- a/bittide/tests/UnitTests.hs
+++ b/bittide/tests/UnitTests.hs
@@ -13,19 +13,12 @@ import Tests.Calendar
 import Tests.DoubleBufferedRam
 import Tests.Link
 import Tests.ScatterGather
+import Tests.Switch
 import Tests.Wishbone
 
--- import Tests.Switch
-
--- TODO: #86 changes the double buffered memory implementations, which causes the switch
--- test to fail. Since this test is completely replaced in #71  it should be enabled again
--- in that PR.
-
--- TODO: This should not be here, Before merging 71, make sure PR #86 is merged,
--- #71 is rebased and the switchGropup is in the test tree.
 tests :: TestTree
 tests = testGroup "Unittests"
-  [calGroup, sgGroup, ramGroup, memMapGroup, linkGroup] -- switchGroup
+  [calGroup, sgGroup, ramGroup, memMapGroup, linkGroup, switchGroup]
 
 setDefaultHedgehogTestLimit :: HedgehogTestLimit -> HedgehogTestLimit
 setDefaultHedgehogTestLimit (HedgehogTestLimit Nothing) = HedgehogTestLimit (Just 10000)

--- a/bittide/tests/UnitTests.hs
+++ b/bittide/tests/UnitTests.hs
@@ -21,6 +21,8 @@ import Tests.Wishbone
 -- test to fail. Since this test is completely replaced in #71  it should be enabled again
 -- in that PR.
 
+-- TODO: This should not be here, Before merging 71, make sure PR #86 is merged,
+-- #71 is rebased and the switchGropup is in the test tree.
 tests :: TestTree
 tests = testGroup "Unittests"
   [calGroup, sgGroup, ramGroup, memMapGroup, linkGroup] -- switchGroup


### PR DESCRIPTION
The new implementation for the bittide Switch contains "degenerate" scatter and gather units with depth 1, which eventually boils down to a single scatter register and gather register.
This PR removes the existing scatter units and replaces them by a scatter register at the input and gather register at the output of the Bittide Switch.
Furthermore this PR adds rxUnits to incoming links (before the scatter register) and txUnits to outgoing links (after the gather register).

- [x] Before merging, make sure the switch test is re-enabled, because #86 disables it.