### PR TITLE
Enable multithreading for unittests

### DIFF
--- a/bittide/bittide.cabal
+++ b/bittide/bittide.cabal
@@ -91,6 +91,7 @@ test-suite unittests
   hs-source-dirs: tests
   type: exitcode-stdio-1.0
   main-is: UnitTests.hs
+  ghc-options: -threaded -with-rtsopts=-N
   other-modules:
     Tests.Calendar
     Tests.DoubleBufferedRAM


### PR DESCRIPTION
Self explanatory title.

At least locally, this significantly reduces the time required to run the unit tests.