### PR TITLE
Force HLS version to 1.6.1.0

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,5 +20,11 @@
   "editor.tabSize": 2,
   "[rust]": {
     "editor.tabSize": 4
+  },
+  "haskell.toolchain": {
+    "hls": "1.6.1.0",
+    "ghc": null,
+    "cabal": null,
+    "stack": null
   }
 }


### PR DESCRIPTION
Prevents ABI-related error messages, see:

https://github.com/haskell/vscode-haskell#ghc-abis-dont-match