### PR TITLE
Bound frequency that clock control requests

### DIFF
--- a/elastic-buffer-sim/src/Bittide/Simulate/Ppm.hs
+++ b/elastic-buffer-sim/src/Bittide/Simulate/Ppm.hs
@@ -2,13 +2,15 @@
 --
 -- SPDX-License-Identifier: Apache-2.0
 
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Bittide.Simulate.Ppm where
 
 import Clash.Explicit.Prelude
 import Data.Ratio
 import Numeric.Natural
 
-newtype Ppm = Ppm Natural
+newtype Ppm = Ppm Natural deriving newtype (Num)
 type PeriodPs = Natural
 type Hz = Ratio Natural
 

--- a/elastic-buffer-sim/tests/Tests/Bittide/Simulate.hs
+++ b/elastic-buffer-sim/tests/Tests/Bittide/Simulate.hs
@@ -33,8 +33,8 @@ fastPeriod :: PeriodPs
 fastPeriod = hzToPeriod 200e3
 
 clockConfig :: Ppm -> ClockControlConfig
-clockConfig (Ppm clockUncertainty) = ClockControlConfig
-  { cccPessimisticPeriod = speedUpPeriod (Ppm clockUncertainty) fastPeriod
+clockConfig clockUncertainty = ClockControlConfig
+  { cccPessimisticPeriod = speedUpPeriod clockUncertainty fastPeriod
   , cccSettlePeriod      = fastPeriod * 200
   , cccDynamicRange      = clockUncertainty * 2
   , cccStepSize          = 10


### PR DESCRIPTION
The clock controller should not request too many clock changes. This addresses that. 

Also fixes a bug with how the mock clock tuner counts cycles.