### PR TITLE
Change rxUnit API to match txUnit

### DIFF
--- a/bittide/src/Bittide/Link.hs
+++ b/bittide/src/Bittide/Link.hs
@@ -127,15 +127,15 @@ rxUnit ::
   , KnownNat scw, 1 <= scw) =>
   -- | Preamble.
   BitVector paw ->
-  -- | Incoming bittide link.
-  Signal core (DataLink fw) ->
   -- | Local sequence counter.
   Signal core (Unsigned scw) ->
+  -- | Incoming bittide link.
+  Signal core (DataLink fw) ->
   -- | Control register Wishbone bus (Master -> slave).
   Signal core (WishboneM2S nBytes aw) ->
   -- | Control register Wishbone bus (Slave -> master).
   Signal core (WishboneS2M nBytes)
-rxUnit preamble linkIn localCounter wbIn = wbOut
+rxUnit preamble localCounter linkIn wbIn = wbOut
  where
   (regOut, wbOut) = registerWbE WishbonePriority regInit wbIn regIn byteEnables
   regInit = (0,resize $ pack Idle)

--- a/bittide/tests/Tests/Link.hs
+++ b/bittide/tests/Tests/Link.hs
@@ -92,8 +92,8 @@ configRxUnit ::
   ( HiddenClockResetEnable System, 1 <= bs, 2 <= aw, 1 <= pw, 1 <= fw, 1 <= scw) =>
   SNat bs -> SNat aw -> SNat pw -> SNat fw -> SNat scw ->
     (  BitVector pw
-    -> Signal System (DataLink fw)
     -> Signal System (Unsigned scw)
+    -> Signal System (DataLink fw)
     -> Signal System (WishboneM2S bs aw)
     -> Signal System (WishboneS2M bs))
 configRxUnit SNat SNat SNat SNat SNat = rxUnit @System @bs @aw @pw @fw @scw
@@ -247,7 +247,7 @@ rxSendSC = property $ do
       localSeqCounts <- forAll . Gen.list simRange $ genUnsigned Range.constantBounded
       let
         topEntity (unbundle -> (wbIn0, linkIn, localCounter)) = wcre
-          configRxUnit bs aw pw fw scw preamble linkIn localCounter wbIn0
+          configRxUnit bs aw pw fw scw preamble localCounter linkIn wbIn0
         -- Compensate for the register write + state machine start delays.
         wbIn = wbWrite : L.replicate (offTime0 + onTime) (wbRead 0) <>
           cycle (fmap wbRead [0..fromIntegral readBackCycles])
@@ -359,7 +359,7 @@ integration = property $ do
          where
           (_, linkIn) = configTxUnit bs aw pw fw scw preamble counter gatherOut wbTxM2S
           linkOut = registerN (snatProxy llProxy) Nothing linkIn
-          wbRxS2M = configRxUnit bs aw pw fw scw preamble linkOut counter wbRxM2S
+          wbRxS2M = configRxUnit bs aw pw fw scw preamble counter linkOut wbRxM2S
           out = bundle (linkIn, wbRxS2M)
         -- Compensate for the register write + state machine start delays.
         wbTxOff = L.replicate (delayCycles - 2) emptyWishboneM2S


### PR DESCRIPTION
The rxUnit and txUnit are very similar, however their APIs have different order of arguments.
```haskell
txUnit ::
  forall core nBytes aw preambleWidth frameWidth seqCountWidth .
  ( HiddenClockResetEnable core
  , KnownNat preambleWidth
  , KnownNat seqCountWidth
  , KnownNat frameWidth
  , KnownNat nBytes
  , 1 <= nBytes
  , KnownNat aw
  , 2 <= aw
  , 1 <= frameWidth) =>
  BitVector preambleWidth ->
  Signal core (Unsigned seqCountWidth) ->
  Signal core (DataLink frameWidth) ->
  Signal core (WishboneM2S nBytes aw) ->
  ( Signal core (WishboneS2M nBytes)
  , Signal core (DataLink frameWidth))
```
and

```haskell
rxUnit ::
  forall core nBytes aw paw fw scw .
  ( HiddenClockResetEnable core
  , KnownNat nBytes, 1 <= nBytes
  , KnownNat aw, 2 <= aw
  , KnownNat paw, 1 <= paw
  , KnownNat fw, 1 <= fw
  , KnownNat scw, 1 <= scw) =>
  BitVector paw ->
  Signal core (Unsigned scw) ->
  Signal core (DataLink fw) ->
  Signal core (WishboneM2S nBytes aw) ->
  Signal core (WishboneS2M nBytes)
```

This order also enables us to more easily map the rxUnit over a vector of links and m2s busses.