### PR TITLE
Fix failing memory-map test

### DIFF
--- a/bittide/tests/Tests/Wishbone.hs
+++ b/bittide/tests/Tests/Wishbone.hs
@@ -177,4 +177,4 @@ findBaseAddress :: Ord a => a -> Vec n a -> Vec m b -> (a, b)
 findBaseAddress a (toList -> config) (toList -> ranges) =
   L.last $ (L.head config, L.head ranges) : lowerAddresses
   where
-    lowerAddresses = L.takeWhile ((<a) . fst) $ L.zip config ranges
+    lowerAddresses = L.takeWhile ((<=a) . fst) $ L.zip config ranges


### PR DESCRIPTION
I encountered a failing memory-map test 
```--hedgehog-replay "Size 32 Seed 1775162954064538396 741503793587890875"```
The test didn't select the last entry when the memory map configuration contains multiple entries with the same base address (which is illegal anyways).