### PR TITLE
add scatter gather configs

### DIFF
--- a/bittide/src/Bittide/ScatterGather.hs
+++ b/bittide/src/Bittide/ScatterGather.hs
@@ -22,16 +22,18 @@ import Bittide.Calendar
 import Bittide.DoubleBufferedRam
 import Bittide.SharedTypes
 
--- | GADT to explicitly differentiate between a configuration for the 'scatterUnitWb' and
--- 'gatherUnitWb' at type level.
+-- | Existential type to explicitly differentiate between a configuration for
+-- the 'scatterUnitWb' and 'gatherUnitWb' at type level and hide the memory depth from
+-- higher level APIs.
 data ScatterConfig nBytes addrW where
   ScatterConfig ::
     (KnownNat memDepth, 1 <= memDepth) =>
     (CalendarConfig nBytes addrW (Index memDepth)) ->
     ScatterConfig nBytes addrW
 
--- | GADT to explicitly differentiate between a configuration for the 'scatterUnitWb' and
--- 'gatherUnitWb' at type level.
+-- | Existential type to explicitly differentiate between a configuration for
+-- the 'scatterUnitWb' and 'gatherUnitWb' at type level and hide the memory depth from
+-- higher level APIs.
 data GatherConfig nBytes addrW where
   GatherConfig ::
     (KnownNat memDepth, 1 <= memDepth) =>

--- a/bittide/tests/Tests/ScatterGather.hs
+++ b/bittide/tests/Tests/ScatterGather.hs
@@ -146,8 +146,8 @@ scatterUnitNoFrameLoss = property $ do
       <$> inputGen (padToLength memDepth Nothing <$> metaCycleGen)
     let
       topEntity (unbundle -> (wbIn, linkIn)) = fst $
-        withClockResetEnable clockGen resetGen enableGen (scatterUnitWb @System @_ @32)
-        calConfig (pure emptyWishboneM2S) linkIn wbIn
+        withClockResetEnable clockGen resetGen enableGen (scatterUnitWb @System @32)
+        (ScatterConfig calConfig) (pure emptyWishboneM2S) linkIn wbIn
 
       wbReadOps = P.take simLength $ P.replicate memDepth emptyWishboneM2S P.++  P.concat
         ( padToLength memDepth emptyWishboneM2S
@@ -186,8 +186,8 @@ gatherUnitNoFrameLoss = property $ do
       <$> inputGen (padToLength memDepth Nothing <$> metaCycleGen)
     let
       topEntity wbIn = (\ (a, _ ,_) -> a) $
-        withClockResetEnable clockGen resetGen enableGen (gatherUnitWb @System @_ @32)
-        calConfig (pure emptyWishboneM2S) wbIn
+        withClockResetEnable clockGen resetGen enableGen (gatherUnitWb @System @32)
+        (GatherConfig calConfig) (pure emptyWishboneM2S) wbIn
 
       wbWriteOps = P.take simLength . P.concat $
         padToLength memDepth emptyWishboneM2S


### PR DESCRIPTION
This PR goes on top of #66
 
This PR adds GADTs to configure the scatter- and gather units. 
These GADTs hide the component specific type variables from the rest of the implementation.