### PR TITLE
Comply with dynamic clocks API

### DIFF
--- a/bittide-extra/bittide-extra.cabal
+++ b/bittide-extra/bittide-extra.cabal
@@ -63,7 +63,7 @@ common common-options
     Cabal,
     array,
     -- clash-prelude will set suitable version bounds for the plugins
-    clash-prelude >= 1.6.3 && < 1.7,
+    clash-prelude >= 1.6.3 && < 1.8,
     containers >= 0.4.0 && < 0.7,
     ghc-typelits-extra,
     ghc-typelits-knownnat,

--- a/bittide/bittide.cabal
+++ b/bittide/bittide.cabal
@@ -64,8 +64,8 @@ common common-options
     array,
     -- clash-prelude will set suitable version bounds for the plugins
     bittide-extra,
-    clash-lib >= 1.6.3 && < 1.7,
-    clash-prelude >= 1.6.3 && < 1.7,
+    clash-lib >= 1.6.3 && < 1.8,
+    clash-prelude >= 1.6.3 && < 1.8,
     constraints >= 0.13.3 && < 0.15,
     containers >= 0.4.0 && < 0.7,
     contranomy,
@@ -106,7 +106,7 @@ test-suite unittests
     Tests.Wishbone
   build-depends:
     bittide,
-    clash-prelude-hedgehog >= 1.6 && < 1.7,
+    clash-prelude-hedgehog >= 1.6 && < 1.8,
     hedgehog >= 1.0 && < 1.1,
     tasty >= 1.4 && < 1.5,
     tasty-hedgehog >= 1.2 && < 1.3,

--- a/cabal.project
+++ b/cabal.project
@@ -21,16 +21,35 @@ package bittide
   -- so we're able to import its css file from the custom theme.
   haddock-options: --theme=linuwial-wrap-types.css --theme=Linuwial
 
+package clash-prelude
+  flags: -multiple-hidden
 
 -- index state, to go along with the cabal.project.freeze file. update the index
 -- state by running `cabal update` twice and looking at the index state it
 -- displays to you (as the second update will be a no-op)
 index-state: 2022-04-20T00:32:49Z
 
--- See: https://github.com/clash-lang/clash-compiler/commits/1.6-dynamic-clocks.
 -- Needed to simulate dynamic clocks.
 source-repository-package
   type: git
   location: https://github.com/clash-lang/clash-compiler.git
-  tag: 366661e91d01bf21bc7027b0320345b4b7952998
+  tag: d09e154ef674cea92c8f345d763606cf85e96403
   subdir: clash-prelude
+
+source-repository-package
+  type: git
+  location: https://github.com/clash-lang/clash-compiler.git
+  tag: d09e154ef674cea92c8f345d763606cf85e96403
+  subdir: clash-ghc
+
+source-repository-package
+  type: git
+  location: https://github.com/clash-lang/clash-compiler.git
+  tag: d09e154ef674cea92c8f345d763606cf85e96403
+  subdir: clash-lib
+
+source-repository-package
+  type: git
+  location: https://github.com/clash-lang/clash-compiler.git
+  tag: d09e154ef674cea92c8f345d763606cf85e96403
+  subdir: clash-prelude-hedgehog

--- a/contranomy-sim/contranomy-sim.cabal
+++ b/contranomy-sim/contranomy-sim.cabal
@@ -64,7 +64,7 @@ common common-options
       -- clash-prelude will set suitable version bounds for the plugins
   build-depends:
     base >= 4.14 && < 4.16,
-    clash-prelude >= 1.6 && < 1.7,
+    clash-prelude >= 1.6 && < 1.8,
     containers >= 0.6 && < 0.7,
     ghc-typelits-natnormalise,
     ghc-typelits-extra,
@@ -84,7 +84,7 @@ library
   build-depends:
     elf >= 0.31 && < 0.32,
     bytestring >= 0.10 && < 0.11,
-    process >= 1.6 && < 1.7,
+    process >= 1.6 && < 1.8,
     directory >= 1.3 && < 1.4
 
 executable simcontranomy

--- a/contranomy/contranomy.cabal
+++ b/contranomy/contranomy.cabal
@@ -77,7 +77,7 @@ common common-options
     array >= 0.5 && < 0.6,
     base >= 4.14 && < 4.16,
     bittide-extra,
-    clash-prelude >= 1.6 && < 1.7,
+    clash-prelude >= 1.6 && < 1.8,
     containers >= 0.6 && < 0.7,
 
     -- clash-prelude will set suitable version bounds for the plugins

--- a/elastic-buffer-sim/elastic-buffer-sim.cabal
+++ b/elastic-buffer-sim/elastic-buffer-sim.cabal
@@ -68,7 +68,7 @@ common common-options
     Cabal,
 
     -- clash-prelude will set suitable version bounds for the plugins
-    clash-prelude >= 1.6.3 && < 1.8,
+    clash-prelude >= 1.7.0 && < 1.8,
     ghc-typelits-natnormalise,
     ghc-typelits-extra,
     ghc-typelits-knownnat

--- a/elastic-buffer-sim/src/Bittide/Simulate.hs
+++ b/elastic-buffer-sim/src/Bittide/Simulate.hs
@@ -88,7 +88,7 @@ tunableClockGen ::
 tunableClockGen settlePeriod periodOffset stepSize _reset =
   case knownDomain @dom of
     SDomainConfiguration _ (snatToNum -> period) _ _ _ _ ->
-      DClock SSymbol . Just . go settlePeriod (fromIntegral (period + periodOffset))
+      Clock SSymbol . Just . go settlePeriod (fromIntegral (period + periodOffset))
  where
   go :: SettlePeriod -> PeriodPs -> Signal dom SpeedChange -> Signal dom StepSize
   go !settleCounter !period (sc :- scs) =
@@ -127,8 +127,8 @@ elasticBuffer ::
   Clock writeDom ->
   Signal readDom DataCount
 elasticBuffer mode size clkRead clkWrite
-  | DClock _ (Just readPeriods) <- clkRead
-  , DClock _ (Just writePeriods) <- clkWrite
+  | Clock _ (Just readPeriods) <- clkRead
+  , Clock _ (Just writePeriods) <- clkWrite
   = go 0 (targetDataCount size) readPeriods writePeriods
  where
   go !relativeTime !fillLevel rps wps@(writePeriod :- _) =
@@ -154,17 +154,17 @@ elasticBuffer mode size clkRead clkWrite
           Error -> error "elasticBuffer: underflow"
       | otherwise = fillLevel - 1
 
-elasticBuffer mode size (DClock ss Nothing) clock1 =
+elasticBuffer mode size (Clock ss Nothing) clock1 =
   -- Convert read clock to a "dynamic" clock if it isn't one
   case knownDomain @readDom of
     SDomainConfiguration _ (snatToNum -> period) _ _ _ _ ->
-      elasticBuffer mode size (DClock ss (Just (pure period))) clock1
+      elasticBuffer mode size (Clock ss (Just (pure period))) clock1
 
-elasticBuffer mode size clock0 (DClock ss Nothing) =
+elasticBuffer mode size clock0 (Clock ss Nothing) =
   -- Convert write clock to a "dynamic" clock if it isn't one
   case knownDomain @writeDom of
     SDomainConfiguration _ (snatToNum -> period) _ _ _ _ ->
-      elasticBuffer mode size clock0 (DClock ss (Just (pure period)))
+      elasticBuffer mode size clock0 (Clock ss (Just (pure period)))
 
 -- | Configuration passed to 'clockControl'
 data ClockControlConfig = ClockControlConfig


### PR DESCRIPTION
Since dynamic clock support was merged into clash, we should use it rather than a prototype. 