### PR TITLE
use clash-protocols for Wishbone types

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -26,5 +26,8 @@
     "ghc": null,
     "cabal": null,
     "stack": null
+  },
+  "[haskell]": {
+    "editor.formatOnSave": false
   }
 }

--- a/bittide-extra/bittide-extra.cabal
+++ b/bittide-extra/bittide-extra.cabal
@@ -65,6 +65,7 @@ common common-options
     -- clash-prelude will set suitable version bounds for the plugins
     clash-prelude >= 1.6.3 && < 1.8,
     containers >= 0.4.0 && < 0.7,
+    clash-protocols,
     ghc-typelits-extra,
     ghc-typelits-knownnat,
     ghc-typelits-natnormalise,

--- a/bittide-extra/src/Bittide/Extra/Wishbone.hs
+++ b/bittide-extra/src/Bittide/Extra/Wishbone.hs
@@ -11,148 +11,90 @@ module Bittide.Extra.Wishbone where
 
 import Clash.Prelude
 import Clash.Signal.Internal
-import qualified Data.IntMap as I
 
-data WishboneM2S bytes addressWidth = WishboneM2S
-  { -- | ADR
-    addr :: "ADR" ::: BitVector addressWidth,
-    -- | DAT
-    writeData :: "DAT_MOSI" ::: BitVector (8 * bytes),
-    -- | SEL
-    busSelect :: "SEL" ::: BitVector bytes,
-    -- | CYC
-    busCycle :: "CYC" ::: Bool,
-    -- | STB
-    strobe :: "STB" ::: Bool,
-    -- | WE
-    writeEnable :: "WE" ::: Bool,
-    -- | CTI
-    cycleTypeIdentifier :: "CTI" ::: CycleTypeIdentifier,
-    -- | BTE
-    burstTypeExtension :: "BTE" ::: BurstTypeExtension
-  }
-  deriving (Generic, NFDataX, Show, Eq, ShowX)
+import Protocols
+import Protocols.Wishbone
 
-data WishboneS2M bytes = WishboneS2M
-  { -- | DAT
-    readData :: "DAT_MISO" ::: BitVector (8 * bytes),
-    -- | ACK
-    acknowledge :: "ACK" ::: Bool,
-    -- | ERR
-    err :: "ERR" ::: Bool
-  }
-  deriving (Generic, NFDataX, Show, Eq, ShowX)
+import qualified Data.IntMap                 as I
 
-newtype CycleTypeIdentifier = CycleTypeIdentifier (BitVector 3) deriving (Generic, NFDataX, Show, Eq, ShowX)
-
-pattern Classic, ConstantAddressBurst, IncrementingBurst, EndOfBurst :: CycleTypeIdentifier
-pattern Classic = CycleTypeIdentifier 0
-pattern ConstantAddressBurst = CycleTypeIdentifier 1
-pattern IncrementingBurst = CycleTypeIdentifier 2
-pattern EndOfBurst = CycleTypeIdentifier 7
-
-data BurstTypeExtension
-  = LinearBurst
-  | Beat4Burst
-  | Beat8Burst
-  | Beat16Burst
-  deriving (Generic, NFDataX, Show, Eq, ShowX)
-
-emptyWishboneM2S :: (KnownNat bytes, KnownNat addressWidth) => WishboneM2S bytes addressWidth
-emptyWishboneM2S =
-  WishboneM2S
-    { addr = deepErrorX "emptyWishboneM2S: address of idle bus is undefined.",
-      writeData = deepErrorX "emptyWishboneM2S: writeData of idle bus is undefined.",
-      busSelect = deepErrorX "emptyWishboneM2S: busSelect of idle bus is undefined.",
-      busCycle = False,
-      strobe = False,
-      writeEnable = False,
-      cycleTypeIdentifier = Classic,
-      burstTypeExtension = LinearBurst
-    }
-
-wishboneS2M :: KnownNat bytes => WishboneS2M bytes
-wishboneS2M =
-  WishboneS2M
-    { readData = deepErrorX "wishboneS2M: readData of idle bus is undefined.",
-      acknowledge = False,
-      err = False
-    }
+type DWord = BitVector (4 * 8)
 
 -- | The wishbone storage is a simulation only memory element that communicates via the
 -- Wishbone protocol : http://cdn.opencores.org/downloads/wbspec_b4.pdf .
 -- It receives a name for error identification, an Intmap of BitVector 8 as initial content.
 -- The storage is byte addressable.
-wishboneStorage ::
-  String ->
-  I.IntMap (BitVector 8) ->
-  Signal dom (WishboneM2S 4 32) ->
-  Signal dom (WishboneS2M 4)
-wishboneStorage name initial inputs = wishboneStorage' name state inputs
-  where
-    state = (initial, False)
+wishboneStorage
+  :: String
+  -> I.IntMap (BitVector 8)
+  -> Circuit (Wishbone dom 'Standard 32 DWord) ()
+wishboneStorage name initial =
+  Circuit $ \(input, ()) -> (wishboneStorage' name state input, ())
+ where
+  state = (initial, False)
 
-wishboneStorage' ::
-  String ->
-  (I.IntMap (BitVector 8), Bool) ->
-  Signal dom (WishboneM2S 4 32) ->
-  Signal dom (WishboneS2M 4)
+wishboneStorage'
+  :: String
+  -> (I.IntMap (BitVector 8), Bool)
+  -> Signal dom (WishboneM2S 32 (BitSize DWord `DivRU` 8) DWord)
+  -> Signal dom (WishboneS2M DWord)
 wishboneStorage' name state inputs = dataOut :- (wishboneStorage' name state' inputs')
-  where
-    input :- inputs' = inputs
-    state' = (file', ack')
-    (file, ack) = state
-    WishboneM2S
-      { addr,
-        writeData,
-        busSelect,
-        busCycle,
-        strobe,
-        writeEnable
-      } = input
-    file'
-      | writeEnable = I.fromList assocList <> file
-      | otherwise = file
-    ack' = busCycle && strobe
-    address = fromIntegral (unpack $ addr :: Unsigned 32)
-    readData =
-      if not writeEnable
-        then
-          (file `lookup'` (address + 3))
-            ++# (file `lookup'` (address + 2))
-            ++# (file `lookup'` (address + 1))
-            ++# (file `lookup'` address)
-        else 0
-    lookup' x addr' = I.findWithDefault (error $ name <> ": Uninitialized Memory Address = " <> show addr') addr' x
-    assocList = case busSelect of
-      $(bitPattern "0001") -> [byte0]
-      $(bitPattern "0010") -> [byte1]
-      $(bitPattern "0100") -> [byte2]
-      $(bitPattern "1000") -> [byte3]
-      $(bitPattern "0011") -> half0
-      $(bitPattern "1100") -> half1
-      _ -> word0
-    byte0 = (address, slice d7 d0 writeData)
-    byte1 = (address + 1, slice d15 d8 writeData)
-    byte2 = (address + 2, slice d23 d16 writeData)
-    byte3 = (address + 3, slice d31 d24 writeData)
-    half0 = [byte0, byte1]
-    half1 = [byte2, byte3]
-    word0 = [byte0, byte1, byte2, byte3]
-    dataOut = WishboneS2M {readData = readData, acknowledge = ack, err = False}
+ where
+  input :- inputs' = inputs
+  state' = (file', ack')
+  (file, ack) = state
+  WishboneM2S{ addr
+  , writeData
+  , busSelect
+  , busCycle
+  , strobe
+  , writeEnable
+  } = input
+  file' | writeEnable = I.fromList assocList <> file
+        | otherwise   = file
+  ack' = busCycle && strobe
+  address = fromIntegral (unpack $ addr :: Unsigned 32)
+  readData = if not writeEnable
+    then
+      (file `lookup'` (address+3)) ++#
+      (file `lookup'` (address+2)) ++#
+      (file `lookup'` (address+1)) ++#
+      (file `lookup'` address)
+    else 0
+  lookup' x addr' = I.findWithDefault (error $ name <> ": Uninitialized Memory Address = " <> show addr') addr' x
+  assocList = case busSelect of
+    $(bitPattern "0001") -> [byte0]
+    $(bitPattern "0010") -> [byte1]
+    $(bitPattern "0100") -> [byte2]
+    $(bitPattern "1000") -> [byte3]
+    $(bitPattern "0011") -> half0
+    $(bitPattern "1100") -> half1
+    _                    -> word0
+  byte0 = (address, slice d7 d0 writeData)
+  byte1 = (address+1, slice d15 d8 writeData)
+  byte2 = (address+2, slice d23 d16 writeData)
+  byte3 = (address+3, slice d31 d24 writeData)
+  half0 = [byte0, byte1]
+  half1 = [byte2, byte3]
+  word0  = [byte0, byte1, byte2, byte3]
+  dataOut = (emptyWishboneS2M @DWord)
+    { readData = readData
+    , acknowledge = ack
+    , err = False
+    }
 
 -- | Wrapper for the wishboneStorage that allows two ports to be connected.
 -- Port A can only be used for reading, port B can read and write to the te storage.
 -- Writing from port A is illegal and write attempts will set the err signal.
-instructionStorage ::
-  String ->
-  I.IntMap (BitVector 8) ->
-  Signal dom (WishboneM2S 4 32) ->
-  Signal dom (WishboneM2S 4 32) ->
-  (Signal dom (WishboneS2M 4), Signal dom (WishboneS2M 4))
-instructionStorage name initial aM2S bM2S = (aS2M, bS2M)
-  where
-    storageOut = wishboneStorage name initial storageIn
+instructionStorage
+  :: String
+  -> I.IntMap (BitVector 8)
+  -> Circuit (Wishbone dom 'Standard 32 DWord, Wishbone dom 'Standard 32 DWord) ()
+instructionStorage name initial = Circuit go
+ where
+  go ((aM2S, bM2S), ()) = ((aS2M, bS2M), ())
+   where
+    Circuit storageFn = wishboneStorage name initial
+    (storageOut, ()) = storageFn (storageIn, ())
     aActive = strobe <$> aM2S .&&. busCycle <$> aM2S
     bActive = strobe <$> bM2S .&&. busCycle <$> bM2S
     aWriting = aActive .&&. writeEnable <$> aM2S

--- a/bittide/bittide.cabal
+++ b/bittide/bittide.cabal
@@ -69,6 +69,7 @@ common common-options
     constraints >= 0.13.3 && < 0.15,
     containers >= 0.4.0 && < 0.7,
     contranomy,
+    clash-protocols,
     ghc-typelits-extra,
     ghc-typelits-knownnat,
     ghc-typelits-natnormalise,

--- a/bittide/src/Bittide/Link.hs
+++ b/bittide/src/Bittide/Link.hs
@@ -12,12 +12,14 @@ module Bittide.Link where
 
 import Clash.Prelude
 
-import Bittide.Extra.Wishbone
-import Bittide.SharedTypes
-import Bittide.DoubleBufferedRam
 import Data.Constraint
 import Data.Constraint.Nat.Extra
 import Data.Maybe
+import Protocols.Wishbone
+
+import Bittide.SharedTypes
+import Bittide.DoubleBufferedRam
+
 
 -- Internal states of the txUnit.
 data TransmissionState preambleWidth seqCountWidth frameWidth
@@ -52,11 +54,11 @@ txUnit ::
   -- | Frame from 'gatherUnitWb'
   Signal core (DataLink frameWidth) ->
   -- | Control register Wishbone bus (Master -> slave).
-  Signal core (WishboneM2S nBytes aw) ->
+  Signal core (WishboneM2S aw nBytes (BitVector (8 * nBytes))) ->
   -- |
   -- 1. Control register Wishbone bus (Slave -> master).
   -- 2. Outgoing frame
-  ( Signal core (WishboneS2M nBytes)
+  ( Signal core (WishboneS2M (BitVector (8 * nBytes)))
   , Signal core (DataLink frameWidth))
 txUnit (getRegs -> RegisterBank preamble) sq frameIn wbIn = (wbOut, frameOut)
  where
@@ -132,9 +134,9 @@ rxUnit ::
   -- | Incoming bittide link.
   Signal core (DataLink fw) ->
   -- | Control register Wishbone bus (Master -> slave).
-  Signal core (WishboneM2S nBytes aw) ->
+  Signal core (WishboneM2S aw nBytes (BitVector (8 * nBytes))) ->
   -- | Control register Wishbone bus (Slave -> master).
-  Signal core (WishboneS2M nBytes)
+  Signal core (WishboneS2M (BitVector (8 * nBytes)))
 rxUnit preamble localCounter linkIn wbIn = wbOut
  where
   (regOut, wbOut) = registerWbE WishbonePriority regInit wbIn regIn byteEnables

--- a/bittide/src/Bittide/SharedTypes.hs
+++ b/bittide/src/Bittide/SharedTypes.hs
@@ -13,13 +13,14 @@
 {-# LANGUAGE UndecidableInstances #-}
 
 module Bittide.SharedTypes where
+
 import Clash.Prelude
 
-import Data.Proxy
-import Data.Type.Equality ((:~:)(Refl))
 import Data.Constraint
 import Data.Constraint.Nat.Extra
-import Bittide.Extra.Wishbone
+import Data.Proxy
+import Data.Type.Equality ((:~:)(Refl))
+import Protocols.Wishbone
 
 -- | A single byte.
 type Byte = BitVector 8

--- a/bittide/src/Bittide/Switch.hs
+++ b/bittide/src/Bittide/Switch.hs
@@ -6,10 +6,11 @@ module Bittide.Switch where
 
 import Clash.Prelude
 
+import Protocols.Wishbone
+
 import Bittide.Calendar
 import Bittide.ScatterGather (scatterEngine)
 import Bittide.SharedTypes
-import Bittide.Extra.Wishbone (WishboneM2S, WishboneS2M)
 
 -- | An index which source is selected by the crossbar, 0 selects Nothing, k selects k - 1.
 type CrossbarIndex links = Index (links+1)
@@ -35,11 +36,12 @@ switch ::
   -- | The calendar configuration
   CalendarConfig nBytes addrW (CalendarEntry links memDepth) ->
   -- | Wishbone interface wired to the calendar.
-  Signal dom (WishboneM2S nBytes addrW) ->
+  Signal dom (WishboneM2S addrW nBytes (BitVector (8 * nBytes))) ->
   -- | All incoming datalinks
   Signal dom (Vec links (DataLink frameWidth)) ->
   -- | All outgoing datalinks
-  (Signal dom (Vec links (DataLink frameWidth)), Signal dom (WishboneS2M nBytes))
+  ( Signal dom (Vec links (DataLink frameWidth))
+  , Signal dom (WishboneS2M (BitVector (8 * nBytes))) )
 switch calConfig wbIn streamsIn =
   (crossBar <$> crossBarConfig <*> availableFrames, wbOut)
  where

--- a/bittide/src/Data/Constraint/Nat/Extra.hs
+++ b/bittide/src/Data/Constraint/Nat/Extra.hs
@@ -32,6 +32,15 @@ timesDivRU = unsafeCoerce (Dict :: Dict ())
 clog2axiom :: CLog 2 (n * 2) :~: (CLog 2 n + 1)
 clog2axiom = unsafeCoerce Refl
 
+timesNDivRU :: forall a b . Dict (DivRU (a * b) b ~ a)
+timesNDivRU = unsafeCoerce (Dict :: Dict ())
+
+timesNDivRU' :: forall a b . Dict (Div ((b * a) + (b - 1)) b ~ a)
+timesNDivRU' = unsafeCoerce (Dict :: Dict ())
+
+timesNDivRU'' :: forall a b . Dict (Div ((a * b) + (b - 1)) b ~ a)
+timesNDivRU'' = unsafeCoerce (Dict :: Dict ())
+
 -- | if (c <= a) or (c <= b), then c <= Max a b
 lessThanMax :: forall a b c . (KnownNat a, KnownNat b, KnownNat c) => Dict (c <= Max a b)
 lessThanMax = case (compareSNat (SNat @c) (SNat @b), compareSNat (SNat @c) (SNat @b)) of

--- a/bittide/tests/Tests/Switch.hs
+++ b/bittide/tests/Tests/Switch.hs
@@ -28,10 +28,10 @@ import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
 
 import Bittide.Calendar (CalendarConfig(..))
-import Bittide.Extra.Wishbone
 import Bittide.Switch
 import Tests.Calendar
 import Tests.Shared
+import Protocols.Wishbone
 
 switchGroup :: TestTree
 switchGroup = testGroup "Switch group"

--- a/cabal.project
+++ b/cabal.project
@@ -11,7 +11,7 @@ packages:
 
 write-ghc-environment-files: always
 
-with-compiler: ghc-9.0
+with-compiler: ghc-9.0.2
 
 tests: True
 
@@ -27,7 +27,7 @@ package clash-prelude
 -- index state, to go along with the cabal.project.freeze file. update the index
 -- state by running `cabal update` twice and looking at the index state it
 -- displays to you (as the second update will be a no-op)
-index-state: 2022-04-20T00:32:49Z
+index-state: 2022-08-09T07:40:43Z
 
 -- Needed to simulate dynamic clocks.
 source-repository-package
@@ -53,3 +53,13 @@ source-repository-package
   location: https://github.com/clash-lang/clash-compiler.git
   tag: d09e154ef674cea92c8f345d763606cf85e96403
   subdir: clash-prelude-hedgehog
+
+source-repository-package
+  type: git
+  location: https://github.com/clash-lang/clash-protocols.git
+  tag: 3f3cbb1cec3153b15142d796801eb740961773c8
+
+source-repository-package
+  type: git
+  location: https://github.com/cchalmers/circuit-notation.git
+  tag: 618e37578e699df235f2e7150108b6401731919b

--- a/contranomy/contranomy.cabal
+++ b/contranomy/contranomy.cabal
@@ -78,6 +78,7 @@ common common-options
     base >= 4.14 && < 4.16,
     bittide-extra,
     clash-prelude >= 1.6 && < 1.8,
+    clash-protocols,
     containers >= 0.6 && < 0.7,
 
     -- clash-prelude will set suitable version bounds for the plugins

--- a/contranomy/src/Contranomy/Core.hs
+++ b/contranomy/src/Contranomy/Core.hs
@@ -15,10 +15,10 @@ import Data.Generics.Labels ()
 import Data.Maybe
 import Control.Monad
 import Clash.Prelude
+import Protocols.Wishbone
 
 import Contranomy.Clash.Extra
 
-import Bittide.Extra.Wishbone
 import Contranomy.Core.ALU
 import Contranomy.Core.CoreState
 import Contranomy.Core.CSR
@@ -39,8 +39,8 @@ type ExternalInterrupt = MachineWord
 
 data CoreIn
   = CoreIn
-  { iBusS2M :: "iBusWishbone" ::: WishboneS2M Bytes
-  , dBusS2M :: "dBusWishbone" :::  WishboneS2M Bytes
+  { iBusS2M :: "iBusWishbone" ::: WishboneS2M MachineWord
+  , dBusS2M :: "dBusWishbone" :::  WishboneS2M MachineWord
   , timerInterrupt :: "timerInterrupt" ::: TimerInterrupt
   , softwareInterrupt :: "softwareInterrupt" ::: SoftwareInterrupt
   , externalInterrupt :: "externalInterrupt" ::: ExternalInterrupt
@@ -48,14 +48,14 @@ data CoreIn
 
 data CoreOut
   = CoreOut
-  { iBusM2S :: "iBusWishbone" ::: WishboneM2S Bytes AddressWidth
-  , dBusM2S :: "dBusWishbone" ::: WishboneM2S Bytes AddressWidth
+  { iBusM2S :: "iBusWishbone" ::: WishboneM2S AddressWidth Bytes MachineWord
+  , dBusM2S :: "dBusWishbone" ::: WishboneM2S AddressWidth Bytes MachineWord
   }
 
 coreOut :: CoreOut
 coreOut = CoreOut
-  { iBusM2S = emptyWishboneM2S @Bytes @AddressWidth
-  , dBusM2S = emptyWishboneM2S @Bytes @AddressWidth
+  { iBusM2S = emptyWishboneM2S
+  , dBusM2S = emptyWishboneM2S
   }
 
 {-# NOINLINE core #-}
@@ -107,7 +107,7 @@ transition s@CoreState{stage=InstructionFetch, pc} (CoreIn{iBusS2M},_) = runStat
             else
               InstructionFetch
 
-  return ( coreOut { iBusM2S = (emptyWishboneM2S @Bytes @AddressWidth)
+  return ( coreOut { iBusM2S = (emptyWishboneM2S @AddressWidth)
                              { addr = pc
                              , busSelect = 0b1111
                              , busCycle = True

--- a/contranomy/src/Contranomy/Core/LoadStore.hs
+++ b/contranomy/src/Contranomy/Core/LoadStore.hs
@@ -9,7 +9,8 @@ module Contranomy.Core.LoadStore where
 
 import Clash.Prelude
 
-import Bittide.Extra.Wishbone
+import Protocols.Wishbone
+
 import Contranomy.Core.Decode
 import Contranomy.Core.SharedTypes
 import Contranomy.Instruction
@@ -30,13 +31,13 @@ loadStoreUnit ::
   -- | The value to store
   MachineWord ->
   -- | Data bus response (slave-to-master)
-  WishboneS2M Bytes ->
+  WishboneS2M MachineWord ->
   -- |
   -- 1. Data bus initiation (master-to-slave)
   -- 2. The address causing a data-access fault on the data bus
   -- 3. The misaligned address
   -- 4. Data bus transaction completed
-  (WishboneM2S Bytes AddressWidth, Maybe MachineWord, Maybe MachineWord, Maybe MachineWord, Bool)
+  (WishboneM2S AddressWidth Bytes MachineWord, Maybe MachineWord, Maybe MachineWord, Maybe MachineWord, Bool)
 loadStoreUnit instruction instructionFault addr toStore dBusS2M = case opcode of
   LOAD | not instructionFault ->
     let loadData = case loadStoreWidth of
@@ -49,7 +50,7 @@ loadStoreUnit instruction instructionFault addr toStore dBusS2M = case opcode of
               sign
               (slice d15 d0 (readData dBusS2M `shiftR` shiftAmount))
           _ -> readData dBusS2M
-     in ( (emptyWishboneM2S @Bytes @AddressWidth)
+     in ( (emptyWishboneM2S @AddressWidth)
             { addr      = slice d31 d2 addr ++# (0 :: BitVector 2)
             , busSelect = mask
             , busCycle  = aligned
@@ -69,7 +70,7 @@ loadStoreUnit instruction instructionFault addr toStore dBusS2M = case opcode of
           Byte _ -> toStore `shiftL` shiftAmount
           Half _ -> toStore `shiftL` shiftAmount
           _ -> toStore
-     in ( (emptyWishboneM2S @Bytes @AddressWidth)
+     in ( (emptyWishboneM2S @AddressWidth @MachineWord)
            { addr        = slice d31 d2 addr ++# (0 :: BitVector 2)
            , writeData   = storeData
            , busSelect   = mask
@@ -84,7 +85,7 @@ loadStoreUnit instruction instructionFault addr toStore dBusS2M = case opcode of
         )
 
   _otherwise ->
-    ( emptyWishboneM2S @Bytes @AddressWidth
+    ( emptyWishboneM2S @AddressWidth
     , Nothing
     , Nothing
     , Nothing

--- a/contranomy/src/Contranomy/Core/RVFI.hs
+++ b/contranomy/src/Contranomy/Core/RVFI.hs
@@ -9,7 +9,8 @@ module Contranomy.Core.RVFI where
 
 import Clash.Prelude
 
-import Bittide.Extra.Wishbone
+import Protocols.Wishbone
+
 import Contranomy.Core.Decode
 import Contranomy.Core.SharedTypes
 import Contranomy.Instruction
@@ -35,9 +36,9 @@ toRVFI ::
   -- | pcN
   PC ->
   -- | dbusM2S
-  WishboneM2S Bytes AddressWidth ->
+  WishboneM2S AddressWidth Bytes MachineWord ->
   -- | dbusS2M
-  WishboneS2M Bytes ->
+  WishboneS2M MachineWord ->
   -- | MISA CRS
   (Maybe MachineWord, MachineWord) ->
   RVFI


### PR DESCRIPTION
This changes the wishbone types previously used from `Bittide.Extra.Wishbone` to the ones in `clash-protocols`.

Where possible and non-invasive, also adds Wishbone spec validation to tests in `bittide/tests`.