### PR TITLE
Add compressed calendar support

### DIFF
--- a/bittide-instances/src/Bittide/Instances/Calendar.hs
+++ b/bittide-instances/src/Bittide/Instances/Calendar.hs
@@ -7,10 +7,10 @@ module Bittide.Instances.Calendar where
 
 import Clash.Prelude
 
-import Bittide.Calendar (mkCalendar, CalendarConfig (CalendarConfig))
+import Bittide.Calendar
 import Bittide.Instances.Domains (Basic200)
 import Bittide.SharedTypes
-import Bittide.Switch
+import Bittide.Switch as SW
 import Protocols.Wishbone
 
 import Bittide.Instances.Hacks (reducePins)
@@ -27,9 +27,11 @@ switchCalendar1k ::
   )
 switchCalendar1k clk rst =
   withClockResetEnable clk syncRst enableGen $
-    mkCalendar (CalendarConfig (SNat @1024) (repeat 0 :> Nil) (repeat 0 :> Nil))
+    mkCalendar (CalendarConfig (SNat @1024) cal cal)
  where
   syncRst = resetSynchronizer clk rst
+  cal = ValidEntry{veEntry =repeat 0, veRepeat = 0 :: Unsigned 8} :> Nil
+
 {-# NOINLINE switchCalendar1k #-}
 
 switchCalendar1kReducedPins ::

--- a/bittide/src/Bittide/ScatterGather.hs
+++ b/bittide/src/Bittide/ScatterGather.hs
@@ -47,7 +47,9 @@ data GatherConfig nBytes addrW where
 scatterUnit ::
   ( HiddenClockResetEnable dom
   , KnownNat memDepth, 1 <= memDepth
-  , KnownNat frameWidth) =>
+  , KnownNat frameWidth
+  , KnownNat nBytes, 1 <= nBytes
+  , KnownNat addrW, 2 <= addrW) =>
   -- | Configuration for the 'calendar'.
   CalendarConfig nBytes addrW (Index memDepth) ->
   -- | Wishbone (master -> slave) port for the 'calendar'.
@@ -75,7 +77,9 @@ gatherUnit ::
   ( HiddenClockResetEnable dom
   , KnownNat memDepth, 1 <= memDepth
   , KnownNat frameWidth, 1 <= frameWidth
-  , KnownNat (DivRU frameWidth 8), 1 <= (DivRU frameWidth 8)) =>
+  , KnownNat (DivRU frameWidth 8), 1 <= (DivRU frameWidth 8)
+  , KnownNat nBytes, 1 <= nBytes
+  , KnownNat addrW, 2 <= addrW) =>
   -- | Configuration for the 'calendar'.
   CalendarConfig nBytes addrW (Index memDepth) ->
   -- | Wishbone (master -> slave) port for the 'calendar'.
@@ -86,7 +90,7 @@ gatherUnit ::
   Signal dom (ByteEnable (BitVector frameWidth)) ->
   -- | (Transmitted  frame to Bittide Link, Wishbone (slave -> master) from 'calendar')
   (Signal dom (DataLink frameWidth), Signal dom (WishboneS2M (Bytes nBytes)))
-gatherUnit calConfig wbIn writeOp byteEnables= (linkOut, wbOut)
+gatherUnit calConfig wbIn writeOp byteEnables = (linkOut, wbOut)
  where
   (readAddr, metaCycle, wbOut) = mkCalendar calConfig wbIn
   linkOut = mux (register True ((==0) <$> readAddr)) (pure Nothing) (Just <$> bramOut)
@@ -132,7 +136,9 @@ wbInterface addressRange WishboneM2S{..} readData =
 scatterUnitWb ::
   forall dom addrWidthSu nBytesCal addrWidthCal .
   ( HiddenClockResetEnable dom
-  , KnownNat addrWidthSu, 2 <= addrWidthSu) =>
+  , KnownNat addrWidthSu, 2 <= addrWidthSu
+  , KnownNat nBytesCal, 1 <= nBytesCal
+  , KnownNat addrWidthCal, 2 <= addrWidthCal) =>
   -- | Configuration for the 'calendar'.
   ScatterConfig nBytesCal addrWidthCal ->
   -- | Wishbone (master -> slave) port 'calendar'.
@@ -160,7 +166,9 @@ scatterUnitWb (ScatterConfig calConfig) wbInCal linkIn wbInSu =
 gatherUnitWb ::
   forall dom addrWidthGu nBytesCal addrWidthCal .
   ( HiddenClockResetEnable dom
-  , KnownNat addrWidthGu, 2 <= addrWidthGu) =>
+  , KnownNat addrWidthGu, 2 <= addrWidthGu
+  , KnownNat nBytesCal, 1 <= nBytesCal
+  , KnownNat addrWidthCal, 2 <= addrWidthCal) =>
   -- | Configuration for the 'calendar'.
   GatherConfig nBytesCal addrWidthCal ->
   -- | Wishbone (master -> slave) data 'calendar'.

--- a/bittide/src/Bittide/ScatterGather.hs
+++ b/bittide/src/Bittide/ScatterGather.hs
@@ -58,15 +58,17 @@ scatterUnit ::
   Signal dom (DataLink frameWidth) ->
   -- | Read address.
   Signal dom (Index memDepth) ->
-  -- | (Data at read address delayed 1 cycle, Wishbone (slave -> master) from 'calendar')
-  (Signal dom (BitVector frameWidth), Signal dom (WishboneS2M (Bytes nBytes)))
-scatterUnit calConfig wbIn linkIn readAddr = (readOut, wbOut)
+  -- | 1. Data at read address delayed 1 cycle
+  --   2. Wishbone (slave -> master) from 'calendar')
+  --   3. End of metacycle.
+  (Signal dom (BitVector frameWidth), Signal dom (WishboneS2M (Bytes nBytes)), Signal dom Bool)
+scatterUnit calConfig wbIn linkIn readAddr = (readOut, wbOut, endOfMetacycle)
  where
-  (writeAddr, metaCycle, wbOut) = mkCalendar calConfig wbIn
+  (writeAddr, endOfMetacycle, wbOut) = mkCalendar calConfig wbIn
   writeOp = (\a b -> (a,) <$> b) <$> writeAddr <*> linkIn
   readOut = doubleBufferedRamU bufSelect0 readAddr writeOp
   bufSelect0 = register A bufSelect1
-  bufSelect1 = mux metaCycle (swapAorB <$> bufSelect0) bufSelect0
+  bufSelect1 = mux endOfMetacycle (swapAorB <$> bufSelect0) bufSelect0
 
 -- | Double buffered memory component that can be written to by a generic write operation. The
 -- write address of the incoming frame is determined by the incorporated 'calendar'. The
@@ -88,16 +90,18 @@ gatherUnit ::
   Signal dom (Maybe (LocatedBits memDepth frameWidth)) ->
   -- | Byte enable for write operation.
   Signal dom (ByteEnable (BitVector frameWidth)) ->
-  -- | (Transmitted  frame to Bittide Link, Wishbone (slave -> master) from 'calendar')
-  (Signal dom (DataLink frameWidth), Signal dom (WishboneS2M (Bytes nBytes)))
-gatherUnit calConfig wbIn writeOp byteEnables = (linkOut, wbOut)
+  -- | 1. Frame to Bittide Link.
+  --   2. Wishbone (slave -> master) from 'calendar')
+  --   3. End of metacycle.
+  (Signal dom (DataLink frameWidth), Signal dom (WishboneS2M (Bytes nBytes)), Signal dom Bool)
+gatherUnit calConfig wbIn writeOp byteEnables = (linkOut, wbOut, endOfMetacycle)
  where
-  (readAddr, metaCycle, wbOut) = mkCalendar calConfig wbIn
+  (readAddr, endOfMetacycle, wbOut) = mkCalendar calConfig wbIn
   linkOut = mux (register True ((==0) <$> readAddr)) (pure Nothing) (Just <$> bramOut)
   bramOut = doubleBufferedRamByteAddressableU
     (bitCoerce <$> bufSelect0) readAddr writeOp byteEnables
   bufSelect0 = register A bufSelect1
-  bufSelect1 = mux metaCycle (swapAorB <$> bufSelect0) bufSelect0
+  bufSelect1 = mux endOfMetacycle (swapAorB <$> bufSelect0) bufSelect0
 
 -- | Wishbone interface for the 'scatterUnit' and 'gatherUnit'. It makes the scatter and gather
 -- unit, which operate on 64 bit frames, addressable via a 32 bit wishbone bus.
@@ -106,28 +110,57 @@ wbInterface ::
   ( KnownNat nBytes
   , KnownNat addresses, 1 <= addresses
   , KnownNat addrW, 2 <= addrW) =>
-  -- | Maximum address of the respective memory element as seen from the wishbone side.
-  Index addresses ->
   -- | Wishbone (master -> slave) data.
   WishboneM2S addrW nBytes (Bytes nBytes) ->
   -- | Read data to be send to over the (slave -> master) port.
   Bytes nBytes ->
   -- | (slave - master data, read address memory element, write data memory element)
   (WishboneS2M (Bytes nBytes), Index addresses, Maybe (Bytes nBytes))
-wbInterface addressRange WishboneM2S{..} readData =
+wbInterface WishboneM2S{..} readData =
   ( (emptyWishboneS2M @(Bytes nBytes)) {readData, acknowledge, err}
-  , memAddr
+  , wbAddr
   , writeOp )
  where
   masterActive = strobe && busCycle
   (alignedAddress, alignment) = split @_ @(addrW - 2) @2 addr
   wordAligned = alignment == 0
-  err = masterActive && ((alignedAddress > resize (pack addressRange)) || not wordAligned)
+  maxAddress = resize $ pack (maxBound :: Index addresses) :: BitVector (addrW - 2)
+  err = masterActive && ((alignedAddress > maxAddress) || not wordAligned)
   acknowledge = masterActive && not err
   wbAddr = unpack . resize $ pack alignedAddress
-  memAddr = wbAddr
   writeOp | strobe && writeEnable && not err = Just writeData
           | otherwise  = Nothing
+
+-- | Adds a stalling address to the 'wbInterface' by demanding an extra address on type level.
+-- When this address is accessed, the outgoing 'WishboneS2M' bus' acknowledge is replaced
+-- with the @endOfMetacycle@ signal to stall the wishbone master until the end of the metacycle.
+addStalling ::
+  ( KnownNat memAddresses, 1 <= memAddresses) =>
+  -- | Controls the 'acknowledge' of the returned 'WishboneS2M' when the incoming address
+  -- is 'maxBound'.
+  Bool ->
+  -- |
+  --  1. Incoming 'WishboneS2M' bus.
+  --  2. Incoming wishbone address (stalling address in range).
+  --  3. Incoming write operation.
+  ( WishboneS2M wbData
+  , Index (memAddresses + 1)
+  , Maybe a) ->
+  -- |
+  --  1. Outgoing 'WishboneS2M' bus (@acknowledge@ replaced with @endOfMetacycle@ when @wbAddr == maxBound@).
+  --  2. Outgoing wishbone address (stalling address not in range).
+  --  3. Outgoing write operation (set to @Nothing@ when @wbAddr == maxBound@).
+  ( WishboneS2M wbData
+  , Index memAddresses
+  , Maybe a)
+addStalling endOfMetacycle (incomingBus@WishboneS2M{..}, wbAddr, writeOp0) =
+  (slaveToMaster1, memAddr, writeOp1)
+ where
+  stalledBus = incomingBus{acknowledge = endOfMetacycle}
+  (slaveToMaster1, writeOp1)
+    | acknowledge && (wbAddr == maxBound) = (stalledBus, Nothing)
+    | otherwise                           = (incomingBus, writeOp0)
+  memAddr = bitCoerce $ resize wbAddr
 
 {-# NOINLINE scatterUnitWb #-}
 -- | Wishbone addressable 'scatterUnit', the wishbone port can read the data from this
@@ -147,14 +180,18 @@ scatterUnitWb ::
   Signal dom (DataLink 64) ->
   -- | Wishbone (master -> slave) port scatter memory.
   Signal dom (WishboneM2S addrWidthSu 4 (Bytes 4)) ->
-  -- | (Wishbone (slave -> master) port scatter memory, Wishbone (slave -> master) port 'calendar')
+  -- |
+  -- 1. Wishbone (slave -> master) port scatter memory
+  -- 2. Wishbone (slave -> master) port 'calendar'
   (Signal dom (WishboneS2M (Bytes 4)), Signal dom (WishboneS2M (Bytes nBytesCal)))
 scatterUnitWb (ScatterConfig calConfig) wbInCal linkIn wbInSu =
   (delayControls wbOutSu, wbOutCal)
  where
-  (wbOutSu, memAddr, _) = unbundle $ wbInterface maxBound <$> wbInSu <*> scatteredData
+  (wbOutSu, memAddr, _) = unbundle $ addStalling <$> endOfMetacycle <*>
+    (wbInterface <$> wbInSu <*> scatteredData)
   (readAddr, upperSelected) = unbundle $ div2Index <$> memAddr
-  (scatterUnitRead, wbOutCal) = scatterUnit calConfig wbInCal linkIn readAddr
+  (scatterUnitRead, wbOutCal, endOfMetacycle) =
+    scatterUnit calConfig wbInCal linkIn readAddr
   (upper, lower) = unbundle $ split <$> scatterUnitRead
   selected = register (errorX "scatterUnitWb: Initial selection undefined") upperSelected
   scatteredData = mux selected upper lower
@@ -175,16 +212,19 @@ gatherUnitWb ::
   Signal dom (WishboneM2S addrWidthCal nBytesCal (Bytes nBytesCal)) ->
   -- | Wishbone (master -> slave) port gather memory.
   Signal dom (WishboneM2S addrWidthGu 4 (Bytes 4)) ->
-  -- | (Wishbone (slave -> master) port gather memory, Wishbone (slave -> master) port 'calendar')
+  -- |
+  -- 1. Wishbone (slave -> master) port gather memory
+  -- 2. Wishbone (slave -> master) port 'calendar'
   ( Signal dom (DataLink 64)
   , Signal dom (WishboneS2M (Bytes 4))
   , Signal dom (WishboneS2M (Bytes nBytesCal)) )
 gatherUnitWb (GatherConfig calConfig) wbInCal wbInGu =
   (linkOut, delayControls wbOutGu, wbOutCal)
  where
-  (wbOutGu, memAddr, writeOp) = unbundle $ wbInterface maxBound <$> wbInGu <*> pure 0b0
+  (wbOutGu, memAddr, writeOp) = unbundle $ addStalling <$> endOfMetacycle <*>
+    (wbInterface <$> wbInGu <*> pure 0b0)
   (writeAddr, upperSelected) = unbundle $ div2Index <$> memAddr
-  (linkOut, wbOutCal) =
+  (linkOut, wbOutCal, endOfMetacycle) =
     gatherUnit calConfig wbInCal gatherWrite gatherByteEnables
   gatherWrite = mkWrite <$> writeAddr <*> writeOp
   gatherByteEnables = mkEnables <$> upperSelected <*> (busSelect <$> wbInGu)

--- a/bittide/src/Data/Constraint/Nat/Extra.hs
+++ b/bittide/src/Data/Constraint/Nat/Extra.hs
@@ -13,7 +13,10 @@ solved by the constraint solver.
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TypeOperators #-}
 
-module Data.Constraint.Nat.Extra where
+module Data.Constraint.Nat.Extra
+  ( module Data.Constraint.Nat.Extra
+  , Data.Constraint.Dict(..)
+  ) where
 
 import Data.Constraint
 import Data.Type.Equality
@@ -61,3 +64,7 @@ strictlyPositiveDivRu = unsafeCoerce (Dict :: Dict ())
 -- are equal/.
 euclid3 :: forall a b c . (a + b <= c) => Dict (a <= c - b)
 euclid3 = unsafeCoerce (Dict :: Dict ())
+
+-- | if (2 <= n) holds, then (1 <= CLog 2 n) also holds.
+oneLeCLog2n :: forall n . (2 <= n) => Dict (1 <= CLog 2 n)
+oneLeCLog2n = unsafeCoerce unsafeCoerce (Dict :: Dict ())

--- a/bittide/tests/Tests/DoubleBufferedRam.hs
+++ b/bittide/tests/Tests/DoubleBufferedRam.hs
@@ -743,6 +743,3 @@ wbStorageBehaviorModel storedList output (address :- addresses) (writeOp :- writ
     | otherwise = storedList
   nextOutput = pack (upper0, lower0)
   outputs = wbStorageBehaviorModel newList nextOutput addresses writeOps
-
-wcre :: KnownDomain dom => (HiddenClockResetEnable dom => r) -> r
-wcre = withClockResetEnable clockGen resetGen enableGen

--- a/bittide/tests/Tests/Haxioms.hs
+++ b/bittide/tests/Tests/Haxioms.hs
@@ -25,6 +25,7 @@ haxiomsGroup = testGroup "Haxioms"
   , testPropertyNamed "leMaxRight holds" "prop_leMaxRight" prop_leMaxRight
   , testPropertyNamed "divWithRemainder holds" "prop_divWithRemainder" prop_divWithRemainder
   , testPropertyNamed "euclid3 holds" "prop_euclid3" prop_euclid3
+  , testPropertyNamed "prop_oneLeCLog2n holds" "prop_oneLeCLog2n" prop_oneLeCLog2n
   ]
 
 -- | Generate a 'Natural' greater than or equal to /n/. Can generate 'Natural's
@@ -168,3 +169,16 @@ prop_euclid3 = property $ do
   b <- forAll (genNatural 0)
   c <- forAll (genNatural (a + b))
   (a + b <= c) === (a <= c - b)
+
+-- | Test whether the following equation (supplied by 'oneLeCLog2n') holds:
+--
+--     1 <= CLog 2 n
+--
+-- Given:
+--
+--     2 <= n
+--
+prop_oneLeCLog2n :: Property
+prop_oneLeCLog2n = property $ do
+  n <- forAll (genNatural 2)
+  assert (1 <= clog 2 n)

--- a/bittide/tests/Tests/Link.hs
+++ b/bittide/tests/Tests/Link.hs
@@ -448,6 +448,3 @@ registerN n a = mealy go (replicate n a)
   go state0 inp = (state1, out)
    where
     (out :> state1) = state0 :< inp
-
-wcre :: KnownDomain dom => (HiddenClockResetEnable dom => r) -> r
-wcre = withClockResetEnable clockGen resetGen enableGen

--- a/bittide/tests/Tests/ScatterGather.hs
+++ b/bittide/tests/Tests/ScatterGather.hs
@@ -62,6 +62,8 @@ sgGroup = testGroup "Scatter Gather group"
       "scatterUnitNoFrameLoss" scatterUnitNoFrameLoss
   , testPropertyNamed "gatherUnitWb - No overwriting implies no lost frames."
       "gatherUnitNoFrameLoss" gatherUnitNoFrameLoss
+  , testPropertyNamed "S/G units - Ack stalling address at metacycle end."
+      "metacycleStalling" metacycleStalling
   ]
 
 -- | Generates a 'CalendarConfig' for the 'gatherUnitWb' or 'scatterUnitWb'
@@ -167,7 +169,7 @@ gatherUnitNoFrameLoss = property $ do
   maxCalSize <- forAll $ Gen.enum 2 32
   case TN.someNatVal (maxCalSize - 2) of
     SomeNat (addSNat d2 . snatProxy -> p) -> do
-      runTest =<< forAll (genCal p)
+      runTest =<< forAll (genCalendarConfig @4 @32 p)
  where
   runTest ::
     (KnownNat maxSize, 1 <= maxSize) =>
@@ -205,17 +207,49 @@ gatherUnitNoFrameLoss = property $ do
 
     directedDecode (prePad writtenFrames) simOut === expectedOutput
 
-  genCal :: forall maxSize .
-   2 <= maxSize =>
-   SNat maxSize ->
-   Gen (CalendarConfig 4 32 (Index maxSize))
-  genCal SNat = genCalendarConfig @4 @32 (SNat @maxSize)
   padToLength l padElement g = P.take l (g P.++ P.repeat padElement)
 
 directedDecode :: [Maybe a] -> [Maybe b] -> [b]
 directedDecode ((Just _) : as) ((Just b) : bs) = b : directedDecode as bs
 directedDecode (Nothing : as) (_ : bs) = directedDecode as bs
 directedDecode _ _ = []
+
+-- | Simple  test which generates a 'scatterUnitWb' and 'gatherUnitWb' with a certain calendar
+-- Their wishbone busses are statically hooked up to a transaction that reads from the
+-- stalling address. This test checks that it generates an acknowledge on this address
+-- one cycle after the end of each metacycle (at the start of every _new_ metacycle).
+metacycleStalling :: Property
+metacycleStalling = property $ do
+  maxCalSize <- forAll $ Gen.enum 2 32
+  case TN.someNatVal (maxCalSize - 2) of
+    SomeNat (addSNat d2 . snatProxy -> p) -> do
+      runTest =<< forAll (genCalendarConfig @4 @32 p)
+ where
+  runTest ::
+    forall maxSize .
+    (KnownNat maxSize, 2 <= maxSize) =>
+    CalendarConfig 4 32 (Index maxSize) -> PropertyT IO ()
+  runTest calConfig@(CalendarConfig _ (length -> calSize) _) = do
+    metacycles <- forAll $ Gen.enum 1 5
+    let
+      simLength = 1 + metacycles * calSize
+      topEntity = bundle (acknowledge <$> suWB,acknowledge <$> guWB)
+       where
+        suWB = wcre $ fst $ scatterUnitWb @System (ScatterConfig calConfig)
+          (pure emptyWishboneM2S) linkIn wbStall
+        guWB = wcre $ (\(_,x,_) -> x) $ gatherUnitWb @System
+          (GatherConfig calConfig) (pure emptyWishboneM2S) wbStall
+        wbStall = pure $ (emptyWishboneM2S @32)
+          -- 4 for word alignment, 2 because addressing is 64 bit aligned.
+          { addr = 4 * (2 * (natToNum @maxSize @(BitVector 32)))
+          , busCycle = True
+          , strobe = True
+          }
+        linkIn = pure $ deepErrorX "linkIn undefined."
+      expectedAcks = P.take simLength $ P.replicate (1 +calSize) False <>
+        cycle (True : P.replicate (calSize -1) False)
+      simOut = sampleN simLength topEntity
+    simOut === fmap (\a -> (a,a)) expectedAcks
 
 -- | Decode an incoming slave bus by consuming two acknowledged signals and concatenating
 -- their readData's.

--- a/bittide/tests/Tests/Shared.hs
+++ b/bittide/tests/Tests/Shared.hs
@@ -11,6 +11,7 @@ module Tests.Shared where
 import Clash.Prelude
 
 import Clash.Hedgehog.Sized.Unsigned
+
 import Data.Constraint (Dict(Dict))
 import Data.Constraint.Nat.Extra (divWithRemainder)
 import GHC.Stack (HasCallStack)
@@ -19,6 +20,7 @@ import Protocols (toSignals)
 import Protocols.Wishbone as Wb
 import Protocols.Wishbone.Standard.Hedgehog (validatorCircuit)
 
+import Bittide.Calendar
 import Bittide.SharedTypes (Bytes)
 
 import qualified Data.List as L
@@ -193,3 +195,11 @@ validateWb m2s0 s2m0 = (m2s1, s2m1)
     case divWithRemainder @bs @8 @7 of
       Dict ->
         validate (m2s0, s2m0)
+
+-- | Satisfies implicit control signal constraints by using default values.
+wcre :: KnownDomain dom => (HiddenClockResetEnable dom => r) -> r
+wcre = withClockResetEnable clockGen resetGen enableGen
+
+-- | Make any @a@ into a non-repeating `ValidEntry` without repetition bits.
+nonRepeatingEntry :: a -> ValidEntry a 0
+nonRepeatingEntry a = ValidEntry{veEntry = a, veRepeat = 0}


### PR DESCRIPTION
This PR depends on main

This addition allows us to write calendar entries as compressed versions, now each entry can contain a value that represent the number of cycles for which a entry is valid.
This allows us to write entries as a tuple (entry, validity) where we can write.
```
(Entry A, 10)
(Entry B, 2)
(Entry C, 5)
```
Instead of 
```
Entry A
Entry A
Entry A
Entry A
Entry A
Entry A
Entry A
Entry A
Entry A
Entry A
Entry B
Entry B
Entry C
Entry C
Entry C
Entry C
Entry C
```
This implementation allows us to still create HDL for uncompressed calendars without additional hardware cost (should be optimized away).

