### PR TITLE
Scatter / Gather stalling address

### DIFF
--- a/bittide/src/Bittide/ScatterGather.hs
+++ b/bittide/src/Bittide/ScatterGather.hs
@@ -118,7 +118,7 @@ wbInterface ::
   (WishboneS2M (Bytes nBytes), Index addresses, Maybe (Bytes nBytes))
 wbInterface WishboneM2S{..} readData =
   ( (emptyWishboneS2M @(Bytes nBytes)) {readData, acknowledge, err}
-  , memAddr
+  , wbAddr
   , writeOp )
  where
   masterActive = strobe && busCycle
@@ -128,7 +128,6 @@ wbInterface WishboneM2S{..} readData =
   err = masterActive && ((alignedAddress > maxAddress) || not wordAligned)
   acknowledge = masterActive && not err
   wbAddr = unpack . resize $ pack alignedAddress
-  memAddr = wbAddr
   writeOp | strobe && writeEnable && not err = Just writeData
           | otherwise  = Nothing
 

--- a/bittide/tests/Tests/DoubleBufferedRam.hs
+++ b/bittide/tests/Tests/DoubleBufferedRam.hs
@@ -736,6 +736,3 @@ wbStorageBehaviorModel storedList output (address :- addresses) (writeOp :- writ
     | otherwise = storedList
   nextOutput = pack (upper0, lower0)
   outputs = wbStorageBehaviorModel newList nextOutput addresses writeOps
-
-wcre :: KnownDomain dom => (HiddenClockResetEnable dom => r) -> r
-wcre = withClockResetEnable clockGen resetGen enableGen

--- a/bittide/tests/Tests/Link.hs
+++ b/bittide/tests/Tests/Link.hs
@@ -448,6 +448,3 @@ registerN n a = mealy go (replicate n a)
   go state0 inp = (state1, out)
    where
     (out :> state1) = state0 :< inp
-
-wcre :: KnownDomain dom => (HiddenClockResetEnable dom => r) -> r
-wcre = withClockResetEnable clockGen resetGen enableGen

--- a/bittide/tests/Tests/Shared.hs
+++ b/bittide/tests/Tests/Shared.hs
@@ -193,3 +193,7 @@ validateWb m2s0 s2m0 = (m2s1, s2m1)
     case timesNDivRU'' @bs @8 of
       Dict ->
         validate (m2s0, s2m0)
+
+-- | Satisfies implicit control signal constraints by using default values.
+wcre :: KnownDomain dom => (HiddenClockResetEnable dom => r) -> r
+wcre = withClockResetEnable clockGen resetGen enableGen


### PR DESCRIPTION
This PR addresses #108.

We add an address to the `scatterUnitWb` and `gatherUnitWb` that, when accessed (read or write) only acknowledges the transaction at the beginning of each new metacycle.

We could later change the implementation to have either contain information regarding the metacycle of have any other behaviour, but we expect to need this for the demo.