### PR TITLE
Cargo: Strip symbols and optimize for size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,13 @@
 #
 # SPDX-License-Identifier: CC0-1.0
 
+[profile.release]
+# Automatically strip symbols from the binary.
+strip = true
+
+# Optimize for size
+opt-level = "z"
+
 [workspace]
 exclude = [
   "firmware/examples",


### PR DESCRIPTION
For the time being, we'll store ILM/DLM of the RISC cores in block rams. By default (without stdlib) `rustc` produces pretty large binaries - weighing almost a MB. By stripping these down, we stay within 64 KiB - a size that we can fit on our FPGAs.

| Binary     | Before (bytes) | After (bytes) | Before (KiB) | After (KiB) |
|------------|----------------|---------------|--------------|-------------|
| management | 883548         | 43108         | 862          | 42          |
| ping       | 865796         | 33700         | 845          | 33          |
| pong       | 865796         | 33700         | 845          | 33          |