### PR TITLE
Add boot mode to clock control, enabling use of smaller FIFOs

### DIFF
--- a/elastic-buffer-sim/elastic-buffer-sim.cabal
+++ b/elastic-buffer-sim/elastic-buffer-sim.cabal
@@ -84,7 +84,7 @@ library
     directory,
     matplotlib,
     random,
-    template-haskell
+    template-haskell ==2.17.*
   exposed-modules:
     Bittide.ClockControl
     Bittide.ClockControl.Strategies

--- a/elastic-buffer-sim/exe/Main.hs
+++ b/elastic-buffer-sim/exe/Main.hs
@@ -26,6 +26,7 @@ sim version 0.1.0
 Usage:
   sim csv <steps> <points>
   sim plot complete3 <steps> <points>
+  sim plot complete5 <steps> <points>
   sim plot complete6 <steps> <points>
   sim plot diamond <steps> <points>
   sim plot star7 <steps> <points>
@@ -59,6 +60,7 @@ main = do
       plotFn
         | args `isPresent` (command "diamond") = plotDiamond
         | args `isPresent` (command "complete3") = plotK3
+        | args `isPresent` (command "complete5") = plotK5
         | args `isPresent` (command "complete6") = plotK6
         | args `isPresent` (command "star7") = plotStar7
         | args `isPresent` (command "tree32") = plotTree32

--- a/elastic-buffer-sim/src/Bittide/ClockControl.hs
+++ b/elastic-buffer-sim/src/Bittide/ClockControl.hs
@@ -75,7 +75,7 @@ defClockConfig = ClockControlConfig
   , cccSettlePeriod      = pessimisticPeriod * 200
   , cccDynamicRange      = 150
   , cccStepSize          = 1
-  , cccBufferSize        = 65536 -- 128
+  , cccBufferSize        = 128
   }
  where
   specPpm = 100

--- a/elastic-buffer-sim/src/Bittide/ClockControl/Strategies.hs
+++ b/elastic-buffer-sim/src/Bittide/ClockControl/Strategies.hs
@@ -30,7 +30,7 @@ callistoClockControl ::
   -- | Configuration for this component, see individual fields for more info.
   ClockControlConfig ->
   -- | Statistics provided by elastic buffers.
-  Vec n (Signal dom DataCount) ->
+  Vec n (Signal dom (Maybe DataCount)) ->
   Signal dom SpeedChange
 callistoClockControl clk rst ena cfg =
   clockControl clk rst ena cfg callisto
@@ -40,7 +40,7 @@ type ClockControlAlgorithm dom n a =
   Reset dom ->
   Enable dom ->
   ClockControlConfig ->
-  Signal dom (Vec n DataCount) ->
+  Signal dom (Vec n (Maybe DataCount)) ->
   Signal dom SpeedChange
 
 clockControl ::
@@ -54,7 +54,7 @@ clockControl ::
   -- | Clock control strategy
   ClockControlAlgorithm dom n a ->
   -- | Statistics provided by elastic buffers.
-  Vec n (Signal dom DataCount) ->
+  Vec n (Signal dom (Maybe DataCount)) ->
   -- | Whether to adjust node clock frequency
   Signal dom SpeedChange
 clockControl clk rst ena cfg f =

--- a/elastic-buffer-sim/src/Bittide/ClockControl/Strategies.hs
+++ b/elastic-buffer-sim/src/Bittide/ClockControl/Strategies.hs
@@ -2,8 +2,6 @@
 --
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE RecordWildCards #-}
-
 -- | Mock clock controller
 module Bittide.ClockControl.Strategies
   ( ClockControlAlgorithm

--- a/elastic-buffer-sim/src/Bittide/ClockControl/Strategies.hs
+++ b/elastic-buffer-sim/src/Bittide/ClockControl/Strategies.hs
@@ -30,7 +30,7 @@ callistoClockControl ::
   -- | Configuration for this component, see individual fields for more info.
   ClockControlConfig ->
   -- | Statistics provided by elastic buffers.
-  Vec n (Signal dom (Maybe DataCount)) ->
+  Vec n (Signal dom DataCount) ->
   Signal dom SpeedChange
 callistoClockControl clk rst ena cfg =
   clockControl clk rst ena cfg callisto
@@ -40,7 +40,7 @@ type ClockControlAlgorithm dom n a =
   Reset dom ->
   Enable dom ->
   ClockControlConfig ->
-  Signal dom (Vec n (Maybe DataCount)) ->
+  Signal dom (Vec n DataCount) ->
   Signal dom SpeedChange
 
 clockControl ::
@@ -54,7 +54,7 @@ clockControl ::
   -- | Clock control strategy
   ClockControlAlgorithm dom n a ->
   -- | Statistics provided by elastic buffers.
-  Vec n (Signal dom (Maybe DataCount)) ->
+  Vec n (Signal dom DataCount) ->
   -- | Whether to adjust node clock frequency
   Signal dom SpeedChange
 clockControl clk rst ena cfg f =

--- a/elastic-buffer-sim/src/Bittide/ClockControl/Strategies/Callisto.hs
+++ b/elastic-buffer-sim/src/Bittide/ClockControl/Strategies/Callisto.hs
@@ -11,8 +11,6 @@ where
 
 import Clash.Explicit.Prelude
 
-import Data.Maybe (isJust, isNothing)
-
 import Bittide.ClockControl
 
 data ControlSt = ControlSt
@@ -24,11 +22,6 @@ data ControlSt = ControlSt
 initControlSt :: ControlSt
 initControlSt = ControlSt 0 0 NoChange
 
-sumMaybes :: Vec n (Maybe DataCount) -> DataCount
-sumMaybes Nil = 0
-sumMaybes (Just x `Cons` xs) = x + sumMaybes xs
-sumMaybes _ = error "Internal error."
-
 callisto ::
   forall n dom.
   (KnownDomain dom, KnownNat n, 1 <= n) =>
@@ -36,13 +29,13 @@ callisto ::
   Reset dom ->
   Enable dom ->
   ClockControlConfig ->
-  Signal dom (Vec n (Maybe DataCount)) ->
+  Signal dom (Vec n DataCount) ->
   Signal dom SpeedChange
 callisto clk rst ena ClockControlConfig{..} =
   mealy clk rst ena go (initControlSt, 0)
  where
   go (ControlSt{..}, settleCounter) dataCounts
-    | settleCounter > cccSettlePeriod && all isJust dataCounts
+    | settleCounter > cccSettlePeriod
     = ((ControlSt x_kNext z_kNext b_kNext, 0), b_kNext)
    where
 
@@ -54,7 +47,7 @@ callisto clk rst ena ClockControlConfig{..} =
     k_i = 1e-11 :: Float
     r_k =
       let
-        measuredSum = realToFrac (sumMaybes dataCounts)
+        measuredSum = realToFrac (sum dataCounts)
         targetCount = realToFrac (targetDataCount cccBufferSize)
         nBuffers = realToFrac (length dataCounts)
       in
@@ -84,10 +77,6 @@ callisto clk rst ena ClockControlConfig{..} =
     sgn NoChange = 0
     sgn SpeedUp = 1
     sgn SlowDown = -1
-
-  go (_, settleCounter) dataCounts
-    | any isNothing dataCounts =
-    ((initControlSt, settleCounter + cccPessimisticPeriod), NoChange)
 
   go (st, settleCounter) _ =
     ((st, settleCounter + cccPessimisticPeriod), NoChange)

--- a/elastic-buffer-sim/src/Bittide/ClockControl/Strategies/Callisto.hs
+++ b/elastic-buffer-sim/src/Bittide/ClockControl/Strategies/Callisto.hs
@@ -11,7 +11,7 @@ where
 
 import Clash.Explicit.Prelude
 
-import Data.Maybe (isJust)
+import Data.Maybe (isJust, isNothing)
 
 import Bittide.ClockControl
 
@@ -84,6 +84,10 @@ callisto clk rst ena ClockControlConfig{..} =
     sgn NoChange = 0
     sgn SpeedUp = 1
     sgn SlowDown = -1
+
+  go (_, settleCounter) dataCounts
+    | any isNothing dataCounts =
+    ((initControlSt, settleCounter + cccPessimisticPeriod), NoChange)
 
   go (st, settleCounter) _ =
     ((st, settleCounter + cccPessimisticPeriod), NoChange)

--- a/elastic-buffer-sim/src/Bittide/ClockControl/Strategies/Callisto.hs
+++ b/elastic-buffer-sim/src/Bittide/ClockControl/Strategies/Callisto.hs
@@ -11,6 +11,8 @@ where
 
 import Clash.Explicit.Prelude
 
+import Data.Maybe (isJust)
+
 import Bittide.ClockControl
 
 data ControlSt = ControlSt
@@ -22,6 +24,11 @@ data ControlSt = ControlSt
 initControlSt :: ControlSt
 initControlSt = ControlSt 0 0 NoChange
 
+sumMaybes :: Vec n (Maybe DataCount) -> DataCount
+sumMaybes Nil = 0
+sumMaybes (Just x `Cons` xs) = x + sumMaybes xs
+sumMaybes _ = error "Internal error."
+
 callisto ::
   forall n dom.
   (KnownDomain dom, KnownNat n, 1 <= n) =>
@@ -29,13 +36,13 @@ callisto ::
   Reset dom ->
   Enable dom ->
   ClockControlConfig ->
-  Signal dom (Vec n DataCount) ->
+  Signal dom (Vec n (Maybe DataCount)) ->
   Signal dom SpeedChange
 callisto clk rst ena ClockControlConfig{..} =
   mealy clk rst ena go (initControlSt, 0)
  where
   go (ControlSt{..}, settleCounter) dataCounts
-    | settleCounter > cccSettlePeriod
+    | settleCounter > cccSettlePeriod && all isJust dataCounts
     = ((ControlSt x_kNext z_kNext b_kNext, 0), b_kNext)
    where
 
@@ -47,7 +54,7 @@ callisto clk rst ena ClockControlConfig{..} =
     k_i = 1e-11 :: Float
     r_k =
       let
-        measuredSum = realToFrac (sum dataCounts)
+        measuredSum = realToFrac (sumMaybes dataCounts)
         targetCount = realToFrac (targetDataCount cccBufferSize)
         nBuffers = realToFrac (length dataCounts)
       in

--- a/elastic-buffer-sim/src/Bittide/Simulate.hs
+++ b/elastic-buffer-sim/src/Bittide/Simulate.hs
@@ -134,12 +134,14 @@ ebController size clkRead rstRead enaRead clkWrite rstWrite enaWrite =
 
   (wrDisableRd, rdDisable) = unbundle direct
 
-  -- write reset process (so that is accurate in the read domain):
+  -- Write reset process (that is accurate in the read domain):
   --
-  -- 1. disable writes (keep reads enabled), drain COMPLETELY (control from read
-  -- domain?)
-  -- 2. re-enable writes, disable reads until EXACTLY half (in the read domain)
-  -- 3. (reads can proceed)
+  -- 1. Disable writes (keep reads enabled), drain completely (control from the
+  -- read domain)
+  -- domain)
+  -- 2. Re-enable writes, disable reads until data count is exactly half (in the
+  -- read domain)
+  -- 3. Proceed reading
 
   direct :: Signal readDom (DisableWrites, DisableReads)
   direct =

--- a/elastic-buffer-sim/src/Bittide/Topology.hs
+++ b/elastic-buffer-sim/src/Bittide/Topology.hs
@@ -58,7 +58,7 @@ plotTorus34 :: Int -> Int -> IO ()
 plotTorus34 = $(plotEbsAPI ("torus34", torus2d 3 4))
 
 plotK3 :: Int -> Int -> IO ()
-plotK3 = $(plotEbsAPI ("compelte3", complete 3))
+plotK3 = $(plotEbsAPI ("complete3", complete 3))
 
 plotK6 :: Int -> Int -> IO ()
 plotK6 = $(plotEbsAPI ("complete6", complete 6))

--- a/elastic-buffer-sim/src/Bittide/Topology.hs
+++ b/elastic-buffer-sim/src/Bittide/Topology.hs
@@ -13,17 +13,18 @@
 -- dumps clock periods and elastic buffer occupancy to csv.
 module Bittide.Topology
   ( dumpCsv
+  , plotC12
+  , plotDiamond
   , plotEbs
   , plotHypercube
   , plotHypercube4
-  , plotTorus34
   , plotK3
+  , plotK5
   , plotK6
-  , plotC12
-  , plotDiamond
-  , plotTree32
-  , plotTree23
   , plotStar7
+  , plotTorus34
+  , plotTree23
+  , plotTree32
   )
 where
 
@@ -59,6 +60,9 @@ plotTorus34 = $(plotEbsAPI ("torus34", torus2d 3 4))
 
 plotK3 :: Int -> Int -> IO ()
 plotK3 = $(plotEbsAPI ("complete3", complete 3))
+
+plotK5 :: Int -> Int -> IO ()
+plotK5 = $(plotEbsAPI ("complete5", complete 5))
 
 plotK6 :: Int -> Int -> IO ()
 plotK6 = $(plotEbsAPI ("complete6", complete 6))

--- a/elastic-buffer-sim/src/Bittide/Topology/TH.hs
+++ b/elastic-buffer-sim/src/Bittide/Topology/TH.hs
@@ -434,12 +434,11 @@ simNodesFromGraph ccc g = do
   bundleV = VarE 'Clash.bundle
   consC = ConE 'Clash.Cons
   nilC = ConE 'Clash.Nil
-  errC = ConE 'Error
-  ebV = VarE 'elasticBuffer
+  ebV = VarE 'ebController
   tunableClockGenV = VarE 'tunableClockGen
   resetGenV = VarE 'Clash.resetGen
   enableGenV = VarE 'Clash.enableGen
-  ebClkClk = ebV `AppE` errC `AppE` ebSize
+  ebClkClk = ebV `AppE` ebSize
   callistoClockControlV = VarE 'callistoClockControl
   mkVecE = foldr (\x -> AppE (AppE consC x)) nilC
 

--- a/elastic-buffer-sim/src/Bittide/Topology/TH.hs
+++ b/elastic-buffer-sim/src/Bittide/Topology/TH.hs
@@ -383,9 +383,13 @@ simNodesFromGraph ccc g = do
   cccE <- lift ccc
   let
     ebE i j =
-        AppE
-          (AppE ebClkClk (VarE (clockNames A.! i)))
-          (VarE (clockNames A.! j))
+        ebClkClk
+          `AppE` VarE (clockNames A.! i)
+          `AppE` resetGenV
+          `AppE` enableGenV
+          `AppE` VarE (clockNames A.! j)
+          `AppE` resetGenV
+          `AppE` enableGenV
     ebD i j = valD (TupP [VarP (ebNames A.! (i, j)), VarP (ebRstNames A.! (i, j))]) (ebE i j)
 
     clkE i =

--- a/elastic-buffer-sim/src/Bittide/Topology/TH/Domain.hs
+++ b/elastic-buffer-sim/src/Bittide/Topology/TH/Domain.hs
@@ -10,4 +10,4 @@ import Clash.Explicit.Prelude
 
 -- 200kHz instead of 200MHz; otherwise the periods are so small that deviations
 -- can't be expressed as 'Natural's
-createDomain vSystem{vName="Bittide", vPeriod=hzToPeriod 200e3}
+createDomain vSystem{vName="Bittide", vPeriod=hzToPeriod 200e3, vResetKind=Synchronous}

--- a/elastic-buffer-sim/tests/Tests/Bittide/Simulate.hs
+++ b/elastic-buffer-sim/tests/Tests/Bittide/Simulate.hs
@@ -28,6 +28,8 @@ tests = testGroup "Simulate"
     , testCase "case_elasticBufferEq" case_elasticBufferEq
     , testCase "case_caseClockControlMaxBound" case_clockControlMaxBound
     , testCase "case_caseClockControlMinBound" case_clockControlMinBound
+    , testCase "case_readDomTerminates" case_readDomTerminates
+    , testCase "case_directEbsTerminates" case_directEbsTerminates
     ]
   ]
 
@@ -42,6 +44,22 @@ clockConfig clockUncertainty = ClockControlConfig
   , cccStepSize          = 10
   , cccBufferSize        = 128
   }
+
+case_readDomTerminates :: Assertion
+case_readDomTerminates =
+  assertBool "doesn't <<loop>>" (ebRdOut `deepseqX` True)
+ where
+  ebRdOut = sampleN 1000 ebRd
+  ebRd =
+    ebReadDom @Fast @Slow clockGen clockGen resetGen resetGen enableGen enableGen (pure Wait)
+
+case_directEbsTerminates :: Assertion
+case_directEbsTerminates =
+  assertBool "doesn't <<loop>>" (outSample `deepseqX` True)
+ where
+  ebCtl = ebReadDom @Fast @Slow clockGen clockGen resetGen resetGen enableGen enableGen
+  (ebRst, ebDat :> Nil) = directEbs clockGen resetGen enableGen (ebCtl :> Nil)
+  outSample = sampleN 5 ebRst
 
 case_clockControlMaxBound :: Assertion
 case_clockControlMaxBound = do

--- a/elastic-buffer-sim/tests/Tests/Bittide/Simulate.hs
+++ b/elastic-buffer-sim/tests/Tests/Bittide/Simulate.hs
@@ -47,7 +47,7 @@ case_clockControlMaxBound :: Assertion
 case_clockControlMaxBound = do
   let
     config = clockConfig (Ppm 100)
-    dataCounts = pure (Just (cccBufferSize config)) :> Nil
+    dataCounts = pure (cccBufferSize config) :> Nil
     changes =
       sampleN
         (fromIntegral (cccPessimisticPeriod config))
@@ -61,7 +61,7 @@ case_clockControlMinBound :: Assertion
 case_clockControlMinBound = do
   let
     config = clockConfig (Ppm 100)
-    dataCounts = pure (Just 0) :> Nil
+    dataCounts = pure 0 :> Nil
     changes =
       sampleN
         (fromIntegral (cccPessimisticPeriod config))


### PR DESCRIPTION
Part of https://github.com/bittide/bittide-hardware/issues/125

It still works! See:

[clockscomplete3.pdf](https://github.com/bittide/bittide-hardware/files/9616871/clockscomplete3.pdf)
[elasticbufferscomplete3.pdf](https://github.com/bittide/bittide-hardware/files/9616872/elasticbufferscomplete3.pdf)
