### PR TITLE
Exclude riscv-formal files from language stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: 2022 Google LLC
+#
+# SPDX-License-Identifier: CC0-1.0
+
+# exclude riscv-formal from language stats
+/riscv-formal/** linguist-vendored


### PR DESCRIPTION
So github doesn't see this as a Verilog project
![language stats bittide-hardware](https://user-images.githubusercontent.com/437852/192302332-ca150d6a-48b9-47a6-99e3-1a6a748d0b69.png)
