### PR TITLE
Use `MemBlob` for initial contents in `wbStorage`

### DIFF
--- a/bittide/src/Bittide/Link.hs
+++ b/bittide/src/Bittide/Link.hs
@@ -7,6 +7,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE PartialTypeSignatures #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 
 module Bittide.Link where
 

--- a/bittide/src/Bittide/ProcessingElement.hs
+++ b/bittide/src/Bittide/ProcessingElement.hs
@@ -24,18 +24,14 @@ import qualified Data.ByteString as BS
 -- | Configuration for a Bittide Processing Element.
 data PeConfig nBusses where
   PeConfig ::
-    ( KnownNat initDepthI, initDepthI <= depthI, 1 <= depthI, 1 <= initDepthI
-    , KnownNat initDepthD, initDepthD <= depthD, 1 <= depthD, 1 <= initDepthD) =>
+    ( KnownNat depthI, 1 <= depthI
+    , KnownNat depthD, 1 <= depthD) =>
     -- | The 'MemoryMap' for the contained 'singleMasterInterconnect'.
     MemoryMap nBusses 32 ->
-    -- | Total depth of the instruction memory.
-    SNat depthI ->
-    -- | Total depth of the data memory.
-    SNat depthD ->
     -- | Initial content of the instruction memory, can be smaller than its total depth.
-    InitialContent initDepthI (Bytes 4) ->
+    InitialContent depthI (Bytes 4) ->
     -- | Initial content of the data memory, can be smaller than its total depth.
-    InitialContent initDepthD (Bytes 4) ->
+    InitialContent depthD (Bytes 4) ->
     -- | Program counter reset value.
     BitVector 32 ->
     PeConfig nBusses
@@ -51,21 +47,20 @@ processingElement ::
   ( Vec (nBusses-3) (Signal dom (WishboneM2S 32 4 (Bytes 4)))
   , Signal dom (Maybe (BitVector 4, BitVector 32)))
 processingElement config bussesIn = case config of
-  PeConfig memMapConfig depthI depthD initI initD pcEntry ->
-    go memMapConfig depthI depthD initI initD pcEntry
+  PeConfig memMapConfig initI initD pcEntry ->
+    go memMapConfig initI initD pcEntry
  where
   go ::
-    ( KnownNat initDepthI, initDepthI <= depthI, 1 <= depthI, 1 <= initDepthI
-    , KnownNat initDepthD, initDepthD <= depthD, 1 <= depthD, 1 <= initDepthD) =>
+    ( KnownNat depthI, 1 <= depthI
+    , KnownNat depthD, 1 <= depthD) =>
     MemoryMap nBusses 32 ->
-    SNat depthI ->
-    SNat depthD ->
-    InitialContent initDepthI (Bytes 4) ->
-    InitialContent initDepthD (Bytes 4) ->
+    InitialContent depthI (Bytes 4) ->
+    InitialContent depthD (Bytes 4) ->
     BitVector 32 ->
     ( Vec (nBusses-3) (Signal dom (WishboneM2S 32 4 (Bytes 4)))
-    , Signal dom (Maybe (BitVector 4, BitVector 32)))
-  go memMapConfig depthI@SNat depthD@SNat initI initD pcEntry = (bussesOut, sinkOut)
+    , Signal dom (Maybe (BitVector 4, BitVector 32))
+    )
+  go memMapConfig initI initD pcEntry = (bussesOut, sinkOut)
    where
     tupToCoreIn (timerInterrupt, softwareInterrupt, externalInterrupt, iBusS2M, dBusS2M) =
       CoreIn {..}
@@ -82,8 +77,8 @@ processingElement config bussesIn = case config of
     fromSlaves = bundle (iToMap :> dToMap :> sinkS2M :> bussesIn)
     (iFromMap :> dFromMap :> sinkM2S :> bussesOut) = toSlaves
 
-    (iToCore, iToMap) = wbStorageDP depthI initI iFromCore iFromMap
-    dToMap = wbStorage' depthD initD dFromMap
+    (iToCore, iToMap) = wbStorageDP initI iFromCore iFromMap
+    dToMap = wbStorage' initD dFromMap
 
     (sinkS2M, sinkOut) = unbundle $ wishboneSink sinkM2S
 


### PR DESCRIPTION
This PR goes on top of #103

This pull requests changes the way we pass initial contents onto memory components.
For wishbone storage components we can define whether we have initial contents or not (and if we do, will they be reloaded on reset?).
We also introduce multiple ways to set the initial contents for more complex storages. (e.g. per byte).