### PR TITLE
Add wishbone sink and character printing function.

### DIFF
--- a/bittide/bittide.cabal
+++ b/bittide/bittide.cabal
@@ -62,14 +62,15 @@ common common-options
     base,
     Cabal,
     array,
-    -- clash-prelude will set suitable version bounds for the plugins
     bittide-extra,
+    bytestring,
+    -- clash-prelude will set suitable version bounds for the plugins
     clash-lib >= 1.6.3 && < 1.8,
     clash-prelude >= 1.6.3 && < 1.8,
+    clash-protocols,
     constraints >= 0.13.3 && < 0.15,
     containers >= 0.4.0 && < 0.7,
     contranomy,
-    clash-protocols,
     ghc-typelits-extra,
     ghc-typelits-knownnat,
     ghc-typelits-natnormalise,

--- a/bittide/src/Bittide/ProcessingElement.hs
+++ b/bittide/src/Bittide/ProcessingElement.hs
@@ -137,7 +137,7 @@ printCharacters ::
   IO ()
 printCharacters Nil _ = pure ()
 printCharacters paths@(Cons _ _) inps = case inps of
-  Just (byteSelect, chars) -> do
+  Just (byteSelect, chars) ->
     sequence_ $ printToFiles <*> take SNat (unpack byteSelect) <*> take SNat chars
   Nothing   -> pure ()
  where

--- a/bittide/src/Bittide/ProcessingElement.hs
+++ b/bittide/src/Bittide/ProcessingElement.hs
@@ -5,6 +5,8 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE NamedFieldPuns #-}
+
 module Bittide.ProcessingElement where
 
 import Clash.Prelude
@@ -16,6 +18,8 @@ import Protocols.Wishbone
 import Bittide.DoubleBufferedRam
 import Bittide.SharedTypes
 import Bittide.Wishbone
+
+import qualified Data.ByteString as BS
 
 -- | Configuration for a Bittide Processing Element.
 data PeConfig nBusses where
@@ -41,10 +45,11 @@ data PeConfig nBusses where
 processingElement ::
   forall dom nBusses .
   ( HiddenClockResetEnable dom
-  , KnownNat nBusses, 2 <= nBusses) =>
+  , KnownNat nBusses, 3 <= nBusses) =>
   PeConfig nBusses ->
-  Vec (nBusses-2) (Signal dom (WishboneS2M (Bytes 4))) ->
-  Vec (nBusses-2) (Signal dom (WishboneM2S 32 4 (Bytes 4)))
+  Vec (nBusses-3) (Signal dom (WishboneS2M (Bytes 4))) ->
+  ( Vec (nBusses-3) (Signal dom (WishboneM2S 32 4 (Bytes 4)))
+  , Signal dom (Maybe (BitVector 4, BitVector 32)))
 processingElement config bussesIn = case config of
   PeConfig memMapConfig depthI depthD initI initD pcEntry ->
     go memMapConfig depthI depthD initI initD pcEntry
@@ -58,8 +63,9 @@ processingElement config bussesIn = case config of
     InitialContent initDepthI (Bytes 4) ->
     InitialContent initDepthD (Bytes 4) ->
     BitVector 32 ->
-    Vec (nBusses-2) (Signal dom (WishboneM2S 32 4 (Bytes 4)))
-  go memMapConfig depthI@SNat depthD@SNat initI initD pcEntry = bussesOut
+    ( Vec (nBusses-3) (Signal dom (WishboneM2S 32 4 (Bytes 4)))
+    , Signal dom (Maybe (BitVector 4, BitVector 32)))
+  go memMapConfig depthI@SNat depthD@SNat initI initD pcEntry = (bussesOut, sinkOut)
    where
     tupToCoreIn (timerInterrupt, softwareInterrupt, externalInterrupt, iBusS2M, dBusS2M) =
       CoreIn {..}
@@ -73,11 +79,13 @@ processingElement config bussesIn = case config of
 
     (dToCore, unbundle -> toSlaves) = singleMasterInterconnect' memMapConfig dFromCore fromSlaves
 
-    fromSlaves = bundle (iToMap :> dToMap :> bussesIn)
-    (iFromMap :> dFromMap :> bussesOut) = toSlaves
+    fromSlaves = bundle (iToMap :> dToMap :> sinkS2M :> bussesIn)
+    (iFromMap :> dFromMap :> sinkM2S :> bussesOut) = toSlaves
 
     (iToCore, iToMap) = wbStorageDP depthI initI iFromCore iFromMap
     dToMap = wbStorage' depthD initD dFromMap
+
+    (sinkS2M, sinkOut) = unbundle $ wishboneSink sinkM2S
 
 -- | Contranomy RV32IMC core
 rv32 ::
@@ -91,3 +99,49 @@ rv32 entry coreIn =
   let (coreResult,regWrite,_) = core entry (coreIn,regOut)
       regOut = registerFile regWrite
    in coreResult
+
+-- | Stateless wishbone device that only acknowledges writes to address 0.
+-- Successful writes return the 'writeData' and 'busSelect'.
+wishboneSink ::
+  (KnownNat addressWidth, Paddable dat) =>
+  -- | Incoming wishbone bus.
+  Signal dom (WishboneM2S addressWidth bs dat) ->
+  -- |
+  -- 1. Outgoing wishbone bus.
+  -- 2. Result of successful write attempt.
+  Signal dom (WishboneS2M dat, Maybe (BitVector bs, dat))
+wishboneSink = fmap go
+ where
+  go WishboneM2S{..} = (wbOut, output)
+   where
+    masterActive = busCycle && strobe
+    addrLegal = addr == 0
+    acknowledge = masterActive && writeEnable && addrLegal
+    err = masterActive && (not writeEnable || not addrLegal)
+
+    output
+      | acknowledge = Just (busSelect, writeData)
+      | otherwise   = Nothing
+
+    wbOut = emptyWishboneS2M{acknowledge, err}
+
+-- | Provide a vector of filepaths, and a write operations containing a byteSelect and
+-- a vector of characters and, for each filepath write the corresponding byte to that file
+-- if the corresponding byteSelect is @1@.
+printCharacters ::
+  (KnownNat paths, KnownNat chars, (paths + n) ~ chars) =>
+  -- | Destination files for received bytes.
+  Vec paths FilePath ->
+  -- | Write attempt, bytes will only be written if the corresponding byteSelect is @1@.
+  Maybe (BitVector chars, Vec chars Byte) ->
+  IO ()
+printCharacters Nil _ = pure ()
+printCharacters paths@(Cons _ _) inps = case inps of
+  Just (byteSelect, chars) -> do
+    sequence_ $ printToFiles <*> take SNat (unpack byteSelect) <*> take SNat chars
+  Nothing   -> pure ()
+ where
+  printToFiles = printToFile <$> paths
+  printToFile path byteSelect char
+    | byteSelect = BS.appendFile path $ BS.singleton $ bitCoerce char
+    | otherwise  = pure ()


### PR DESCRIPTION
This PR adds a `wishboneSink` component that is hooked up to a `processingElement`. 
This component exposes succesful wishbone write transactions as `Maybe (byteSelect, writeData)` to be used for printing characters to files. 

Furthermore this PR adds a `printCharacters` function that receives a vector of filepaths and `Maybe (BitVector chars, Vec chars Byte). 
This function writes for each filepath the corresponding byte to the file if the corresponing byteSelect is high.

It can be used as follows:
```haskell
simulationResult :: [Maybe (BitVector chars, Vec chars Byte)]
let simulationResult = _ -- Imagine some function returning the simulation results.
printCharacters ("stdOut.txt" :> "stdErr.txt" :> Nil) <$> simulationResult
```

The printing function is to be added to node simulations. 