### PR TITLE
Eliminate need for ascending addresses in `singleMasterInterconnect`

### DIFF
--- a/bittide/src/Bittide/ProcessingElement.hs
+++ b/bittide/src/Bittide/ProcessingElement.hs
@@ -27,7 +27,7 @@ data PeConfig nBusses where
     ( KnownNat depthI, 1 <= depthI
     , KnownNat depthD, 1 <= depthD) =>
     -- | The 'MemoryMap' for the contained 'singleMasterInterconnect'.
-    MemoryMap nBusses 32 ->
+    MemoryMap nBusses ->
     -- | Initial content of the instruction memory, can be smaller than its total depth.
     InitialContent depthI (Bytes 4) ->
     -- | Initial content of the data memory, can be smaller than its total depth.
@@ -41,10 +41,10 @@ data PeConfig nBusses where
 processingElement ::
   forall dom nBusses .
   ( HiddenClockResetEnable dom
-  , KnownNat nBusses, 3 <= nBusses) =>
+  , KnownNat nBusses, 3 <= nBusses, CLog 2 nBusses <= 30) =>
   PeConfig nBusses ->
   Vec (nBusses-3) (Signal dom (WishboneS2M (Bytes 4))) ->
-  ( Vec (nBusses-3) (Signal dom (WishboneM2S 32 4 (Bytes 4)))
+  ( Vec (nBusses-3) (Signal dom (WishboneM2S (32 - CLog 2 nBusses) 4 (Bytes 4)))
   , Signal dom (Maybe (BitVector 4, BitVector 32)))
 processingElement config bussesIn = case config of
   PeConfig memMapConfig initI initD pcEntry ->
@@ -53,11 +53,11 @@ processingElement config bussesIn = case config of
   go ::
     ( KnownNat depthI, 1 <= depthI
     , KnownNat depthD, 1 <= depthD) =>
-    MemoryMap nBusses 32 ->
+    MemoryMap nBusses ->
     InitialContent depthI (Bytes 4) ->
     InitialContent depthD (Bytes 4) ->
     BitVector 32 ->
-    ( Vec (nBusses-3) (Signal dom (WishboneM2S 32 4 (Bytes 4)))
+    ( Vec (nBusses-3) (Signal dom (WishboneM2S (32 - CLog 2 nBusses) 4 (Bytes 4)))
     , Signal dom (Maybe (BitVector 4, BitVector 32))
     )
   go memMapConfig initI initD pcEntry = (bussesOut, sinkOut)

--- a/bittide/src/Bittide/SharedTypes.hs
+++ b/bittide/src/Bittide/SharedTypes.hs
@@ -8,6 +8,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -27,6 +28,20 @@ data AorB = A | B deriving (Eq, Generic, BitPack, Show, NFDataX)
 swapAorB :: AorB -> AorB
 swapAorB A = B
 swapAorB B = A
+
+-- | Polymorphic record update of 'addr'.
+updateM2SAddr ::
+  BitVector addressWidthNew ->
+  WishboneM2S addressWidthOld selWidth dat ->
+  WishboneM2S addressWidthNew selWidth dat
+updateM2SAddr newAddr WishboneM2S{..} = WishboneM2S{addr = newAddr, ..}
+
+-- | Resize 'WishboneM2S's 'addr' field.
+resizeM2SAddr ::
+  (KnownNat addressWidthOld, KnownNat addressWidthNew) =>
+  WishboneM2S addressWidthOld selWidth dat ->
+  WishboneM2S addressWidthNew selWidth dat
+resizeM2SAddr WishboneM2S{..} = WishboneM2S{addr = resize addr, ..}
 
 -- | A single byte.
 type Byte = BitVector 8

--- a/bittide/src/Bittide/Wishbone.hs
+++ b/bittide/src/Bittide/Wishbone.hs
@@ -19,6 +19,10 @@ import Data.Constraint.Nat.Extra (divWithRemainder)
 import Data.Maybe
 import Data.Bool(bool)
 
+{- $setup
+>>> import Clash.Prelude
+-}
+
 -- Applying this hint yields a compile error
 {-# ANN module "HLint: ignore Functor law" #-}
 

--- a/bittide/src/Data/Constraint/Nat/Extra.hs
+++ b/bittide/src/Data/Constraint/Nat/Extra.hs
@@ -56,6 +56,10 @@ leMaxLeft :: forall a b c. Dict (a <= Max (a + c) b)
 leMaxLeft = unsafeCoerce (Dict :: Dict ())
 {-# NOINLINE leMaxLeft #-} -- https://github.com/clash-lang/clash-compiler/issues/2376
 
+-- | If @c <= a@ and @c <= b@, then @c <= Max a b@
+lessThanMax :: forall a b c . (c <= a, c <= b) => Dict (c <= Max a b)
+lessThanMax = unsafeCoerce (Dict :: Dict ())
+
 -- | Postulates that a part is less than or equal to a sum parts, in context
 -- of 'Max's right argument.
 leMaxRight :: forall a b c. Dict (b <= Max a (b + c))

--- a/bittide/tests/Tests/Haxioms.hs
+++ b/bittide/tests/Tests/Haxioms.hs
@@ -26,6 +26,7 @@ haxiomsGroup = testGroup "Haxioms"
   , testPropertyNamed "divWithRemainder holds" "prop_divWithRemainder" prop_divWithRemainder
   , testPropertyNamed "euclid3 holds" "prop_euclid3" prop_euclid3
   , testPropertyNamed "prop_oneLeCLog2n holds" "prop_oneLeCLog2n" prop_oneLeCLog2n
+  , testPropertyNamed "prop_lessThanMax holds" "prop_lessThanMax" prop_lessThanMax
   ]
 
 -- | Generate a 'Natural' greater than or equal to /n/. Can generate 'Natural's
@@ -182,3 +183,18 @@ prop_oneLeCLog2n :: Property
 prop_oneLeCLog2n = property $ do
   n <- forAll (genNatural 2)
   assert (1 <= clog 2 n)
+
+-- | Test whether the following equation (supplied by 'lessThanMax') holds:
+--
+--     c <= Max a b
+--
+-- Given:
+--
+--     c <= a, c <= b
+--
+prop_lessThanMax :: Property
+prop_lessThanMax = property $ do
+  c <- forAll (genNatural 0)
+  a <- forAll (genNatural c)
+  b <- forAll (genNatural c)
+  assert (c <= max a b)

--- a/bittide/tests/Tests/Wishbone.hs
+++ b/bittide/tests/Tests/Wishbone.hs
@@ -2,20 +2,24 @@
 --
 -- SPDX-License-Identifier: Apache-2.0
 
+{-# OPTIONS_GHC -fconstraint-solver-iterations=5 #-}
+
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PartialTypeSignatures #-}
 {-# LANGUAGE RecordWildCards #-}
 
 module Tests.Wishbone(memMapGroup) where
 
 import Clash.Prelude
 
-import Clash.Hedgehog.Sized.BitVector
+import Clash.Hedgehog.Sized.Index
 import Clash.Hedgehog.Sized.Vector
 import Clash.Sized.Vector(unsafeFromList)
 import Data.Constraint (Dict(Dict))
 import Data.Constraint.Nat.Extra (cancelMulDiv, divWithRemainder)
-import Data.Proxy
+import Data.Maybe
 import Data.String
 import Hedgehog
 import Hedgehog.Range as Range
@@ -26,7 +30,8 @@ import Test.Tasty
 import Test.Tasty.Hedgehog
 
 import Bittide.SharedTypes
-import Bittide.Wishbone ( MemoryMap, singleMasterInterconnect' )
+import Bittide.Wishbone
+import Tests.Shared
 
 import qualified Data.List as L
 import qualified Data.Set as Set
@@ -41,106 +46,154 @@ memMapGroup = testGroup "Memory Map group"
 
 -- | generates a 'MemoryMap' for 'singleMasterInterconnect'.
 genConfig ::
-  forall nSlaves aw .
-  (KnownNat nSlaves, KnownNat aw) =>
-  Proxy nSlaves ->
-  Gen (MemoryMap nSlaves aw)
-genConfig = do
-  let s = Gen.set (Range.singleton $ natToNum @nSlaves) genDefinedBitVector
-  return $ unsafeFromList . Set.elems <$> s
+  forall nSlaves .
+  SNat nSlaves ->
+  Gen (MemoryMap nSlaves)
+genConfig SNat = do
+  let
+    s = Gen.set (Range.singleton $ natToNum @nSlaves) (genIndex Range.constantBounded)
+    l = Set.toList <$> s
+  unsafeFromList <$> (Gen.shuffle =<< l)
 
 -- | Creates a memory map with 'simpleSlave' devices and a list of read addresses and checks
 -- if the correct 'simpleSlave' responds to the read operation. Reading outside of a 'simpleSlave' its
 -- range should return an err.
 readingSlaves :: Property
 readingSlaves = property $ do
-  devices <- forAll $ Gen.enum 1 32
-  case TN.someNatVal devices of
-   SomeNat devices0 -> runTest devices0
+  devices <- forAll $ Gen.enum 2 16
+  case TN.someNatVal (devices - 1)of
+   SomeNat (succSNat . snatProxy -> devices0@SNat) ->
+    case compareSNat (clogBaseSNat d2 devices0) d32 of
+      SNatLE -> runTest devices0
+      _      -> errorX "readingSlaves: number of devices can't be represented with 32 bits."
  where
   runTest devices = do
-    config <- forAll $ genConfig @_ @32 devices
-    nrOfReads <- forAll $ Gen.enum 1 100
+    config <- forAll $ genConfig @_ devices
+    nrOfReads <- forAll $ Gen.enum 1 32
     let nrOfReadsRange = Range.singleton nrOfReads
-    readAddresses <- forAll . Gen.list nrOfReadsRange $ Gen.integral Range.constantBounded
-    ranges <- forAll $ genVec $ Gen.integral Range.constantBounded
+    readAddresses <- forAll $ Gen.list nrOfReadsRange (genDefinedBitVector @32)
+    ranges <- forAll $ genVec genDefinedBitVector
     let
       topEntityInput = (wbRead <$> readAddresses) <> [emptyWishboneM2S]
       simOut = simulateN (L.length topEntityInput) (topEntity config ranges) topEntityInput
+      realTransactions = wbToTransaction topEntityInput simOut
+      expectedOutput = fmap (getExpected config ranges) topEntityInput
+      expectedTransactions = wbToTransaction topEntityInput expectedOutput
+    footnote . fromString $ "expectedTransactions: " <> showX expectedTransactions
+    footnote . fromString $ "realTransactions: " <> showX realTransactions
     footnote . fromString $ "simOut: " <> showX simOut
     footnote . fromString $ "simIn: " <> showX topEntityInput
     footnote . fromString $ "reads: " <> show readAddresses
     footnote . fromString $ "ranges: " <> show ranges
     footnote . fromString $ "config: " <> show config
-    fmap filterSimOut (L.tail simOut) === fmap (getExpected config ranges) readAddresses
+    realTransactions === expectedTransactions
 
   topEntity config ranges masterIn = toMaster
    where
     slaves = withClockResetEnable @System clockGen resetGen enableGen simpleSlave <$>
       ranges <*> config <*> unbundle toSlaves
     (toMaster, toSlaves) = withClockResetEnable clockGen resetGen enableGen
-      (singleMasterInterconnect' @System @_ @4 @32) config masterIn $ bundle slaves
+      singleMasterInterconnect' config masterIn $ bundle slaves
 
-  filterSimOut WishboneS2M{..}
-    | acknowledge && not err = Just readData
-    | otherwise              = Nothing
-
-  getExpected config ranges a
-    | a >= baseAddr && (a - baseAddr) <= range = Just $ bitCoerce baseAddr
-    | otherwise                                = Nothing
+  getExpected ::
+    forall nSlaves .
+    ( KnownNat nSlaves, 1 <= nSlaves, BitSize (Index nSlaves) <= 32
+    , BitSize (Index nSlaves) <= 32) =>
+    Vec nSlaves (Index nSlaves) ->
+    Vec nSlaves (BitVector (32 - BitSize (Index nSlaves))) ->
+    WishboneM2S 32 (Regs (Index nSlaves) 8) (Index nSlaves) ->
+    WishboneS2M (Index nSlaves)
+  getExpected config ranges WishboneM2S{..}
+    | commAttempt && isMapped && inRange =
+      (emptyWishboneS2M @(Index nSlaves)){acknowledge, readData}
+    | commAttempt && isMapped            = emptyWishboneS2M{err}
+    | otherwise                          = emptyWishboneS2M
    where
-    (baseAddr, range) = findBaseAddress a config ranges
+    (readData, acknowledge, err) = (index, True, True)
+    (indexBV, restAddr) = split addr
+    index = unpack indexBV
+    commAttempt = busCycle && strobe
+    isMapped = bitCoerce (resize indexBV) < length config
+    range = ranges !! fromJust (elemIndex index config)
+    inRange = restAddr <= range
 
 -- | Creates a memory map with 'simpleSlave' devices and a list of write addresses and checks
 -- that if we 'simpleSlave' responds to the read operation. Reading outside of a 'simpleSlave' its
 -- range should return an err.
 writingSlaves :: Property
 writingSlaves = property $ do
-  devices <- forAll $ Gen.enum 1 32
-  case TN.someNatVal devices of
-   SomeNat devices0 -> runTest devices0
+  devices <- forAll $ Gen.enum 1 16
+  case TN.someNatVal (devices - 1)of
+   SomeNat (succSNat . snatProxy -> devices0) ->
+    case compareSNat (clogBaseSNat d2 devices0 ) d32 of
+      SNatLE -> runTest devices0
+      _      -> errorX "readingSlaves: number of devices can't be represented with 32 bits."
  where
+
   runTest devices = do
-    config <- forAll $ genConfig @_ @32 devices
-    nrOfWrites <- forAll $ Gen.enum 1 100
+    config <- forAll $ genConfig @_ devices
+    nrOfWrites <- forAll $ Gen.enum 1 32
     let nrOfWritesRange = Range.singleton nrOfWrites
-    writeAddresses <- forAll . Gen.list nrOfWritesRange $ Gen.integral Range.constantBounded
-    ranges <- forAll $ genVec $ Gen.integral Range.constantBounded
+    writeAddresses <- forAll $ Gen.list nrOfWritesRange genDefinedBitVector
+    ranges <- forAll $ genVec genDefinedBitVector
     let
-      topEntityInput = L.concatMap wbWriteThenRead writeAddresses <> [emptyWishboneM2S @32 @(BitVector 32)]
+      topEntityInput = L.concatMap wbWriteThenRead writeAddresses <> [emptyWishboneM2S ]
       simLength = L.length topEntityInput
-      simOut = simulateN simLength (topEntity ranges config) topEntityInput
+      simOut = simulateN simLength (topEntity config ranges) topEntityInput
+      realTransactions = wbToTransaction topEntityInput simOut
+      expectedOutput = fmap (getExpected config ranges) topEntityInput
+      expectedTransactions = wbToTransaction topEntityInput expectedOutput
+    footnote . fromString $ "expectedTransactions: " <> showX expectedTransactions
+    footnote . fromString $ "realTransactions: " <> showX realTransactions
     footnote . fromString $ "simOut: " <> showX simOut
     footnote . fromString $ "simIn: " <> showX topEntityInput
     footnote . fromString $ "writes: " <> show writeAddresses
     footnote . fromString $ "ranges: " <> show ranges
     footnote . fromString $ "config: " <> show config
-    fmap filterSimOut (every2nd $ L.tail simOut) === fmap (getExpected config ranges) writeAddresses
+    realTransactions === expectedTransactions
 
-  topEntity ranges config masterIn = toMaster
+  topEntity config ranges masterIn = toMaster
    where
     slaves = withClockResetEnable @System clockGen resetGen enableGen simpleSlave <$>
-      ranges <*> config <*> unbundle toSlaves
+      ranges <*> ranges <*> unbundle toSlaves
     (toMaster, toSlaves) = withClockResetEnable clockGen resetGen enableGen
-      (singleMasterInterconnect' @System @_ @4 @32) config masterIn $ bundle slaves
-  filterSimOut WishboneS2M{..} | acknowledge = Just readData
-                               | otherwise   = Nothing
-  wbWriteThenRead a = [wbWrite a, wbRead a]
-  every2nd (_:b:cs) = b : every2nd cs
-  every2nd _ = []
-  getExpected config ranges a
-    | a >= baseAddr && (a - baseAddr) <= range = Just $ bitCoerce a
-    | otherwise                                = Nothing
+      singleMasterInterconnect' config masterIn $ bundle slaves
+
+  wbWriteThenRead a = [wbWrite a (resize a), wbRead a]
+
+  getExpected ::
+    forall nSlaves .
+    ( KnownNat nSlaves, 1 <= nSlaves, BitSize (Index nSlaves) <= 32
+    , BitSize (Index nSlaves) <= 32) =>
+    Vec nSlaves (Index nSlaves) ->
+    Vec nSlaves (BitVector (32 - BitSize (Index nSlaves))) ->
+    WishboneM2S 32 (DivRU (32 - BitSize (Index nSlaves)) 8)
+      (BitVector (32 - BitSize (Index nSlaves))) ->
+    WishboneS2M (BitVector (32 - BitSize (Index nSlaves)))
+  getExpected config ranges WishboneM2S{..}
+    | commAttempt && isMapped && inRange && writeEnable =
+      emptyWishboneS2M{acknowledge}
+    | commAttempt && isMapped && inRange                =
+      (emptyWishboneS2M @(Index nSlaves)){acknowledge, readData}
+    | commAttempt && isMapped                           =
+      (emptyWishboneS2M @(BitVector (32 - BitSize (Index nSlaves)))){err}
+    | otherwise                                         = emptyWishboneS2M
    where
-    (baseAddr, range) = findBaseAddress a config ranges
+    (readData, acknowledge, err) = (restAddr, True, True)
+    (indexBV, restAddr) = split @_ @(BitSize (Index nSlaves)) addr
+    index = unpack indexBV
+    commAttempt = busCycle && strobe
+    isMapped = bitCoerce (resize indexBV) < length config
+    range = ranges !! fromJust (elemIndex index config)
+    inRange = restAddr <= range
 
 -- | transforms an address to a 'WishboneM2S' read operation.
 wbRead
-  :: forall bs addressWidth
-  . (KnownNat bs, KnownNat addressWidth)
+  :: forall addressWidth a
+  . (KnownNat addressWidth, NFDataX a, KnownNat (BitSize a))
   => BitVector addressWidth
-  -> WishboneM2S addressWidth bs (Bytes bs)
-wbRead address = case cancelMulDiv @bs @8 of
+  -> WishboneM2S addressWidth (Regs a 8) a
+wbRead address = case cancelMulDiv @(Regs a 8) @8 of
   Dict ->
     (emptyWishboneM2S @addressWidth)
     { addr = address
@@ -152,31 +205,32 @@ wbRead address = case cancelMulDiv @bs @8 of
 -- | transforms an address to a 'WishboneM2S' write operation that writes the given address
 -- to the given address.
 wbWrite
-  :: forall bs addressWidth
-  . (KnownNat bs, KnownNat addressWidth)
+  :: forall addressWidth a
+  . (KnownNat addressWidth, NFDataX a, KnownNat (BitSize a))
   => BitVector addressWidth
-  -> WishboneM2S addressWidth bs (Bytes bs)
-wbWrite address = (emptyWishboneM2S @addressWidth @(Bytes bs))
+  -> a
+  -> WishboneM2S addressWidth (Regs a 8) a
+wbWrite address a = (emptyWishboneM2S @addressWidth @a)
   { addr = address
   , strobe = True
   , busCycle = True
-  , writeData = resize address
+  , writeData = a
   , writeEnable = True
   , busSelect = maxBound
   }
 
 simpleSlave' ::
-  forall dom aw bs .
-  (HiddenClockResetEnable dom, KnownNat aw, KnownNat bs, aw ~ (bs * 8)) =>
+  forall dom aw a .
+  (HiddenClockResetEnable dom, KnownNat aw, NFDataX a) =>
   BitVector aw ->
-  Bytes bs ->
-  Circuit (Wishbone dom 'Standard aw (Bytes bs)) ()
+  a ->
+  Circuit (Wishbone dom 'Standard aw a) ()
 simpleSlave' range readData0 = Circuit $ \(wbIn, ()) -> (mealy go readData0 wbIn, ())
  where
   go readData1 WishboneM2S{..} =
-    (readData2, (emptyWishboneS2M @(Bytes bs)) {readData, acknowledge, err})
+    (readData2, (emptyWishboneS2M @a){readData, acknowledge, err})
    where
-     masterActive = strobe && busCycle
+     masterActive = busCycle && strobe
      addrInRange = addr <= range
      acknowledge = masterActive && addrInRange
      err = masterActive && not addrInRange
@@ -184,29 +238,21 @@ simpleSlave' range readData0 = Circuit $ \(wbIn, ()) -> (mealy go readData0 wbIn
      readData2 | writeOp    = writeData
                | otherwise  = readData1
      readData | writeOp     = writeData
-              | acknowledge = readData1
-              | otherwise   = errorX "simpleSlave: readData is undefined because when ack is False"
+              | otherwise   = readData1
 
 
 -- | Simple wishbone slave that responds to addresses [0..range], it responds by returning
 -- a stored value (initialized by readData0), which can be overwritten by the wishbone bus.
 -- any read/write attempt to an address outside of the supplied range sets the err signal.
 simpleSlave ::
-  forall dom bs .
-  (HiddenClockResetEnable dom, KnownNat bs) =>
-  Bytes bs ->
-  Bytes bs ->
-  Signal dom (WishboneM2S (bs * 8) bs (Bytes bs)) ->
-  Signal dom (WishboneS2M (Bytes bs))
+  forall dom aw a .
+  (HiddenClockResetEnable dom, KnownNat aw, BitPack a, NFDataX a, ShowX a) =>
+  BitVector aw ->
+  a ->
+  Signal dom (WishboneM2S aw (Regs a 8) a) ->
+  Signal dom (WishboneS2M a)
 simpleSlave range readData wbIn =
-  case divWithRemainder @bs @8 @7 of
+  case divWithRemainder @(Regs a 8) @8 @7 of
     Dict -> fst $ toSignals circuit (wbIn, ())
  where
-  circuit = validatorCircuit |> simpleSlave' @dom @(bs * 8) @bs range readData
-
--- findBaseAddress returns the base address that responds to a and its range
-findBaseAddress :: Ord a => a -> Vec n a -> Vec m b -> (a, b)
-findBaseAddress a (toList -> config) (toList -> ranges) =
-  L.last $ (L.head config, L.head ranges) : lowerAddresses
-  where
-    lowerAddresses = L.takeWhile ((<=a) . fst) $ L.zip config ranges
+  circuit = validatorCircuit |> simpleSlave' range readData


### PR DESCRIPTION
This PR allows for unordered baseaddresses in the `MemoryMap` for `singleMasterInterconnect`. 

Due to the method of slave selecting, the base addresses were required to be in ascending order.
With this change we first sort the 'MemoryMap' alongside the incoming busses to satisfy this requirement.
We also keep track of the original order of the incoming busses to make sure we correctly route the outgoing busses.

The tests were also adjust to now generate configurations with unordered base addresses.

Furthermore we decreased the size of the tests to improve speed, it is expected that this has no effect on the thoroughness of the tests.
