### PR TITLE
Use Xilinx FIFO model

### DIFF
--- a/elastic-buffer-sim/elastic-buffer-sim.cabal
+++ b/elastic-buffer-sim/elastic-buffer-sim.cabal
@@ -78,6 +78,7 @@ library
     aeson,
     bytestring,
     cassava,
+    clash-cores,
     containers,
     clash-cores,
     directory,


### PR DESCRIPTION
This closes https://github.com/bittide/bittide-hardware/issues/124

With the actual Xilinx FIFO model we are closer to a synthesizable clock control (what remains is the float conversion IP).