### PR TITLE
Improve endianness throughout designs + rxUnit refactor.

### DIFF
--- a/bittide/src/Bittide/Link.hs
+++ b/bittide/src/Bittide/Link.hs
@@ -2,7 +2,7 @@
 --
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# OPTIONS_GHC -fconstraint-solver-iterations=0 #-}
+{-# OPTIONS_GHC -fconstraint-solver-iterations=10 #-}
 
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}

--- a/bittide/src/Bittide/Link.hs
+++ b/bittide/src/Bittide/Link.hs
@@ -2,7 +2,7 @@
 --
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# OPTIONS_GHC -fconstraint-solver-iterations=5 #-}
+{-# OPTIONS_GHC -fconstraint-solver-iterations=0 #-}
 
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
@@ -36,7 +36,7 @@ data TransmissionState preambleWidth seqCountWidth frameWidth
   | TransmitPreamble (Index (Regs (BitVector preambleWidth) frameWidth))
   -- ^ The txUnit is transmitting the preamble, the index keeps track of which frame of
   -- the preamble is being transmitted.
-  | TransmitSeqCounter (Index (Regs (BitVector seqCountWidth) frameWidth))
+  | TransmitSeqCounter (Index (DivRU seqCountWidth frameWidth))
   -- ^ The txUnit is transmitting the stored sequence counter, the index keeps track
   -- of which frame of the sequence counter is being transmitted.
    deriving (Generic, NFDataX)
@@ -68,7 +68,7 @@ txUnit ::
   -- 2. Outgoing frame
   ( Signal core (WishboneS2M (Bytes nBytes))
   , Signal core (DataLink frameWidth))
-txUnit (getRegs -> RegisterBank preamble) sq frameIn wbIn = (wbOut, frameOut)
+txUnit (getRegsBe -> RegisterBank preamble) sq frameIn wbIn = (wbOut, frameOut)
  where
   (stateMachineOn, wbOut)
     | Dict <- timesDivRU @(nBytes * 8) @1
@@ -84,7 +84,7 @@ txUnit (getRegs -> RegisterBank preamble) sq frameIn wbIn = (wbOut, frameOut)
     ( (Unsigned seqCountWidth
     , TransmissionState preambleWidth seqCountWidth frameWidth)
     , DataLink frameWidth)
-  stateMachine (scStored@(getRegs -> RegisterBank sqVec), state) (fIn, scIn) =
+  stateMachine (scStored@(getRegsBe -> RegisterBank sqVec), state) (fIn, scIn) =
     ((nextSc, nextState state), out)
    where
     (nextSc, out) = case state of
@@ -97,10 +97,6 @@ txUnit (getRegs -> RegisterBank preamble) sq frameIn wbIn = (wbOut, frameOut)
 
   -- Once turned on, the txUnit continues to transmit the preamble followed by the sequence
   -- counter.
-  nextState ::
-    (KnownNat pw, KnownNat scw, KnownNat fw, 1 <= fw) =>
-    TransmissionState pw scw fw ->
-    TransmissionState pw scw fw
   nextState = \case
       LinkThrough       -> TransmitPreamble 0
       TransmitPreamble n
@@ -120,11 +116,17 @@ data ReceiverState
   -- ^ Receiver is capturing the sequence counter.
   | Done
   -- ^ Receiver has captured a remote and corresponding local sequence counter.
-  deriving (Generic, ShowX, BitPack)
+  deriving (Generic, ShowX, BitPack, NFDataX)
 
--- | The width of the internal shift register used for capturing the preamble and two
--- sequence counters.
-type ShiftRegWidth paw scw = Max paw (scw + scw)
+-- | We store the remote sequence counter, local sequence counter and 'ReceiverState'
+-- as a vector of words to make sure they are word-aligned.
+type RxRegister nBytes scw =
+  Vec
+  ( Regs (Unsigned scw) (nBytes * 8)
+  + Regs (Unsigned scw) (nBytes * 8)
+  + Regs ReceiverState (nBytes * 8)
+  )
+  (BitVector (nBytes * 8))
 
 {-# NOINLINE rxUnit #-}
 -- | Receives a Bittide link and can be set to detect the given preamble and capture the
@@ -149,71 +151,81 @@ rxUnit ::
   Signal core (WishboneS2M (Bytes nBytes))
 rxUnit preamble localCounter linkIn wbIn = wbOut
  where
-  (regOut, wbOut) = registerWbE WishbonePriority regInit wbIn regIn byteEnables
-  regInit = (0,resize $ pack Empty)
-  (regIn, byteEnables) = unbundle . mealy go 0 $ bundle (regOut, linkIn, localCounter)
+  (regOut, wbOut) = registerWbE WishbonePriority regInit wbIn regIn (pure maxBound)
+  regInit = mkWordAligned (0 :: Unsigned scw, 0 :: Unsigned scw, Empty)
+  regIn = unbundle . mealy go
+    (0,0) $ bundle
+    ( fmap fromWordAligned regOut, linkIn, localCounter)
 
   go ::
-    Index (DivRU scw fw) ->
-    ((BitVector (ShiftRegWidth paw scw), Bytes nBytes), DataLink fw, Unsigned scw) ->
-    ( Index (DivRU scw fw)
-    , (Maybe (BitVector (ShiftRegWidth paw scw), Bytes nBytes)
-    , ByteEnable (BitVector (ShiftRegWidth paw scw + nBytes * 8))))
-  go _ ((shiftOld, unpack . resize -> WaitingForPreamble), link, _) =
-    (0, (regNew, maxBound))
+    (Index (DivRU scw fw), BitVector paw) ->
+    ( (Unsigned scw, Unsigned scw, ReceiverState)
+    , DataLink fw, Unsigned scw) ->
+    ( (Index (DivRU scw fw), BitVector paw)
+    , Maybe (RxRegister nBytes scw)
+    )
+  go
+    (count, shiftOld)
+    ( ( remoteSc0
+      , localSc0
+      , state
+      )
+    , link
+    , localSc1) =
+    ( (nextCount, shiftNext), mkWordAligned <$> wbRegNew)
    where
+    (remoteSc1, RegisterBank remoteFrames0) = convertBe (RegisterBank newVec, remoteSc0)
+     where
+      newVec = tail $ remoteFrames0 :< fromJust link
+    (shiftNew, RegisterBank oldVec) = convertBe (RegisterBank newVec, shiftOld)
+     where
+      newVec = tail $ oldVec :< fromJust link
+
+    preambleFound = validFrame && shiftNew == preamble
+
     validFrame = isJust link
+    firstFrame = validFrame && count == minBound
+    lastFrame  = validFrame && count == maxBound
 
-    shiftNew :: BitVector (ShiftRegWidth paw scw)
-    shiftNew = resize (shiftOld ++# fromMaybe (deepErrorX "undefined ") link)
-    preambleFound = validFrame && resize shiftNew == preamble
+    shiftNext = case (validFrame, state) of
+      (True, WaitingForPreamble) -> shiftNew
+      _                          -> shiftOld
 
-    nextState
-      | preambleFound = CaptureSequenceCounter
-      | otherwise = WaitingForPreamble
+    wbRegNew = case (state, validFrame, firstFrame) of
+      (WaitingForPreamble    ,True,_)    -> Just (remoteSc0, localSc0, nextState)
+      (CaptureSequenceCounter,True,True) -> Just (remoteSc1, localSc1, nextState)
+      (CaptureSequenceCounter,True,_)    -> Just (remoteSc1, localSc0, nextState)
+      _                                  -> Nothing
 
-    regNew
-      | validFrame = Just (shiftNew, resize (pack nextState))
-      | otherwise  = Nothing
+    (nextState, nextCount) = case (preambleFound, lastFrame , state) of
+      (False, _    , WaitingForPreamble)    -> (WaitingForPreamble    , 0)
+      (True , _    , WaitingForPreamble)    -> (CaptureSequenceCounter, 0)
+      (_    , False, CaptureSequenceCounter)-> (CaptureSequenceCounter, succ count)
+      (_    , True , CaptureSequenceCounter)-> (Done                  , 0)
+      _                                     -> (state                 , 0)
 
-  go cnt ((shiftOld, unpack . resize -> CaptureSequenceCounter), link, lc) =
-    (nextCnt, (regNew, maxBound))
+  mkWordAligned ::
+    forall wordSize a b c .
+    (KnownNat wordSize, 1 <= wordSize, Paddable a, Paddable b, Paddable c) =>
+    (a,b,c) ->
+    Vec (Regs a wordSize + Regs b wordSize + Regs c wordSize) (BitVector wordSize)
+  mkWordAligned (a,b,c) = regsA ++ regsB ++ regsC
    where
-    validFrame = isJust link
-    firstFrame = validFrame && cnt == minBound
-    lastFrame = validFrame && cnt == maxBound
+    RegisterBank regsA = getRegsBe a
+    RegisterBank regsB = getRegsBe b
+    RegisterBank regsC = getRegsBe c
 
-    withShifted = resize @_ @_ @scw (shiftOld ++# fromMaybe (deepErrorX "undefined ") link)
-
-    shiftNew :: BitVector (ShiftRegWidth paw scw)
-    shiftNew
-      | firstFrame
-      = setLowerSlice (pack lc ++# withShifted) shiftOld
-      | Dict <- leMaxRight @paw @scw @scw
-      = setLowerSlice withShifted shiftOld
-
-    nextState
-      | lastFrame = Done
-      | otherwise = CaptureSequenceCounter
-
-    nextCnt = case strictlyPositiveDivRu @scw @fw of
-      Dict -> satSucc SatWrap cnt
-
-    regNew
-      | validFrame = Just (shiftNew, resize (pack nextState))
-      | otherwise  = Nothing
-
-  go _ _ = (0, (Nothing,minBound))
-
--- | Accepts two 'BitVector's and replaces the lower bits of the second 'BitVector' with
---  the first 'BitVector'.
-setLowerSlice ::
-  forall slice bv .
-  (KnownNat slice, 1 <= slice, KnownNat bv, slice <= bv) =>
-  BitVector slice ->
-  BitVector bv ->
-  BitVector bv
-setLowerSlice = setSlice @_ @_ @(bv - slice) (SNat @(slice -1)) d0
+  fromWordAligned ::
+    forall wordSize a b c .
+    (KnownNat wordSize, 1 <= wordSize, Paddable a, Paddable b, Paddable c) =>
+    Vec (Regs a wordSize + Regs b wordSize + Regs c wordSize) (BitVector wordSize) ->
+    (a,b,c)
+  fromWordAligned vec = (a,b,c)
+   where
+    (vecA, splitAtI -> (vecB, vecC)) = splitAtI vec
+    a = getDataBe (RegisterBank vecA)
+    b = getDataBe (RegisterBank vecB)
+    c = getDataBe (RegisterBank vecC)
 
 -- | Configuration for a 'Bittide.Link.
 data LinkConfig nBytes addrW where
@@ -237,7 +249,7 @@ linkToPe ::
   , KnownNat nBytesMu, 1 <= nBytesMu
   , KnownNat addrWMu, 2 <= addrWMu
   , KnownNat addrWPe, 2 <= addrWPe
-  , KnownNat scw, 1 <= scw)=>
+  , KnownNat scw, 1 <= scw) =>
   -- | Configuration for a 'Bittide.Link', the receiving end uses this for its @preamble@
   -- and 'ScatterConfig'.
   LinkConfig nBytesMu addrWMu ->

--- a/bittide/src/Bittide/ScatterGather.hs
+++ b/bittide/src/Bittide/ScatterGather.hs
@@ -192,7 +192,7 @@ scatterUnitWb (ScatterConfig calConfig) wbInCal linkIn wbInSu =
   (readAddr, upperSelected) = unbundle $ div2Index <$> memAddr
   (scatterUnitRead, wbOutCal, endOfMetacycle) =
     scatterUnit calConfig wbInCal linkIn readAddr
-  (upper, lower) = unbundle $ split <$> scatterUnitRead
+  (lower, upper) = unbundle $ split <$> scatterUnitRead
   selected = register (errorX "scatterUnitWb: Initial selection undefined") upperSelected
   scatteredData = mux selected upper lower
 
@@ -235,5 +235,5 @@ gatherUnitWb (GatherConfig calConfig) wbInCal wbInGu =
   mkWrite address (Just write) = Just (address, write ++# write)
   mkWrite _ _ = Nothing
   mkEnables selected byteEnables
-    | selected  = byteEnables ++# 0b0
-    | otherwise = 0b0 ++# byteEnables
+    | selected  = 0 ++# byteEnables
+    | otherwise = byteEnables ++# 0

--- a/bittide/src/Bittide/SharedTypes.hs
+++ b/bittide/src/Bittide/SharedTypes.hs
@@ -2,7 +2,7 @@
 --
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# OPTIONS_GHC -fconstraint-solver-iterations=0 #-}
+{-# OPTIONS_GHC -fconstraint-solver-iterations=8 #-}
 
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -11,8 +11,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE UndecidableInstances #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
 module Bittide.SharedTypes where
 
 import Clash.Prelude

--- a/bittide/src/Bittide/SharedTypes.hs
+++ b/bittide/src/Bittide/SharedTypes.hs
@@ -68,10 +68,12 @@ type Pad a bw  = (Regs a bw * bw) - BitSize a
 type Regs a bw = DivRU (BitSize a) bw
 
 data ByteOrder = LittleEndian | BigEndian
+
 -- | Stores any arbitrary datatype as a vector of registers.
-newtype RegisterBank regSize content (byteOrder :: ByteOrder)=
+newtype RegisterBank regSize content (byteOrder :: ByteOrder) =
   RegisterBank (Vec (Regs content regSize) (BitVector regSize))
   deriving Generic
+
 instance (KnownNat regSize, 1 <= regSize, BitPack content) =>
   BitPack (RegisterBank regSize content byteOrder) where
   type BitSize _ = Regs content regSize * regSize
@@ -84,12 +86,6 @@ deriving newtype instance
 
 deriving newtype instance (KnownNat regSize, ShowX (RegisterBank regSize content byteOrder)) =>
   ShowX (RegisterBank regSize content byteOrder)
-
-convertLe ::
-  (Paddable a, KnownNat bw, 1 <= bw) =>
-  (RegisterBank bw a 'LittleEndian, a)  ->
-  (a, RegisterBank bw a 'LittleEndian)
-convertLe (regBank, a) = (getDataLe regBank, getRegsLe a)
 
 convertBe ::
   (Paddable a, KnownNat bw, 1 <= bw) =>

--- a/bittide/src/Bittide/SharedTypes.hs
+++ b/bittide/src/Bittide/SharedTypes.hs
@@ -17,8 +17,8 @@ import Clash.Prelude
 
 import Data.Constraint
 import Data.Constraint.Nat.Extra
+import Data.Type.Equality ((:~:)(Refl))
 import Protocols.Wishbone
-import Data.Typeable
 
 -- | To be used when there are two options.
 data AorB = A | B deriving (Eq, Generic, BitPack, Show, NFDataX)

--- a/bittide/src/Bittide/SharedTypes.hs
+++ b/bittide/src/Bittide/SharedTypes.hs
@@ -2,7 +2,7 @@
 --
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# OPTIONS_GHC -fconstraint-solver-iterations=8 #-}
+{-# OPTIONS_GHC -fconstraint-solver-iterations=0 #-}
 
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -11,16 +11,16 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE UndecidableInstances #-}
-
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 module Bittide.SharedTypes where
 
 import Clash.Prelude
 
 import Data.Constraint
 import Data.Constraint.Nat.Extra
-import Data.Proxy
-import Data.Type.Equality ((:~:)(Refl))
 import Protocols.Wishbone
+import Data.Typeable
 
 -- | To be used when there are two options.
 data AorB = A | B deriving (Eq, Generic, BitPack, Show, NFDataX)
@@ -69,75 +69,61 @@ type Pad a bw  = (Regs a bw * bw) - BitSize a
 -- Amount of bw sized registers required to store a.
 type Regs a bw = DivRU (BitSize a) bw
 
--- | Vector of registers that stores data coming from a communication bus. It can be used
--- to store any arbitrary data type, the last register is padded with p bits. The number of
--- registers and the amount of padding depends on the bit size of the stored data.
-newtype RegisterBank regSize content =
+data ByteOrder = LittleEndian | BigEndian
+-- | Stores any arbitrary datatype as a vector of registers.
+newtype RegisterBank regSize content (byteOrder :: ByteOrder)=
   RegisterBank (Vec (Regs content regSize) (BitVector regSize))
+  deriving Generic
+instance (KnownNat regSize, 1 <= regSize, BitPack content) =>
+  BitPack (RegisterBank regSize content byteOrder) where
+  type BitSize _ = Regs content regSize * regSize
+  pack (RegisterBank vec) = pack vec
+  unpack bv = RegisterBank (unpack bv)
 
 deriving newtype instance
-  (KnownNat regSize, 1 <= regSize, Paddable content, NFDataX (RegisterBank regSize content))
-  => NFDataX (RegisterBank regSize content)
+  (KnownNat regSize, 1 <= regSize, Paddable content, NFDataX (RegisterBank regSize content byteOrder))
+  => NFDataX (RegisterBank regSize content byteOrder)
 
-deriving newtype instance (KnownNat regSize, ShowX (RegisterBank regSize content)) =>
-  ShowX (RegisterBank regSize content)
+deriving newtype instance (KnownNat regSize, ShowX (RegisterBank regSize content byteOrder)) =>
+  ShowX (RegisterBank regSize content byteOrder)
 
--- | Stores any a, along with a type level variable that contains a bit width to which @a@
--- should be padded.
-newtype Padded bw a = Padded {paddedToData :: a}
+convertLe ::
+  (Paddable a, KnownNat bw, 1 <= bw) =>
+  (RegisterBank bw a 'LittleEndian, a)  ->
+  (a, RegisterBank bw a 'LittleEndian)
+convertLe (regBank, a) = (getDataLe regBank, getRegsLe a)
 
-deriving newtype instance (KnownNat bw, Paddable a, NFDataX a, NFDataX (Padded bw a)) =>
-  NFDataX (Padded bw a)
+convertBe ::
+  (Paddable a, KnownNat bw, 1 <= bw) =>
+  (RegisterBank bw a 'BigEndian, a)  ->
+  (a, RegisterBank bw a 'BigEndian)
+convertBe (regBank, a) = (getDataBe regBank, getRegsBe a)
 
--- | Transforms a @BitVector bw@ containing a @Padded bw a@ to _Padded_.
-bvAsPadded ::
-  forall bw a.
-  ( Paddable a
-  , KnownNat bw
-  , 1 <= bw ) =>
-  BitVector bw ->
-  Padded bw a
-bvAsPadded bv =
+-- | Transforms a to _RegisterBank_.
+getRegsLe ::
+  forall bw a .
+  (Paddable a, KnownNat bw, 1 <= bw)
+  => a
+  -> RegisterBank bw a 'LittleEndian
+getRegsLe a = case timesDivRU @bw @(BitSize a) of
+  Dict -> RegisterBank (reverse $ bitCoerce (0 :: BitVector (Pad a bw),a))
+
+-- | Transforms a to _RegisterBank_.
+getRegsBe :: forall bw a . (Paddable a, KnownNat bw, 1 <= bw) => a -> RegisterBank bw a 'BigEndian
+getRegsBe a = case timesDivRU @bw @(BitSize a) of
+  Dict -> RegisterBank (bitCoerce (0 :: BitVector (Pad a bw),a))
+
+-- | Transforms _RegisterBank_ to a.
+getDataBe :: forall bw a . (Paddable a, KnownNat bw, 1 <= bw) => RegisterBank bw a 'BigEndian -> a
+getDataBe (RegisterBank vec) =
   case timesDivRU @bw @(BitSize a) of
-    Dict -> case sameNat (Proxy @(Pad a bw + BitSize a)) (Proxy @bw) of
-      Just Refl -> Padded . unpack . snd $ split @_ @(Pad a bw) @(BitSize a) bv
-      _ -> error "bvAsPadded: Negative padding"
+    Dict -> unpack . snd $ split @_ @(Pad a bw) @(BitSize a) (pack vec)
 
--- | Gets the stored data from a _RegisterBank_.
-registersToData ::
-  ( Paddable a
-  , KnownNat regSize
-  , 1 <= regSize ) =>
-  RegisterBank regSize a ->
-  a
-registersToData = paddedToData . registersToPadded
-
--- | Transforms _Padded_ to _RegisterBank_.
-paddedToRegisters ::
-  forall bw a.
-  ( BitPack a
-  , KnownNat bw
-  , 1 <= bw ) =>
-  Padded bw a ->
-  RegisterBank bw a
-paddedToRegisters (Padded a) = case timesDivRU @bw @(BitSize a) of
-  Dict -> RegisterBank (unpack ((0b0 :: BitVector (Pad a bw)) ++# pack a))
-
--- | Transforms _RegisterBank_ to _Padded_.
-registersToPadded ::
-  forall bw a.
-  ( Paddable a
-  , KnownNat bw
-  , 1 <= bw ) =>
-  RegisterBank bw a ->
-  Padded bw a
-registersToPadded (RegisterBank vec) =
+-- | Transforms _RegisterBank_ to a.
+getDataLe :: forall bw a . (Paddable a, KnownNat bw, 1 <= bw) => RegisterBank bw a 'LittleEndian -> a
+getDataLe (RegisterBank (reverse -> vec)) =
   case timesDivRU @bw @(BitSize a) of
-    Dict -> Padded . unpack . snd $ split @_ @(Pad a bw) @(BitSize a) (pack vec)
-
--- Stores its argument in a _RegisterBank_ based on a context-supplied register size.
-getRegs :: (BitPack a, KnownNat regSize, 1 <= regSize) => a -> RegisterBank regSize a
-getRegs = paddedToRegisters . Padded
+    Dict -> unpack . snd $ split @_ @(Pad a bw) @(BitSize a) (pack vec)
 
 -- | Coerces a tuple of index n and a boolean to index (n*2) where the LSB of the result
 -- is determined by the boolean.

--- a/bittide/tests/Tests/ScatterGather.hs
+++ b/bittide/tests/Tests/ScatterGather.hs
@@ -261,7 +261,7 @@ wbDecoding (s2m0 : s2m1 : s2ms)
   | acknowledge s2m0 && acknowledge s2m1 = out : wbDecoding s2ms
   | otherwise = wbDecoding (s2m1 : s2ms)
  where
-  out = readData s2m1 ++# readData s2m0
+  out = readData s2m0 ++# readData s2m1
 wbDecoding _ = []
 
 -- | Tranform a read address with expected frame into a wishbone read operation for testing
@@ -320,5 +320,5 @@ wbWrite writeAddr (Just frame) =
     , writeData = upper }
   ]
  where
-  (upper, lower) = split frame
+  (lower, upper) = split frame
 wbWrite _ Nothing = []


### PR DESCRIPTION
During the simiulation of Bittide nodes, I encountered the problem that the endianness of components was mostly big endian, while riscv uses little endian.

To fix it I changed our `RegisterBank` type to contain endianness information with a new type `ByteOrder`.

The purpose of the changes is to create clarity regarding the endianness of components (Everything accessible with Wishbone should be `LittleEndian`) and enforce the correct conversion between `RegisterBank`s and the contained data. 