### PR TITLE
Update to latest Clash and add `clash-cores`

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -33,26 +33,32 @@ index-state: 2022-08-09T07:40:43Z
 source-repository-package
   type: git
   location: https://github.com/clash-lang/clash-compiler.git
-  tag: d09e154ef674cea92c8f345d763606cf85e96403
+  tag: 743c88e95671cb6eb214e0a363f707a466b9c972
   subdir: clash-prelude
 
 source-repository-package
   type: git
   location: https://github.com/clash-lang/clash-compiler.git
-  tag: d09e154ef674cea92c8f345d763606cf85e96403
+  tag: 743c88e95671cb6eb214e0a363f707a466b9c972
   subdir: clash-ghc
 
 source-repository-package
   type: git
   location: https://github.com/clash-lang/clash-compiler.git
-  tag: d09e154ef674cea92c8f345d763606cf85e96403
+  tag: 743c88e95671cb6eb214e0a363f707a466b9c972
   subdir: clash-lib
 
 source-repository-package
   type: git
   location: https://github.com/clash-lang/clash-compiler.git
-  tag: d09e154ef674cea92c8f345d763606cf85e96403
+  tag: 743c88e95671cb6eb214e0a363f707a466b9c972
   subdir: clash-prelude-hedgehog
+
+source-repository-package
+  type: git
+  location: https://github.com/clash-lang/clash-compiler.git
+  tag: 743c88e95671cb6eb214e0a363f707a466b9c972
+  subdir: clash-cores
 
 source-repository-package
   type: git


### PR DESCRIPTION
CI triggers formal tests if anything in Clash/Contranomy changes, hence burning a lot of minutes if this change is part of another (WIP) PR.