### PR TITLE
Add various bittide instances

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -647,8 +647,21 @@ jobs:
     strategy:
       matrix:
         target:
-          - {top: switchCalendar1k,            stage: hdl}
-          - {top: switchCalendar1kReducedPins, stage: netlist}
+          - {top: gatherUnit1K,                              stage: synth}
+          - {top: rxUnit64_1K,                               stage: synth}
+          - {top: scatterUnit1K,                             stage: synth}
+          - {top: singleMasterInterconnect_32_32,            stage: synth}
+          - {top: switchCalendar1k,                          stage: synth}
+          - {top: switch_16_64,                              stage: synth}
+          - {top: txUnit64_1K,                               stage: synth}
+
+          - {top: gatherUnit1KReducedPins,                   stage: netlist}
+          - {top: rxUnit64_1KReducedPins,                    stage: netlist}
+          - {top: scatterUnit1KReducedPins,                  stage: netlist}
+          - {top: singleMasterInterconnect_32_32ReducedPins, stage: netlist}
+          - {top: switchCalendar1kReducedPins,               stage: netlist}
+          - {top: switch_16_64ReducedPins,                   stage: netlist}
+          - {top: txUnit64_1KReducedPins,                    stage: netlist}
 
     container:
       image: ghcr.io/clash-lang/clash-ci-9.0.2:2022-02-02

--- a/bittide-instances/bin/Shake.hs
+++ b/bittide-instances/bin/Shake.hs
@@ -22,6 +22,7 @@ import System.FilePath (isDrive, (</>), takeDirectory)
 import Clash.Shake.Vivado
 
 import qualified Bittide.Instances.Calendar as Calendar
+import qualified Bittide.Instances.ClockControl as ClockControl
 import qualified Bittide.Instances.Link as Link
 import qualified Bittide.Instances.ScatterGather as ScatterGather
 import qualified Bittide.Instances.Switch as Switch
@@ -80,6 +81,7 @@ targets =
   , 'Switch.switch_16_64ReducedPins
   , 'Wishbone.singleMasterInterconnect_32_32
   , 'Wishbone.singleMasterInterconnect_32_32ReducedPins
+  , 'ClockControl.callisto3
   ]
 
 shakeOpts :: FilePath -> ShakeOptions

--- a/bittide-instances/bin/Shake.hs
+++ b/bittide-instances/bin/Shake.hs
@@ -22,6 +22,10 @@ import System.FilePath (isDrive, (</>), takeDirectory)
 import Clash.Shake.Vivado
 
 import qualified Bittide.Instances.Calendar as Calendar
+import qualified Bittide.Instances.Link as Link
+import qualified Bittide.Instances.ScatterGather as ScatterGather
+import qualified Bittide.Instances.Switch as Switch
+import qualified Bittide.Instances.Wishbone as Wishbone
 import qualified Clash.Util.Interpolate as I
 import qualified Language.Haskell.TH as TH
 import qualified System.Directory as Directory
@@ -64,6 +68,18 @@ targets :: [TH.Name]
 targets =
   [ 'Calendar.switchCalendar1k
   , 'Calendar.switchCalendar1kReducedPins
+  , 'Link.rxUnit64_1K
+  , 'Link.rxUnit64_1KReducedPins
+  , 'Link.txUnit64_1K
+  , 'Link.txUnit64_1KReducedPins
+  , 'ScatterGather.gatherUnit1K
+  , 'ScatterGather.gatherUnit1KReducedPins
+  , 'ScatterGather.scatterUnit1K
+  , 'ScatterGather.scatterUnit1KReducedPins
+  , 'Switch.switch_16_64
+  , 'Switch.switch_16_64ReducedPins
+  , 'Wishbone.singleMasterInterconnect_32_32
+  , 'Wishbone.singleMasterInterconnect_32_32ReducedPins
   ]
 
 shakeOpts :: FilePath -> ShakeOptions

--- a/bittide-instances/bin/Shake.hs
+++ b/bittide-instances/bin/Shake.hs
@@ -101,6 +101,11 @@ main = do
   projectRoot <- findProjectRoot
 
   shakeArgs (shakeOpts projectRoot) $ do
+    -- 'all' builds all targets defined below
+    phony "all" $ do
+      for_ targets $ \target -> do
+        need [nameBase target <> ":synth"]
+
     -- For each target, generate a user callable command (PHONY). Run with
     -- '--help' to list them.
     for_ targets $ \target -> do

--- a/bittide-instances/bittide-instances.cabal
+++ b/bittide-instances/bittide-instances.cabal
@@ -71,6 +71,7 @@ common common-options
     clash-prelude,
     clash-protocols,
     containers,
+    elastic-buffer-sim,
     filepath,
     ghc-typelits-extra,
     ghc-typelits-knownnat,
@@ -96,6 +97,7 @@ library
     Bittide.Instances.ScatterGather
     Bittide.Instances.Switch
     Bittide.Instances.Wishbone
+    Bittide.Instances.ClockControl
     Clash.Shake.Extra
     Clash.Shake.Vivado
     Development.Shake.Extra

--- a/bittide-instances/bittide-instances.cabal
+++ b/bittide-instances/bittide-instances.cabal
@@ -92,7 +92,10 @@ library
     Bittide.Instances.Calendar
     Bittide.Instances.Domains
     Bittide.Instances.Hacks
-
+    Bittide.Instances.Link
+    Bittide.Instances.ScatterGather
+    Bittide.Instances.Switch
+    Bittide.Instances.Wishbone
     Clash.Shake.Extra
     Clash.Shake.Vivado
     Development.Shake.Extra

--- a/bittide-instances/src/Bittide/Instances/Calendar.hs
+++ b/bittide-instances/src/Bittide/Instances/Calendar.hs
@@ -18,6 +18,21 @@ import Bittide.Instances.Hacks (reducePins)
 type WishboneWidth = 4
 type WishboneAddrWidth = 32
 
+{-# ANN switchCalendar1k
+  (Synthesize
+    { t_name = "switchCalendar1k"
+    , t_inputs =
+        [ PortName "clk"
+        , PortName "rst"
+        , PortName "wbM2S"
+        ]
+    , t_output = PortProduct ""
+        [ PortName "activeEntry"
+        , PortName "metaCycleIndicator"
+        , PortName "wbS2M"
+        ]
+    }
+  )#-}
 
 switchCalendar1k ::
   Clock Basic200 -> Reset Basic200 ->

--- a/bittide-instances/src/Bittide/Instances/ClockControl.hs
+++ b/bittide-instances/src/Bittide/Instances/ClockControl.hs
@@ -1,0 +1,25 @@
+-- SPDX-FileCopyrightText: 2022 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+
+module Bittide.Instances.ClockControl where
+
+import Clash.Prelude
+
+import Bittide.ClockControl.Callisto
+import Bittide.Instances.Domains
+import Bittide.ClockControl
+
+config :: ClockControlConfig Basic200 12
+config = $(lift (defClockConfig @Basic200))
+
+callisto3 ::
+  Clock Basic200 ->
+  Reset Basic200 ->
+  Enable Basic200 ->
+  -- | Data counts from elastic buffers
+  Vec 3 (Signal Basic200 (DataCount 12)) ->
+  -- | Speed change requested from clock multiplier
+  Signal Basic200 SpeedChange
+callisto3 clk rst ena dataCounts =
+  callistoClockControl clk rst ena config dataCounts

--- a/bittide-instances/src/Bittide/Instances/Domains.hs
+++ b/bittide-instances/src/Bittide/Instances/Domains.hs
@@ -8,3 +8,4 @@ module Bittide.Instances.Domains where
 import Clash.Explicit.Prelude
 
 createDomain vXilinxSystem{vName="Basic200", vPeriod=hzToPeriod 200e6}
+createDomain vXilinxSystem{vName="Basic100", vPeriod=hzToPeriod 100e6}

--- a/bittide-instances/src/Bittide/Instances/Link.hs
+++ b/bittide-instances/src/Bittide/Instances/Link.hs
@@ -1,0 +1,85 @@
+-- SPDX-FileCopyrightText: 2022 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+
+{-# OPTIONS_GHC -fconstraint-solver-iterations=7 #-}
+
+module Bittide.Instances.Link where
+
+import Clash.Prelude
+
+import Bittide.Instances.Domains
+import Bittide.Instances.Hacks
+import Bittide.Link
+import Bittide.SharedTypes
+import Protocols.Wishbone
+
+type FrameWidth = 64
+type SequenceCounterWidth = 64
+type WishboneAddrWidth = 32
+type WishboneWidth = 4
+
+preamble :: BitVector 1024
+preamble = pack $ iterate d16 ((*3) . succ) (0 :: Unsigned 64)
+
+{-# ANN txUnit64_1K
+  (Synthesize
+    { t_name = "txUnit64_1K"
+    , t_inputs =
+        [ PortName "clk"
+        , PortName "rst"
+        , PortName "localSequenceCounter"
+        , PortName "linkIn"
+        , PortName "wbM2S"
+        ]
+    , t_output = PortProduct ""
+        [ PortName "wbS2M"
+        , PortName "linkOut"
+        ]
+    }
+  )#-}
+
+txUnit64_1K ::
+  Clock Basic200 ->
+  Reset Basic200 ->
+  Signal Basic200 (Unsigned SequenceCounterWidth) ->
+  Signal Basic200 (DataLink FrameWidth) ->
+  Signal Basic200 (WishboneM2S WishboneAddrWidth WishboneWidth (Bytes WishboneWidth)) ->
+  ( Signal Basic200 (WishboneS2M (Bytes WishboneWidth))
+  , Signal Basic200 (DataLink FrameWidth))
+txUnit64_1K clk rst = withClockResetEnable clk rst enableGen (txUnit preamble)
+{-# NOINLINE txUnit64_1K #-}
+
+txUnit64_1KReducedPins :: Clock Basic200 -> Reset Basic200 -> Signal Basic200 Bit -> Signal Basic200 Bit
+txUnit64_1KReducedPins clk rst = withClockResetEnable clk rst enableGen (reducePins txUnit64_1K')
+ where
+  txUnit64_1K' (unbundle -> (a,b,c)) = bundle $ txUnit64_1K clk rst a b c
+
+{-# ANN rxUnit64_1K
+  (Synthesize
+    { t_name = "rxUnit64_1K"
+    , t_inputs =
+        [ PortName "clk"
+        , PortName "rst"
+        , PortName "localSequenceCounter"
+        , PortName "linkIn"
+        , PortName "wbM2S"
+        ]
+    , t_output = PortName "wbS2M"
+    }
+  )#-}
+
+rxUnit64_1K ::
+  Clock Basic200 ->
+  Reset Basic200 ->
+  Signal Basic200 (Unsigned SequenceCounterWidth) ->
+  Signal Basic200 (DataLink FrameWidth) ->
+  Signal Basic200 (WishboneM2S WishboneAddrWidth WishboneWidth (Bytes WishboneWidth)) ->
+  Signal Basic200 (WishboneS2M (Bytes WishboneWidth))
+rxUnit64_1K clk rst = withClockResetEnable clk rst enableGen (rxUnit preamble)
+{-# NOINLINE rxUnit64_1K #-}
+
+rxUnit64_1KReducedPins :: Clock Basic200 -> Reset Basic200 -> Signal Basic200 Bit -> Signal Basic200 Bit
+rxUnit64_1KReducedPins clk rst = withClockResetEnable clk rst enableGen (reducePins rxUnit64_1K')
+ where
+  rxUnit64_1K' (unbundle -> (a,b,c)) = rxUnit64_1K clk rst a b c

--- a/bittide-instances/src/Bittide/Instances/ScatterGather.hs
+++ b/bittide-instances/src/Bittide/Instances/ScatterGather.hs
@@ -1,0 +1,104 @@
+-- SPDX-FileCopyrightText: 2022 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+{-# OPTIONS_GHC -fconstraint-solver-iterations=7 #-}
+
+module Bittide.Instances.ScatterGather where
+
+import Clash.Prelude
+
+import Bittide.Calendar
+import Bittide.Instances.Domains
+import Bittide.Instances.Hacks
+import Bittide.ScatterGather
+import Bittide.SharedTypes
+import Protocols.Wishbone
+
+type FrameWidth = 64
+type NLinks = 16
+type WishboneAddrWidth = 32
+type WishboneWidth = 4
+
+scatterCal1K :: ScatterConfig WishboneWidth WishboneAddrWidth
+scatterCal1K = ScatterConfig cal
+ where
+  cal :: CalendarConfig WishboneWidth WishboneAddrWidth (Index 1024)
+  cal = CalendarConfig (SNat @1024)
+    (ValidEntry{veEntry=0, veRepeat = 0 :: Unsigned 8} :> Nil)
+    (ValidEntry{veEntry=0, veRepeat = 0 :: Unsigned 8} :> Nil)
+
+gatherCal1K :: GatherConfig WishboneWidth WishboneAddrWidth
+gatherCal1K = GatherConfig cal
+ where
+  cal :: CalendarConfig WishboneWidth WishboneAddrWidth (Index 1024)
+  cal = CalendarConfig (SNat @1024)
+    (ValidEntry{veEntry=0, veRepeat = 0 :: Unsigned 8} :> Nil)
+    (ValidEntry{veEntry=0, veRepeat = 0 :: Unsigned 8} :> Nil)
+
+{-# ANN scatterUnit1K
+  (Synthesize
+    { t_name = "scatterUnit1K"
+    , t_inputs =
+      [ PortName "clk"
+      , PortName "rst"
+      , PortName "wbInCal"
+      , PortName "linkIn"
+      , PortName "wbInSu"
+      ]
+    , t_output = PortProduct ""
+      [ PortName "wbOutSu"
+      , PortName "wbOutCal"
+      ]
+    }
+  )#-}
+scatterUnit1K ::
+  Clock Basic200 ->
+  Reset Basic200 ->
+  Signal Basic200 (WishboneM2S WishboneAddrWidth WishboneWidth (Bytes WishboneWidth)) ->
+  Signal Basic200 (DataLink 64) ->
+  Signal Basic200 (WishboneM2S WishboneAddrWidth WishboneWidth (Bytes WishboneWidth)) ->
+  ( Signal Basic200 (WishboneS2M (Bytes WishboneWidth))
+  , Signal Basic200 (WishboneS2M (Bytes WishboneWidth)))
+scatterUnit1K clk rst = withClockResetEnable clk rst enableGen $ scatterUnitWb scatterCal1K
+{-# NOINLINE scatterUnit1K #-}
+
+scatterUnit1KReducedPins ::
+  Clock Basic200 -> Reset Basic200 -> Signal Basic200 Bit -> Signal Basic200 Bit
+scatterUnit1KReducedPins clk rst =
+  withClockResetEnable clk rst enableGen $ reducePins scatterUnit1K'
+ where
+  scatterUnit1K' (unbundle -> (a,b,c)) = bundle $ scatterUnit1K clk rst a b c
+
+{-# ANN gatherUnit1K
+  (Synthesize
+    { t_name = "gatherUnit1K"
+    , t_inputs =
+        [ PortName "clk"
+        , PortName "rst"
+        , PortName "wbInCal"
+        , PortName "wbInGu"
+        ]
+    , t_output = PortProduct ""
+        [ PortName "linkOut"
+        , PortName "wbOutGu"
+        , PortName "wbOutCal"
+        ]
+    }
+  )#-}
+gatherUnit1K ::
+  Clock Basic200 ->
+  Reset Basic200 ->
+  Signal Basic200 (WishboneM2S WishboneAddrWidth WishboneWidth (Bytes WishboneWidth)) ->
+  Signal Basic200 (WishboneM2S WishboneAddrWidth WishboneWidth (Bytes WishboneWidth)) ->
+  ( Signal Basic200 (DataLink 64)
+  , Signal Basic200 (WishboneS2M (Bytes WishboneWidth))
+  , Signal Basic200 (WishboneS2M (Bytes WishboneWidth)))
+gatherUnit1K clk rst = withClockResetEnable clk rst enableGen $ gatherUnitWb gatherCal1K
+{-# NOINLINE gatherUnit1K #-}
+
+gatherUnit1KReducedPins ::
+  Clock Basic200 -> Reset Basic200 -> Signal Basic200 Bit -> Signal Basic200 Bit
+gatherUnit1KReducedPins clk rst =
+  withClockResetEnable clk rst enableGen $ reducePins gatherUnit1K'
+ where
+  gatherUnit1K' (unbundle -> (a,b)) = bundle $ gatherUnit1K clk rst a b

--- a/bittide-instances/src/Bittide/Instances/Switch.hs
+++ b/bittide-instances/src/Bittide/Instances/Switch.hs
@@ -1,0 +1,73 @@
+-- SPDX-FileCopyrightText: 2022 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+
+{-# OPTIONS_GHC -fconstraint-solver-iterations=8 #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE MagicHash #-}
+
+module Bittide.Instances.Switch where
+
+import Clash.Prelude
+
+import Bittide.Calendar
+import Bittide.Instances.Domains
+import Bittide.Instances.Hacks
+import Bittide.SharedTypes
+import Bittide.Switch
+import Data.Bifunctor
+import Protocols.Wishbone
+
+type WishboneWidth = 4
+type WishboneAddrWidth = 32
+type FrameWidth = 64
+type NLinks = 16
+
+{-# ANN switch_16_64
+  (Synthesize
+    { t_name = "switch_16_64"
+    , t_inputs =
+        [ PortName "clk"
+        , PortName "rst"
+        , PortName "calM2S"
+        , PortName "rxM2Ss"
+        , PortName "txM2Ss"
+        , PortName "linksIn"
+        ]
+    , t_output = PortProduct ""
+        [ PortName "linksOu"
+        , PortName "s2Ms"
+        ]
+    }
+  )#-}
+
+switch_16_64 ::
+  Clock Basic200 ->
+  Reset Basic200 ->
+  Signal Basic200 (WishboneM2S WishboneAddrWidth WishboneWidth (Bytes WishboneWidth)) ->
+  Vec NLinks (Signal Basic200 (WishboneM2S WishboneAddrWidth WishboneWidth (Bytes WishboneWidth))) ->
+  Vec NLinks (Signal Basic200 (WishboneM2S WishboneAddrWidth WishboneWidth (Bytes WishboneWidth))) ->
+  Vec NLinks (Signal Basic200 (DataLink FrameWidth)) ->
+  ( Vec NLinks  (Signal Basic200 (DataLink FrameWidth))
+  , Vec (1 + (2 * NLinks)) (Signal Basic200 (WishboneS2M (Bytes WishboneWidth))))
+switch_16_64 clk rst = exposeClockResetEnable (mkSwitch switchConfig) clk rst enableGen
+ where
+  switchConfig = SwitchConfig{preamble, calendarConfig}
+  preamble = concatBitVector#
+    (0xDEADBABE :> 0xDEADBEEF :> 0xA5A5A5A5 :> 0xABABABAB :> Nil) :: BitVector 1024
+  calendarConfig = CalendarConfig
+    (SNat @2)
+    (ValidEntry{veEntry=repeat 0, veRepeat = 0 :: Unsigned 0} :> Nil)
+    (ValidEntry{veEntry=repeat 0, veRepeat = 0 :: Unsigned 0} :> Nil)
+
+{-# NOINLINE switch_16_64 #-}
+
+switch_16_64ReducedPins ::
+  Clock Basic200 -> Reset Basic200 -> Signal Basic200 Bit -> Signal Basic200 Bit
+switch_16_64ReducedPins clk rst bitIn = bitOut
+ where
+  bitOut = withClockResetEnable clk rst enableGen (reducePins switch_16_64' bitIn)
+
+  switch_16_64' allInputs = bundle $ bimap bundle bundle (switch_16_64 clk rst a b c d)
+   where
+    (a, unbundle -> (unbundle -> b, unbundle -> c, unbundle -> d)) = unbundle allInputs

--- a/bittide-instances/src/Bittide/Instances/Wishbone.hs
+++ b/bittide-instances/src/Bittide/Instances/Wishbone.hs
@@ -1,0 +1,55 @@
+-- SPDX-FileCopyrightText: 2022 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+
+module Bittide.Instances.Wishbone where
+
+import Clash.Prelude
+
+import Bittide.Wishbone
+import Bittide.Instances.Domains
+import Protocols.Wishbone
+import Bittide.SharedTypes
+import Bittide.Instances.Hacks (reducePins)
+
+type NSlaves = 32
+type WishboneAddrWidth = 32
+type WishboneWidth = 4
+
+memMap :: (KnownNat addrWidth, KnownNat nSlaves ) => MemoryMap nSlaves addrWidth
+memMap = iterateI (+0x10000) 0
+
+{-# ANN singleMasterInterconnect_32_32
+  (Synthesize
+    { t_name = "singleMasterInterconnect_32_32"
+    , t_inputs =
+        [ PortName "clk"
+        , PortName "rst"
+        , PortName "fromMaster"
+        , PortName "fromSlaves"
+        ]
+    , t_output = PortProduct ""
+        [ PortName "toMaster"
+        , PortName "toSlaves"
+        ]
+    }
+  )#-}
+
+singleMasterInterconnect_32_32 ::
+  Clock Basic200 ->
+  Reset Basic200 ->
+  Signal Basic200 (WishboneM2S WishboneAddrWidth WishboneWidth (Bytes WishboneWidth)) ->
+  Signal Basic200 (Vec NSlaves (WishboneS2M (Bytes WishboneWidth))) ->
+  ( Signal Basic200 (WishboneS2M (Bytes WishboneWidth))
+  , Signal Basic200 (Vec NSlaves (WishboneM2S WishboneAddrWidth WishboneWidth (Bytes WishboneWidth)))
+  )
+singleMasterInterconnect_32_32 clk rst =
+  withClockResetEnable clk rst enableGen $ singleMasterInterconnect' memMap
+
+singleMasterInterconnect_32_32ReducedPins ::
+  Clock Basic200 -> Reset Basic200 -> Signal Basic200 Bit -> Signal Basic200 Bit
+singleMasterInterconnect_32_32ReducedPins clk rst =
+  withClockResetEnable clk rst enableGen (reducePins singleMasterInterconnect'')
+ where
+  singleMasterInterconnect'' (unbundle -> (a,b)) =
+    bundle $ singleMasterInterconnect_32_32 clk rst a b

--- a/bittide-instances/src/Clash/Shake/Extra.hs
+++ b/bittide-instances/src/Clash/Shake/Extra.hs
@@ -47,6 +47,7 @@ clashCmd buildDir hdl topName extraArgs =
     , "-main-is", funcName
     , hdlToFlag hdl
     , "-fclash-clear"
+    , "-fclash-spec-limit=100"
     ] <> extraArgs
   )
  where


### PR DESCRIPTION
This PR adds instances of Bittide components to `bittide-instances` which enables us to more easily generate HDL and process it with Vivado.
Because we can run this on CI automatically, we ensure that the components are synthesizable and meet our target frequency of 200 MHz.

Furthermore this PR adds the generation of post synthesis utilization reports and adds an `all` target to shake.