### PR TITLE
Use type level nat in `DataCount`

### DIFF
--- a/elastic-buffer-sim/elastic-buffer-sim.cabal
+++ b/elastic-buffer-sim/elastic-buffer-sim.cabal
@@ -76,10 +76,12 @@ library
   build-depends:
     array,
     aeson,
+    bittide,
     bytestring,
     cassava,
-    containers,
     clash-cores,
+    constraints,
+    containers,
     directory,
     matplotlib,
     random,

--- a/elastic-buffer-sim/tests/Tests/Bittide/Simulate.hs
+++ b/elastic-buffer-sim/tests/Tests/Bittide/Simulate.hs
@@ -34,24 +34,24 @@ tests = testGroup "Simulate"
 fastPeriod :: PeriodPs
 fastPeriod = hzToPeriod 200e6
 
-clockConfig :: Ppm -> ClockControlConfig
+clockConfig :: Ppm -> ClockControlConfig 7
 clockConfig clockUncertainty = ClockControlConfig
   { cccPessimisticPeriod = speedUpPeriod clockUncertainty fastPeriod
   , cccSettlePeriod      = fastPeriod * 200
   , cccDynamicRange      = clockUncertainty * 2
   , cccStepSize          = 10
-  , cccBufferSize        = 128
+  , cccBufferSize        = d7 -- 2**7 ~ 128
   }
 
 case_clockControlMaxBound :: Assertion
 case_clockControlMaxBound = do
   let
     config = clockConfig (Ppm 100)
-    dataCounts = pure (cccBufferSize config) :> Nil
+    dataCounts = pure maxBound :> Nil
     changes =
       sampleN
         (fromIntegral (cccPessimisticPeriod config))
-        (callistoClockControl @_ @Fast clockGen resetGen enableGen config dataCounts)
+        (callistoClockControl @_ @_ @Fast clockGen resetGen enableGen config dataCounts)
 
   assertBool
     "only requests speed up"
@@ -65,7 +65,7 @@ case_clockControlMinBound = do
     changes =
       sampleN
         (fromIntegral (cccPessimisticPeriod config))
-        (callistoClockControl @_ @Fast clockGen resetGen enableGen config dataCounts)
+        (callistoClockControl @_ @_ @Fast clockGen resetGen enableGen config dataCounts)
 
   assertBool
     "only requests slow down"
@@ -75,24 +75,24 @@ case_clockControlMinBound = do
 -- its data count should reach 'maxBound'.
 case_elasticBufferMaxBound :: Assertion
 case_elasticBufferMaxBound = do
-  let dataCounts = sampleN 1024 (elasticBuffer Saturate 32 (clockGen @Slow) (clockGen @Fast))
+  let dataCounts = sampleN 2048 (elasticBuffer @5 Saturate (clockGen @Slow) (clockGen @Fast))
   -- it never hits exactly the maximum because the occupancy is in the read
   -- domain, i.e. we have to look for one less than the max
-  assertBool "elastic buffer should reach its near maximum (read domain)" (31 `elem` dataCounts)
+  assertBool "elastic buffer should reach its near maximum (read domain)" ((maxBound-1) `elem` dataCounts)
   assertBool "elastic buffer should not reach its minimum" (0 `notElem` dataCounts)
 
 -- | When the elasticBuffer is written to more quickly than it is being read from,
 -- its data count should reach 'maxBound'.
 case_elasticBufferMinBound :: Assertion
 case_elasticBufferMinBound = do
-  let dataCounts = sampleN 1024 (elasticBuffer Saturate 32 (clockGen @Fast) (clockGen @Slow))
+  let dataCounts = sampleN 1024 (elasticBuffer @5 Saturate (clockGen @Fast) (clockGen @Slow))
   assertBool "elastic buffer should reach its minimum" (0 `elem` dataCounts)
-  assertBool "elastic buffer should not reach its maximum" (32 `notElem` dataCounts)
+  assertBool "elastic buffer should not reach its maximum" (maxBound `notElem` dataCounts)
 
 -- | When the elasticBuffer written to as quikly to as it is read from, it should
 -- reach neiher its maxBound nor minBound.
 case_elasticBufferEq :: Assertion
 case_elasticBufferEq = do
-  let dataCounts = sampleN 1024 (elasticBuffer Saturate 32 (clockGen @Slow) (clockGen @Slow))
+  let dataCounts = sampleN 1024 (elasticBuffer @5 Saturate (clockGen @Slow) (clockGen @Slow))
   assertBool "elastic buffer should not reach its minimum" (0 `notElem` dataCounts)
-  assertBool "elastic buffer should not reach its maximum" (32 `notElem` dataCounts)
+  assertBool "elastic buffer should not reach its maximum" (maxBound `notElem` dataCounts)


### PR DESCRIPTION
This makes integration with the Xilinx FIFO easier, as well as `callisto` safer.