### PR TITLE
Use femtoseconds instead of picoseconds

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -34,31 +34,31 @@ index-state: 2022-10-31T09:07:19Z
 source-repository-package
   type: git
   location: https://github.com/clash-lang/clash-compiler.git
-  tag: 68f429b90e8183cb1fccb488f7bf0f6c9f3119b5
+  tag: 11ef54f9d7254d952eedf8e63f80ed430851df58
   subdir: clash-prelude
 
 source-repository-package
   type: git
   location: https://github.com/clash-lang/clash-compiler.git
-  tag: 68f429b90e8183cb1fccb488f7bf0f6c9f3119b5
+  tag: 11ef54f9d7254d952eedf8e63f80ed430851df58
   subdir: clash-ghc
 
 source-repository-package
   type: git
   location: https://github.com/clash-lang/clash-compiler.git
-  tag: 68f429b90e8183cb1fccb488f7bf0f6c9f3119b5
+  tag: 11ef54f9d7254d952eedf8e63f80ed430851df58
   subdir: clash-lib
 
 source-repository-package
   type: git
   location: https://github.com/clash-lang/clash-compiler.git
-  tag: 68f429b90e8183cb1fccb488f7bf0f6c9f3119b5
+  tag: 11ef54f9d7254d952eedf8e63f80ed430851df58
   subdir: clash-prelude-hedgehog
 
 source-repository-package
   type: git
   location: https://github.com/clash-lang/clash-compiler.git
-  tag: 68f429b90e8183cb1fccb488f7bf0f6c9f3119b5
+  tag: 11ef54f9d7254d952eedf8e63f80ed430851df58
   subdir: clash-cores
 
 source-repository-package

--- a/elastic-buffer-sim/elastic-buffer-sim.cabal
+++ b/elastic-buffer-sim/elastic-buffer-sim.cabal
@@ -92,6 +92,7 @@ library
     Bittide.ClockControl.Strategies.Callisto
     Bittide.Simulate
     Bittide.Simulate.Ppm
+    Bittide.Simulate.Time
     Bittide.Topology
     Bittide.Topology.Graph
     Bittide.Topology.TH

--- a/elastic-buffer-sim/src/Bittide/ClockControl/Strategies.hs
+++ b/elastic-buffer-sim/src/Bittide/ClockControl/Strategies.hs
@@ -35,7 +35,7 @@ callistoClockControl ::
   Reset dom ->
   Enable dom ->
   -- | Configuration for this component, see individual fields for more info.
-  ClockControlConfig m ->
+  ClockControlConfig dom m ->
   -- | Statistics provided by elastic buffers.
   Vec n (Signal dom (DataCount m)) ->
   Signal dom SpeedChange
@@ -66,7 +66,7 @@ clockControl ::
   Reset dom ->
   Enable dom ->
   -- | Configuration for this component, see individual fields for more info.
-  ClockControlConfig m ->
+  ClockControlConfig dom m ->
   -- | Clock control strategy
   ClockControlAlgorithm dom n m a ->
   -- | Statistics provided by elastic buffers.
@@ -74,6 +74,4 @@ clockControl ::
   -- | Whether to adjust node clock frequency
   Signal dom SpeedChange
 clockControl clk rst ena ClockControlConfig{..} f =
-  f clk rst ena targetDataCount updateEveryNCycles . bundle
- where
-  updateEveryNCycles = fromIntegral (cccSettlePeriod `div` cccPessimisticPeriod) + 1
+  f clk rst ena targetDataCount cccPessimisticSettleCycles . bundle

--- a/elastic-buffer-sim/src/Bittide/Simulate/Time.hs
+++ b/elastic-buffer-sim/src/Bittide/Simulate/Time.hs
@@ -1,0 +1,33 @@
+-- SPDX-FileCopyrightText: 2022 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+
+module Bittide.Simulate.Time where
+
+import Prelude
+
+import Clash.Signal.Internal (Femtoseconds (Femtoseconds), mapFemtoseconds)
+import Data.Int (Int64)
+
+seconds :: Int64 -> Femtoseconds
+seconds s = mapFemtoseconds (* 1000) (milliseconds s)
+
+milliseconds :: Int64 -> Femtoseconds
+milliseconds s = mapFemtoseconds (* 1000) (microseconds s)
+{-# INLINE milliseconds #-}
+
+microseconds :: Int64 -> Femtoseconds
+microseconds s = mapFemtoseconds (* 1000) (nanoseconds s)
+{-# INLINE microseconds #-}
+
+nanoseconds :: Int64 -> Femtoseconds
+nanoseconds s = mapFemtoseconds (* 1000) (picoseconds s)
+{-# INLINE nanoseconds #-}
+
+picoseconds :: Int64 -> Femtoseconds
+picoseconds s = mapFemtoseconds (* 1000) (femtoseconds s)
+{-# INLINE picoseconds #-}
+
+femtoseconds :: Int64 -> Femtoseconds
+femtoseconds = Femtoseconds
+{-# INLINE femtoseconds #-}

--- a/elastic-buffer-sim/src/Bittide/Topology.hs
+++ b/elastic-buffer-sim/src/Bittide/Topology.hs
@@ -37,9 +37,9 @@ import Prelude qualified as P
 import Data.Array qualified as A
 import Data.ByteString.Lazy qualified as BSL
 
-import Bittide.ClockControl
 import Bittide.Topology.Graph
 import Bittide.Topology.TH
+import Bittide.Topology.TH.Domain (defBittideClockConfig)
 
 -- | This samples @n@ steps, taking every @k@th datum, and plots clock speeds
 -- and elastic buffer occupancy
@@ -83,7 +83,7 @@ plotTree23 = $(plotEbsAPI ("tree23", tree 2 3))
 -- @script.py@
 dumpCsv :: Int -> Int -> IO ()
 dumpCsv m k = do
-  offs <- genOffsN n
+  offs <- genOffsN defBittideClockConfig n
   createDirectoryIfMissing True "_build"
   forM_ [0..n] $ \i ->
     let eb = g A.! i in
@@ -93,7 +93,7 @@ dumpCsv m k = do
   let dats =
           $(onN 6) ($(encodeDats 6) m)
         $ takeEveryN k
-        $ $(simNodesFromGraph defClockConfig (complete 6)) offs
+        $ $(simNodesFromGraph defBittideClockConfig (complete 6)) offs
   zipWithM_ (\dat i ->
     BSL.appendFile ("_build/clocks" <> show i <> ".csv") dat) dats [(0::Int)..]
  where

--- a/elastic-buffer-sim/src/Bittide/Topology/TH/Domain.hs
+++ b/elastic-buffer-sim/src/Bittide/Topology/TH/Domain.hs
@@ -8,6 +8,13 @@ module Bittide.Topology.TH.Domain where
 
 import Clash.Explicit.Prelude
 
--- 200kHz instead of 200MHz; otherwise the periods are so small that deviations
--- can't be expressed as 'Natural's
-createDomain vSystem{vName="Bittide", vPeriod=hzToPeriod 200e3}
+import Bittide.ClockControl (ClockControlConfig, defClockConfig)
+
+createDomain vSystem{
+    vName="Bittide"
+  , vPeriod=hzToPeriod 200e6
+  , vResetKind=Synchronous
+  }
+
+defBittideClockConfig :: ClockControlConfig Bittide 12
+defBittideClockConfig = defClockConfig

--- a/elastic-buffer-sim/tests/Tests/Bittide/Simulate.hs
+++ b/elastic-buffer-sim/tests/Tests/Bittide/Simulate.hs
@@ -2,6 +2,7 @@
 --
 -- SPDX-License-Identifier: Apache-2.0
 
+{-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
@@ -15,7 +16,6 @@ import Test.Tasty.HUnit
 import Bittide.ClockControl
 import Bittide.ClockControl.Strategies
 import Bittide.Simulate
-import Bittide.Simulate.Ppm
 
 createDomain vXilinxSystem{vPeriod=hzToPeriod 200e6, vName="Fast"}
 createDomain vXilinxSystem{vPeriod=hzToPeriod 20e6, vName="Slow"}
@@ -31,26 +31,15 @@ tests = testGroup "Simulate"
     ]
   ]
 
-fastPeriod :: PeriodPs
-fastPeriod = hzToPeriod 200e6
-
-clockConfig :: Ppm -> ClockControlConfig 7
-clockConfig clockUncertainty = ClockControlConfig
-  { cccPessimisticPeriod = speedUpPeriod clockUncertainty fastPeriod
-  , cccSettlePeriod      = fastPeriod * 200
-  , cccDynamicRange      = clockUncertainty * 2
-  , cccStepSize          = 10
-  , cccBufferSize        = d7 -- 2**7 ~ 128
-  }
-
 case_clockControlMaxBound :: Assertion
 case_clockControlMaxBound = do
   let
-    config = clockConfig (Ppm 100)
+    config = defClockConfig
     dataCounts = pure maxBound :> Nil
     changes =
       sampleN
-        (fromIntegral (cccPessimisticPeriod config))
+        -- +10_000 assumes callisto's pipeline less than 10_000 deep
+        (fromIntegral (cccPessimisticSettleCycles config + 10_000))
         (callistoClockControl @_ @_ @Fast clockGen resetGen enableGen config dataCounts)
 
   assertBool
@@ -60,11 +49,12 @@ case_clockControlMaxBound = do
 case_clockControlMinBound :: Assertion
 case_clockControlMinBound = do
   let
-    config = clockConfig (Ppm 100)
+    config = defClockConfig
     dataCounts = pure 0 :> Nil
     changes =
       sampleN
-        (fromIntegral (cccPessimisticPeriod config))
+        -- +100 assumes callisto's pipeline less than 100 deep
+        (fromIntegral (cccPessimisticSettleCycles config + 100))
         (callistoClockControl @_ @_ @Fast clockGen resetGen enableGen config dataCounts)
 
   assertBool


### PR DESCRIPTION
Clash stores clock periods in picoseconds by default. A recent Clash PR allows dynamic clocks to use femtoseconds instead:

https://github.com/clash-lang/clash-compiler/pull/2353

With that in place, this commit has been able to remove the workarounds we had to apply to simulate something meaningful. As a happy coincidence, this fixes a bug where plots would display the wrong (or at least, very counterintuitive) timescale.

Interestingly enough, Callisto doesn't really seem to care at which frequency it is running -- even though its parameters depend on specific clock frequencies. De-hardcoding them is left as future work.

---------------------

A few plots with the new code (which look identical as before, except for the axis):

* complete3:
  * [clockscomplete3.pdf](https://github.com/bittide/bittide-hardware/files/9998191/clockscomplete3.pdf)
  * [elasticbufferscomplete3.pdf](https://github.com/bittide/bittide-hardware/files/9998192/elasticbufferscomplete3.pdf)
* complete6
  * [clockscomplete6.pdf](https://github.com/bittide/bittide-hardware/files/9998174/clockscomplete6.pdf)
  * [elasticbufferscomplete6.pdf](https://github.com/bittide/bittide-hardware/files/9998175/elasticbufferscomplete6.pdf)
* hypercube3
  * [clockshypercube3.pdf](https://github.com/bittide/bittide-hardware/files/9998215/clockshypercube3.pdf)
  * [elasticbuffershypercube3.pdf](https://github.com/bittide/bittide-hardware/files/9998216/elasticbuffershypercube3.pdf)