### PR TITLE
Add a controlled version of the xilinxElasticBuffer

### DIFF
--- a/bittide-instances/bin/Shake.hs
+++ b/bittide-instances/bin/Shake.hs
@@ -24,6 +24,7 @@ import Clash.Shake.Vivado
 import qualified Bittide.Instances.Calendar as Calendar
 import qualified Bittide.Instances.ClockControl as ClockControl
 import qualified Bittide.Instances.Synchronizer as Synchronizer
+import qualified Bittide.Instances.ElasticBuffer as ElasticBuffer
 import qualified Clash.Util.Interpolate as I
 import qualified Language.Haskell.TH as TH
 import qualified System.Directory as Directory
@@ -67,6 +68,7 @@ targets =
   [ 'Calendar.switchCalendar1k
   , 'Calendar.switchCalendar1kReducedPins
   , 'ClockControl.callisto3
+  , 'ElasticBuffer.elasticBuffer5
   , 'Synchronizer.tripleFlipFlopSynchronizer
   ]
 

--- a/bittide-instances/bittide-instances.cabal
+++ b/bittide-instances/bittide-instances.cabal
@@ -70,6 +70,7 @@ common common-options
     clash-lib,
     clash-prelude,
     clash-protocols,
+    elastic-buffer-sim,
     containers,
     elastic-buffer-sim,
     filepath,
@@ -93,8 +94,10 @@ library
     Bittide.Instances.Calendar
     Bittide.Instances.ClockControl
     Bittide.Instances.Domains
+    Bittide.Instances.ElasticBuffer
     Bittide.Instances.Hacks
     Bittide.Instances.Synchronizer
+
     Clash.Shake.Extra
     Clash.Shake.Vivado
     Development.Shake.Extra

--- a/bittide-instances/src/Bittide/Instances/ElasticBuffer.hs
+++ b/bittide-instances/src/Bittide/Instances/ElasticBuffer.hs
@@ -1,0 +1,27 @@
+-- SPDX-FileCopyrightText: 2022 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Bittide.Instances.ElasticBuffer where
+
+import Clash.Prelude
+import Clash.Annotations.TH
+
+import Bittide.ElasticBuffer
+
+createDomain vXilinxSystem{vPeriod=hzToPeriod 201e6, vName="Fast"}
+createDomain vXilinxSystem{vPeriod=hzToPeriod 199e6, vName="Slow"}
+
+elasticBuffer5 ::
+  "clkReadFast" ::: Clock Fast ->
+  "clkWriteSlow" :::Clock Slow ->
+  "resetRead" ::: Reset Fast ->
+  ( "dataCount" ::: Signal Fast (Unsigned 5)
+  , "underflow" ::: Signal Fast Underflow
+  , "overrflow" ::: Signal Fast Overflow
+  , "ebMode" ::: Signal Fast EbMode
+  )
+elasticBuffer5 = resettableXilinxElasticBuffer
+
+makeTopEntity 'elasticBuffer5

--- a/bittide/bittide.cabal
+++ b/bittide/bittide.cabal
@@ -99,6 +99,7 @@ library
     Bittide.ClockControl.Callisto
     Bittide.ClockControl.Callisto.Util
     Bittide.DoubleBufferedRam
+    Bittide.ElasticBuffer
     Bittide.Link
     Bittide.Node
     Bittide.ProcessingElement
@@ -123,6 +124,7 @@ test-suite unittests
   other-modules:
     Tests.Calendar
     Tests.DoubleBufferedRam
+    Tests.ElasticBuffer
     Tests.Haxioms
     Tests.Link
     Tests.ScatterGather
@@ -135,4 +137,5 @@ test-suite unittests
     hedgehog >= 1.0 && < 1.1,
     tasty >= 1.4 && < 1.5,
     tasty-hedgehog >= 1.2 && < 1.3,
+    tasty-hunit,
     constraints >= 0.13.3 && < 0.15

--- a/bittide/src/Bittide/ClockControl.hs
+++ b/bittide/src/Bittide/ClockControl.hs
@@ -21,6 +21,7 @@ where
 
 import Clash.Explicit.Prelude
 import Clash.Signal.Internal (Femtoseconds(..))
+import Clash.Cores.Xilinx.DcFifo (DataCount)
 import Data.Aeson (ToJSON(toJSON))
 import Data.Proxy (Proxy(..))
 import GHC.Stack (HasCallStack)
@@ -30,7 +31,6 @@ import Bittide.Arithmetic.Time (microseconds)
 
 import Data.Csv
 
-type DataCount n = Unsigned n
 type SettlePeriod = Femtoseconds
 
 -- | Configuration passed to 'clockControl'

--- a/bittide/src/Bittide/ElasticBuffer.hs
+++ b/bittide/src/Bittide/ElasticBuffer.hs
@@ -1,0 +1,144 @@
+-- SPDX-FileCopyrightText: 2022 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+{-# LANGUAGE NamedFieldPuns #-}
+
+module Bittide.ElasticBuffer where
+
+import Clash.Prelude
+import Clash.Cores.Xilinx.DcFifo
+import GHC.Stack
+
+import Bittide.ClockControl (targetDataCount)
+
+import qualified Clash.Explicit.Prelude as E
+import qualified Clash.Cores.Extra as CE
+
+
+data EbMode
+  -- | Disable write, enable read
+  = Drain
+  -- | Enable write, disable read
+  | Fill
+  -- | Enable write, enable read
+  | Pass
+ deriving (Generic, NFDataX, Eq, Show)
+
+type Underflow = Bool
+type Overflow = Bool
+
+ebModeToReadWrite :: EbMode -> (Bool, Bool)
+ebModeToReadWrite = \case
+  Fill  -> (False, True)
+  Drain -> (True, False)
+  Pass  -> (True, True)
+
+-- | Create a sticky version of a boolean signal.
+sticky ::
+  KnownDomain dom =>
+  Clock dom ->
+  Reset dom ->
+  Signal dom Bool ->
+  Signal dom Bool
+sticky clk rst a = stickyA
+ where
+  stickyA = E.register clk rst enableGen False (stickyA .||. a)
+
+-- | An elastic buffer backed by a Xilinx FIFO. It exposes all its control and
+-- monitor signals in its read domain.
+xilinxElasticBuffer ::
+  forall n readDom writeDom.
+  ( HasCallStack
+  , KnownDomain readDom
+  , KnownDomain writeDom
+  , KnownNat n
+  , 4 <= n, n <= 17
+  ) =>
+  Clock readDom ->
+  Clock writeDom ->
+  -- | Resetting resets the 'Underflow' and 'Overflow' signals, but not the 'DataCount'
+  -- ones. Make sure to hold the reset at least 3 cycles in both clock domains.
+  Reset readDom ->
+  Signal readDom EbMode ->
+  ( Signal readDom (DataCount n)
+
+  -- Indicates whether the FIFO under or overflowed. This signal is sticky: it
+  -- will only deassert upon reset.
+  , Signal readDom Underflow
+  , Signal writeDom Overflow
+  )
+xilinxElasticBuffer clkRead clkWrite rstRead ebMode =
+  (readCount, isUnderflowSticky, isOverflowSticky)
+ where
+  rstWrite = unsafeFromHighPolarity rstWriteBool
+  rstWriteBool =
+    CE.tripleFlipFlopSynchronizer clkRead clkWrite False (unsafeToHighPolarity rstRead)
+
+  FifoOut{readCount, isUnderflow, isOverflow} = dcFifo
+    (defConfig @n){dcOverflow=True, dcUnderflow=True}
+    clkWrite noResetWrite clkRead noResetRead
+    writeData readEnable
+
+
+  -- We make sure to "stickify" the signals in their original domain. The
+  -- synchronizer might lose samples depending on clock configurations.
+  isUnderflowSticky = sticky clkRead rstRead isUnderflow
+  isOverflowSticky = sticky clkWrite rstWrite isOverflow
+
+  -- We don't reset the Xilix FIFO: its reset documentation is self-contradictory
+  -- and mentions situations where the FIFO can end up in an unrecoverable state.
+  noResetWrite = unsafeFromHighPolarity (pure False)
+  noResetRead = unsafeFromHighPolarity (pure False)
+
+  (readEnable, writeEnable) = unbundle (ebModeToReadWrite <$> ebMode)
+
+  writeEnableSynced = CE.tripleFlipFlopSynchronizer clkRead clkWrite False writeEnable
+
+  -- For the time being, we're only interested in data counts, so we feed the
+  -- FIFO with static data when writing (@0@).
+  writeData = mux writeEnableSynced (pure (Just (0 :: Unsigned 8))) (pure Nothing)
+
+
+resettableXilinxElasticBuffer ::
+  forall readDom writeDom n.
+  ( KnownDomain writeDom
+  , KnownDomain readDom
+  , KnownNat n
+  , 4 <= n, n <= 17) =>
+  Clock readDom ->
+  Clock writeDom ->
+  -- | Resetting resets the 'Underflow' and 'Overflow' signals, but not the 'DataCount'
+  -- ones. Make sure to hold the reset at least 3 cycles in both clock domains.
+  Reset readDom ->
+  ( Signal readDom (DataCount n)
+  , Signal readDom Underflow
+  , Signal readDom Overflow
+  , Signal readDom EbMode
+  )
+resettableXilinxElasticBuffer clkRead clkWrite rstRead =
+  (dataCount, under, over1, ebMode)
+ where
+  (dataCount, under, over) = xilinxElasticBuffer @n clkRead clkWrite fifoReset ebMode
+  fifoReset = unsafeFromHighPolarity $ not <$> stable
+  over1 = CE.tripleFlipFlopSynchronizer clkWrite clkRead False over
+
+  controllerReset = unsafeFromHighPolarity (unsafeToHighPolarity rstRead .||. under .||. over1)
+
+  (ebMode, stable) = unbundle $
+    withClockResetEnable clkRead controllerReset enableGen $
+     mealy goControl Drain dataCount
+
+  goControl :: EbMode -> DataCount n -> (EbMode, (EbMode, Bool))
+  goControl state0 datacount = (state1, (state0, stable0))
+   where
+    state1 =
+      case state0 of
+        Drain
+          | datacount == 0 -> Fill
+          | otherwise -> Drain
+        Fill
+          | datacount < targetDataCount -> Fill
+          | otherwise -> Pass
+        Pass -> state0
+
+    stable0 = state0 == Pass

--- a/bittide/tests/Tests/ElasticBuffer.hs
+++ b/bittide/tests/Tests/ElasticBuffer.hs
@@ -1,0 +1,134 @@
+-- SPDX-FileCopyrightText: 2022 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Tests.ElasticBuffer where
+
+import Clash.Prelude
+
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import Bittide.ElasticBuffer
+
+import qualified Data.List as L
+
+createDomain vXilinxSystem{vPeriod=hzToPeriod 200e6, vName="Fast"}
+createDomain vXilinxSystem{vPeriod=hzToPeriod 20e6, vName="Slow"}
+
+ebGroup :: TestTree
+ebGroup = testGroup "ElasticBuffer group"
+  [ testGroup "xilinxElasticBuffer"
+    [ testCase "case_xilinxElasticBufferMaxBound" case_xilinxElasticBufferMaxBound
+    , testCase "case_xilinxElasticBufferMinBound" case_xilinxElasticBufferMinBound
+    , testCase "case_xilinxElasticBufferEq" case_xilinxElasticBufferEq
+    ]
+  , testGroup "resettableXilinxElasticBuffer"
+    [ testCase "case_resettableXilinxElasticBufferEq" case_resettableXilinxElasticBufferEq
+    , testCase "case_resettableXilinxElasticBufferMaxBound" case_resettableXilinxElasticBufferMaxBound
+    , testCase "case_resettableXilinxElasticBufferMinBound" case_resettableXilinxElasticBufferMinBound
+    ]
+  ]
+
+-- | When the xilinxElasticBuffer is written to more quickly than it is being read from,
+-- its data count should overflow.
+case_xilinxElasticBufferMaxBound :: Assertion
+case_xilinxElasticBufferMaxBound = do
+  let
+    ebMode = fromList $ L.replicate 3 Fill <> L.repeat Pass
+    underflows =
+      sampleN 256
+        ((\(_,under, _)-> under) (xilinxElasticBuffer @6 (clockGen @Slow) (clockGen @Fast) resetGen ebMode))
+    overflows =
+      sampleN 256
+        ((\(_,_, over)-> over) (xilinxElasticBuffer @6 (clockGen @Slow) (clockGen @Fast) resetGen ebMode))
+
+  assertBool "elastic buffer should overflow" (or overflows)
+  assertBool "elastic buffer should not underflow" (not $ or underflows)
+
+-- | When the xilinxElasticBuffer is read from more quickly than it is being written to,
+-- its data count should underflow.
+case_xilinxElasticBufferMinBound :: Assertion
+case_xilinxElasticBufferMinBound = do
+  let
+    ebMode = fromList $ L.replicate 32 Fill <> L.repeat Pass
+    underflows =
+      sampleN 256
+        ((\(_,under, _)-> under) (xilinxElasticBuffer @6 (clockGen @Fast) (clockGen @Slow) resetGen ebMode))
+    overflows =
+      sampleN 256
+        ((\(_,_, over)-> over) (xilinxElasticBuffer @6 (clockGen @Fast) (clockGen @Slow) resetGen ebMode))
+  assertBool "elastic buffer should underflow" (or underflows)
+  assertBool "elastic buffer should not overflow" (not $ or overflows)
+
+-- | When the xilinxElasticBuffer is written to as quickly to as it is read from, it should
+-- neither overflow nor underflow.
+case_xilinxElasticBufferEq :: Assertion
+case_xilinxElasticBufferEq = do
+  let
+    ebMode = fromList $ L.replicate 32 Fill <> L.repeat Pass
+    underflows =
+      sampleN 256
+        ((\(_,under, _)-> under) (xilinxElasticBuffer @5 (clockGen @Slow) (clockGen @Slow) resetGen ebMode))
+    overflows =
+      sampleN 256
+        ((\(_,_, over)-> over) (xilinxElasticBuffer @5 (clockGen @Slow) (clockGen @Slow) resetGen ebMode))
+  assertBool "elastic buffer should not underflow" (not $ or underflows)
+  assertBool "elastic buffer should not overflow" (not $ or overflows)
+
+-- | When the resettableXilinxElasticBuffer is written to as quickly as it is read from, it eventually
+--  stabalises.
+case_resettableXilinxElasticBufferEq :: Assertion
+case_resettableXilinxElasticBufferEq = do
+  let
+    (dataCounts, underflows, overflows, ebModes) = L.unzip4 .
+      L.dropWhile (\(_, _, _, eb)-> eb == Drain || eb == Fill) $ sampleN 256
+        (bundle (resettableXilinxElasticBuffer @_ @_ @5 (clockGen @Slow) (clockGen @Slow) resetGen))
+    dataCountBounds = L.all ((< 3) . abs . subtract (shiftR maxBound 1)) dataCounts
+
+  assertBool "elastic buffer should not overflow after stabalising" (not $ or overflows)
+  assertBool "elastic buffer should not underflow after stabalising" (not $ or underflows)
+  assertBool "elastic buffer should be in Pass mode after stabalising" (L.all (== Pass) ebModes)
+  assertBool "elastic buffer datacount should be half full (margin 3 elements) after stabalising" dataCountBounds
+
+
+-- | When the xilinxElasticBuffer is written to more quickly than it is being read from,
+-- its data count should overflow. Upon an overflow, the fifo is Drained and then filled
+-- to half full, after which the cycle repeats.
+case_resettableXilinxElasticBufferMaxBound :: Assertion
+case_resettableXilinxElasticBufferMaxBound = do
+  let
+    (_, underflows, overflows, _) = L.unzip4 .
+      L.filter (\(_, _, _, eb)-> eb == Pass) $ sampleN 256
+        (bundle (resettableXilinxElasticBuffer @_ @_ @5 (clockGen @Slow) (clockGen @Fast) resetGen))
+
+  -- After the fifo overflows, it should Drain the buffer, then fill it to half full and
+  -- reset.
+  assertBool "elastic buffer should reset after an overflow" ([True,False] `L.isInfixOf` overflows)
+  -- Since the overflows list is filtered on eb==Pass, the Drain and Fill operations are
+  -- left out. Therefore, the fifo should not return the overflow signal twice in a row.
+  assertBool "elastic buffer should not overflow twice in a row" (not $ L.isInfixOf [True,True] overflows)
+  assertBool "elastic buffer should not underflow when written to faster than read from" (not $ or underflows)
+
+
+-- | When the xilinxElasticBuffer is read from more quickly than it is being written to,
+-- its data count should overflow. Upon an overflow, the fifo is Drained and then filled
+-- to half full, after which the cycle repeats.
+case_resettableXilinxElasticBufferMinBound :: Assertion
+case_resettableXilinxElasticBufferMinBound = do
+  let
+    (_, underflows, overflows, _) = L.unzip4 .
+      L.filter (\(_, _, _, eb)-> eb == Pass) $ sampleN 512
+        (bundle (resettableXilinxElasticBuffer @_ @_ @5 (clockGen @Fast) (clockGen @Slow) resetGen))
+
+  -- After the fifo underflows, it should Drain for 1 cycle and then fill it to half
+  -- full and reset.
+  assertBool "elastic buffer should reset after an underflow" ([True,False] `L.isInfixOf` underflows)
+  -- Since the underflows list is filtered on eb==Pass, the Drain and Fill operations are
+  -- left out. Therefore, the fifo should not return the underflow signal twice in a row.
+  assertBool "elastic buffer should not underflow twice in a row" (not $ L.isInfixOf [True,True] underflows)
+  assertBool "elastic buffer should not overflow when read from faster than written to" (not $ or overflows)

--- a/bittide/tests/UnitTests.hs
+++ b/bittide/tests/UnitTests.hs
@@ -11,6 +11,7 @@ import Test.Tasty.Hedgehog
 
 import Tests.Calendar
 import Tests.DoubleBufferedRam
+import Tests.ElasticBuffer
 import Tests.Haxioms
 import Tests.Link
 import Tests.ScatterGather
@@ -20,6 +21,7 @@ import Tests.Wishbone
 tests :: TestTree
 tests = testGroup "Unittests"
   [ calGroup
+  , ebGroup
   , haxiomsGroup
   , linkGroup
   , memMapGroup

--- a/elastic-buffer-sim/tests/Tests/Bittide/Simulate.hs
+++ b/elastic-buffer-sim/tests/Tests/Bittide/Simulate.hs
@@ -71,15 +71,15 @@ case_elasticBufferMaxBound = do
   assertBool "elastic buffer should reach its near maximum (read domain)" ((maxBound-1) `elem` dataCounts)
   assertBool "elastic buffer should not reach its minimum" (0 `notElem` dataCounts)
 
--- | When the elasticBuffer is written to more quickly than it is being read from,
--- its data count should reach 'maxBound'.
+-- | When the elasticBuffer is read from more quickly than it is being written to,
+-- its data count should reach 'minBound'.
 case_elasticBufferMinBound :: Assertion
 case_elasticBufferMinBound = do
   let dataCounts = sampleN 1024 (elasticBuffer @5 Saturate (clockGen @Fast) (clockGen @Slow))
   assertBool "elastic buffer should reach its minimum" (0 `elem` dataCounts)
   assertBool "elastic buffer should not reach its maximum" (maxBound `notElem` dataCounts)
 
--- | When the elasticBuffer written to as quikly to as it is read from, it should
+-- | When the elasticBuffer is written to as quickly to as it is read from, it should
 -- reach neiher its maxBound nor minBound.
 case_elasticBufferEq :: Assertion
 case_elasticBufferEq = do


### PR DESCRIPTION
This PR is an extention of Martijn's addition of the `xilinxElasticBuffer`, for which I added tests. It also adds a controller for this buffer which gives it the following behaviour:
1. Drain FIFO
2. Fill to half full
3. Wait for under/overflow (or external trigger)
4. Goto 1

The `controlledFifo` instance implements this controller, and works as intended. 

To check if this instance passes timing, a topEntity was added to `bittide-instances`. It currently does not pass timing due to domain crosing using a `dualFlipFlopSynchronizer`.