### PR TITLE
Add elastic buffer stability checker

### DIFF
--- a/bittide-instances/bin/Shake.hs
+++ b/bittide-instances/bin/Shake.hs
@@ -23,8 +23,9 @@ import Clash.Shake.Vivado
 
 import qualified Bittide.Instances.Calendar as Calendar
 import qualified Bittide.Instances.ClockControl as ClockControl
-import qualified Bittide.Instances.Synchronizer as Synchronizer
 import qualified Bittide.Instances.ElasticBuffer as ElasticBuffer
+import qualified Bittide.Instances.StabilityChecker as StabilityChecker
+import qualified Bittide.Instances.Synchronizer as Synchronizer
 import qualified Clash.Util.Interpolate as I
 import qualified Language.Haskell.TH as TH
 import qualified System.Directory as Directory
@@ -69,6 +70,7 @@ targets =
   , 'Calendar.switchCalendar1kReducedPins
   , 'ClockControl.callisto3
   , 'ElasticBuffer.elasticBuffer5
+  , 'StabilityChecker.stabilityChecker_3_1M
   , 'Synchronizer.tripleFlipFlopSynchronizer
   ]
 

--- a/bittide-instances/bittide-instances.cabal
+++ b/bittide-instances/bittide-instances.cabal
@@ -96,6 +96,7 @@ library
     Bittide.Instances.Domains
     Bittide.Instances.ElasticBuffer
     Bittide.Instances.Hacks
+    Bittide.Instances.StabilityChecker
     Bittide.Instances.Synchronizer
 
     Clash.Shake.Extra

--- a/bittide-instances/src/Bittide/Instances/StabilityChecker.hs
+++ b/bittide-instances/src/Bittide/Instances/StabilityChecker.hs
@@ -1,0 +1,22 @@
+-- SPDX-FileCopyrightText: 2022 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE NumericUnderscores #-}
+
+module Bittide.Instances.StabilityChecker where
+
+import Clash.Prelude
+
+import Bittide.ClockControl.StabilityChecker
+import Bittide.Instances.Domains (Basic200)
+
+stabilityChecker_3_1M ::
+  Clock Basic200 ->
+  Reset Basic200 ->
+  Signal Basic200 (Unsigned 16) ->
+  Signal Basic200 Bool
+stabilityChecker_3_1M clk rst = withClockResetEnable clk rst enableGen
+  stabilityChecker strategy
+ where
+  strategy = stabilityChecker d3 (SNat @1_000_000)

--- a/bittide/bittide.cabal
+++ b/bittide/bittide.cabal
@@ -98,6 +98,7 @@ library
     Bittide.ClockControl
     Bittide.ClockControl.Callisto
     Bittide.ClockControl.Callisto.Util
+    Bittide.ClockControl.StabilityChecker
     Bittide.DoubleBufferedRam
     Bittide.ElasticBuffer
     Bittide.Link
@@ -108,6 +109,7 @@ library
     Bittide.Switch
     Bittide.Wishbone
     Clash.Cores.Extra
+    Clash.Sized.Extra
     Data.Constraint.Nat.Extra
 
 executable clash
@@ -129,6 +131,7 @@ test-suite unittests
     Tests.Link
     Tests.ScatterGather
     Tests.Shared
+    Tests.StabilityChecker
     Tests.Switch
     Tests.Wishbone
   build-depends:

--- a/bittide/src/Bittide/ClockControl/Callisto.hs
+++ b/bittide/src/Bittide/ClockControl/Callisto.hs
@@ -15,6 +15,7 @@ import Data.Constraint.Nat.Extra (euclid3)
 
 import Bittide.ClockControl
 import Bittide.ClockControl.Callisto.Util
+import Clash.Sized.Extra
 
 import qualified Clash.Cores.Xilinx.Floating as F
 import qualified Clash.Signal.Delayed as D

--- a/bittide/src/Bittide/ClockControl/Callisto/Util.hs
+++ b/bittide/src/Bittide/ClockControl/Callisto/Util.hs
@@ -7,6 +7,8 @@ module Bittide.ClockControl.Callisto.Util where
 
 import Clash.Prelude
 
+import Clash.Sized.Extra
+
 -- | A counter that starts at a given value, counts down, and if it reaches
 -- zero wraps around to the initial value.
 wrappingCounter ::
@@ -44,7 +46,3 @@ sumTo32 =
     extend @_ @_ @(32 - (m+n))
   . unsignedToSigned
   . safeSum
-
--- | Safe 'Unsigned' to 'Signed' conversion
-unsignedToSigned :: forall n. KnownNat n => Unsigned n -> Signed (n + 1)
-unsignedToSigned n = bitCoerce (zeroExtend n)

--- a/bittide/src/Bittide/ClockControl/StabilityChecker.hs
+++ b/bittide/src/Bittide/ClockControl/StabilityChecker.hs
@@ -1,0 +1,42 @@
+-- SPDX-FileCopyrightText: 2022 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+{-# LANGUAGE GADTs #-}
+module Bittide.ClockControl.StabilityChecker where
+
+import Clash.Prelude
+
+import Bittide.ClockControl (targetDataCount)
+import Clash.Sized.Extra
+
+-- | Checks whether the @Signal@ of buffer occupancies from an elastic buffer is stable.
+-- The @Signal@ is considered stable if it stays within a @margin@ of the target buffer
+-- occupancy for @cyclesStable@ number of cycles. The next target is set to the current
+-- buffer occupancy when the current buffer occupancy is not within margin of
+-- the target.
+stabilityChecker ::
+  forall dom margin cyclesStable n .
+  (HiddenClockResetEnable dom, 1 <= cyclesStable, KnownNat n) =>
+  -- | Maximum number of elements the incoming buffer occupancy is allowed to deviate
+  -- from the current @target@ for it to be considered "stable".
+  SNat margin ->
+  -- | Minimum number of clock cycles the incoming buffer occupancy must remain within the
+  -- @margin@ for it to be considered "stable".
+  SNat cyclesStable ->
+  -- | Incoming buffer occupancy.
+  Signal dom (Unsigned n) ->
+  -- | Stability indicator.
+  Signal dom Bool
+stabilityChecker SNat SNat = mealy go (0, targetDataCount)
+ where
+  go (cnt, target) input = (newState, isStable)
+   where
+    withinMargin =
+      abs (unsignedToSigned target `sub` unsignedToSigned input) <= (natToNum @margin)
+
+    newState :: (Index (cyclesStable + 1), Unsigned n)
+    newState
+      | withinMargin = (satSucc SatBound cnt, target)
+      | otherwise    = (0, input)
+
+    isStable = withinMargin && cnt == maxBound

--- a/bittide/src/Clash/Sized/Extra.hs
+++ b/bittide/src/Clash/Sized/Extra.hs
@@ -1,0 +1,11 @@
+-- SPDX-FileCopyrightText: 2022 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+
+module Clash.Sized.Extra where
+
+import Clash.Prelude
+
+-- | Safe 'Unsigned' to 'Signed' conversion
+unsignedToSigned :: forall n. KnownNat n => Unsigned n -> Signed (n + 1)
+unsignedToSigned n = bitCoerce (zeroExtend n)

--- a/bittide/tests/Tests/Shared.hs
+++ b/bittide/tests/Tests/Shared.hs
@@ -19,11 +19,13 @@ import Hedgehog
 import Protocols (toSignals)
 import Protocols.Wishbone as Wb
 import Protocols.Wishbone.Standard.Hedgehog (validatorCircuit)
+import Numeric.Natural
 
 import Bittide.Calendar
 import Bittide.SharedTypes (Bytes)
 
 import qualified Data.List as L
+import qualified GHC.TypeNats as TypeNats
 import qualified Hedgehog.Range as Range
 
 
@@ -32,6 +34,16 @@ data IsInBounds a b c where
   NotInBounds :: IsInBounds a b c
 
 deriving instance Show (IsInBounds a b c)
+
+data SomeSNat where
+  SomeSNat :: forall m. SNat m -> SomeSNat
+
+-- Like 'TypeNats.someNatVal', but generates 'SomeSNat'
+someSNat :: Natural -> SomeSNat
+someSNat n =
+  case TypeNats.someNatVal n of
+    SomeNat p ->
+      SomeSNat (snatProxy p)
 
 -- | Returns 'InBounds' when a <= b <= c, otherwise returns 'NotInBounds'.
 isInBounds :: SNat a -> SNat b -> SNat c -> IsInBounds a b c

--- a/bittide/tests/Tests/StabilityChecker.hs
+++ b/bittide/tests/Tests/StabilityChecker.hs
@@ -1,0 +1,75 @@
+-- SPDX-FileCopyrightText: 2022 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+
+{-# LANGUAGE OverloadedStrings #-}
+
+module Tests.StabilityChecker where
+
+
+import Clash.Prelude hiding ((^), someNatVal)
+import Prelude ((^))
+
+import Clash.Hedgehog.Sized.Unsigned (genUnsigned)
+import Hedgehog
+import Test.Tasty
+import Test.Tasty.Hedgehog
+
+import Bittide.ClockControl
+import Bittide.ClockControl.StabilityChecker
+import Tests.Shared
+
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
+
+stabilityGroup :: TestTree
+stabilityGroup = testGroup "StabilityChecker"
+  [ testPropertyNamed "stabilityCheckerTest behaves the same as its golden reference"
+    "stabilityCheckerTest" stabilityCheckerTest]
+
+stabilityCheckerTest :: Property
+stabilityCheckerTest = property $ do
+  dataCountBits <- forAll $ Gen.integral $ Range.linear 2 128
+  cyclesStable  <- forAll $ Gen.integral $ Range.linear 1 128
+  margin        <- forAll $ Gen.integral $ Range.linear 0 (2^dataCountBits - 1)
+
+  -- Convert generated variables to type level ones
+  case ( someSNat dataCountBits
+       , someSNat (cyclesStable - 1)
+       , someSNat margin
+       ) of
+    (SomeSNat sDataCountBits, SomeSNat sCyclesStable, SomeSNat sMargin) ->
+      prop sDataCountBits (succSNat sCyclesStable) sMargin
+ where
+  -- Property locked to arbitrary type level values
+  prop ::
+    forall cyclesStable dataCountBits margin.
+    (1 <= cyclesStable) =>
+    SNat dataCountBits ->
+    SNat cyclesStable ->
+    SNat margin ->
+    PropertyT IO ()
+  prop SNat sCyclesStable@SNat sMargin@SNat = do
+    simLength <- forAll $ Gen.integral (Range.linear 4 1024)
+    dataCounts <- forAll $ Gen.list (Range.singleton simLength)
+      (genUnsigned @_ @dataCountBits Range.constantBounded)
+    let
+      topEntity = wcre $ stabilityChecker @System sMargin sCyclesStable
+      simOut = simulateN simLength topEntity dataCounts
+
+    simOut === golden (snatToNum sMargin) (snatToNum sCyclesStable) dataCounts
+
+  -- 'stabilityChecker' reference design
+  golden :: forall n . KnownNat n => Integer -> Integer -> [Unsigned n] -> [Bool]
+  golden margin cyclesStable dataCounts =
+    f
+    (0, fromIntegral (targetDataCount :: Unsigned n))
+    (fmap fromIntegral dataCounts)
+   where
+    f _ [] = []
+    f (!cnt, target) (x:xs)
+      | inMargin && cnt >= cyclesStable = True  : f (cnt + 1, target) xs
+      | inMargin                        = False : f (cnt + 1, target) xs
+      | otherwise                       = False : f (0, x) xs
+     where
+      inMargin = abs (x - target) <= margin

--- a/bittide/tests/UnitTests.hs
+++ b/bittide/tests/UnitTests.hs
@@ -15,6 +15,7 @@ import Tests.ElasticBuffer
 import Tests.Haxioms
 import Tests.Link
 import Tests.ScatterGather
+import Tests.StabilityChecker
 import Tests.Switch
 import Tests.Wishbone
 
@@ -27,6 +28,7 @@ tests = testGroup "Unittests"
   , memMapGroup
   , ramGroup
   , sgGroup
+  , stabilityGroup
   , switchGroup
   ]
 


### PR DESCRIPTION
An initial implementation for a component that observes the buffer occupancy of an elastic buffer and determines if it is stable. (see #126)

I added the possibility to create multiple strategies to determine whether the buffer occupancies have converged to an equilibrium. This enables us to try multiple different approaches.

TODO:
- [x] ~~Add more strategies?~~
- [x] Add tests that verify that the available strategies work as intended.