### PR TITLE
Add Xilinx specific 'tripleFlipFlopSynchronizer'

### DIFF
--- a/bittide-instances/bin/Shake.hs
+++ b/bittide-instances/bin/Shake.hs
@@ -23,6 +23,7 @@ import Clash.Shake.Vivado
 
 import qualified Bittide.Instances.Calendar as Calendar
 import qualified Bittide.Instances.ClockControl as ClockControl
+import qualified Bittide.Instances.Synchronizer as Synchronizer
 import qualified Clash.Util.Interpolate as I
 import qualified Language.Haskell.TH as TH
 import qualified System.Directory as Directory
@@ -66,6 +67,7 @@ targets =
   [ 'Calendar.switchCalendar1k
   , 'Calendar.switchCalendar1kReducedPins
   , 'ClockControl.callisto3
+  , 'Synchronizer.tripleFlipFlopSynchronizer
   ]
 
 shakeOpts :: FilePath -> ShakeOptions

--- a/bittide-instances/bittide-instances.cabal
+++ b/bittide-instances/bittide-instances.cabal
@@ -91,9 +91,10 @@ library
   hs-source-dirs: src
   exposed-modules:
     Bittide.Instances.Calendar
+    Bittide.Instances.ClockControl
     Bittide.Instances.Domains
     Bittide.Instances.Hacks
-    Bittide.Instances.ClockControl
+    Bittide.Instances.Synchronizer
     Clash.Shake.Extra
     Clash.Shake.Vivado
     Development.Shake.Extra

--- a/bittide-instances/src/Bittide/Instances/Domains.hs
+++ b/bittide-instances/src/Bittide/Instances/Domains.hs
@@ -8,3 +8,4 @@ module Bittide.Instances.Domains where
 import Clash.Explicit.Prelude
 
 createDomain vXilinxSystem{vName="Basic200", vPeriod=hzToPeriod 200e6}
+createDomain vXilinxSystem{vName="Basic199", vPeriod=hzToPeriod 199e6}

--- a/bittide-instances/src/Bittide/Instances/Synchronizer.hs
+++ b/bittide-instances/src/Bittide/Instances/Synchronizer.hs
@@ -1,0 +1,22 @@
+-- SPDX-FileCopyrightText: 2022 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+
+module Bittide.Instances.Synchronizer where
+
+import Clash.Explicit.Prelude
+
+import Bittide.Instances.Domains
+
+import qualified Clash.Cores.Extra as Cores
+import Clash.Annotations.TH (makeTopEntity)
+
+
+tripleFlipFlopSynchronizer ::
+  "clk1"   ::: Clock Basic200 ->
+  "clk2"   ::: Clock Basic199 ->
+  "source" ::: Signal Basic200 Bit ->
+  "target" ::: Signal Basic199 Bit
+tripleFlipFlopSynchronizer clk1 clk2 =
+  Cores.tripleFlipFlopSynchronizer @Basic200 @Basic199 @Bit clk1 clk2 0
+makeTopEntity 'tripleFlipFlopSynchronizer

--- a/bittide-instances/src/Clash/Shake/Vivado.hs
+++ b/bittide-instances/src/Clash/Shake/Vivado.hs
@@ -130,6 +130,18 @@ mkPlaceTcl outputDir = [__i|
     \# Pick up where synthesis left off
     open_checkpoint {#{outputDir </> "checkpoints" </> "post_synth.dcp"}}
 
+    \# See documentation of 'tripleFlipFlopSynchronizer'
+    \# TODO: Primitive should generate this
+    set from_pins [get_pins -quiet -filter {NAME =~ "dff_sync_a*_reg/C"}]
+    set to_pins   [get_pins -quiet -filter {NAME =~ "dff_sync_b*_reg/D"}]
+
+    if {[llength $from_pins]} {
+      if {[llength $to_pins]} {
+        set min_clock_period [get_property -min PERIOD [get_clocks]]
+        set_max_delay -datapath_only -from $from_pins -to $to_pins $min_clock_period
+      }
+    }
+
     \# Run optimization & placement
     opt_design
     place_design

--- a/bittide/bittide.cabal
+++ b/bittide/bittide.cabal
@@ -87,6 +87,7 @@ common common-options
     ghc-typelits-knownnat,
     ghc-typelits-natnormalise,
     random,
+    string-interpolate ^>= 0.3,
 library
   import: common-options
   hs-source-dirs: src
@@ -105,6 +106,7 @@ library
     Bittide.SharedTypes
     Bittide.Switch
     Bittide.Wishbone
+    Clash.Cores.Extra
     Data.Constraint.Nat.Extra
 
 executable clash

--- a/bittide/src/Clash/Cores/Extra.hs
+++ b/bittide/src/Clash/Cores/Extra.hs
@@ -1,0 +1,166 @@
+-- SPDX-FileCopyrightText: 2022 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+{-# LANGUAGE QuasiQuotes #-}
+
+module Clash.Cores.Extra where
+
+import Clash.Annotations.Primitive
+import Clash.Explicit.Prelude
+
+import Data.String.Interpolate (__i)
+
+
+-- | A typical dual flipflop synchronizer, prepended with a flipflop operating
+-- in the source domain. The two flipflops operating in the target domain are
+-- packed tightly together using Vivado's ASYNC_REG synthesis attribute. For more
+-- information see:
+--
+--     https://docs.xilinx.com/r/en-US/ug901-vivado-synthesis/ASYNC_REG
+--
+-- The first flipflop, i.e. the one operating in the source domain, is called
+-- @dff_sync_a@. This might not exactly match the name Clash produces, as it
+-- needs to generate unique names. I.e., the real signal names will be named
+-- according to the following pattern:
+--
+--   * @dff_sync_a@
+--   * @dff_sync_a_0@
+--   * @dff_sync_a_1@
+--   * etc.
+--
+-- Similarly, the two flipflops operating in the target domain are called
+-- @dff_sync_b@ and @dff_sync_c@. While the registers are automatically packed
+-- together, you'll still need to set max delay constraints to prevent undesirable,
+-- long paths between the first flipflop and the pair of flipflops. To do so,
+-- use the following:
+--
+-- @
+-- set_max_delay
+--   -from [get_pins * -filter {NAME =~ "dff_sync_a*_reg/C"}]
+--   -to   [get_pins * -filter {NAME =~ "dff_sync_b*_reg/D"}]
+--   -datapath_only
+--   [get_property -min PERIOD [get_clocks]]
+-- @
+--
+-- __N.B.__: You cannot synchronize words by combining multiple instantiations
+--           of 'tripleFlipFlopSynchronizer'. If you want to do this, look into
+--           'dcFifo'.
+--
+tripleFlipFlopSynchronizer ::
+  forall dom1 dom2 a.
+  ( KnownDomain dom1
+  , KnownDomain dom2
+  , NFDataX a
+  , BitSize a ~ 1 ) =>
+  Clock dom1 ->
+  Clock dom2 ->
+  a ->
+  Signal dom1 a ->
+  Signal dom2 a
+tripleFlipFlopSynchronizer clk1 clk2 initVal =
+    flipflop clk2
+  . flipflop clk2
+  . unsafeSynchronizer clk1 clk2
+  . flipflop clk1
+ where
+  flipflop :: KnownDomain dom => Clock dom -> Signal dom a -> Signal dom a
+  flipflop clk = delay clk enableGen initVal
+{-# NOINLINE tripleFlipFlopSynchronizer #-}
+{-# ANN tripleFlipFlopSynchronizer hasBlackBox #-}
+{-# ANN tripleFlipFlopSynchronizer (
+  let
+    (  dom1
+     : dom2
+     : _nfdatax
+     : _bitsize
+     : clock1
+     : clock2
+     : initVal
+     : inp
+     : _
+     ) = [(0::Int)..]
+
+    (  regA
+     : regB
+     : regC
+     : _
+     ) = [(0::Int)..]
+  in
+    InlineYamlPrimitive [Verilog, SystemVerilog] [__i|
+      BlackBox:
+        kind: Declaration
+        name: Clash.Cores.Extra.tripleFlipFlopSynchronizer
+        template: |-
+          // begin tripleFlipFlopSynchronizer
+          (* DONT_TOUCH = "yes" *) reg ~GENSYM[dff_sync_a][#{regA}] = ~CONST[#{initVal}];
+          (* ASYNC_REG = "TRUE" *) reg ~GENSYM[dff_sync_b][#{regB}] = ~CONST[#{initVal}], ~GENSYM[dff_sync_c][#{regC}] = ~CONST[#{initVal}];
+
+          always @(~IF~ACTIVEEDGE[Rising][#{dom1}]~THENposedge~ELSEnegedge~FI ~ARG[#{clock1}]) begin
+            ~SYM[#{regA}] <= ~VAR[in][#{inp}];
+          end
+
+          always @(~IF~ACTIVEEDGE[Rising][#{dom2}]~THENposedge~ELSEnegedge~FI ~ARG[#{clock2}]) begin
+            ~SYM[#{regB}] <= ~SYM[#{regA}];
+            ~SYM[#{regC}] <= ~SYM[#{regB}];
+          end
+
+          assign ~RESULT = ~SYM[#{regC}];
+          // end tripleFlipFlopSynchronizer
+|]) #-}
+{-# ANN tripleFlipFlopSynchronizer (
+  let
+    (  dom1
+     : dom2
+     : _nfdatax
+     : _bitsize
+     : clock1
+     : clock2
+     : initVal
+     : inp
+     : _
+     ) = [(0::Int)..]
+
+    (  regA
+     : regB
+     : regC
+     : block
+     : _
+     ) = [(0::Int)..]
+  in
+    InlineYamlPrimitive [VHDL] [__i|
+      BlackBox:
+        kind: Declaration
+        name: Clash.Cores.Extra.tripleFlipFlopSynchronizer
+        template: |-
+          -- begin tripleFlipFlopSynchronizer
+          ~GENSYM[tripleFlipFlopSynchronizer][#{block}] : block
+            signal ~GENSYM[dff_sync_a][#{regA}] : ~TYPO := ~CONST[#{initVal}];
+            signal ~GENSYM[dff_sync_b][#{regB}] : ~TYPO := ~CONST[#{initVal}];
+            signal ~GENSYM[dff_sync_c][#{regC}] : ~TYPO := ~CONST[#{initVal}];
+
+            attribute DONT_TOUCH : string;
+            attribute DONT_TOUCH of ~SYM[#{regA}] : signal is "TRUE";
+
+            attribute ASYNC_REG : string;
+            attribute ASYNC_REG of ~SYM[#{regB}] : signal is "TRUE";
+            attribute ASYNC_REG of ~SYM[#{regC}] : signal is "TRUE";
+          begin
+            process(~ARG[#{clock1}])
+            begin
+              if ~IF~ACTIVEEDGE[Rising][#{dom1}]~THENrising_edge~ELSEfalling_edge~FI(~ARG[#{clock1}]) then
+                ~SYM[#{regA}] <= ~VAR[in][#{inp}];
+              end if;
+            end process;
+
+            process(~ARG[#{clock2}])
+            begin
+              if ~IF~ACTIVEEDGE[Rising][#{dom2}]~THENrising_edge~ELSEfalling_edge~FI(~ARG[#{clock2}]) then
+                ~SYM[#{regB}] <= ~SYM[#{regA}];
+                ~SYM[#{regC}] <= ~SYM[#{regB}];
+              end if;
+            end process;
+
+            ~RESULT <= ~SYM[#{regC}];
+          end block;
+          -- end tripleFlipFlopSynchronizer
+|]) #-}


### PR DESCRIPTION
This adds a Xilinx specific `tripleFlipFlopSynchronizer`: a single-bit synchronization primitive. 

-----------

Schematic:

![Selection_016](https://user-images.githubusercontent.com/5658854/203513786-bd11808c-1d0a-4389-8275-bfa0e93b93bb.png)

-----------

Given how close we are to a clock control demo, I'd suggest we leave the TODO for next week. I'll create issues for each of these before merging.

TODO:

 - [x] Use TCL API to generate register constraints, remove "hack" from `mkPlaceTcl`.
 - [x] Add Clash simulation / HDL simulation identity checks (like `clash-testsuite`).