### PR TITLE
Add Clock control first demo to bittidde-instances

### DIFF
--- a/bittide-instances/bin/Shake.hs
+++ b/bittide-instances/bin/Shake.hs
@@ -24,6 +24,7 @@ import Clash.Shake.Vivado
 import qualified Bittide.Instances.Calendar as Calendar
 import qualified Bittide.Instances.ClockControl as ClockControl
 import qualified Bittide.Instances.ElasticBuffer as ElasticBuffer
+import qualified Bittide.Instances.MVPs as MVPs
 import qualified Bittide.Instances.Si539xSpi as Si539xSpi
 import qualified Bittide.Instances.StabilityChecker as StabilityChecker
 import qualified Bittide.Instances.Synchronizer as Synchronizer
@@ -71,9 +72,10 @@ targets =
   , 'Calendar.switchCalendar1kReducedPins
   , 'ClockControl.callisto3
   , 'ElasticBuffer.elasticBuffer5
+  , 'MVPs.clockControlDemo0
+  , 'Si539xSpi.si5391Spi
   , 'StabilityChecker.stabilityChecker_3_1M
   , 'Synchronizer.safeDffSynchronizer
-  , 'Si539xSpi.si5391Spi
   ]
 
 shakeOpts :: FilePath -> ShakeOptions

--- a/bittide-instances/bittide-instances.cabal
+++ b/bittide-instances/bittide-instances.cabal
@@ -96,6 +96,7 @@ library
     Bittide.Instances.Domains
     Bittide.Instances.ElasticBuffer
     Bittide.Instances.Hacks
+    Bittide.Instances.MVPs
     Bittide.Instances.Si539xSpi
     Bittide.Instances.StabilityChecker
     Bittide.Instances.Synchronizer

--- a/bittide-instances/demo-files/clockControlDemo0/README.md
+++ b/bittide-instances/demo-files/clockControlDemo0/README.md
@@ -1,0 +1,24 @@
+<!--
+SPDX-FileCopyrightText: 2022 Google LLC
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+## How to set up clockControlDemo0
+1. Generate HDL for clockControlDemo0 as by calling: `cabal run bittide-instances:shake -- clockControlDemo0:hdl`
+2. Start new Vivado project.
+3. Import the following files in Vivado:
+  * all generated verilog files from `_build/clash/Bittide_Instances_MVPs_clockControlDemo0`
+  * `topEntity.v`
+  * `topEntity.xdc`
+4. Set `topEntity.v` as top entity.
+5. Set `topEntity.xdc` as target constraint file.
+6. Generate `clashConnector.tcl` using `cabal run -- clash-lib:static-files --tcl-connector=clashConnector.tcl`.
+7. In Vivado's TCL console, source the `clashConnector.tcl` file
+8. In Vivado's TCL console, read the generated metadata file with `clash::readMetaData _build/clash/Bittide_Instances_MVPs_clockControlDemo0`
+9. In Vivado's TCL console, generate all the IPs in the design with `clash::createIp`
+10. In Vivado's IP catalog, use the clock wizard to generate a PLL or MMCM that converts SYSCLK_300 to a 200MHz clock, see `topEntity.v` for enabled ports.
+11. In Vivado's IP catalog, use the clock wizard to generate a clock buffer for the incoming `USER_SMA_CLOCK`, see `topEntity.v` for enabled ports.
+
+See the constraint file for all pin mappings.
+You should be able to create a bitstream now.

--- a/bittide-instances/demo-files/clockControlDemo0/topEntity.v
+++ b/bittide-instances/demo-files/clockControlDemo0/topEntity.v
@@ -1,0 +1,78 @@
+`timescale 1ns / 1ps
+//////////////////////////////////////////////////////////////////////////////////
+// Company:
+// Engineer:
+//
+// Create Date: 11/23/2022 04:39:35 PM
+// Design Name:
+// Module Name: topEntity
+// Project Name:
+// Target Devices:
+// Tool Versions:
+// Description:
+//
+// Dependencies:
+//
+// Revision:
+// Revision 0.01 - File Created
+// Additional Comments:
+//
+//////////////////////////////////////////////////////////////////////////////////
+
+// SPDX-FileCopyrightText: 2022 Google LLC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+module topEntity
+    ( // Inputs
+      input wire  SYSCLK_300_P // clock
+    , input wire  SYSCLK_300_N // clock
+    , input wire  USER_SMA_CLOCK_P // clock
+    , input wire  USER_SMA_CLOCK_N // clock
+    , input wire  reset // reset
+    , input wire  drainFifo
+    , input wire  stabilityCheckReset
+
+      // Outputs
+    , output wire  FINC
+    , output wire  FDEC
+    , output wire  Underflowed
+    , output wire  Overflowed
+    , output wire  isStable
+    , output wire [1:0] EbMode
+    );
+
+    wire clkInternal;
+    wire clkExternal;
+    clockControlDemo0 clockControlDemo0
+    ( // Inputs
+      .clkInteral(clkInternal) // clock
+    , .clkExternal(clkExternal) // clock
+    , .rstExternal(reset) // reset
+    , .drainFifo(drainFifo)
+    , .stabilityCheckReset(stabilityCheckReset)
+      // Outputs
+    , .FINC(FINC)
+    , .FDEC(FDEC)
+
+    , .Underflowed(Underflowed)
+    , .Overflowed(Overflowed)
+    , .isStable(isStable)
+    , .EbMode(EbMode)
+
+    );
+
+    clk_wiz_0 clk_wiz_0
+    (
+        .clkInternal(clkInternal),
+        // Status and control signals
+        .clk_in1_p(SYSCLK_300_P),
+        .clk_in1_n(SYSCLK_300_N));
+
+    clk_wiz_1 clk_wiz_1
+        (
+            .clkExternal(clkExternal),
+             .clk_in1_p(USER_SMA_CLOCK_P),
+             .clk_in1_n(USER_SMA_CLOCK_N));
+
+endmodule

--- a/bittide-instances/demo-files/clockControlDemo0/topEntity.xdc
+++ b/bittide-instances/demo-files/clockControlDemo0/topEntity.xdc
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: 2022 Google LLC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# create_clock -name {SYSCLK_300_P} -period 3.333 -waveform {0.000 1.667} [get_ports {SYSCLK_300_P}]
+# create_clock -name {USER_SMA_CLOCK_P} -period 5.000 -waveform {0.000 2.500} [get_ports {USER_SMA_CLOCK_P}]
+
+set_property IOSTANDARD DIFF_SSTL12 [get_ports SYSCLK_300_P]
+set_property ODT RTT_48 [get_ports SYSCLK_300_P]
+#
+# Bank  45 VCCO - VCC1V2_FPGA_3A - IO_L12N_T1U_N11_GC_45
+set_property PACKAGE_PIN AK17 [get_ports SYSCLK_300_P]
+set_property PACKAGE_PIN AK16 [get_ports SYSCLK_300_N]
+set_property IOSTANDARD DIFF_SSTL12 [get_ports SYSCLK_300_N]
+set_property ODT RTT_48 [get_ports SYSCLK_300_N]
+
+# Bank  67 VCCO - VADJ_1V8_FPGA_10A - IO_L13P_T2L_N0_GC_QBC_67
+set_property IOSTANDARD LVDS [get_ports USER_SMA_CLOCK_P]
+#
+# Bank  67 VCCO - VADJ_1V8_FPGA_10A - IO_L13N_T2L_N1_GC_QBC_67
+set_property PACKAGE_PIN D23 [get_ports USER_SMA_CLOCK_P]
+set_property PACKAGE_PIN C23 [get_ports USER_SMA_CLOCK_N]
+set_property IOSTANDARD LVDS [get_ports USER_SMA_CLOCK_N]
+
+
+set_clock_groups -asynchronous -group USER_SMA_CLOCK_P -group SYSCLK_300_P
+
+# GPIO_SW_E
+set_property PACKAGE_PIN AE8 [get_ports drainFifo]
+set_property IOSTANDARD LVCMOS18 [get_ports drainFifo]
+
+# GPIO_SW_C
+set_property PACKAGE_PIN AE10 [get_ports reset]
+set_property IOSTANDARD LVCMOS18 [get_ports reset]
+
+# GPIO_SW_W
+set_property PACKAGE_PIN AF9 [get_ports stabilityCheckReset]
+set_property IOSTANDARD LVCMOS18 [get_ports stabilityCheckReset]
+
+
+set_property PACKAGE_PIN AP16 [get_ports FDEC]
+set_property IOSTANDARD LVCMOS12 [get_ports FDEC]
+
+set_property PACKAGE_PIN AN18 [get_ports FINC]
+set_property IOSTANDARD LVCMOS12 [get_ports FINC]
+
+#GPIO_LED_0_LS
+set_property PACKAGE_PIN AP8 [get_ports isStable]
+set_property IOSTANDARD LVCMOS18 [get_ports isStable]
+
+#GPIO_LED_1_LS
+set_property PACKAGE_PIN H23 [get_ports Underflowed]
+set_property IOSTANDARD LVCMOS18 [get_ports Underflowed]
+
+#GPIO_LED_2_LS
+set_property PACKAGE_PIN P20 [get_ports Overflowed]
+set_property IOSTANDARD LVCMOS18 [get_ports Overflowed]
+
+# Bank  85 VCCO -          - IO_L20N_T3L_N3_AD1N_D09_65
+#set_property PACKAGE_PIN P21      [get_ports "GPIO_LED_3_LS"]
+#set_property IOSTANDARD  LVCMOS18 [get_ports "GPIO_LED_3_LS"]
+# Bank  85 VCCO -          - IO_L19P_T3L_N0_DBC_AD9P_D10_65
+#set_property PACKAGE_PIN N22      [get_ports "GPIO_LED_4_LS"]
+#set_property IOSTANDARD  LVCMOS18 [get_ports "GPIO_LED_4_LS"]
+# Bank  85 VCCO -          - IO_L19N_T3L_N1_DBC_AD9N_D11_65
+#set_property PACKAGE_PIN M22      [get_ports "GPIO_LED_5_LS"]
+#set_property IOSTANDARD  LVCMOS18 [get_ports "GPIO_LED_5_LS"]
+# Bank  85 VCCO -          - IO_L18P_T2U_N10_AD2P_D12_65
+#GPIO_LED_6_LS
+set_property PACKAGE_PIN R23 [get_ports {EbMode[0]}]
+set_property IOSTANDARD LVCMOS18 [get_ports {EbMode[0]}]
+# Bank  85 VCCO -          - IO_L18N_T2U_N11_AD2N_D13_65
+#GPIO_LED_7_LS
+set_property PACKAGE_PIN P23 [get_ports {EbMode[1]}]
+set_property IOSTANDARD LVCMOS18 [get_ports {EbMode[1]}]

--- a/bittide-instances/src/Bittide/Instances/Domains.hs
+++ b/bittide-instances/src/Bittide/Instances/Domains.hs
@@ -10,3 +10,5 @@ import Clash.Explicit.Prelude
 createDomain vXilinxSystem{vName="Basic125", vPeriod= hzToPeriod 125e6}
 createDomain vXilinxSystem{vName="Basic199", vPeriod=hzToPeriod 199e6}
 createDomain vXilinxSystem{vName="Basic200", vPeriod=hzToPeriod 200e6}
+createDomain vXilinxSystem{vName="Internal", vPeriod=hzToPeriod 200e6}
+createDomain vXilinxSystem{vName="External", vPeriod=hzToPeriod 200e6}

--- a/bittide-instances/src/Bittide/Instances/MVPs.hs
+++ b/bittide-instances/src/Bittide/Instances/MVPs.hs
@@ -1,0 +1,103 @@
+-- SPDX-FileCopyrightText: 2022 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE NumericUnderscores #-}
+module Bittide.Instances.MVPs where
+
+import Clash.Prelude
+
+import Bittide.Instances.Domains
+import Bittide.ElasticBuffer
+import Bittide.ClockControl.Callisto
+import Bittide.ClockControl
+import Clash.Annotations.TH (makeTopEntity)
+import Bittide.ClockControl.StabilityChecker (stabilityChecker)
+
+type FINC = Bool
+type FDEC = Bool
+
+speedChangeToPins :: SpeedChange -> (FINC, FDEC)
+speedChangeToPins = \case
+ SpeedUp -> (True, False)
+ SlowDown -> (False, True)
+ NoChange -> (False, False)
+
+genericClockControlDemo0 ::
+  forall recovered controlled  dataCountBits .
+  ( KnownDomain recovered, KnownDomain controlled, KnownNat dataCountBits, 4 <= dataCountBits, dataCountBits <= 17) =>
+  ClockControlConfig controlled  dataCountBits ->
+  Clock recovered ->
+  Clock controlled ->
+  Reset controlled ->
+  Reset controlled->
+  Reset controlled->
+  Signal controlled ((FINC, FDEC), Bool, Bool, Bool, EbMode)
+genericClockControlDemo0 config clkRecovered clkControlled rstControlled drainFifo stabilityCheckReset =
+  bundle (speedChangeSticky, underFlowed, overFlowed, isStable, ebMode)
+ where
+  speedChangeSticky =
+    withClockResetEnable clkControlled rstControlled enableGen $
+      stickyBits d15 (speedChangeToPins <$> speedChange)
+
+  speedChange = callistoClockControl @1 clkControlled clockControlReset enableGen
+    config (bufferOccupancy :> Nil)
+  clockControlReset = unsafeFromLowPolarity $ (==Pass) <$> ebMode
+
+  (bufferOccupancy, underFlowed, overFlowed, ebMode) =
+    withReset rstControlled $
+      resettableXilinxElasticBuffer clkControlled clkRecovered drainFifo
+
+  isStable =
+    withClockResetEnable clkControlled stabilityCheckReset enableGen $
+      stabilityChecker d2 (SNat @20_000_000) bufferOccupancy
+
+clockControlDemo0 ::
+  "clkRecovered" ::: Clock Internal ->
+  "clkControlled" ::: Clock External ->
+  "rstExternal" ::: Reset External ->
+  "drainFifo" ::: Reset External ->
+  "stabilityCheckReset" ::: Reset External ->
+  "" :::Signal External
+    (
+      "" :::
+      ( "FINC" ::: FINC
+      , "FDEC" ::: FDEC
+      )
+    , "Underflowed" ::: Bool
+    , "Overflowed" ::: Bool
+    , "isStable" ::: Bool
+    , "EbMode" ::: EbMode)
+clockControlDemo0 = genericClockControlDemo0 clockConfig
+ where
+  clockConfig :: ClockControlConfig External 12
+  clockConfig = $(lift (defClockConfig @External))
+
+-- | Holds any @a@ which has any bits set for @stickyCycles@ clock cycles.
+-- On receiving a new @a@ with non-zero bits, it sets the new incoming value as it output
+-- and holds it for @stickyCycles@ clock cycles.
+stickyBits ::
+  forall dom stickyCycles a .
+  ( HiddenClockResetEnable dom
+  , KnownNat (BitSize a)
+  , NFDataX a
+  , BitPack a
+  , 1 <= stickyCycles) =>
+  SNat stickyCycles ->
+  Signal dom a ->
+  Signal dom a
+stickyBits SNat = mealy go (0 , unpack 0)
+ where
+  go :: (Index stickyCycles, a) -> a -> ((Index stickyCycles, a), a)
+  go (count, storedBits) incomingBits = ((nextCount, nextStored), storedBits)
+   where
+    newIncoming = pack incomingBits /= 0
+    predCount = satPred SatZero count
+    holdingBits = count /= 0
+    (nextStored, nextCount)
+      | newIncoming = (incomingBits, maxBound)
+      | holdingBits = (storedBits, predCount)
+      | otherwise   = (unpack 0, predCount)
+
+makeTopEntity 'clockControlDemo0

--- a/bittide/src/Bittide/ClockControl/Callisto.hs
+++ b/bittide/src/Bittide/ClockControl/Callisto.hs
@@ -20,6 +20,7 @@ import Clash.Sized.Extra
 import qualified Clash.Cores.Xilinx.Floating as F
 import qualified Clash.Signal.Delayed as D
 
+{-# NOINLINE callistoClockControl #-}
 -- | Determines how to influence clock frequency given statistics provided by
 -- all elastic buffers. See 'callisto' for more information.
 --

--- a/bittide/src/Bittide/ElasticBuffer.hs
+++ b/bittide/src/Bittide/ElasticBuffer.hs
@@ -33,6 +33,7 @@ ebModeToReadWrite = \case
   Drain -> (True, False)
   Pass  -> (True, True)
 
+{-# NOINLINE sticky #-}
 -- | Create a sticky version of a boolean signal.
 sticky ::
   KnownDomain dom =>
@@ -44,6 +45,7 @@ sticky clk rst a = stickyA
  where
   stickyA = E.register clk rst enableGen False (stickyA .||. a)
 
+{-# NOINLINE xilinxElasticBuffer #-}
 -- | An elastic buffer backed by a Xilinx FIFO. It exposes all its control and
 -- monitor signals in its read domain.
 xilinxElasticBuffer ::
@@ -99,6 +101,7 @@ xilinxElasticBuffer clkRead clkWrite rstRead ebMode =
   writeData = mux writeEnableSynced (pure (Just (0 :: Unsigned 8))) (pure Nothing)
 
 
+{-# NOINLINE resettableXilinxElasticBuffer #-}
 resettableXilinxElasticBuffer ::
   forall readDom writeDom n.
   ( KnownDomain writeDom


### PR DESCRIPTION
This PR adds a bittide-instances for the first clock control demo.

This demo uses the `controlledFifo` that manages its own buffer occupancy with the following statemachine:

1. Drain FIFO
2. Fill FIFO to ~50%
3. Passthrough mode

The statemachine is reset to step 1 when over or underflow occurs.


Furthermore the buffer occupancy from the `controlledFifo` is fed into the callisto clock controller.