### PR TITLE
Add Clock control demo1 to bittide-instances

### DIFF
--- a/bittide-instances/bin/Shake.hs
+++ b/bittide-instances/bin/Shake.hs
@@ -74,6 +74,7 @@ targets =
   , 'ClockControl.callisto3
   , 'ElasticBuffer.elasticBuffer5
   , 'MVPs.clockControlDemo0
+  , 'MVPs.clockControlDemo1
   , 'ScatterGather.gatherUnit1K
   , 'ScatterGather.gatherUnit1KReducedPins
   , 'ScatterGather.scatterUnit1K

--- a/bittide-instances/demo-files/clockControlDemo1/README.md
+++ b/bittide-instances/demo-files/clockControlDemo1/README.md
@@ -4,20 +4,20 @@ SPDX-FileCopyrightText: 2022 Google LLC
 SPDX-License-Identifier: Apache-2.0
 -->
 ## How to set up clockControlDemo1
-1. Generate HDL for clockControlDemo1 as by calling:
-  cabal run bittide-instances:shake -- clockControlDemo1:hdl
+1. Generate HDL for clockControlDemo1 as by calling: `cabal run bittide-instances:shake -- clockControlDemo1:hdl`
 2. Start new Vivado project.
 3. Import the following files in Vivado:
-  * all generated verilog files from _build/clash/Bittide_Instances_MVPs_clockControlDemo1
-  * topEntity.v
-  * topEntity.xdc
-4. Set topEntity.v as top entity.
-5. Set topEntity.xdc as target constraint file.
-6. In Vivado's TCL console, source the clashConnector.tcl file
-7. In Vivado's TCL console, read the generated metadata file with "clash::readMetaData _build/clash/Bittide_Instances_MVPs_clockControlDemo1"
-8. In Vivado's TCL console, generate all the IPs in the design with "clash::createIp"
-9. In Vivado's IP catalog, use the clock wizard to generate a clock buffer for the incoming FMC_HPC_CLK1_M2S clock, see topEntity.v for enabled ports.
-10. In Vivado's IP catalog, use the clock wizard to generate a clock buffer for the incoming USER_SMA_CLOCK, see topEntity.v for enabled ports.
+  * all generated verilog files from `_build/clash/Bittide_Instances_MVPs_clockControlDemo1`
+  * `topEntity.v`
+  * `topEntity.xdc`
+4. Set `topEntity.v` as top entity.
+5. Set `topEntity.xdc` as target constraint file.
+6. Generate `clashConnector.tcl` using `cabal run -- clash-lib:static-files --tcl-connector=clashConnector.tcl`.
+7. In Vivado's TCL console, source the `clashConnector.tcl` file
+8. In Vivado's TCL console, read the generated metadata file with `clash::readMetaData _build/clash/Bittide_Instances_MVPs_clockControlDemo1`
+9. In Vivado's TCL console, generate all the IPs in the design with `clash::createIp`
+10. In Vivado's IP catalog, use the clock wizard to generate a clock buffer for the incoming `FMC_HPC_CLK1_M2S clock`, see `topEntity.v` for enabled ports.
+11. In Vivado's IP catalog, use the clock wizard to generate a clock buffer for the incoming `USER_SMA_CLOCK`, see `topEntity.v` for enabled ports.
 
 See the constraint file for all pin mappings.
 You should be able to create a bitstream now.

--- a/bittide-instances/demo-files/clockControlDemo1/README.md
+++ b/bittide-instances/demo-files/clockControlDemo1/README.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2022 Google LLC
+SPDX-FileCopyrightText: 2022-2023 Google LLC
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/bittide-instances/demo-files/clockControlDemo1/README.md
+++ b/bittide-instances/demo-files/clockControlDemo1/README.md
@@ -19,5 +19,5 @@ SPDX-License-Identifier: Apache-2.0
 10. In Vivado's IP catalog, use the clock wizard to generate a clock buffer for the incoming `FMC_HPC_CLK1_M2S clock`, see `topEntity.v` for enabled ports.
 11. In Vivado's IP catalog, use the clock wizard to generate a clock buffer for the incoming `USER_SMA_CLOCK`, see `topEntity.v` for enabled ports.
 
-See the constraint file for all pin mappings.
+See the constraint file, `topEntity.xdc`, for all pin mappings.
 You should be able to create a bitstream now.

--- a/bittide-instances/demo-files/clockControlDemo1/README.md
+++ b/bittide-instances/demo-files/clockControlDemo1/README.md
@@ -1,0 +1,23 @@
+<!--
+SPDX-FileCopyrightText: 2022 Google LLC
+
+SPDX-License-Identifier: Apache-2.0
+-->
+## How to set up clockControlDemo1
+1. Generate HDL for clockControlDemo1 as by calling:
+  cabal run bittide-instances:shake -- clockControlDemo1:hdl
+2. Start new Vivado project.
+3. Import the following files in Vivado:
+  * all generated verilog files from _build/clash/Bittide_Instances_MVPs_clockControlDemo1
+  * topEntity.v
+  * topEntity.xdc
+4. Set topEntity.v as top entity.
+5. Set topEntity.xdc as target constraint file.
+6. In Vivado's TCL console, source the clashConnector.tcl file
+7. In Vivado's TCL console, read the generated metadata file with "clash::readMetaData _build/clash/Bittide_Instances_MVPs_clockControlDemo1"
+8. In Vivado's TCL console, generate all the IPs in the design with "clash::createIp"
+9. In Vivado's IP catalog, use the clock wizard to generate a clock buffer for the incoming FMC_HPC_CLK1_M2S clock, see topEntity.v for enabled ports.
+10. In Vivado's IP catalog, use the clock wizard to generate a clock buffer for the incoming USER_SMA_CLOCK, see topEntity.v for enabled ports.
+
+See the constraint file for all pin mappings.
+You should be able to create a bitstream now.

--- a/bittide-instances/demo-files/clockControlDemo1/topEntity.v
+++ b/bittide-instances/demo-files/clockControlDemo1/topEntity.v
@@ -19,6 +19,10 @@
 //
 //////////////////////////////////////////////////////////////////////////////////
 
+// SPDX-FileCopyrightText: 2022 Google LLC
+//
+// SPDX-License-Identifier: Apache-2.0
+
 
 module topEntity
     ( // Inputs

--- a/bittide-instances/demo-files/clockControlDemo1/topEntity.v
+++ b/bittide-instances/demo-files/clockControlDemo1/topEntity.v
@@ -1,0 +1,74 @@
+`timescale 1ns / 1ps
+//////////////////////////////////////////////////////////////////////////////////
+// Company:
+// Engineer:
+//
+// Create Date: 11/23/2022 04:39:35 PM
+// Design Name:
+// Module Name: topEntity
+// Project Name:
+// Target Devices:
+// Tool Versions:
+// Description:
+//
+// Dependencies:
+//
+// Revision:
+// Revision 0.01 - File Created
+// Additional Comments:
+//
+//////////////////////////////////////////////////////////////////////////////////
+
+
+module topEntity
+    ( // Inputs
+      input wire  USER_SMA_CLOCK_P // clock
+    , input wire  USER_SMA_CLOCK_N // clock
+    , input wire  FMC_HPC_CLK1_M2C_P // clock
+    , input wire  FMC_HPC_CLK1_M2C_N // clock
+    , input wire  drainFifoA
+    , input wire  drainFifoB
+
+      // Outputs
+    , output wire  domA_FINC
+    , output wire  domA_FDEC
+    , output wire  domA_isStable
+    , output wire  domB_FINC
+    , output wire  domB_FDEC
+    , output wire  domB_isStable
+    );
+
+    wire clkA;
+    wire clkB;
+
+    clockControlDemo1 clockControlDemo1
+    ( // Inputs
+      .clkA(clkA) // clock
+    , .clkB(clkB) // clock
+    , .drainFifoA(drainFifoA)
+    , .drainFifoB(drainFifoB)
+
+      // Outputs
+    , .domA_FINC(domA_FINC)
+    , .domA_FDEC(domA_FDEC)
+    , .domA_isStable(domA_isStable)
+    , .domB_FINC(domB_FINC)
+    , .domB_FDEC(domB_FDEC)
+    , .domB_isStable(domB_isStable)
+
+    );
+
+    clk_wiz_0 clk_wiz_0
+    (
+        .clkA(clkA),
+        // Status and control signals
+        .clk_in1_p(FMC_HPC_CLK1_M2C_P),
+        .clk_in1_n(FMC_HPC_CLK1_M2C_N));
+
+    clk_wiz_1 clk_wiz_1
+    (
+       .clkB(clkB),
+       .clk_in1_p(USER_SMA_CLOCK_P),
+       .clk_in1_n(USER_SMA_CLOCK_N));
+
+endmodule

--- a/bittide-instances/demo-files/clockControlDemo1/topEntity.v
+++ b/bittide-instances/demo-files/clockControlDemo1/topEntity.v
@@ -1,29 +1,7 @@
 `timescale 1ns / 1ps
-//////////////////////////////////////////////////////////////////////////////////
-// Company:
-// Engineer:
-//
-// Create Date: 11/23/2022 04:39:35 PM
-// Design Name:
-// Module Name: topEntity
-// Project Name:
-// Target Devices:
-// Tool Versions:
-// Description:
-//
-// Dependencies:
-//
-// Revision:
-// Revision 0.01 - File Created
-// Additional Comments:
-//
-//////////////////////////////////////////////////////////////////////////////////
-
-// SPDX-FileCopyrightText: 2022 Google LLC
+// SPDX-FileCopyrightText: 2022-2023 Google LLC
 //
 // SPDX-License-Identifier: Apache-2.0
-
-
 module topEntity
     ( // Inputs
       input wire  USER_SMA_CLOCK_P // clock

--- a/bittide-instances/demo-files/clockControlDemo1/topEntity.xdc
+++ b/bittide-instances/demo-files/clockControlDemo1/topEntity.xdc
@@ -1,0 +1,90 @@
+# create_clock -name {SYSCLK_300_P} -period 3.333 -waveform {0.000 1.667} [get_ports {SYSCLK_300_P}]
+# create_clock -name {USER_SMA_CLOCK_P} -period 5.000 -waveform {0.000 2.500} [get_ports {USER_SMA_CLOCK_P}]
+
+#set_property IOSTANDARD DIFF_SSTL12 [get_ports SYSCLK_300_P]
+#set_property ODT RTT_48 [get_ports SYSCLK_300_P]
+#
+# Bank  45 VCCO - VCC1V2_FPGA_3A - IO_L12N_T1U_N11_GC_45
+#set_property PACKAGE_PIN AK17 [get_ports SYSCLK_300_P]
+#set_property PACKAGE_PIN AK16 [get_ports SYSCLK_300_N]
+#set_property IOSTANDARD DIFF_SSTL12 [get_ports SYSCLK_300_N]
+#set_property ODT RTT_48 [get_ports SYSCLK_300_N]
+
+# Bank  67 VCCO - VADJ_1V8_FPGA_10A - IO_L13P_T2L_N0_GC_QBC_67
+set_property IOSTANDARD LVDS [get_ports "USER_SMA_CLOCK_P"]
+set_property PACKAGE_PIN D23 [get_ports "USER_SMA_CLOCK_P"]
+set_property DIFF_TERM  TRUE [get_ports "USER_SMA_CLOCK_P"]
+#
+# Bank  67 VCCO - VADJ_1V8_FPGA_10A - IO_L13N_T2L_N1_GC_QBC_67
+set_property PACKAGE_PIN C23 [get_ports "USER_SMA_CLOCK_N"]
+set_property IOSTANDARD LVDS [get_ports "USER_SMA_CLOCK_N"]
+set_property DIFF_TERM  TRUE [get_ports "USER_SMA_CLOCK_N"]
+
+# Bank  67 VCCO - VADJ_1V8_FPGA_10A - IO_L11P_T1U_N8_GC_67
+set_property PACKAGE_PIN E25      [get_ports "FMC_HPC_CLK1_M2C_P"]
+set_property IOSTANDARD  LVDS     [get_ports "FMC_HPC_CLK1_M2C_P"]
+set_property DIFF_TERM   TRUE     [get_ports "FMC_HPC_CLK1_M2C_P"]
+#
+# Bank  67 VCCO - VADJ_1V8_FPGA_10A - IO_L11N_T1U_N9_GC_67
+set_property PACKAGE_PIN D25      [get_ports "FMC_HPC_CLK1_M2C_N"]
+set_property IOSTANDARD  LVDS     [get_ports "FMC_HPC_CLK1_M2C_N"]
+set_property DIFF_TERM   TRUE     [get_ports "FMC_HPC_CLK1_M2C_N"]
+
+
+set_clock_groups -asynchronous -group USER_SMA_CLOCK_P -group FMC_HPC_CLK1_M2C_P
+
+# GPIO_SW_E
+set_property PACKAGE_PIN AE8 [get_ports "drainFifoA"]
+set_property IOSTANDARD LVCMOS18 [get_ports "drainFifoA"]
+
+# GPIO_SW_W
+set_property PACKAGE_PIN AF9 [get_ports "drainFifoB"]
+set_property IOSTANDARD LVCMOS18 [get_ports "drainFifoB"]
+
+#clkA
+set_property PACKAGE_PIN AP16 [get_ports "domA_FDEC"]
+set_property IOSTANDARD LVCMOS12 [get_ports "domA_FDEC"]
+
+set_property PACKAGE_PIN AN18 [get_ports "domA_FINC"]
+set_property IOSTANDARD LVCMOS12 [get_ports "domA_FINC"]
+
+#clkB
+set_property PACKAGE_PIN AL14 [get_ports "domB_FDEC"]
+set_property IOSTANDARD LVCMOS12 [get_ports "domB_FDEC"]
+
+set_property PACKAGE_PIN AM16 [get_ports "domB_FINC"]
+set_property IOSTANDARD LVCMOS12 [get_ports "domB_FINC"]
+
+#GPIO_LED_0_LS
+set_property PACKAGE_PIN AP8 [get_ports "domA_isStable"]
+set_property IOSTANDARD LVCMOS18 [get_ports "domA_isStable"]
+
+#GPIO_LED_1_LS
+set_property PACKAGE_PIN H23 [get_ports "domB_isStable"]
+set_property IOSTANDARD LVCMOS18 [get_ports "domB_isStable"]
+
+#GPIO_LED_1_LS
+#set_property PACKAGE_PIN H23 [get_ports Underflowed]
+#set_property IOSTANDARD LVCMOS18 [get_ports Underflowed]
+
+#GPIO_LED_2_LS
+#set_property PACKAGE_PIN P20 [get_ports Overflowed]
+#set_property IOSTANDARD LVCMOS18 [get_ports Overflowed]
+
+# Bank  85 VCCO -          - IO_L20N_T3L_N3_AD1N_D09_65
+#set_property PACKAGE_PIN P21      [get_ports "GPIO_LED_3_LS"]
+#set_property IOSTANDARD  LVCMOS18 [get_ports "GPIO_LED_3_LS"]
+# Bank  85 VCCO -          - IO_L19P_T3L_N0_DBC_AD9P_D10_65
+#set_property PACKAGE_PIN N22      [get_ports "GPIO_LED_4_LS"]
+#set_property IOSTANDARD  LVCMOS18 [get_ports "GPIO_LED_4_LS"]
+# Bank  85 VCCO -          - IO_L19N_T3L_N1_DBC_AD9N_D11_65
+#set_property PACKAGE_PIN M22      [get_ports "GPIO_LED_5_LS"]
+#set_property IOSTANDARD  LVCMOS18 [get_ports "GPIO_LED_5_LS"]
+# Bank  85 VCCO -          - IO_L18P_T2U_N10_AD2P_D12_65
+#GPIO_LED_6_LS
+#set_property PACKAGE_PIN R23 [get_ports {EbMode[0]}]
+#set_property IOSTANDARD LVCMOS18 [get_ports {EbMode[0]}]
+# Bank  85 VCCO -          - IO_L18N_T2U_N11_AD2N_D13_65
+#GPIO_LED_7_LS
+#set_property PACKAGE_PIN P23 [get_ports {EbMode[1]}]
+#set_property IOSTANDARD LVCMOS18 [get_ports {EbMode[1]}]

--- a/bittide-instances/demo-files/clockControlDemo1/topEntity.xdc
+++ b/bittide-instances/demo-files/clockControlDemo1/topEntity.xdc
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2022 Google LLC
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # create_clock -name {SYSCLK_300_P} -period 3.333 -waveform {0.000 1.667} [get_ports {SYSCLK_300_P}]
 # create_clock -name {USER_SMA_CLOCK_P} -period 5.000 -waveform {0.000 2.500} [get_ports {USER_SMA_CLOCK_P}]
 

--- a/bittide-instances/demo-files/clockControlDemo1/topEntity.xdc
+++ b/bittide-instances/demo-files/clockControlDemo1/topEntity.xdc
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Google LLC
+# SPDX-FileCopyrightText: 2022-2023 Google LLC
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/bittide-instances/src/Bittide/Instances/Domains.hs
+++ b/bittide-instances/src/Bittide/Instances/Domains.hs
@@ -10,5 +10,7 @@ import Clash.Explicit.Prelude
 createDomain vXilinxSystem{vName="Basic125", vPeriod= hzToPeriod 125e6}
 createDomain vXilinxSystem{vName="Basic199", vPeriod=hzToPeriod 199e6}
 createDomain vXilinxSystem{vName="Basic200", vPeriod=hzToPeriod 200e6}
+createDomain vXilinxSystem{vName="Basic200A", vPeriod=hzToPeriod 200e6}
+createDomain vXilinxSystem{vName="Basic200B", vPeriod=hzToPeriod 200e6}
 createDomain vXilinxSystem{vName="Internal", vPeriod=hzToPeriod 200e6}
 createDomain vXilinxSystem{vName="External", vPeriod=hzToPeriod 200e6}

--- a/bittide-instances/src/Bittide/Instances/Domains.hs
+++ b/bittide-instances/src/Bittide/Instances/Domains.hs
@@ -1,4 +1,4 @@
--- SPDX-FileCopyrightText: 2022 Google LLC
+-- SPDX-FileCopyrightText: 2022-2023 Google LLC
 --
 -- SPDX-License-Identifier: Apache-2.0
 {-# OPTIONS_GHC -Wno-orphans #-}

--- a/bittide-instances/src/Bittide/Instances/MVPs.hs
+++ b/bittide-instances/src/Bittide/Instances/MVPs.hs
@@ -1,4 +1,4 @@
--- SPDX-FileCopyrightText: 2022 Google LLC
+-- SPDX-FileCopyrightText: 2022-2023 Google LLC
 --
 -- SPDX-License-Identifier: Apache-2.0
 

--- a/bittide-instances/src/Bittide/Instances/MVPs.hs
+++ b/bittide-instances/src/Bittide/Instances/MVPs.hs
@@ -53,8 +53,12 @@ clockControlDemo1 ::
   )
 clockControlDemo1 clkA clkB drainFifoA drainFifoB = (demoA, demoB)
  where
-  demoA = genericClockControlDemo0 clockConfigA clkB clkA (unsafeFromHighPolarity $ pure False) drainFifoA (unsafeFromHighPolarity $ pure False)
-  demoB = genericClockControlDemo0 clockConfigB clkA clkB (unsafeFromHighPolarity $ pure False) drainFifoB (unsafeFromHighPolarity $ pure False)
+  demoA =
+    genericClockControlDemo0 clockConfigA clkB clkA (unsafeFromHighPolarity $ pure False)
+    drainFifoA (unsafeFromHighPolarity $ pure False)
+  demoB =
+    genericClockControlDemo0 clockConfigB clkA clkB (unsafeFromHighPolarity $ pure False)
+    drainFifoB (unsafeFromHighPolarity $ pure False)
 
   clockConfigA :: ClockControlConfig Basic200A 12
   clockConfigA = $(lift (defClockConfig @Basic200A))
@@ -64,7 +68,11 @@ clockControlDemo1 clkA clkB drainFifoA drainFifoB = (demoA, demoB)
 
 genericClockControlDemo0 ::
   forall recovered controlled  dataCountBits .
-  ( KnownDomain recovered, KnownDomain controlled, KnownNat dataCountBits, 4 <= dataCountBits, dataCountBits <= 17) =>
+  ( KnownDomain recovered
+  , KnownDomain controlled
+  , KnownNat dataCountBits
+  , 4 <= dataCountBits
+  , dataCountBits <= 17) =>
   ClockControlConfig controlled  dataCountBits ->
   Clock recovered ->
   Clock controlled ->

--- a/bittide-instances/src/Bittide/Instances/MVPs.hs
+++ b/bittide-instances/src/Bittide/Instances/MVPs.hs
@@ -24,6 +24,44 @@ speedChangeToPins = \case
  SlowDown -> (False, True)
  NoChange -> (False, False)
 
+clockControlDemo1 ::
+  "clkA" ::: Clock Basic200A ->
+  "clkB" ::: Clock Basic200B ->
+  "drainFifoA" ::: Reset Basic200A ->
+  "drainFifoB" ::: Reset Basic200B ->
+  ( "domA" ::: Signal Basic200A
+    ( "" :::
+      ( "FINC" ::: FINC
+      , "FDEC" ::: FDEC
+      )
+    , "Underflowed" ::: Bool
+    , "Overflowed" ::: Bool
+    , "isStable" ::: Bool
+    , "EbMode" ::: EbMode
+    )
+  ,  "domB" ::: Signal Basic200B
+    (
+      "" :::
+      ( "FINC" ::: FINC
+      , "FDEC" ::: FDEC
+      )
+    , "Underflowed" ::: Bool
+    , "Overflowed" ::: Bool
+    , "isStable" ::: Bool
+    , "EbMode" ::: EbMode
+    )
+  )
+clockControlDemo1 clkA clkB drainFifoA drainFifoB = (demoA, demoB)
+ where
+  demoA = genericClockControlDemo0 clockConfigA clkB clkA (unsafeFromHighPolarity $ pure False) drainFifoA (unsafeFromHighPolarity $ pure False)
+  demoB = genericClockControlDemo0 clockConfigB clkA clkB (unsafeFromHighPolarity $ pure False) drainFifoB (unsafeFromHighPolarity $ pure False)
+
+  clockConfigA :: ClockControlConfig Basic200A 12
+  clockConfigA = $(lift (defClockConfig @Basic200A))
+
+  clockConfigB :: ClockControlConfig Basic200B  12
+  clockConfigB = $(lift (defClockConfig @Basic200B))
+
 genericClockControlDemo0 ::
   forall recovered controlled  dataCountBits .
   ( KnownDomain recovered, KnownDomain controlled, KnownNat dataCountBits, 4 <= dataCountBits, dataCountBits <= 17) =>
@@ -103,3 +141,4 @@ stickyBits SNat = mealy go (0 , unpack 0)
       | otherwise   = (unpack 0, predCount)
 
 makeTopEntity 'clockControlDemo0
+makeTopEntity 'clockControlDemo1


### PR DESCRIPTION
This PR adds a `bittide-instance` for clock control demo 1 and the required files to produce the bitstream.

Clock control demo 1 consists of:
* One FPGA board
* Two clock generation boards

The FPGA design contains:
* Two callisto clock control instances
* Two elastic buffers.

This demo shows that we can instantiate two instances of the callisto clock control algorithm and control two independent clocks based on the elastic buffer buffer occupancy's. 