### PR TITLE
Add Tcl to place all clocks in asynchronous groups

### DIFF
--- a/bittide-instances/src/Clash/Shake/Vivado.hs
+++ b/bittide-instances/src/Clash/Shake/Vivado.hs
@@ -142,6 +142,13 @@ mkPlaceTcl outputDir = [__i|
       }
     }
 
+    \# Place all clocks in individual clock groups and make them asynchronous
+    set clkArgs {}
+    foreach clk [get_clocks] {
+      lappend clkArgs -group $clk
+    }
+    set_clock_groups -asynchronous {*}$clkArgs
+
     \# Run optimization & placement
     opt_design
     place_design


### PR DESCRIPTION
By default, Vivado assumes all clocks are related, which it uses in its timing analysis. However, in the bittide system, clocks are not synchronous. Therefore, we need to explicitely tell Vivado that all clocks are asynchronous.

Note that this change makes Vivado ignore all timing checks between clock domains.