### PR TITLE
Lower number of Hedgehog tests in Bittide

### DIFF
--- a/bittide/tests/UnitTests.hs
+++ b/bittide/tests/UnitTests.hs
@@ -33,7 +33,7 @@ tests = testGroup "Unittests"
   ]
 
 setDefaultHedgehogTestLimit :: HedgehogTestLimit -> HedgehogTestLimit
-setDefaultHedgehogTestLimit (HedgehogTestLimit Nothing) = HedgehogTestLimit (Just 10000)
+setDefaultHedgehogTestLimit (HedgehogTestLimit Nothing) = HedgehogTestLimit (Just 1000)
 setDefaultHedgehogTestLimit opt = opt
 
 main :: IO ()


### PR DESCRIPTION
Previously every property would be tested `10_000` times. This change reduces the number of tests per property to `1_000`.