### PR TITLE
`safeDffSynchronizer` with SDC files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,5 @@ vhdl/
 vivado.jou
 log
 vivado_*
+tight_setup_hold_pins.txt
+.Xil

--- a/bittide-instances/bin/Shake.hs
+++ b/bittide-instances/bin/Shake.hs
@@ -71,7 +71,7 @@ targets =
   , 'ClockControl.callisto3
   , 'ElasticBuffer.elasticBuffer5
   , 'StabilityChecker.stabilityChecker_3_1M
-  , 'Synchronizer.tripleFlipFlopSynchronizer
+  , 'Synchronizer.safeDffSynchronizer
   ]
 
 shakeOpts :: FilePath -> ShakeOptions

--- a/bittide-instances/src/Bittide/Instances/Synchronizer.hs
+++ b/bittide-instances/src/Bittide/Instances/Synchronizer.hs
@@ -12,11 +12,11 @@ import qualified Clash.Cores.Extra as Cores
 import Clash.Annotations.TH (makeTopEntity)
 
 
-tripleFlipFlopSynchronizer ::
+safeDffSynchronizer ::
   "clk1"   ::: Clock Basic200 ->
   "clk2"   ::: Clock Basic199 ->
   "source" ::: Signal Basic200 Bit ->
   "target" ::: Signal Basic199 Bit
-tripleFlipFlopSynchronizer clk1 clk2 =
-  Cores.tripleFlipFlopSynchronizer @Basic200 @Basic199 @Bit clk1 clk2 0
-makeTopEntity 'tripleFlipFlopSynchronizer
+safeDffSynchronizer clk1 clk2 =
+  Cores.safeDffSynchronizer @Basic200 @Basic199 @Bit clk1 clk2 0
+makeTopEntity 'safeDffSynchronizer

--- a/bittide-instances/src/Clash/Shake/Vivado.hs
+++ b/bittide-instances/src/Clash/Shake/Vivado.hs
@@ -130,18 +130,6 @@ mkPlaceTcl outputDir = [__i|
     \# Pick up where synthesis left off
     open_checkpoint {#{outputDir </> "checkpoints" </> "post_synth.dcp"}}
 
-    \# See documentation of 'tripleFlipFlopSynchronizer'
-    \# TODO: Primitive should generate this
-    set from_pins [get_pins -quiet -filter {NAME =~ "dff_sync_a*_reg/C"}]
-    set to_pins   [get_pins -quiet -filter {NAME =~ "dff_sync_b*_reg/D"}]
-
-    if {[llength $from_pins]} {
-      if {[llength $to_pins]} {
-        set min_clock_period [get_property -min PERIOD [get_clocks]]
-        set_max_delay -datapath_only -from $from_pins -to $to_pins $min_clock_period
-      }
-    }
-
     \# Place all clocks in individual clock groups and make them asynchronous
     set clkArgs {}
     foreach clk [get_clocks] {

--- a/bittide/src/Bittide/ElasticBuffer.hs
+++ b/bittide/src/Bittide/ElasticBuffer.hs
@@ -72,7 +72,7 @@ xilinxElasticBuffer clkRead clkWrite rstRead ebMode =
  where
   rstWrite = unsafeFromHighPolarity rstWriteBool
   rstWriteBool =
-    CE.tripleFlipFlopSynchronizer clkRead clkWrite False (unsafeToHighPolarity rstRead)
+    CE.safeDffSynchronizer clkRead clkWrite False (unsafeToHighPolarity rstRead)
 
   FifoOut{readCount, isUnderflow, isOverflow} = dcFifo
     (defConfig @n){dcOverflow=True, dcUnderflow=True}
@@ -92,7 +92,7 @@ xilinxElasticBuffer clkRead clkWrite rstRead ebMode =
 
   (readEnable, writeEnable) = unbundle (ebModeToReadWrite <$> ebMode)
 
-  writeEnableSynced = CE.tripleFlipFlopSynchronizer clkRead clkWrite False writeEnable
+  writeEnableSynced = CE.safeDffSynchronizer clkRead clkWrite False writeEnable
 
   -- For the time being, we're only interested in data counts, so we feed the
   -- FIFO with static data when writing (@0@).
@@ -120,7 +120,7 @@ resettableXilinxElasticBuffer clkRead clkWrite rstRead =
  where
   (dataCount, under, over) = xilinxElasticBuffer @n clkRead clkWrite fifoReset ebMode
   fifoReset = unsafeFromHighPolarity $ not <$> stable
-  over1 = CE.tripleFlipFlopSynchronizer clkWrite clkRead False over
+  over1 = CE.safeDffSynchronizer clkWrite clkRead False over
 
   controllerReset = unsafeFromHighPolarity (unsafeToHighPolarity rstRead .||. under .||. over1)
 


### PR DESCRIPTION
- The `tripleFlipFlopSynchronizer` is renamed to `safeDffSynchronizer` because while it has three flip-flops, the first flip-flop is not part of the synchronizer. Rather, the first flip-flop is the _safe_ part: it makes sure the signal going into the synchronizer is as clean as can be.
- HDL generation generates an `.sdc` file that matches the globally unique names of the registers in the primitive and provides the desirable `max_delay` timing constraint. The unique name generation is hacky and it would be good if we could improve Clash to make this convenient, but the current solution works completely without caveats as far as I'm aware.

  Names for the two first flip-flops look like: `topEntity_dff_sync_8B6D4D15F5D7771F_dff_sync_a`

  The reason for the names containing `dff_sync` twice in the name is that the first occurence isn't part of the _locally_ unique name generated with `~GENSYM`. If we would have used `~GENSYM[a]`, it would need to be differentiated from all things named `a`. Picking `dff_sync_a` greatly reduces the contention for the name.
- A second function, `safeDffSynchronizer0`, provides access to the flip-flop in the source domain, in case the value is also needed in that domain.
- TemplateHaskell is leveraged to provide the function names in the primitive annotation.