### PR TITLE
Expose read/write data ports of elastic buffer

### DIFF
--- a/bittide-instances/src/Bittide/Instances/ElasticBuffer.hs
+++ b/bittide-instances/src/Bittide/Instances/ElasticBuffer.hs
@@ -17,10 +17,12 @@ elasticBuffer5 ::
   "clkReadFast" ::: Clock Fast ->
   "clkWriteSlow" :::Clock Slow ->
   "resetRead" ::: Reset Fast ->
+  "writeData" ::: Signal Slow (Unsigned 8) ->
   ( "dataCount" ::: Signal Fast (Unsigned 5)
   , "underflow" ::: Signal Fast Underflow
   , "overrflow" ::: Signal Fast Overflow
   , "ebMode" ::: Signal Fast EbMode
+  , "readData" ::: Signal Fast (Unsigned 8)
   )
 elasticBuffer5 = resettableXilinxElasticBuffer
 

--- a/bittide-instances/src/Bittide/Instances/MVPs.hs
+++ b/bittide-instances/src/Bittide/Instances/MVPs.hs
@@ -45,9 +45,11 @@ genericClockControlDemo0 config clkRecovered clkControlled rstControlled drainFi
     config (bufferOccupancy :> Nil)
   clockControlReset = unsafeFromLowPolarity $ (==Pass) <$> ebMode
 
-  (bufferOccupancy, underFlowed, overFlowed, ebMode) =
+  writeData = pure (0 :: Unsigned 8)
+
+  (bufferOccupancy, underFlowed, overFlowed, ebMode, _) =
     withReset rstControlled $
-      resettableXilinxElasticBuffer clkControlled clkRecovered drainFifo
+      resettableXilinxElasticBuffer clkControlled clkRecovered drainFifo writeData
 
   isStable =
     withClockResetEnable clkControlled stabilityCheckReset enableGen $

--- a/bittide/tests/Tests/ElasticBuffer.hs
+++ b/bittide/tests/Tests/ElasticBuffer.hs
@@ -14,6 +14,7 @@ import Test.Tasty
 import Test.Tasty.HUnit
 
 import Bittide.ElasticBuffer
+import Bittide.ClockControl (targetDataCount)
 
 import qualified Data.List as L
 
@@ -40,12 +41,13 @@ case_xilinxElasticBufferMaxBound :: Assertion
 case_xilinxElasticBufferMaxBound = do
   let
     ebMode = fromList $ L.replicate 3 Fill <> L.repeat Pass
+    wData = pure (0 :: Unsigned 8)
     underflows =
       sampleN 256
-        ((\(_,under, _)-> under) (xilinxElasticBuffer @6 (clockGen @Slow) (clockGen @Fast) resetGen ebMode))
+        ((\(_, under, _, _)-> under) (xilinxElasticBuffer @6 (clockGen @Slow) (clockGen @Fast) resetGen ebMode wData))
     overflows =
       sampleN 256
-        ((\(_,_, over)-> over) (xilinxElasticBuffer @6 (clockGen @Slow) (clockGen @Fast) resetGen ebMode))
+        ((\(_, _, over, _) -> over) (xilinxElasticBuffer @6 (clockGen @Slow) (clockGen @Fast) resetGen ebMode wData))
 
   assertBool "elastic buffer should overflow" (or overflows)
   assertBool "elastic buffer should not underflow" (not $ or underflows)
@@ -56,12 +58,14 @@ case_xilinxElasticBufferMinBound :: Assertion
 case_xilinxElasticBufferMinBound = do
   let
     ebMode = fromList $ L.replicate 32 Fill <> L.repeat Pass
+    wData = pure (0 :: Unsigned 8)
     underflows =
       sampleN 256
-        ((\(_,under, _)-> under) (xilinxElasticBuffer @6 (clockGen @Fast) (clockGen @Slow) resetGen ebMode))
+        ((\(_, under, _, _)-> under) (xilinxElasticBuffer @6 (clockGen @Fast) (clockGen @Slow) resetGen ebMode wData))
     overflows =
       sampleN 256
-        ((\(_,_, over)-> over) (xilinxElasticBuffer @6 (clockGen @Fast) (clockGen @Slow) resetGen ebMode))
+        ((\(_, _, over, _)-> over) (xilinxElasticBuffer @6 (clockGen @Fast) (clockGen @Slow) resetGen ebMode wData))
+
   assertBool "elastic buffer should underflow" (or underflows)
   assertBool "elastic buffer should not overflow" (not $ or overflows)
 
@@ -71,12 +75,14 @@ case_xilinxElasticBufferEq :: Assertion
 case_xilinxElasticBufferEq = do
   let
     ebMode = fromList $ L.replicate 32 Fill <> L.repeat Pass
+    wData = pure (0 :: Unsigned 8)
     underflows =
       sampleN 256
-        ((\(_,under, _)-> under) (xilinxElasticBuffer @5 (clockGen @Slow) (clockGen @Slow) resetGen ebMode))
+        ((\(_, under, _, _)-> under) (xilinxElasticBuffer @5 (clockGen @Slow) (clockGen @Slow) resetGen ebMode wData))
     overflows =
       sampleN 256
-        ((\(_,_, over)-> over) (xilinxElasticBuffer @5 (clockGen @Slow) (clockGen @Slow) resetGen ebMode))
+        ((\(_, _, over, _)-> over) (xilinxElasticBuffer @5 (clockGen @Slow) (clockGen @Slow) resetGen ebMode wData))
+
   assertBool "elastic buffer should not underflow" (not $ or underflows)
   assertBool "elastic buffer should not overflow" (not $ or overflows)
 
@@ -85,15 +91,17 @@ case_xilinxElasticBufferEq = do
 case_resettableXilinxElasticBufferEq :: Assertion
 case_resettableXilinxElasticBufferEq = do
   let
-    (dataCounts, underflows, overflows, ebModes) = L.unzip4 .
-      L.dropWhile (\(_, _, _, eb)-> eb == Drain || eb == Fill) $ sampleN 256
-        (bundle (resettableXilinxElasticBuffer @_ @_ @5 (clockGen @Slow) (clockGen @Slow) resetGen))
-    dataCountBounds = L.all ((< 3) . abs . subtract (shiftR maxBound 1)) dataCounts
+    wData = pure (0 :: Unsigned 8)
+    (dataCounts, underflows, overflows, ebModes, _) = L.unzip5 .
+      L.dropWhile (\(_, _, _, eb, _)-> eb == Drain || eb == Fill) $ sampleN 256
+        (bundle (resettableXilinxElasticBuffer @5 (clockGen @Slow) (clockGen @Slow) resetGen wData))
+    dataCountBounds = L.all ((< 3) . abs . subtract (toInteger (targetDataCount :: Unsigned 5)) . toInteger) dataCounts
 
+  assertBool "elastic buffer should get out of its Fill state" ((>0) $ L.length ebModes)
   assertBool "elastic buffer should not overflow after stabalising" (not $ or overflows)
   assertBool "elastic buffer should not underflow after stabalising" (not $ or underflows)
   assertBool "elastic buffer should be in Pass mode after stabalising" (L.all (== Pass) ebModes)
-  assertBool "elastic buffer datacount should be half full (margin 3 elements) after stabalising" dataCountBounds
+  assertBool "elastic buffer datacount should be `targetDataCount` (margin 3 elements) after stabalising" dataCountBounds
 
 
 -- | When the xilinxElasticBuffer is written to more quickly than it is being read from,
@@ -102,9 +110,10 @@ case_resettableXilinxElasticBufferEq = do
 case_resettableXilinxElasticBufferMaxBound :: Assertion
 case_resettableXilinxElasticBufferMaxBound = do
   let
-    (_, underflows, overflows, _) = L.unzip4 .
-      L.filter (\(_, _, _, eb)-> eb == Pass) $ sampleN 256
-        (bundle (resettableXilinxElasticBuffer @_ @_ @5 (clockGen @Slow) (clockGen @Fast) resetGen))
+    wData = pure (0 :: Unsigned 8)
+    (_, underflows, overflows, _, _) = L.unzip5 .
+      L.filter (\(_, _, _, eb, _)-> eb == Pass) $ sampleN 256
+        (bundle (resettableXilinxElasticBuffer @5 (clockGen @Slow) (clockGen @Fast) resetGen wData))
 
   -- After the fifo overflows, it should Drain the buffer, then fill it to half full and
   -- reset.
@@ -121,9 +130,10 @@ case_resettableXilinxElasticBufferMaxBound = do
 case_resettableXilinxElasticBufferMinBound :: Assertion
 case_resettableXilinxElasticBufferMinBound = do
   let
-    (_, underflows, overflows, _) = L.unzip4 .
-      L.filter (\(_, _, _, eb)-> eb == Pass) $ sampleN 512
-        (bundle (resettableXilinxElasticBuffer @_ @_ @5 (clockGen @Fast) (clockGen @Slow) resetGen))
+    wData = pure (0 :: Unsigned 8)
+    (_, underflows, overflows, _, _) = L.unzip5 .
+      L.filter (\(_, _, _, eb, _)-> eb == Pass) $ sampleN 512
+        (bundle (resettableXilinxElasticBuffer @5 (clockGen @Fast) (clockGen @Slow) resetGen wData))
 
   -- After the fifo underflows, it should Drain for 1 cycle and then fill it to half
   -- full and reset.


### PR DESCRIPTION
In the previous version the read and write ports of the `xilinxElasticBuffer` and the `resettableXilinxElasticBuffer` were not exposed as we were only interested in its status (datacount and over/underflow flags). Now we do want access to the data in the elastic buffers.

See #205