### PR TITLE
Add Bittide domain

### DIFF
--- a/bittide/bittide.cabal
+++ b/bittide/bittide.cabal
@@ -104,6 +104,7 @@ library
     Bittide.ClockControl.Si539xSpi
     Bittide.ClockControl.StabilityChecker
     Bittide.DoubleBufferedRam
+    Bittide.Domain
     Bittide.ElasticBuffer
     Bittide.Link
     Bittide.Node

--- a/bittide/src/Bittide/Domain.hs
+++ b/bittide/src/Bittide/Domain.hs
@@ -1,0 +1,80 @@
+-- SPDX-FileCopyrightText: 2022 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE GADTs #-}
+
+module Bittide.Domain where
+
+
+import Clash.Prelude hiding (DomainConfiguration)
+import Bittide.ClockControl (SpeedChange, ClockControlConfig, targetDataCount)
+import Clash.Cores.Xilinx.DcFifo
+import Bittide.ClockControl.Callisto
+import Bittide.ClockControl.StabilityChecker
+import Bittide.ElasticBuffer
+import Bittide.SharedTypes
+
+import qualified Clash.Explicit.Prelude as E
+
+data DomainConfiguration dom incomingDomains stabilityMargin stabilityCycles =
+   1 <= stabilityCycles =>
+  DomainConfiguration
+    { clockControlConfig :: ClockControlConfig dom incomingDomains
+    , stabilityConfig :: (SNat stabilityMargin, SNat stabilityCycles)
+    }
+
+data BootProcedure
+  = AllUnstable
+  | ResetBuffers
+  | WaitForPasses
+  | Stable
+  deriving (Generic, NFDataX)
+
+domain ::
+  ( KnownDomain dom, KnownNat n, 1 <= n, KnownNat m, 1 <= m, n + m <= 32) =>
+  DomainConfiguration dom m stabilityMargin stabilityCycles ->
+  Clock dom ->
+  Reset dom ->
+  Enable dom ->
+  Vec n (Signal dom (DataCount m)) ->
+  Vec n (Signal dom EbMode) ->
+  ( Signal dom SpeedChange
+  , Signal dom BootProcedure)
+domain DomainConfiguration{..} clkCallisto externalReset enableCallisto dataCounts ebModes =
+  ( speedChange, bootState)
+ where
+  -- Active clock control
+  speedChange = callistoClockControl clkCallisto callistoReset enableCallisto
+    clockControlConfig callistoCounts
+
+-- Reset callisto whenever one of the elastic buffers goes from Pass to any other mode.
+  callistoReset = withClockResetEnable clkCallisto externalReset enableCallisto
+    (forceReset $ holdTrue d3 (or <$> bundle (lostPass <$> ebModes)))
+  lostPass ebMode = register Drain ebMode  .==. pure Pass .&&. ebMode ./=. pure Pass
+
+  -- Pass targetDataCount to callisto when the elastic buffer is not in Pass mode.
+  callistoCounts = (\ bool a -> mux bool a $ pure targetDataCount) <$> allPasses <*> dataCounts
+
+  allPasses = fmap (fmap (== Pass)) ebModes
+  -- Boot procedure
+
+  -- The stabilityCheckers are in reset when the corresponding elastic buffer is not in
+  -- Pass mode.
+  (margin, cyclesStable) = stabilityConfig
+  stabilityIndicators =
+    (\ isPass ->
+      withClockResetEnable clkCallisto (unsafeFromLowPolarity isPass) enableCallisto
+      stabilityChecker margin cyclesStable
+    ) <$> allPasses <*> dataCounts
+
+  -- The state machine changes state depending on the stability indicators.
+  bootState = E.mealy clkCallisto externalReset enableCallisto go AllUnstable $ bundle stabilityIndicators
+  go currentState stableIndicatorsGo = (nextState, nextState)
+   where
+    nextState = case (currentState, and stableIndicatorsGo) of
+      (AllUnstable   , True)  -> ResetBuffers
+      (ResetBuffers  , False) -> WaitForPasses
+      (WaitForPasses , True)  -> Stable
+      (Stable        , _)     -> Stable
+      _                       -> currentState

--- a/bittide/src/Bittide/SharedTypes.hs
+++ b/bittide/src/Bittide/SharedTypes.hs
@@ -158,6 +158,17 @@ forceReset ::
   Reset dom
 forceReset force = unsafeFromHighPolarity (unsafeToHighPolarity hasReset .||. force)
 
+holdTrue ::
+  forall dom holdCycles .
+  (HiddenClockResetEnable dom, 1 <= holdCycles) =>
+  SNat holdCycles ->
+  Signal dom Bool ->
+  Signal dom Bool
+holdTrue SNat = mealy go (repeat False)
+ where
+  go :: 1 <= holdCycles => Vec holdCycles Bool -> Bool -> (Vec holdCycles Bool, Bool)
+  go state@(Cons _ _) input = (takeI $ input :> state, fold (||) state)
+
 -- | Divide and round up.
 divRU :: Integral a => a -> a -> a
 divRU b a = (b + a - 1) `div` a


### PR DESCRIPTION
Draft of me working on the Bittide clock control domain, this domain does not contain the elastic buffers as they all introduce new clock domains, which is hard if not impossible to generalise. 

The domain consumes a vector of `DataCount`s and `EbModes` from all elastic buffers.
This domain contains:
* Callisto
* StabilityCheckers for all incoming datacounts
* A statemachine that makes sure the clocks are stabilized and buffer occupancies are all close to `targetDataCount` 

The datacounts that are passed to callisto are set to `targetDataCount` whenever the producing elastic buffer is not in `Pass` mode, this essentially causes callisto to act as if this link does not exist.

Callisto will be reset whenever one of the elastic buffer overflows or underflows, it does so by monitoring the `EbMode`.
Recall that `EbMode` consists of the states: `Idle`, `Drain`, `Fill` and `Pass`.

The boot procedure state machine contains 4 states which will be explained below: 
* `Allunstable` : Clocks have yet to converge, callisto controls the local clock . In this state we wait untill *all* stability indicators are `True`.  Once all stability indicators are `True`, we move into the `ResetBuffers` state.
* `ResetBuffers`: We reset all elastic buffers to set all their dataCounts to `targetDataCount`. Important to note is that, since the elastic buffers are not part of this component, resetting the buffer has to be done based on the exposed state. We go to the `WaitForPassesState` as soon as not all the stability indicators are `True` anymore.
* `WaitForPasses`: We have reset all elastic buffers and are now waiting for them to become stable again. Once all stability indicators are `True`, we go into the final `Stable` state. This state should be used as indicator that system is synchronized.