### PR TITLE
Add missing shake instances to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -652,10 +652,15 @@ jobs:
       matrix:
         target:
           - {top: callisto3,                   stage: netlist}
+          - {top: clockControlDemo0,           stage: netlist}
+          - {top: elasticBuffer5,              stage: netlist}
           - {top: gatherUnit1K,                stage: hdl}
           - {top: gatherUnit1KReducedPins,     stage: netlist}
+          - {top: safeDffSynchronizer,         stage: netlist}
           - {top: scatterUnit1K,               stage: hdl}
           - {top: scatterUnit1KReducedPins,    stage: netlist}
+          - {top: si5391Spi,                   stage: netlist}
+          - {top: stabilityChecker_3_1M,       stage: netlist}
           - {top: switchCalendar1k,            stage: hdl}
           - {top: switchCalendar1kReducedPins, stage: netlist}
 


### PR DESCRIPTION
I noticed we have multiple shake instances that do not run on CI.
Does anyone have any thoughts about which we want to run on CI and when we want to have `ReducedPins` versions of the relevant components?