### PR TITLE
Bump CI action versions

### DIFF
--- a/.github/scripts/set_de_mirror.sh
+++ b/.github/scripts/set_de_mirror.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2022 Google LLC
+#
+# SPDX-License-Identifier: Apache-2.0
 
 # This is a temporary workaround for 'archive.ubuntu.com' being down. Our CI
 # runners are located in Germany, hence us using a German mirror.

--- a/.github/scripts/set_de_mirror.sh
+++ b/.github/scripts/set_de_mirror.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# This is a temporary workaround for 'archive.ubuntu.com' being down. Our CI
+# runners are located in Germany, hence us using a German mirror.
+sed -i 's/archive.ubuntu.com/de.archive.ubuntu.com/g' /etc/apt/sources.list
+sed -i 's/security.ubuntu.com/de.archive.ubuntu.com/g' /etc/apt/sources.list

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
 
       - name: Install dependencies
         run: |
+          .github/scripts/set_de_mirror.sh
           apt-get update
           apt-get install -y pcregrep
 
@@ -115,6 +116,7 @@ jobs:
 
       - name: Install poetry
         run: |
+          .github/scripts/set_de_mirror.sh
           apt-get update
           apt-get install python3-distutils -y
           curl -sSL https://install.python-poetry.org | python3 -
@@ -344,6 +346,7 @@ jobs:
 
       - name: Install Device Tree Compiler
         run: |
+          .github/scripts/set_de_mirror.sh
           apt-get update
           apt-get install -y device-tree-compiler
 
@@ -427,6 +430,7 @@ jobs:
 
       - name: Install dependencies
         run: |
+          .github/scripts/set_de_mirror.sh
           apt-get update
           apt-get install -y curl build-essential
 
@@ -460,6 +464,7 @@ jobs:
 
       - name: Install dependencies
         run: |
+          .github/scripts/set_de_mirror.sh
           apt-get update
           apt-get install -y curl build-essential
 
@@ -497,6 +502,7 @@ jobs:
 
       - name: Install dependencies
         run: |
+          .github/scripts/set_de_mirror.sh
           apt-get update
           apt-get install -y curl build-essential
 
@@ -537,6 +543,7 @@ jobs:
 
       - name: Install dependencies
         run: |
+          .github/scripts/set_de_mirror.sh
           apt-get update
           apt-get install -y curl build-essential
 
@@ -700,6 +707,7 @@ jobs:
 
       - name: HDL generation and synthesis
         run : |
+          .github/scripts/set_de_mirror.sh
           .github/scripts/with_vivado.sh cabal run -- bittide-instances:shake ${{ matrix.target.top }}:${{ matrix.target.stage }}
 
       - name: Archive synthesis artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
     runs-on: self-hosted
 
     container:
-      image: ghcr.io/clash-lang/clash-ci-9.0.2:2022-02-02
+      image: ghcr.io/clash-lang/clash-ci-9.0.2:2022-12-13
 
     steps:
       - name: Checkout
@@ -77,8 +77,8 @@ jobs:
           path: |
             ~/.cabal/store
 
-          key: packages-${{ hashFiles('cabal.project.freeze') }}
-          restore-keys: packages-
+          key: packages-cachebust-1-${{ hashFiles('cabal.project.freeze') }}
+          restore-keys: packages-cachebust-1-
 
       - name: Build
         run: |
@@ -90,7 +90,7 @@ jobs:
     needs: [build, lint]
 
     container:
-      image: ghcr.io/clash-lang/clash-ci-9.0.2:2022-02-02
+      image: ghcr.io/clash-lang/clash-ci-9.0.2:2022-12-13
 
     steps:
       - name: Checkout
@@ -111,8 +111,8 @@ jobs:
           path: |
             ~/.cabal/store
 
-          key: packages-${{ hashFiles('cabal.project.freeze') }}
-          restore-keys: packages-
+          key: packages-cachebust-1-${{ hashFiles('cabal.project.freeze') }}
+          restore-keys: packages-cachebust-1-
 
       - name: Install poetry
         run: |
@@ -150,7 +150,7 @@ jobs:
     needs: [build, lint]
 
     container:
-      image: ghcr.io/clash-lang/clash-ci-9.0.2:2022-02-02
+      image: ghcr.io/clash-lang/clash-ci-9.0.2:2022-12-13
 
     steps:
       - name: Checkout
@@ -171,8 +171,8 @@ jobs:
           path: |
             ~/.cabal/store
 
-          key: packages-${{ hashFiles('cabal.project.freeze') }}
-          restore-keys: packages-
+          key: packages-cachebust-1-${{ hashFiles('cabal.project.freeze') }}
+          restore-keys: packages-cachebust-1-
 
       - name: Run unittests
         run: |
@@ -184,7 +184,7 @@ jobs:
     needs: [build, lint]
 
     container:
-      image: ghcr.io/clash-lang/clash-ci-9.0.2:2022-02-02
+      image: ghcr.io/clash-lang/clash-ci-9.0.2:2022-12-13
 
     steps:
       - name: Checkout
@@ -205,8 +205,8 @@ jobs:
           path: |
             ~/.cabal/store
 
-          key: packages-${{ hashFiles('cabal.project.freeze') }}
-          restore-keys: packages-
+          key: packages-cachebust-1-${{ hashFiles('cabal.project.freeze') }}
+          restore-keys: packages-cachebust-1-
 
       - name: Run unittests
         run: |
@@ -218,7 +218,7 @@ jobs:
     needs: [build, lint]
 
     container:
-      image: ghcr.io/clash-lang/clash-ci-9.0.2:2022-02-02
+      image: ghcr.io/clash-lang/clash-ci-9.0.2:2022-12-13
 
     steps:
       - name: Checkout
@@ -239,8 +239,8 @@ jobs:
           path: |
             ~/.cabal/store
 
-          key: packages-${{ hashFiles('cabal.project.freeze') }}
-          restore-keys: packages-
+          key: packages-cachebust-1-${{ hashFiles('cabal.project.freeze') }}
+          restore-keys: packages-cachebust-1-
 
       - name: Build Contranomy
         run: |
@@ -293,7 +293,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: ghcr.io/clash-lang/clash-ci-9.0.2:2022-02-02
+      image: ghcr.io/clash-lang/clash-ci-9.0.2:2022-12-13
 
     strategy:
       matrix:
@@ -334,7 +334,7 @@ jobs:
     needs: [build, lint, firmware-build-integration-tests]
 
     container:
-      image: ghcr.io/clash-lang/clash-ci-9.0.2:2022-02-02
+      image: ghcr.io/clash-lang/clash-ci-9.0.2:2022-12-13
 
     steps:
       - name: Checkout
@@ -361,8 +361,8 @@ jobs:
           path: |
             ~/.cabal/store
 
-          key: packages-${{ hashFiles('cabal.project.freeze') }}
-          restore-keys: packages-
+          key: packages-cachebust-1-${{ hashFiles('cabal.project.freeze') }}
+          restore-keys: packages-cachebust-1-
 
       - name: Download Firmware Integration Tests
         uses: actions/download-artifact@v2
@@ -384,7 +384,7 @@ jobs:
     needs: [build, lint]
 
     container:
-      image: ghcr.io/clash-lang/clash-ci-9.0.2:2022-02-02
+      image: ghcr.io/clash-lang/clash-ci-9.0.2:2022-12-13
 
     steps:
       - name: Checkout
@@ -405,8 +405,8 @@ jobs:
           path: |
             ~/.cabal/store
 
-          key: packages-${{ hashFiles('cabal.project.freeze') }}
-          restore-keys: packages-
+          key: packages-cachebust-1-${{ hashFiles('cabal.project.freeze') }}
+          restore-keys: packages-cachebust-1-
 
       - name: Unittests
         run: |
@@ -482,7 +482,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: cargo-cache-${{ hashFiles('Cargo.lock') }}
+          key: cargo-cache-cachebust-1-${{ hashFiles('Cargo.lock') }}
 
       - name: Running Tests
         uses: actions-rs/cargo@v1
@@ -521,7 +521,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             ./target/
-          key: cargo-cache-${{ hashFiles('firmware/examples/hello/Cargo.lock') }}
+          key: cargo-cache-cachebust-1-${{ hashFiles('firmware/examples/hello/Cargo.lock') }}
 
       - name: Building "hello" Example
         run: cargo build --release
@@ -562,7 +562,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             ./target/
-          key: cargo-cache-${{ hashFiles('firmware/tests/Cargo.lock') }}
+          key: cargo-cache-cachebust-1-${{ hashFiles('firmware/tests/Cargo.lock') }}
 
       - name: Building Firmware Integration Tests
         run: cargo build --release
@@ -585,7 +585,7 @@ jobs:
     needs: [build, lint]
 
     container:
-      image: ghcr.io/clash-lang/clash-ci-9.0.2:2022-02-02
+      image: ghcr.io/clash-lang/clash-ci-9.0.2:2022-12-13
 
     steps:
       - name: Checkout
@@ -606,8 +606,8 @@ jobs:
           path: |
             ~/.cabal/store
 
-          key: packages-${{ hashFiles('cabal.project.freeze') }}
-          restore-keys: packages-
+          key: packages-cachebust-1-${{ hashFiles('cabal.project.freeze') }}
+          restore-keys: packages-cachebust-1-
 
       - name: Doctests
         run : |
@@ -619,7 +619,7 @@ jobs:
     needs: [build, lint]
 
     container:
-      image: ghcr.io/clash-lang/clash-ci-9.0.2:2022-02-02
+      image: ghcr.io/clash-lang/clash-ci-9.0.2:2022-12-13
 
     steps:
       - name: Checkout
@@ -640,8 +640,8 @@ jobs:
           path: |
             ~/.cabal/store
 
-          key: packages-${{ hashFiles('cabal.project.freeze') }}
-          restore-keys: packages-
+          key: packages-cachebust-1-${{ hashFiles('cabal.project.freeze') }}
+          restore-keys: packages-cachebust-1-
 
       - name: Unit tests
         run : |
@@ -672,7 +672,7 @@ jobs:
           - {top: switchCalendar1kReducedPins, stage: netlist}
 
     container:
-      image: ghcr.io/clash-lang/clash-ci-9.0.2:2022-02-02
+      image: ghcr.io/clash-lang/clash-ci-9.0.2:2022-12-13
       volumes:
         - /opt/tools:/opt/tools
       options: --mac-address="6c:5a:b0:6c:13:0b"
@@ -702,8 +702,8 @@ jobs:
           path: |
             ~/.cabal/store
 
-          key: packages-${{ hashFiles('cabal.project.freeze') }}
-          restore-keys: packages-
+          key: packages-cachebust-1-${{ hashFiles('cabal.project.freeze') }}
+          restore-keys: packages-cachebust-1-
 
       - name: HDL generation and synthesis
         run : |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     container:
       image: ubuntu:22.04
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: REUSE Compliance Check
       uses: fsfe/reuse-action@v1
 
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Install dependencies
         run: |
@@ -60,7 +60,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Set CI flags
         run: |
@@ -94,7 +94,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Set CI flags
         run: |
@@ -154,7 +154,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Set CI flags
         run: |
@@ -188,7 +188,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Set CI flags
         run: |
@@ -222,7 +222,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Set CI flags
         run: |
@@ -303,7 +303,7 @@ jobs:
     steps:
       - name: Checkout
         if: matrix.check != 'formal-checks-disabled'
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Download Contranomy HDL
         if: matrix.check != 'formal-checks-disabled'
@@ -338,7 +338,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Set CI flags
         run: |
@@ -388,7 +388,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Set CI flags
         run: |
@@ -426,7 +426,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Install dependencies
         run: |
@@ -460,7 +460,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Install dependencies
         run: |
@@ -498,7 +498,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Install dependencies
         run: |
@@ -539,7 +539,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Install dependencies
         run: |
@@ -589,7 +589,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Set CI flags
         run: |
@@ -623,7 +623,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Set CI flags
         run: |
@@ -679,7 +679,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Set CI flags
         run: |
@@ -742,7 +742,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Check dependencies for failures
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
           cabal freeze
 
       - name: Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.cabal/store
@@ -106,7 +106,7 @@ jobs:
           cabal freeze
 
       - name: Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.cabal/store
@@ -166,7 +166,7 @@ jobs:
           cabal freeze
 
       - name: Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.cabal/store
@@ -200,7 +200,7 @@ jobs:
           cabal freeze
 
       - name: Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.cabal/store
@@ -234,7 +234,7 @@ jobs:
           cabal freeze
 
       - name: Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.cabal/store
@@ -356,7 +356,7 @@ jobs:
           cabal freeze
 
       - name: Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.cabal/store
@@ -400,7 +400,7 @@ jobs:
           cabal freeze
 
       - name: Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.cabal/store
@@ -601,7 +601,7 @@ jobs:
           cabal freeze
 
       - name: Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.cabal/store
@@ -635,7 +635,7 @@ jobs:
           cabal freeze
 
       - name: Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.cabal/store
@@ -697,7 +697,7 @@ jobs:
           cabal freeze
 
       - name: Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.cabal/store


### PR DESCRIPTION
[Use actions/checkout@v3 on CI](https://github.com/bittide/bittide-hardware/commit/b39b1442e4eefb46982cfcd2789ec8a72bfd3258):

Way back we decided to use v1, because it was the only version that
properly supported git submodules. We don't use submodules anymore
though, so we can freely upgrade - removing quite a few warnings
from CI.

----------------

[Use actions/cache@v3 on CI](https://github.com/bittide/bittide-hardware/commit/9e332f70e5135ba9af1070c3233eec3b7ea4cb39):

Reduces warning noise
