### PR TITLE
fix Rust warnings in CI

### DIFF
--- a/firmware/examples/fdt-read/build.rs
+++ b/firmware/examples/fdt-read/build.rs
@@ -10,7 +10,7 @@ use std::path::Path;
 fn main() {
     let out_dir = env::var("OUT_DIR").expect("No out dir");
     let dest_path = Path::new(&out_dir).join("memory.x");
-    fs::write(&dest_path, include_bytes!("memory.x")).expect("Could not write file");
+    fs::write(dest_path, include_bytes!("memory.x")).expect("Could not write file");
 
     if env::var("CARGO_CFG_TARGET_ARCH").unwrap() == "riscv32" {
         println!("cargo:rustc-link-arg=-Tmemory.x");

--- a/firmware/examples/fdt-read/src/main.rs
+++ b/firmware/examples/fdt-read/src/main.rs
@@ -6,6 +6,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use core::fmt::Write;
+
+#[cfg(not(test))]
 use riscv_rt::entry;
 
 use bittide_sys::{print, println};

--- a/firmware/examples/hello/build.rs
+++ b/firmware/examples/hello/build.rs
@@ -10,7 +10,7 @@ use std::path::Path;
 fn main() {
     let out_dir = env::var("OUT_DIR").expect("No out dir");
     let dest_path = Path::new(&out_dir).join("memory.x");
-    fs::write(&dest_path, include_bytes!("memory.x")).expect("Could not write file");
+    fs::write(dest_path, include_bytes!("memory.x")).expect("Could not write file");
 
     if env::var("CARGO_CFG_TARGET_ARCH").unwrap() == "riscv32" {
         println!("cargo:rustc-link-arg=-Tmemory.x");

--- a/firmware/examples/hello/src/main.rs
+++ b/firmware/examples/hello/src/main.rs
@@ -6,6 +6,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use core::fmt::Write;
+
+#[cfg(not(test))]
 use riscv_rt::entry;
 
 use bittide_sys::println;

--- a/firmware/tests/build.rs
+++ b/firmware/tests/build.rs
@@ -10,7 +10,7 @@ use std::path::Path;
 fn main() {
     let out_dir = env::var("OUT_DIR").expect("No out dir");
     let dest_path = Path::new(&out_dir).join("memory.x");
-    fs::write(&dest_path, include_bytes!("memory.x")).expect("Could not write file");
+    fs::write(dest_path, include_bytes!("memory.x")).expect("Could not write file");
 
     if env::var("CARGO_CFG_TARGET_ARCH").unwrap() == "riscv32" {
         println!("cargo:rustc-link-arg=-Tmemory.x");

--- a/firmware/tests/src/bin/ebreak_exception.rs
+++ b/firmware/tests/src/bin/ebreak_exception.rs
@@ -6,6 +6,8 @@
 #![cfg_attr(not(test), no_main)]
 
 use core::fmt::Write;
+
+#[cfg(not(test))]
 use riscv_rt::entry;
 
 use bittide_sys::println;

--- a/firmware/tests/src/bin/hello_world.rs
+++ b/firmware/tests/src/bin/hello_world.rs
@@ -6,6 +6,8 @@
 #![cfg_attr(not(test), no_main)]
 
 use core::fmt::Write;
+
+#[cfg(not(test))]
 use riscv_rt::entry;
 
 use bittide_sys::println;

--- a/firmware/tests/src/bin/print_numbers.rs
+++ b/firmware/tests/src/bin/print_numbers.rs
@@ -6,6 +6,8 @@
 #![cfg_attr(not(test), no_main)]
 
 use core::fmt::Write;
+
+#[cfg(not(test))]
 use riscv_rt::entry;
 
 use bittide_sys::println;


### PR DESCRIPTION
Because some code needs to be built (but not run) on the host architecture, more conditional compilation flags are necessary.

Also removes some needless borrows that clippy complained about.