### PR TITLE
update riscv-rt and riscv crate dependencies

### DIFF
--- a/firmware/examples/fdt-read/Cargo.toml
+++ b/firmware/examples/fdt-read/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-riscv-rt = "0.10.0"
+riscv-rt = "0.11.0"
 bittide-sys = { path = "../../bittide-sys" }
 fdt = "0.1.0"
-heapless = "0.7.11"
+heapless = { version = "0.7.16", default-features = false }

--- a/firmware/examples/hello/Cargo.toml
+++ b/firmware/examples/hello/Cargo.toml
@@ -12,5 +12,5 @@ authors = ["Google LLC"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-riscv-rt = "0.10.0"
+riscv-rt = "0.11.0"
 bittide-sys = { path = "../../bittide-sys" }

--- a/firmware/tests/Cargo.toml
+++ b/firmware/tests/Cargo.toml
@@ -10,6 +10,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-riscv-rt = "0.10.0"
-riscv = "0.7.0"
+riscv-rt = "0.11.0"
+riscv = "^0.10"
 bittide-sys = { path = "../bittide-sys" }

--- a/firmware/tests/src/bin/ebreak_exception.rs
+++ b/firmware/tests/src/bin/ebreak_exception.rs
@@ -34,7 +34,7 @@ fn main() -> ! {
 
 #[export_name = "ExceptionHandler"]
 fn exception_handler(_trap_frame: &riscv_rt::TrapFrame) -> ! {
-    riscv::interrupt::free(|_| {
+    riscv::interrupt::free(|| {
         println!("... caught an exception. Looping forever now.");
     });
     loop {


### PR DESCRIPTION
Previous versions have been yanked from crates.io