### PR TITLE
Run CI on every push and branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,14 +3,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 name: CI
-on:
-  push:
-    branches:
-      - main
-  pull_request:
-    types:
-      - opened
-      - synchronize
+
+# XXX: What we'd really like is run on every pull request / pull request change,
+#      which allows GitHub to cancel runs after (force) pushes. Triggering on
+#      these seems to be broken since January 19th 2023 however. Note that not
+#      everyone likes auto-cancellation so we should probably recognize [no-skip]
+#      commits.
+on: [push]
 
 concurrency:
  group: ${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
PR trigger seem to be broken at the moment, though triggering on pushes still works. Given that all our development happens in PRs anyway, there is no functional difference between running on every push or running on PR updates.