### PR TITLE
Add stability checker to the simulation

### DIFF
--- a/.github/simulation/all.json
+++ b/.github/simulation/all.json
@@ -1,0 +1,10 @@
+[
+  {"topology": "diamond",   "steps": 8000000,  "args": "" },
+  {"topology": "complete",  "steps": 8000000,  "args": "--nodes 3"},
+  {"topology": "line",      "steps": 8000000,  "args": "--nodes 4"},
+  {"topology": "star",      "steps": 20000000, "args": "--nodes 7"},
+  {"topology": "torus2d",   "steps": 20000000, "args": "--rows 2 --cols 3"},
+  {"topology": "cycle",     "steps": 20000000, "args": "--nodes 5"},
+  {"topology": "hypercube", "steps": 50000000, "args": "--dimensions 3"},
+  {"topology": "random",    "steps": 50000000, "args": "--nodes 5"}
+]

--- a/.github/simulation/staging.json
+++ b/.github/simulation/staging.json
@@ -1,0 +1,3 @@
+[
+  {"topology": "complete", "steps": 1000000, "args": "--nodes 2 --offsets [-2,2] --frame-size 1500"}
+]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,13 +100,41 @@ jobs:
         run: |
           cabal build all --only-dependencies
 
+  elastic-buffer-sim-topologies-matrix:
+    name: elastic-buffer-sim-topologies simulation matrix generation
+    runs-on: self-hosted
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Generate matrix
+        run: |
+          if [[ "${{ github.event_name }}" == "schedule" || $(.github/scripts/force_expensive_checks.sh) == "true" ]]; then
+            cp .github/simulation/all.json sim.json
+          else
+            cp .github/simulation/staging.json sim.json
+          fi
+
+      - name: Set simulation matrix
+        id: set-sim-matrix
+        run: |
+          echo "sim_matrix=$(cat sim.json | tr '\n' ' ')" | tee -a "$GITHUB_OUTPUT"
+
+    outputs:
+      sim_matrix: ${{ steps.set-sim-matrix.outputs.sim_matrix }}
+
   elastic-buffer-sim-topologies:
     name: Simulate network
     runs-on: self-hosted
     defaults:
       run:
         shell: git-nix-shell {0} --pure
-    needs: [build, lint]
+    needs: [build, lint, elastic-buffer-sim-topologies-matrix]
+
+    strategy:
+      matrix:
+        target: ${{ fromJson(needs.elastic-buffer-sim-topologies-matrix.outputs.sim_matrix) }}
+      fail-fast: false
 
     container:
       image: ghcr.io/clash-lang/nixos-bittide-hardware:2023-02-01
@@ -134,18 +162,21 @@ jobs:
           restore-keys: packages-cachebust-3-
           fail-on-cache-miss: true
 
-      # TODO: simulate + plot multiple topologies
       - name: Plot mesh grid
         run: |
-          cabal run -- elastic-buffer-sim:sim +RTS -M8M -RTS plot complete3 150000 100
+          cabal run -- elastic-buffer-sim:sim +RTS -M16M -RTS \
+            --output-mode pdf \
+            --steps ${{ matrix.target.steps }} \
+            --samples 1000 \
+            --stop-when-stable \
+            ${{ matrix.target.topology }} ${{ matrix.target.args }}
 
       - name: Upload plots
         uses: actions/upload-artifact@v3
         with:
           name: gen-plots-hs
-          path: |
-            _build/clockscomplete3.pdf
-            _build/elasticbufferscomplete3.pdf
+          path: _build
+          retention-days: 14
 
   elastic-buffer-sim-tests:
     name: elastic-buffer-sim unittests
@@ -828,6 +859,7 @@ jobs:
         contranomy-sim-tests,
         contranomy-tests,
         elastic-buffer-sim-tests,
+        elastic-buffer-sim-topologies-matrix,
         elastic-buffer-sim-topologies,
         firmware-build-examples,
         firmware-build-integration-tests,

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -48,3 +48,7 @@ License: Apache-2.0
 Files: .github/synthesis/*
 Copyright: 2022 Google LLC
 License: Apache-2.0
+
+Files: .github/simulation/*
+Copyright: 2022 Google LLC
+License: Apache-2.0

--- a/elastic-buffer-sim/elastic-buffer-sim.cabal
+++ b/elastic-buffer-sim/elastic-buffer-sim.cabal
@@ -80,29 +80,37 @@ library
     bytestring,
     cassava,
     clash-cores,
-    constraints,
     containers,
+    deepseq,
     directory,
+    filepath,
     matplotlib,
     random,
-    deepseq,
-    template-haskell
+    text,
+    typelits-witnesses
   exposed-modules:
     Bittide.ClockControl.ElasticBuffer
+    Bittide.Domain
+    Bittide.Plot
     Bittide.Simulate
     Bittide.Topology
     Bittide.Topology.Graph
-    Bittide.Topology.TH.Domain
-  other-modules:
-    Graphics.Matplotlib.Ext
   default-language: Haskell2010
 
 executable sim
   import: common-options
   main-is: exe/Main.hs
   build-depends:
+    aeson,
+    array,
+    random,
+    bytestring,
+    containers,
+    directory,
+    happy-dot,
+    filepath,
     elastic-buffer-sim,
-    docopt
+    optparse-applicative,
   default-language: Haskell2010
   default-extensions: ImplicitPrelude
   -- enable rtsopts so we can setup memory limits

--- a/elastic-buffer-sim/exe/Main.hs
+++ b/elastic-buffer-sim/exe/Main.hs
@@ -2,70 +2,670 @@
 --
 -- SPDX-License-Identifier: Apache-2.0
 
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE OverloadedStrings #-}
+
 module Main (main) where
 
-import Control.Monad (when)
-import Data.Proxy (Proxy (..))
-import Data.Typeable (Typeable, typeRep)
-import System.Console.Docopt
-import System.Environment (getArgs)
-import Text.Read (readMaybe)
+import Data.Aeson
+  ( ToJSON(..)
+  , FromJSON(..)
+  , Value(..)
+  , (.=)
+  , (.:)
+  , encode
+  , decode
+  , object
+  )
+import Data.Aeson.Types (typeMismatch)
+import Control.Monad (forM, forM_, when, replicateM, replicateM_)
+import GHC.Generics (Generic)
+import GHC.Int (Int64)
+import System.Exit (exitSuccess, exitFailure, die)
+import System.FilePath ((</>))
+import System.Directory (createDirectoryIfMissing)
+import Data.ByteString.Lazy qualified as BS
+import Data.Set qualified as S (fromList, toList)
+import Data.Map.Strict qualified as M ((!), fromList)
+import Data.Maybe (catMaybes)
+import Data.Graph (Graph, buildG, edges, scc)
+import Data.Array.MArray (newListArray, readArray, writeArray, getElems, freeze)
+import Data.Array.IO (IOUArray)
+import Data.Array qualified as A ((!))
+import System.Random (randomIO, randomRIO)
 
-import Bittide.Topology
+import Language.Dot.Graph
+import Language.Dot.Pretty (render)
+import Language.Dot.Parser (parse)
 
-readOrError :: forall a. (Typeable a, Read a) => String -> a
-readOrError s =
-  case readMaybe s of
-    Nothing -> error ("Could not parse '" <> s <> "' as '" ++ show (typeRep (Proxy @a)) ++ "'")
-    Just a  -> a
+import Options.Applicative
+import Options.Applicative.Help.Pretty (text)
 
-patterns :: Docopt
-patterns = [docopt|
-sim version 0.1.0
+import Bittide.Plot
 
-Usage:
-  sim csv <steps> <points>
-  sim plot complete2 <steps> <points>
-  sim plot complete3 <steps> <points>
-  sim plot complete6 <steps> <points>
-  sim plot diamond <steps> <points>
-  sim plot star7 <steps> <points>
-  sim plot tree32 <steps> <points>
-  sim plot tree23 <steps> <points>
-  sim plot hypercube3 <steps> <points>
-  sim plot hypercube4 <steps> <points>
+data Topology =
+    Diamond
+  | Line Int
+  | HyperCube Int
+  | Grid Int Int
+  | Torus2D Int Int
+  | Torus3D Int Int Int
+  | Tree Int Int
+  | Star Int
+  | Cycle Int
+  | Complete Int
+  | DotFile FilePath
+  | Random Int
+  deriving (Show, Ord, Eq)
 
-Options:
-  <points> Number of points to keep + pass to plotting library
-|]
+ttype :: Topology -> String
+ttype = \case
+  Diamond{}   -> "diamond"
+  Line{}      -> "line"
+  HyperCube{} -> "hypercube"
+  Grid{}      -> "grid"
+  Torus2D{}   -> "torus2d"
+  Torus3D{}   -> "torus3d"
+  Tree{}      -> "tree"
+  Star{}      -> "star"
+  Cycle{}     -> "cycle"
+  Complete{}  -> "complete"
+  DotFile{}   -> "dotfile"
+  Random{}    -> "random"
 
-getArgOrExit :: Arguments -> Option -> IO String
-getArgOrExit = getArgOrExitWith patterns
+instance ToJSON Topology where
+  toJSON t = object $ case t of
+    Diamond       -> [ gt ]
+    DotFile f     -> [ gt, "filepath"   .= f ]
+    Line n        -> [ gt, "nodes"      .= n ]
+    HyperCube n   -> [ gt, "dimensions" .= n ]
+    Star n        -> [ gt, "nodes"      .= n ]
+    Cycle n       -> [ gt, "nodes"      .= n ]
+    Complete n    -> [ gt, "nodes"      .= n ]
+    Random n      -> [ gt, "nodes"      .= n ]
+    Tree d c      -> [ gt, "depth"      .= d, "childs" .= c ]
+    Grid r c      -> [ gt, "rows"       .= r, "cols"   .= c ]
+    Torus2D r c   -> [ gt, "rows"       .= r, "cols"   .= c ]
+    Torus3D r c p -> [ gt, "rows"       .= r, "cols"   .= c, "planes" .= p ]
+   where
+    gt = "graph" .= ttype t
+
+instance FromJSON Topology where
+  parseJSON v = case v of
+    Object o -> o .: "graph" >>= \(name :: String) -> case name of
+      "diamond"   -> return Diamond
+      "dotfile"   -> DotFile   <$> o .: "filepath"
+      "line"      -> Line      <$> o .: "nodes"
+      "hypercube" -> HyperCube <$> o .: "dimensions"
+      "star"      -> Star      <$> o .: "nodes"
+      "cycle"     -> Cycle     <$> o .: "nodes"
+      "complete"  -> Complete  <$> o .: "nodes"
+      "random"    -> Random    <$> o .: "nodes"
+      "tree"      -> Tree      <$> o .: "depth" <*> o .: "childs"
+      "grid"      -> Grid      <$> o .: "rows"  <*> o .: "cols"
+      "torus2d"   -> Torus2D   <$> o .: "rows"  <*> o .: "cols"
+      "torus3d"   ->
+        Torus3D
+          <$> o .: "rows"
+          <*> o .: "cols"
+          <*> o .: "planes"
+      _ -> tmm
+    _ -> tmm
+   where
+    tmm = typeMismatch "Topology" v
+
+topologyParser :: Parser Topology
+topologyParser = hsubparser
+  (  commandGroup "Available topologies:"
+  <> metavar "TOPOLOGY"
+  <> command (ttype Diamond)
+       (  info
+            ( pure Diamond
+            )
+            $ progDesc "diamond graph"
+       <> footerDoc
+            ( Just $ text $ unlines
+                [ "looks like:"
+                , ""
+                , "      o"
+                , "     / \\"
+                , "    o---o"
+                , "     \\ /"
+                , "      o"
+                ]
+            )
+       )
+  <> command (ttype $ Line undefined)
+       (  info
+            ( Line <$> option auto
+                (  long "nodes"
+                <> short 'n'
+                <> metavar "NUM"
+                <> help "number of nodes of the graph"
+                )
+            )
+            $ progDesc "line graph"
+       <> footerDoc
+            ( Just $ text $ unlines
+                [ "looks like: (for n = 3)"
+                , ""
+                , "  o---o---o"
+                ]
+            )
+       )
+  <> command (ttype $ HyperCube undefined)
+       (  info
+            ( HyperCube <$> option auto
+                (  long "dimensions"
+                <> short 'n'
+                <> metavar "NUM"
+                <> help "number of dimensions"
+                )
+            )
+            $ progDesc "hyper cube"
+       <> footerDoc
+            ( Just $ text $ unlines
+                [ "looks like: (for n = 3)"
+                , ""
+                , "      o---o"
+                , "     /|  /|"
+                , "    o---o |"
+                , "    | o-|-o"
+                , "    |/  |/"
+                , "    o---o"
+                ]
+            )
+       )
+  <> command (ttype $ Grid undefined undefined)
+       (  info
+            ( Grid
+                <$> option auto
+                      (  long "rows"
+                      <> short 'r'
+                      <> metavar "NUM"
+                      <> help "number of rows"
+                      )
+                <*> option auto
+                      (  long "cols"
+                      <> short 'c'
+                      <> metavar "NUM"
+                      <> help "number of columns"
+                      )
+            ) $ progDesc "2-dimensional grid"
+       <> footerDoc
+            ( Just $ text $ unlines
+                [ "looks like: (for r = 3, c = 4)"
+                , ""
+                , "   o---o---o---o"
+                , "   |   |   |   |"
+                , "   o---o---o---o"
+                , "   |   |   |   |"
+                , "   o---o---o---o"
+                ]
+            )
+       )
+  <> command (ttype $ Torus2D undefined undefined)
+       (  info
+            ( Torus2D
+                <$> option auto
+                      (  long "rows"
+                      <> short 'r'
+                      <> metavar "NUM"
+                      <> help "number of rows"
+                      )
+                <*> option auto
+                      (  long "cols"
+                      <> short 'c'
+                      <> metavar "NUM"
+                      <> help "number of columns"
+                      )
+            )
+            $ progDesc "2-dimensional torus"
+       <> footerDoc
+            ( Just $ text $ unlines
+                [  "c.f. https://www.researchgate.net/figure/"
+                <> "The-two-dimensional-torus-4x4_fig1_221134153"
+                ]
+            )
+       )
+  <> command (ttype $ Torus3D undefined undefined undefined)
+       (  info
+            ( Torus3D
+                <$> option auto
+                      (  long "rows"
+                      <> short 'r'
+                      <> metavar "NUM"
+                      <> help "number of rows"
+                      )
+                <*> option auto
+                      (  long "cols"
+                      <> short 'c'
+                      <> metavar "NUM"
+                      <> help "number of columns"
+                      )
+                <*> option auto
+                      (  long "planes"
+                      <> short 'k'
+                      <> metavar "NUM"
+                      <> help "number of planes"
+                      )
+            ) $ progDesc "3-dimensional torus"
+       <> footerDoc
+            ( Just $ text $ unlines
+                [  "c.f. https://upload.wikimedia.org/wikipedia/"
+                <> "commons/thumb/3/3f/2x2x2torus.svg/"
+                <> "220px-2x2x2torus.svg.png"
+                ]
+            )
+       )
+  <> command (ttype $ Tree undefined undefined)
+       (  info
+            ( Tree
+                <$> option auto
+                      (  long "depth"
+                      <> short 'd'
+                      <> metavar "NUM"
+                      <> help "depth of the tree"
+                      )
+                <*> option auto
+                      (  long "childs"
+                      <> short 'c'
+                      <> metavar "NUM"
+                      <> help "number of children"
+                      )
+            ) $ progDesc "balanced tree"
+       <> footerDoc
+            ( Just $ text $ unlines
+                [ "looks like: (for d = 2, c = 2)"
+                , ""
+                , "       o"
+                , "      / \\"
+                , "     o   o"
+                , "    /|   |\\"
+                , "   o o   o o"
+                ]
+            )
+       )
+  <> command (ttype $ Star undefined)
+       (  info
+            ( Star <$> option auto
+                (  long "nodes"
+                <> short 'n'
+                <> metavar "NUM"
+                <> help "number of non-central nodes of the graph"
+                )
+            ) $ progDesc "star shaped graph"
+       <> footerDoc
+            ( Just $ text $ unlines
+                [ "looks like: (for n = 8)"
+                , ""
+                , "    o o o"
+                , "     \\|/"
+                , "   o--o--o"
+                , "     /|\\"
+                , "    o o o"
+                ]
+            )
+       )
+  <> command (ttype $ Cycle undefined)
+       (  info
+            ( Cycle <$> option auto
+                (  long "nodes"
+                <> short 'n'
+                <> metavar "NUM"
+                <> help "number of nodes of the graph"
+                )
+            ) $ progDesc "cycle shaped graph"
+       <> footerDoc
+            ( Just $ text $ unlines
+                [ "looks like: (for NODES = 6)"
+                , ""
+                , "     o--o"
+                , "    /    \\"
+                , "   o      o"
+                , "    \\    /"
+                , "     o--o"
+                ]
+            )
+       )
+  <> command (ttype $ Complete undefined)
+       (  info
+            ( Complete <$> option auto
+                (  long "nodes"
+                <> short 'n'
+                <> metavar "NUM"
+                <> help "number of nodes of the graph"
+                )
+            ) $ progDesc "fully connected graph"
+       <> footerDoc
+            ( Just $ text $ unlines
+                [ "looks like: (for NODES = 4)"
+                , ""
+                , "      o"
+                , "     /|\\"
+                , "    o-+-o"
+                , "     \\|/"
+                , "      o"
+                ]
+            )
+       )
+  <> command (ttype $ Random undefined)
+       (  info
+            ( Random <$> option auto
+                (  long "nodes"
+                <> short 'n'
+                <> metavar "NUM"
+                <> help "number of nodes of the graph"
+                )
+            ) $ progDesc "random connected graph"
+       )
+  <> command (ttype $ DotFile undefined)
+       (  info
+            ( DotFile <$> strOption
+                (  long "dot"
+                <> short 'd'
+                <> metavar "FILE"
+                <> action "file"
+                <> help "GraphViz DOT file"
+                )
+            ) $ progDesc "GraphViz DOT graph"
+       )
+  )
+
+data Options =
+  Options
+    { topology           :: Maybe Topology
+    , outMode            :: OutputMode
+    , simulationSteps    :: Int
+    , simulationSamples  :: Int
+    , stabilityMargin    :: Int
+    , stabilityFrameSize :: Int
+    , stopWhenStable     :: Bool
+    , offsets            :: [Int64]
+    , outDir             :: FilePath
+    , jsonArgs           :: Maybe FilePath
+    , stable             :: Bool
+    }
+  deriving (Show, Ord, Eq, Generic, ToJSON, FromJSON)
+
+optionParser :: Parser Options
+optionParser =
+  Options
+    <$> optional topologyParser
+    <*> option auto
+          (  long "output-mode"
+          <> short 'm'
+          <> metavar "MODE"
+          <> value PDF
+          <> showDefault
+          <> help "Available modes are: csv, pdf"
+          )
+    <*> option auto
+          (  long "steps"
+          <> short 's'
+          <> metavar "NUM"
+          <> value 150000
+          <> showDefault
+          <> help "Number of clock cycles to simulate"
+          )
+    <*> option auto
+          (  long "samples"
+          <> short 'a'
+          <> metavar "NUM"
+          <> value 100
+          <> showDefault
+          <> help "Number of samples to keep & pass to matplotlib"
+          )
+    <*> option auto
+          (  long "margin"
+          <> short 'g'
+          <> metavar "NUM"
+          <> value 8
+          <> showDefault
+          <> help
+               (  "Maximum number of elements a buffer occupancy is "
+               <> "allowed to deviate to be considered stable"
+               )
+          )
+    <*> option auto
+          (  long "frame-size"
+          <> short 'f'
+          <> metavar "NUM"
+          <> value 1500000
+          <> showDefault
+          <> help
+               (  "Minimum number of clock cycles a buffer occupancy "
+               <> "must remain within to be considered stable"
+               )
+          )
+    <*> flag False True
+          (  long "stop-when-stable"
+          <> short 'x'
+          <> help "Stop simulation as soon as all buffers get stable"
+          )
+    <*> option auto
+          (  long "offsets"
+          <> short 't'
+          <> metavar "NUM LIST"
+          <> value []
+          <> showDefault
+          <> help "Initital clock offsets (randomly generated if missing"
+          )
+    <*> strOption
+          (  long "output-directory"
+          <> short 'o'
+          <> metavar "DIR"
+          <> action "directory"
+          <> value "_build"
+          <> showDefault
+          <> help "Directory, to which the generated files are written"
+          )
+    <*> optional
+          ( strOption
+              (  long "json-args"
+              <> short 'j'
+              <> metavar "FILE"
+              <> action "file"
+              <> help
+                   (  "Read arguments from a 'simulate.json' file "
+                   <> "(overwrites all arguments other than '-jz')"
+                   )
+              )
+          )
+    <*> pure False
+
+cliParser :: ParserInfo Options
+cliParser = info (optionParser <**> helper)
+  (  fullDesc
+  <> header "Bittide Hardware Topology Simulator"
+  )
 
 main :: IO ()
 main = do
-  args <- parseArgsOrExit patterns =<< getArgs
+  options@Options{..} <- do
+    opts@Options{..} <- execParser cliParser
+    case jsonArgs of
+      Nothing   -> return opts
+      Just file -> do
+        cnt <- BS.readFile file
+        case decode cnt of
+          Nothing -> die $ "ERROR: Invalid JSON file - " <> file
+          Just o  -> return o { jsonArgs }
 
-  when (args `isPresent` (command "csv")) $ do
-    n <- readOrError <$> args `getArgOrExit` (argument "steps")
-    p <- readOrError <$> args `getArgOrExit` (argument "points")
-    let k = n `quot` p
-    dumpCsv p k
+  let
+    settings =
+      SimulationSettings
+        { margin     = stabilityMargin
+        , framesize  = stabilityFrameSize
+        , samples    = simulationSamples
+        , periodsize = simulationSteps `quot` simulationSamples
+        , mode       = outMode
+        , dir        = outDir
+        , stopStable = stopWhenStable
+        , fixOffsets = offsets
+        }
 
-  when (args `isPresent` (command "plot")) $ do
-    n <- readOrError <$> args `getArgOrExit` (argument "steps")
-    p <- readOrError <$> args `getArgOrExit` (argument "points")
-    let k = n `quot` p
-    let
-      plotFn
-        | args `isPresent` (command "diamond") = plotDiamond
-        | args `isPresent` (command "complete2") = plotK2
-        | args `isPresent` (command "complete3") = plotK3
-        | args `isPresent` (command "complete6") = plotK6
-        | args `isPresent` (command "star7") = plotStar7
-        | args `isPresent` (command "tree32") = plotTree32
-        | args `isPresent` (command "tree23") = plotTree23
-        | args `isPresent` (command "hypercube3") = plotHypercube
-        | args `isPresent` (command "hypercube4") = plotHypercube4
-        | otherwise = error "Internal error: Unknown command"
-    plotFn p k
+  createDirectoryIfMissing True outDir
+
+  (((isStable, offs), g), name) <- case topology of
+    Just t -> let dName = ttype t in case t of
+      Diamond       -> (,dName) <$> plotDiamond settings
+      Line n        -> (,dName) <$> plotLine settings n
+      HyperCube n   -> (,dName) <$> plotHyperCube settings n
+      Grid r c      -> (,dName) <$> plotGrid settings r c
+      Torus2D r c   -> (,dName) <$> plotTorus2D settings r c
+      Torus3D r c p -> (,dName) <$> plotTorus3D settings r c p
+      Tree d c      -> (,dName) <$> plotTree settings d c
+      Star n        -> (,dName) <$> plotStar settings n
+      Cycle n       -> (,dName) <$> plotCyclic settings n
+      Complete n    -> (,dName) <$> plotComplete settings n
+      Random n      -> (,dName) <$> (randomGraph n >>= plotGraph settings)
+      DotFile f     -> (fromDot <$> readFile f) >>= \case
+        Right (g, name) -> (,name) <$> plotGraph settings g
+        Left err        -> die $ "ERROR: Invalid DOT file - " <> f <> "\n" <> err
+    Nothing ->
+      handleParseResult $ Failure
+        $ parserFailure defaultPrefs cliParser (ShowHelpText Nothing) []
+
+  let topologyFile = outDir </> "topology.gv"
+  writeFile topologyFile $ (<> "\n") $ render $ toDot g name
+  BS.writeFile (outDir </> "simulate.json") $ encode options
+     { stable   = isStable
+     , offsets  = offs
+     , jsonArgs = Nothing
+     , topology = case topology of
+         Just (Random _) -> Just $ DotFile topologyFile
+         _               -> topology
+     }
+
+  if isStable
+  then exitSuccess
+  else exitFailure
+
+randomGraph :: Int -> IO Graph
+randomGraph n = do
+  let is = [0,1..n - 1]
+
+  -- get some random vertex permuation for ensuring connectivity
+  aP <- newListArray (0, n - 1) is
+  replicateM_ (10 * n) $ do
+    p1 <- randomRIO (0, n - 1)
+    p2 <- randomRIO (0, n - 1)
+    v1 <- readArray aP p1
+    v2 <- readArray aP p2
+    writeArray aP p1 v2
+    writeArray aP p2 v1
+
+  randomPermutation <- getElems (aP :: IOUArray Int Int)
+
+  -- get some random edge availability matrix for self-loop-free,
+  -- undirected graphs
+  aE <- replicateM (n * n) randomIO >>= newListArray ((0, 0), (n - 1, n - 1))
+  forM_ is $ \i ->
+    writeArray aE (i, i) False
+  forM_ [(i, j) | i <- is, j <- is, i /= j] $ \(i, j) -> do
+    d1 <- readArray aE (i, j)
+    d2 <- readArray aE (j, i)
+    when (d1 /= d2) $ do
+      writeArray aE (i, j) False
+      writeArray aE (j, i) False
+
+  -- ensure connectivity
+  forM_ (pairwise randomPermutation) $ \(i, j) -> do
+    writeArray aE (i, j) True
+    writeArray aE (j, i) True
+
+  available <- freeze (aE :: IOUArray (Int, Int) Bool)
+
+  -- create the graph
+  return $ buildG (0, n - 1)
+    [ (i, j)
+    | i <- is
+    , j <- is
+    , available A.! (i, j)
+    ]
+
+-- | Turns a graph into a graphviz dot structure, as it is required by
+-- the [happy-dot](https://hackage.haskell.org/package/happy-dot) library.
+toDot ::
+  Graph ->
+  -- ^ graph to be turned into graphviz dot
+  String ->
+  -- ^ some name for the graph to be used within gravhviz dot
+  (Bool, GraphType, Maybe Name, [Statement])
+  -- ^ the result, as it is needed by happy-dot
+toDot g name = (True, Graph, Just $ StringID name, map asEdgeStatement $ edges g)
+ where
+  asEdgeStatement (x, y) =
+    EdgeStatement (map (\i -> NodeRef (XMLID ('n' : show i)) Nothing) [x,y]) []
+
+-- | Reads a graph from a dot file. Only the name and structure of the
+-- graph is used, i.e., any additional graphviz dot specific
+-- annotations are ignored.
+fromDot ::
+  String
+  -- ^ the string holding the graphviz dot content
+  -> Either String (Graph, String)
+  -- ^ either an error, if given an unusable input, or the extracted
+  -- graph and name
+fromDot cnt = do
+  (strict, gType, maybe "" fromDotName -> name, statements) <- parse cnt
+
+  when (not strict) $ Left "Graph must be strict"
+  when (gType == Digraph) $ Left "Graph must be undirected"
+
+  edgeChains <- catMaybes <$> mapM fromStatement statements
+
+  let
+    namedEdges = concatMap (pairwise . map asString) edgeChains
+    edgeNames = dedupAndSort $ concatMap (\(x, y) -> [x, y]) namedEdges
+    n = length edgeNames - 1
+    idx = (M.!) $ M.fromList $ zip edgeNames [0,1..]
+    g = buildG (0,n)
+      -- Self loops are removed at this point as they are redundant in
+      -- terms of the simulated topology. In terms of connectivity, a
+      -- node can synchronize its clock with itself even without a
+      -- elastic buffer in between. Therefore, we all self-loops in
+      -- the input, but remove them here, since they don't have any
+      -- effect on the topology that is created out of the graph.
+      $ filter (uncurry (/=))
+      -- remove duplicate edges and sort for pretty printing
+      $ dedupAndSort
+      $ concatMap (\(x, y) -> [(idx x, idx y), (idx y, idx x)])
+        namedEdges
+
+  when (length (scc g) > 1) $ Left "Graph must be strongly connected"
+
+  return (g, name)
+
+ where
+  fromStatement :: Statement -> Either String (Maybe [Name])
+  fromStatement = \case
+    EdgeStatement xs _ -> fmap Just $ forM xs $ \case
+      NodeRef n _ -> return n
+      Subgraph{}  -> Left "Subgraphs are not supported"
+    -- we are only interested in the edges, everthing else can be
+    -- ignored
+    _ -> pure Nothing
+
+  dedupAndSort :: Ord a => [a] -> [a]
+  dedupAndSort = S.toList . S.fromList
+
+  asString = \case
+    StringID x -> 's' : x
+    XMLID x    -> 'x' : x
+
+  fromDotName = \case
+    StringID x -> x
+    XMLID x    -> x
+
+-- | Successive overlapping pairs.
+--
+-- >>> pairwise [1, 2, 3, 4]
+-- [(1,2), (2, 3), (3, 4), (4, 5)]
+-- >>> pairwise []
+-- []
+pairwise :: [a] -> [(a,a)]
+pairwise as = zip as (tail as)

--- a/elastic-buffer-sim/src/Bittide/Domain.hs
+++ b/elastic-buffer-sim/src/Bittide/Domain.hs
@@ -4,7 +4,7 @@
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
-module Bittide.Topology.TH.Domain where
+module Bittide.Domain where
 
 import Clash.Explicit.Prelude
 

--- a/elastic-buffer-sim/src/Bittide/Plot.hs
+++ b/elastic-buffer-sim/src/Bittide/Plot.hs
@@ -1,0 +1,503 @@
+-- SPDX-FileCopyrightText: 2022 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ExistentialQuantification #-}
+
+module Bittide.Plot
+  ( OutputMode(..)
+  , SimulationSettings(..)
+  , plotDiamond
+  , plotCyclic
+  , plotComplete
+  , plotGrid
+  , plotStar
+  , plotTorus2D
+  , plotTorus3D
+  , plotTree
+  , plotLine
+  , plotHyperCube
+  , plotGraph
+  , simulateTopology
+  ) where
+
+import Prelude
+
+import Clash.Prelude
+  ( KnownDomain
+  , KnownNat
+  , SomeNat(..)
+  , SNat(..)
+  , type (<=)
+  , type (+)
+  , someNatVal
+  , natToNum
+  )
+
+import Clash.Sized.Vector qualified as V
+import Clash.Signal.Internal (Femtoseconds(..))
+
+import GHC.Int (Int64)
+import System.Exit (die)
+import Text.Read (Read(..), lexP, pfail, readMaybe)
+import Text.Read.Lex (Lexeme(Ident))
+import Data.List (foldl', transpose)
+import Data.Proxy (Proxy(..))
+import Data.Aeson (ToJSON, FromJSON, Value(..))
+import Data.Aeson.Types (typeMismatch)
+import Data.Aeson qualified as A
+import Data.Text qualified as T
+import Data.Graph qualified as G (Graph, buildG)
+import Data.Array ((!), bounds)
+import Data.Bifunctor (bimap)
+import Data.Csv (toField, encode)
+import Control.Monad (void, zipWithM_, forM_)
+import System.FilePath ((</>))
+import System.Random (randomRIO)
+import Data.Maybe (isNothing)
+import Data.ByteString.Lazy qualified as BSL (appendFile)
+
+import Data.Type.Equality ((:~:)(..))
+import GHC.TypeLits.Compare ((:<=?)(..))
+import GHC.TypeLits.Witnesses ((%<=?))
+import GHC.TypeLits.Witnesses qualified as TLW (SNat(..))
+
+import Graphics.Matplotlib
+  (Matplotlib, (%), (@@), file, plot, xlabel, ylabel, o1, o2, mp)
+
+import Bittide.Simulate (Offset)
+import Bittide.Domain (defBittideClockConfig)
+import Bittide.ClockControl (ClockControlConfig(..), clockPeriodFs)
+import Bittide.Topology (simulate, simulationEntity, allStable)
+import Bittide.Arithmetic.Ppm (diffPeriod)
+import Bittide.Topology.Graph
+
+data OutputMode =
+    CSV
+  | PDF
+  deriving (Ord, Eq)
+
+instance Show OutputMode where
+  show = \case
+    CSV -> "csv"
+    PDF -> "pdf"
+
+instance Read OutputMode where
+  readPrec = lexP >>= \case
+    Ident "csv" -> return CSV
+    Ident "pdf" -> return PDF
+    _           -> pfail
+
+instance ToJSON OutputMode where
+  toJSON = String . T.pack . show
+
+instance FromJSON OutputMode where
+  parseJSON v = case v of
+    String str -> maybe tmm return $ readMaybe $ T.unpack str
+    _          -> tmm
+   where
+    tmm = typeMismatch "OutputMode" v
+
+data SimulationSettings =
+  SimulationSettings
+    { margin     :: Int
+    , framesize  :: Int
+    , samples    :: Int
+    , periodsize :: Int
+    , mode       :: OutputMode
+    , dir        :: FilePath
+    , stopStable :: Bool
+    , fixOffsets :: [Int64]
+    }
+  deriving (Show)
+
+plotDiamond :: SimulationSettings -> IO ((Bool, [Int64]), G.Graph)
+plotDiamond settings@SimulationSettings{..} =
+  case ( someNat margin
+       , somePositiveNat framesize
+       ) of
+    (  Just (SomeNat (_ :: Proxy margin))
+     , Just (SomePositiveNat (_ :: Proxy framesize))
+     ) -> (, unboundGraph diamond) <$>
+       simulateTopology defBittideClockConfig
+         (SNat @margin) (SNat @framesize) diamond settings
+    (x, y) -> invalidArgs False (isNothing x) $ isNothing y
+
+plotCyclic :: SimulationSettings -> Int -> IO ((Bool, [Int64]), G.Graph)
+plotCyclic settings@SimulationSettings{..} nodes =
+  case ( simulatableG (SomeGraph . cyclic) nodes
+       , someNat margin
+       , somePositiveNat framesize
+       ) of
+    (  Just (SomeSimulatableGraph graph)
+     , Just (SomeNat (_ :: Proxy margin))
+     , Just (SomePositiveNat (_ :: Proxy framesize))
+     ) -> (, unboundGraph graph) <$>
+       simulateTopology defBittideClockConfig
+         (SNat @margin) (SNat @framesize) graph settings
+    (x, y, z) -> invalidArgs (isNothing x) (isNothing y) (isNothing z)
+
+plotComplete :: SimulationSettings -> Int -> IO ((Bool, [Int64]), G.Graph)
+plotComplete settings@SimulationSettings{..} nodes =
+  case ( simulatableG (SomeGraph . complete) nodes
+       , someNat margin
+       , somePositiveNat framesize
+       ) of
+    (  Just (SomeSimulatableGraph graph)
+     , Just (SomeNat (_ :: Proxy margin))
+     , Just (SomePositiveNat (_ :: Proxy framesize))
+     ) -> (, unboundGraph graph) <$>
+       simulateTopology defBittideClockConfig
+         (SNat @margin) (SNat @framesize) graph settings
+    (x, y, z) -> invalidArgs (isNothing x) (isNothing y) (isNothing z)
+
+plotGrid :: SimulationSettings -> Int -> Int -> IO ((Bool, [Int64]), G.Graph)
+plotGrid settings@SimulationSettings{..} rows cols =
+  case ( simulatableG2 ((SomeGraph .) . grid) rows cols
+       , someNat margin
+       , somePositiveNat framesize
+       ) of
+    (  Just (SomeSimulatableGraph graph)
+     , Just (SomeNat (_ :: Proxy margin))
+     , Just (SomePositiveNat (_ :: Proxy framesize))
+     ) -> (, unboundGraph graph) <$>
+       simulateTopology defBittideClockConfig
+         (SNat @margin) (SNat @framesize) graph settings
+    (x, y, z) -> invalidArgs (isNothing x) (isNothing y) (isNothing z)
+
+plotStar :: SimulationSettings -> Int -> IO ((Bool, [Int64]), G.Graph)
+plotStar settings@SimulationSettings{..} nodes =
+  case ( simulatableG (SomeGraph . star) nodes
+       , someNat margin
+       , somePositiveNat framesize
+       ) of
+    (  Just (SomeSimulatableGraph graph)
+     , Just (SomeNat (_ :: Proxy margin))
+     , Just (SomePositiveNat (_ :: Proxy framesize))
+     ) -> (, unboundGraph graph) <$>
+       simulateTopology defBittideClockConfig
+         (SNat @margin) (SNat @framesize) graph settings
+    (x, y, z) -> invalidArgs (isNothing x) (isNothing y) (isNothing z)
+
+plotTorus2D :: SimulationSettings -> Int -> Int -> IO ((Bool, [Int64]), G.Graph)
+plotTorus2D settings@SimulationSettings{..} rows cols =
+  case ( simulatableG2 ((SomeGraph .) . torus2d) rows cols
+       , someNat margin
+       , somePositiveNat framesize
+       ) of
+    (  Just (SomeSimulatableGraph graph)
+     , Just (SomeNat (_ :: Proxy margin))
+     , Just (SomePositiveNat (_ :: Proxy framesize))
+     ) -> (, unboundGraph graph) <$>
+       simulateTopology defBittideClockConfig
+         (SNat @margin) (SNat @framesize) graph settings
+    (x, y, z) -> invalidArgs (isNothing x) (isNothing y) (isNothing z)
+
+plotTorus3D :: SimulationSettings -> Int -> Int -> Int -> IO ((Bool, [Int64]), G.Graph)
+plotTorus3D settings@SimulationSettings{..} rows cols planes =
+  case ( simulatableG3 (((SomeGraph .) .) . torus3d) rows cols planes
+       , someNat margin
+       , somePositiveNat framesize
+       ) of
+    (  Just (SomeSimulatableGraph graph)
+     , Just (SomeNat (_ :: Proxy margin))
+     , Just (SomePositiveNat (_ :: Proxy framesize))
+     ) -> (, unboundGraph graph) <$>
+       simulateTopology defBittideClockConfig
+         (SNat @margin) (SNat @framesize) graph settings
+    (x, y, z) -> invalidArgs (isNothing x) (isNothing y) (isNothing z)
+
+plotTree :: SimulationSettings -> Int -> Int -> IO ((Bool, [Int64]), G.Graph)
+plotTree settings@SimulationSettings{..} depth childs =
+  case ( simulatableG2 ((SomeGraph .) . tree) depth childs
+       , someNat margin
+       , somePositiveNat framesize
+       ) of
+    (  Just (SomeSimulatableGraph graph)
+     , Just (SomeNat (_ :: Proxy margin))
+     , Just (SomePositiveNat (_ :: Proxy framesize))
+     ) -> (, unboundGraph graph) <$>
+       simulateTopology defBittideClockConfig
+         (SNat @margin) (SNat @framesize) graph settings
+    (x, y, z) -> invalidArgs (isNothing x) (isNothing y) (isNothing z)
+
+plotLine :: SimulationSettings -> Int -> IO ((Bool, [Int64]), G.Graph)
+plotLine settings@SimulationSettings{..} nodes =
+  case ( simulatableG (SomeGraph . line) nodes
+       , someNat margin
+       , somePositiveNat framesize
+       ) of
+    (  Just (SomeSimulatableGraph graph)
+     , Just (SomeNat (_ :: Proxy margin))
+     , Just (SomePositiveNat (_ :: Proxy framesize))
+     ) -> (, unboundGraph graph) <$>
+       simulateTopology defBittideClockConfig
+         (SNat @margin) (SNat @framesize) graph settings
+    (x, y, z) -> invalidArgs (isNothing x) (isNothing y) (isNothing z)
+
+plotHyperCube :: SimulationSettings -> Int -> IO ((Bool, [Int64]), G.Graph)
+plotHyperCube settings@SimulationSettings{..} nodes =
+  case ( simulatableG (SomeGraph . hypercube) nodes
+       , someNat margin
+       , somePositiveNat framesize
+       ) of
+    (  Just (SomeSimulatableGraph graph)
+     , Just (SomeNat (_ :: Proxy margin))
+     , Just (SomePositiveNat (_ :: Proxy framesize))
+     ) -> (, unboundGraph graph) <$>
+       simulateTopology defBittideClockConfig
+         (SNat @margin) (SNat @framesize) graph settings
+    (x, y, z) -> invalidArgs (isNothing x) (isNothing y) (isNothing z)
+
+
+plotGraph :: SimulationSettings -> G.Graph -> IO ((Bool, [Int64]), G.Graph)
+plotGraph settings@SimulationSettings{..} g =
+  case ( simulatableG (SomeGraph . givenGraph) n
+       , someNat margin
+       , somePositiveNat framesize
+       ) of
+    (  Just (SomeSimulatableGraph graph)
+     , Just (SomeNat (_ :: Proxy margin))
+     , Just (SomePositiveNat (_ :: Proxy framesize))
+     ) -> (, g) <$>
+       simulateTopology defBittideClockConfig
+         (SNat @margin) (SNat @framesize) graph settings
+    (x, y, z) -> invalidArgs (isNothing x) (isNothing y) (isNothing z)
+ where
+  n = let (l, u) = bounds g in u - l + 1
+  givenGraph :: KnownNat n => SNat n -> Graph n
+  givenGraph = const $ boundGraph g
+
+invalidArgs :: Bool -> Bool -> Bool -> IO ((Bool, [Int64]), G.Graph)
+invalidArgs invalidGraph invalidMargin invalidFramesize
+  | invalidGraph     = die "ERROR: the given topology must have between 1 and 20 nodes"
+  | invalidMargin    = die "ERROR: the given margin must be non-negative"
+  | invalidFramesize = die "ERROR: the given frame size must be positive"
+  | otherwise        = return ((False, []), G.buildG (0,0) [])
+
+-- | Creates and write plots for a given topology according to the
+-- given output mode.
+simulateTopology ::
+  forall dom nodes dcount margin framesize.
+  ( KnownDomain dom
+  -- ^ domain
+  , KnownNat nodes
+  -- ^ the size of the topology is know
+  , KnownNat dcount
+  -- ^ the size of the data counts is known
+  , KnownNat margin
+  -- ^ the margins of the stability checker are known
+  , KnownNat framesize
+  -- ^ the frame size of cycles within the margins required is known
+  , 1 <= nodes
+  -- ^ the topology consists of at least one node
+  , 1 <= dcount
+  -- ^ data counts must contain data
+  , nodes + dcount <= 32
+  -- ^ computational limit of the clock control
+  , 1 + nodes <= 32
+  -- ^ computational limit of the clock control
+  , 1 <= framesize
+  -- ^ frames must at least cover one element
+  ) =>
+  ClockControlConfig dom dcount ->
+  -- ^ clock control configuration
+  SNat margin ->
+  -- ^ margin of the stability checker
+  SNat framesize ->
+  -- ^ frame size of cycles within the margins required
+  Graph nodes ->
+  -- ^ the topology
+  SimulationSettings ->
+  -- ^ simulation settings
+  IO (Bool, [Int64])
+  -- ^ stability result & offsets
+simulateTopology ccc margin framesize graph settings = do
+  offs <- V.zipWith (maybe id const) givenOffsets <$> genOffs ccc
+  let simResult = sim offs
+  case mode of
+    PDF -> plotTopology simResult
+    CSV -> dumpCsv simResult
+  return
+    ( allStable $ V.map last simResult
+    , (\(Femtoseconds x) -> x) <$> V.toList offs
+    )
+ where
+  SimulationSettings
+    { samples
+    , periodsize
+    , mode
+    , dir
+    , stopStable
+    , fixOffsets
+    } = settings
+
+  sim =
+   simulate graph stopStable samples periodsize
+    . simulationEntity graph ccc margin framesize
+
+  plotTopology =
+    uncurry (matplotWrite dir) . V.unzip . V.map plotDats
+
+  plotDats =
+      bimap
+        (uncurry plot . unzip)
+        (foldPlots . fmap plotEbData . transpose)
+    . unzip
+    . fmap (\(x,y,z) -> ((x,y), (x,) <$> z))
+
+  givenOffsets =
+      V.unsafeFromList
+    $ take (natToNum @nodes)
+    $ (Just . Femtoseconds <$> fixOffsets) <> repeat Nothing
+
+  dumpCsv simulationResult = do
+    forM_ [0..n] $ \i -> do
+      let eb = unboundGraph graph ! i
+      writeFile (filename i)
+        ( "t,clk" <> show i
+            <> concatMap (\j -> ",eb" <> show i <> show j) eb <>  "\n")
+    let dats = V.map (encode . fmap flatten) simulationResult
+    zipWithM_
+      (\dat i -> BSL.appendFile (filename i) dat)
+      (V.toList dats)
+      [(0 :: Int)..]
+
+  filename i = dir </> "clocks" <> "_" <> show i <> ".csv"
+  flatten (a, b, v) = toField a : toField b : (toField . fst <$> v)
+  (0, n) = bounds $ unboundGraph $ graph
+
+-- | Plots the datacount of an elastic buffer and marks those parts of
+-- the plots that are reported to be stable by the stability checker
+-- for the repsective buffer.
+plotEbData ::
+  (ToJSON t, ToJSON d) => [(t, (d, Bool))] -> Matplotlib
+plotEbData xs = foldPlots markedIntervals % ebPlot
+ where
+  mark = (@@ [ o1 "g-", o2 "linewidth" (10 :: Int)])
+  ebPlot = uncurry plot $ unzip (pData <$> xs)
+
+  markedIntervals =
+    mark . uncurry plot . unzip
+      <$> stableIvs [] False xs
+
+  stableIvs a _       []     = a
+  stableIvs a collect (x:xr) = stableIvs a' (stable x) xr
+   where
+    a' | stable x       && not collect = [pData x] : a
+       | stable x       && collect     = (pData x : y) : yr
+       | not (stable x) && collect     = reverse y : yr
+       | otherwise                     = a
+    y : yr = a
+
+  stable (_, (_, s)) = s
+  pData (t, (d, _)) = (t, d)
+
+-- | Folds the vectors of generated plots and writes the results to
+-- the disk.
+matplotWrite ::
+  KnownNat n =>
+  FilePath ->
+  -- ^ output directory
+  V.Vec n Matplotlib ->
+  -- ^ clock plots
+  V.Vec n Matplotlib ->
+  -- ^ elastic buffer plots
+  IO ()
+matplotWrite dir clockDats ebDats = do
+  void $
+    file
+      ( dir </> "clocks" <> ".pdf")
+      ( xlabel "Time (fs)"
+      % ylabel "Relative period (fs) [0 = ideal frequency]"
+      % foldPlots (V.toList clockDats)
+      )
+  void $
+    file
+      ( dir </> "elasticbuffers" <> ".pdf")
+      (xlabel "Time (fs)" % foldPlots (V.toList ebDats))
+
+-- | Folds multiple plots together
+foldPlots :: [Matplotlib] -> Matplotlib
+foldPlots = foldl' (%) mp
+
+-- | Generates a vector of random offsets.
+genOffs ::
+  (KnownDomain dom, KnownNat n, KnownNat m) =>
+  ClockControlConfig dom m ->
+  IO (V.Vec n Offset)
+genOffs = V.traverse# genOffsets . V.replicate SNat
+
+-- | Randomly generate an 'Offset', how much a real clock's period may
+-- differ from its spec.
+genOffsets ::
+  forall dom n.
+  KnownDomain dom =>
+  ClockControlConfig dom n ->
+  IO Offset
+genOffsets ClockControlConfig{cccDeviation} = do
+  offsetPpm <- randomRIO (-cccDeviation, cccDeviation)
+  pure (diffPeriod offsetPpm (clockPeriodFs @dom Proxy))
+
+someNat :: Int -> Maybe SomeNat
+someNat = someNatVal . toInteger
+
+data SomePositiveNat =
+  forall n. (KnownNat n, 1 <= n) =>
+    SomePositiveNat (Proxy n)
+
+somePositiveNat :: Int -> Maybe SomePositiveNat
+somePositiveNat n = someNatVal (toInteger n) >>= \(SomeNat (_ :: p n)) ->
+  case TLW.SNat @1 %<=? TLW.SNat @n of
+    LE Refl -> Just $ SomePositiveNat (Proxy @n)
+    _       -> Nothing
+
+data SomeGraph =
+    forall n. KnownNat n =>
+      SomeGraph (Graph n)
+
+data SomeSimulatableGraph =
+  forall n. (KnownNat n, 1 <= n, n <= 20)
+    => SomeSimulatableGraph (Graph n)
+
+simulatableG ::
+  ( forall n.
+    KnownNat n =>
+    SNat n -> SomeGraph
+  ) ->
+  Int -> Maybe SomeSimulatableGraph
+simulatableG build n =
+  someNatVal (toInteger n) >>= \case
+    (SomeNat (_ :: Proxy s)) -> case build (SNat @s) of
+      SomeGraph g -> case TLW.SNat @1 %<=? (graphSize g) of
+        LE Refl -> case (graphSize g) %<=? TLW.SNat @20 of
+          LE Refl -> Just $ SomeSimulatableGraph g
+          _       -> Nothing
+        _       -> Nothing
+
+simulatableG2 ::
+  ( forall n m.
+    (KnownNat n, KnownNat m) =>
+    SNat n -> SNat m -> SomeGraph
+  ) ->
+  Int -> Int -> Maybe SomeSimulatableGraph
+simulatableG2 build x y =
+  someNatVal (toInteger x) >>= \case
+    (SomeNat (_ :: Proxy s)) ->
+      simulatableG (build (SNat @s)) y
+
+simulatableG3 ::
+  ( forall n m k.
+    (KnownNat n, KnownNat m, KnownNat k) =>
+    SNat n -> SNat m -> SNat k -> SomeGraph) ->
+  Int -> Int -> Int -> Maybe SomeSimulatableGraph
+simulatableG3 build x y z =
+  someNatVal (toInteger x) >>= \case
+    (SomeNat (_ :: Proxy s)) ->
+      simulatableG2 (build (SNat @s)) y z
+
+graphSize :: KnownNat n => Graph n -> TLW.SNat n
+graphSize = const TLW.SNat

--- a/elastic-buffer-sim/src/Bittide/Topology.hs
+++ b/elastic-buffer-sim/src/Bittide/Topology.hs
@@ -4,252 +4,181 @@
 
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE MagicHash #-}
 
--- | This module generates a static topology using template haskell and then
--- dumps clock periods and elastic buffer occupancy to csv.
+-- | This module defines the top entity for simulation, where every
+--  non-empty topology is supported. The top entity can be simulated
+--  using 'simulate'.
 module Bittide.Topology
-  ( dumpCsv
-  , plotEbs
-  , plotHypercube
-  , plotHypercube4
-  , plotTorus34
-  , plotK2
-  , plotK3
-  , plotK6
-  , plotC12
-  , plotDiamond
-  , plotTree32
-  , plotTree23
-  , plotStar7
-  , simulateMesh
-  , plotMesh
-  , absTimes
+  ( simulationEntity
+  , simulate
+  , allStable
   )
 where
 
+import Clash.Prelude hiding (simulate)
+import Clash.Signal.Internal
+  ( Signal(..)
+  , Clock(..)
+  , Femtoseconds(..)
+  )
+
 import Data.Maybe (catMaybes)
-import Control.Monad (void, zipWithM_, forM_)
-import Data.Bifunctor (bimap)
-import Data.Csv (toField, encode)
-import Data.Graph (edges)
-import Data.Proxy
-import System.Directory (createDirectoryIfMissing)
-import Graphics.Matplotlib (Matplotlib, (%), file, plot, xlabel, ylabel)
-import System.Random (randomRIO)
-
-import Prelude qualified as P
-import Data.List qualified as L
-import Data.Array qualified as A
-import Data.ByteString.Lazy qualified as BSL
-
-import Clash.Explicit.Prelude
-import Clash.Explicit.Prelude qualified as Clash
-import Clash.Signal.Internal qualified as Clash
+import Data.Proxy (Proxy(..))
+import Data.List qualified as L (take, drop)
+import Control.DeepSeq (NFData, force)
 
 import Bittide.Simulate
-import Bittide.Arithmetic.Ppm
 import Bittide.ClockControl
 import Bittide.ClockControl.Callisto
 import Bittide.ClockControl.ElasticBuffer
+import Bittide.ClockControl.StabilityChecker
 import Bittide.Topology.Graph
-import Graphics.Matplotlib.Ext
-import Bittide.Topology.TH.Domain (defBittideClockConfig)
-import Control.DeepSeq
 
--- | A 'Graph' with a name and a link availability check
-data Mesh (n :: Nat) =
-  Mesh
-    { name :: String
-    , graph :: Graph n
-    , available :: Index n -> Index n -> Bool
-    }
-
--- | Smart 'Mesh' constructor
-mesh :: KnownNat n => String -> Graph n -> Mesh n
-mesh name graph = Mesh name graph available
- where
-  available = curry $ (A.!) $
-    A.accumArray
-      (const id)
-      False
-      ((minBound, minBound), (maxBound, maxBound))
-      (P.zip (filter (uncurry (/=)) edgeIndices) [True, True ..])
-  edgeIndices =
-    fmap (bimap fromIntegral fromIntegral)
-      $ edges
-      $ unboundGraph graph
-
--- | This samples @n@ steps, taking every @k@th datum, and plots clock speeds
--- and elastic buffer occupancy
-plotEbs :: Int -> Int -> IO ()
-plotEbs = plotC12
-
-plotDiamond :: Int -> Int -> IO ()
-plotDiamond = plotMesh $ mesh "diamond" diamond
-
-plotHypercube :: Int -> Int -> IO ()
-plotHypercube = plotMesh $ mesh "hypercube3" $ hypercube (SNat @3)
-
-plotHypercube4 :: Int -> Int -> IO ()
-plotHypercube4 = plotMesh $ mesh "hypercube4" $ hypercube (SNat @4)
-
-plotTorus34 :: Int -> Int -> IO ()
-plotTorus34 = plotMesh $ mesh "torus34" $ torus2d (SNat @3) (SNat @4)
-
-plotK2 :: Int -> Int -> IO ()
-plotK2 = plotMesh $ mesh "complete2" $ complete (SNat @2)
-
-plotK3 :: Int -> Int -> IO ()
-plotK3 = plotMesh $ mesh "complete3" $ complete (SNat @3)
-
-plotK6 :: Int -> Int -> IO ()
-plotK6 = plotMesh $ mesh "complete6" $ complete (SNat @6)
-
-plotC12 :: Int -> Int -> IO ()
-plotC12 = plotMesh $ mesh "cyclic12" $ cyclic (SNat @12)
-
-plotStar7 :: Int -> Int -> IO ()
-plotStar7 = plotMesh $ mesh "star7" $ star (SNat @7)
-
-plotTree32 :: Int -> Int -> IO ()
-plotTree32 = plotMesh $ mesh "tree32" $ tree (SNat @3) (SNat @2)
-
-plotTree23 :: Int -> Int -> IO ()
-plotTree23 = plotMesh $ mesh "tree23" $ tree (SNat @2) (SNat @3)
-
--- | This samples @n@ steps, taking every @k@th datum; the result can be fed to
--- @script.py@
-dumpCsv :: Int -> Int -> IO ()
-dumpCsv m k = do
-  offs <- genOffs
-  createDirectoryIfMissing True "_build"
-  forM_ [0..n] $ \i ->
-    let eb = unboundGraph (graph g) A.! i in
-    writeFile
-      ("_build/clocks" <> show i <> ".csv")
-      ("t,clk" <> show i <> P.concatMap (\j -> ",eb" <> show i <> show j) eb <>  "\n")
-  let dats = map (encode . fmap flatten) $ simulateMesh defBittideClockConfig g m k offs
-  zipWithM_
-    (\dat i -> BSL.appendFile ("_build/clocks" <> show i <> ".csv") dat)
-    (toList dats)
-    [(0 :: Int)..]
- where
-  flatten (a, b, v) = toField a : toField b : (toField <$> v)
-  (0, n) = A.bounds $ unboundGraph $ graph g
-  g = mesh "complete" $ complete (SNat @6)
-
--- | Creates a and write the plots for a given mesh of type
---
--- > Int -> Int -> IO ()
---
--- for a given mesh, which writes/dumps simulation results for a
--- particular graph.
-plotMesh ::
-  forall n.
-  (KnownNat n, 1 <= n, n <= 20) =>
-  Mesh n ->
-  Int ->
-  Int ->
-  IO ()
-plotMesh api m k = do
-  offs <- genOffs
-  uncurry (matplotWrite api)
-    $ unzip
-    $ map plotDats
-    $ simulateMesh defBittideClockConfig api m k offs
- where
-  plotDats =
-      bimap
-        (uncurry plot . P.unzip)
-        (foldPlots . P.fmap (uncurry plot . P.unzip) . L.transpose)
-    . P.unzip
-    . fmap (\(x,y,z) -> ((x,y), (x,) <$> z))
-
--- | Given a mesh with \(n\) vertices, creates a function which takes
--- a bound @m@ for the number of samples, a bound @k@ for the sampling
--- period, a vector of \(n\) offsets (divergence from spec) and a
--- vertex @i@ selected for simulation.
+-- | The entity to be simulated consisting of the tunable clock
+-- generators, the elastic buffers, the stability checkers, and the
+-- clock controls, wired according to the given topology.
 --
 -- NOTE: All clocks are implicitly synchronized to the same clock
 -- domain at this point, which is ok as long as the dynamic clock
 -- generator is used. Otherwise the domains have to be differentiated
--- at the type level, which is not straightforward to archive for fully
--- connected topologies.
-simulateMesh ::
-  forall n m dom.
-  ( Clash.KnownDomain dom
-  , KnownNat n
-  , KnownNat m
-  , 1 <= n
-  , 1 <= m
-  , n + m <= 32
-  , 1 + n <= 32
+-- at the type level, which is not straightforward to archive for
+-- fully connected topologies.
+simulationEntity ::
+  ( KnownDomain dom
+  -- ^ domain
+  , KnownNat nodes
+  -- ^ the size of the topology is known
+  , KnownNat dcount
+  -- ^ the size of the data counts is known
+  , KnownNat margin
+  -- ^ the margins of the stability checker are known
+  , KnownNat framesize
+  -- ^ the frame size of cycles within the margins required is known
+  , 1 <= nodes
+  -- ^ the topology consists of at least one node
+  , 1 <= dcount
+  -- ^ data counts must contain data
+  , nodes + dcount <= 32
+  -- ^ computational limit of the clock control
+  , 1 + nodes <= 32
+  -- ^ computational limit of the clock control
+  , 1 <= framesize
+  -- ^ frames must at least cover one element
   ) =>
-  ClockControlConfig dom m ->
-  Mesh n ->
-  Int ->
-  Int ->
-  Vec n Offset ->
-  Vec n [(Period, Period, [DataCount m])]
-simulateMesh ccc Mesh{..} m k !offsets =
-    transposeLV
-  $ P.take m
-  $ takeEveryN k
-  $ absTimes available
-  $ bundle
-  $ zipWith (curry bundle) clkSignals (bundle <$> ebs)
+  Graph nodes ->
+  -- ^ the topology
+  ClockControlConfig dom dcount ->
+  -- ^ clock control configuration
+  SNat margin ->
+  -- ^ margin of the stability checker
+  SNat framesize ->
+  -- ^ frame size of cycles within the margins required
+  Vec nodes Offset ->
+  -- ^ initial clock offsets
+  Signal dom (Vec nodes (Period, Vec nodes (DataCount dcount, Bool)))
+  -- ^ simulation entity
+simulationEntity topology ccc margin framesize !offsets =
+    bundle
+  $ zipWith (curry bundle) clkSignals
+  $ bundle <$> zipWith (zipWith (curry bundle)) ebs scs
  where
   -- elastic buffers
   !ebs = imap ebv clocks
   ebv x = flip imap clocks . eb x
   eb x xClk y yClk
-    | available x y = elasticBuffer Error xClk yClk
-    | otherwise     = pure 0
-  -- clocks
+    | hasEdge topology x y = elasticBuffer Error xClk yClk
+    | otherwise            = pure 0
+  -- stability checkers
+  !scs = imap (\i (v, clk) -> imap (sc i clk) v) $ zip ebs clocks
+  sc x clk y
+    | hasEdge topology x y =
+        withClockResetEnable clk resetGen enableGen $
+          stabilityChecker margin framesize
+    | otherwise     = const $ pure False
+  -- clock generators
   !clocks = clock <$> offsets <*> clockControls
   clock offset =
     tunableClockGen
       (cccSettlePeriod ccc)
       offset
       (cccStepSize ccc)
-      Clash.resetGen
+      resetGen
   -- clock controls
   !clockControls = clockControl <$> clocks <*> masks <*> ebs
   clockControl clk =
     callistoClockControl
       clk
-      Clash.resetGen
-      Clash.enableGen
+      resetGen
+      enableGen
       ccc
     . pure
   -- clock signals
   !clkSignals = extractPeriods <$> clocks
   -- available link mask vectors
   !masks = nVec (v2bv . nVec . avail)
-  avail x y = if available x y then high else low
+  avail x y = if hasEdge topology x y then high else low
   nVec = flip map indicesI
+
+-- | Simulates some topology simulation entity.
+simulate ::
+  ( KnownDomain dom
+  -- ^ domain
+  , KnownNat nodes
+  -- ^ the size of the topology is known
+  , KnownNat dcount
+  -- ^ the size of the data counts is known
+  ) =>
+  Graph nodes ->
+  -- ^ the topology
+  Bool ->
+  -- ^ stop simulation as soon as all buffers get stable
+  Int ->
+  -- ^ number of samples to keep & pass
+  Int ->
+  -- ^ number of cycles in one sample period
+  Signal dom (Vec nodes (Period, Vec nodes (DataCount dcount, Bool))) ->
+  -- ^ simulation entity
+  Vec nodes [(Period, Period, [(DataCount dcount, Bool)])]
+simulate topology stopWhenStable samples periodsize =
+    transposeLV
+  . takeWhilePlus unstable
+  . L.take samples
+  . takeEveryN periodsize
+  . absTimes topology
+ where
+  unstable
+    | stopWhenStable = not . allStable
+    | otherwise      = const True
+
+  takeWhilePlus p = \case
+    []   -> []
+    x:xs -> if p x then x : takeWhilePlus p xs else [x]
+
+-- | Checks whether all stability checkers report a stable result.
+allStable :: KnownNat n => Vec n (a, b, [(c, Bool)]) -> Bool
+allStable = and . toList . map ((\(_,_,xs) -> all snd xs))
 
 -- | Absolute time unfolding of the produced signal for generating the
 -- simulation data.
 absTimes ::
-  (KnownNat n, NFData a) =>
-  (Index n -> Index n -> Bool) ->
-  -- ^ Available links according to the graph topology
-  Signal dom (Vec n (Period, Vec n a)) ->
+  (KnownNat nodes, NFData a) =>
+  Graph nodes ->
+  -- ^ the topology
+  Signal dom (Vec nodes (Period, Vec nodes a)) ->
   -- ^ The signal holding the the simulation result
-  [Vec n (Period, Period, [a])]
+  [Vec nodes (Period, Period, [a])]
   -- ^ The same data as in the input signal, only lazily unfolded as
   -- an infinite data stream and with the unavailable links
   -- already thrown out from the last tuple member.
-absTimes available = go $ replicate SNat (Clash.Femtoseconds 0)
+absTimes topology = go $ replicate SNat (Femtoseconds 0)
  where
-  go !ts (v Clash.:- vs) =
+  go !ts (v :- vs) =
     force (izipWith (\i t (p, es) -> (t, p, filterAvailable i es)) ts v)
       : go (force $ zipWith addFs ts $ map fst v) vs
   -- turns a fixed sized vector of data corresponding to the topology
-  -- links to a list data entries reduced to the available links
-  filterAvailable i = catMaybes . toList . imap (asMaybe . available i)
+  -- links to a list of data entries, reduced to the available links
+  filterAvailable i =
+    catMaybes . toList . imap (asMaybe . hasEdge topology i)
   asMaybe = \case
     True  -> Just
     False -> const Nothing
@@ -262,48 +191,12 @@ transposeLV = \case
 
 -- | Extracts the time periods from a clock
 extractPeriods ::
-  forall dom. Clash.KnownDomain dom =>
-  Clash.Clock dom ->
-  Clash.Signal dom Period
+  forall dom. KnownDomain dom =>
+  Clock dom ->
+  Signal dom Period
 extractPeriods = \case
-  (Clash.Clock _ (Just s)) -> s
-  _                        -> pure (clockPeriodFs @dom Proxy)
-
--- | Randomly generate a 'Offset', how much a real clock's period may differ
--- from its spec.
-genOffsets ::
-  forall dom n.
-  Clash.KnownDomain dom =>
-  ClockControlConfig dom n ->
-  IO Offset
-genOffsets ClockControlConfig{cccDeviation} = do
-  offsetPpm <- randomRIO (-cccDeviation, cccDeviation)
-  pure (diffPeriod offsetPpm (clockPeriodFs @dom Proxy))
-
--- | Folds the vectors of generated plots and writes the results to
--- the disk.
-matplotWrite ::
-  KnownNat n =>
-  Mesh n ->
-  -- ^ the `Mesh` the data is generated for
-  Vec n Matplotlib ->
-  -- ^ clock plots
-  Vec n Matplotlib ->
-  -- ^ elastic buffer plots
-  IO ()
-matplotWrite Mesh{..} clockDats ebDats = do
-  createDirectoryIfMissing True "_build"
-  void $
-    file
-      ("_build/clocks" P.++ name P.++ ".pdf")
-      ( xlabel "Time (fs)"
-      % ylabel "Relative period (fs) [0 = ideal frequency]"
-      % foldPlots (toList clockDats)
-      )
-  void $
-    file
-      ("_build/elasticbuffers" P.++ name P.++ ".pdf")
-      (xlabel "Time (fs)" % foldPlots (toList ebDats))
+  (Clock _ (Just s)) -> s
+  _                  -> pure (clockPeriodFs @dom Proxy)
 
 -- | As an example:
 --
@@ -312,7 +205,4 @@ matplotWrite Mesh{..} clockDats ebDats = do
 takeEveryN :: Int -> [a] -> [a]
 takeEveryN n = \case
   []     -> []
-  (x:xs) -> x : takeEveryN n (P.drop (n - 1) xs)
-
-genOffs :: forall n. KnownNat n => IO (Vec n Offset)
-genOffs = traverse# genOffsets $ replicate SNat defBittideClockConfig
+  (x:xs) -> x : takeEveryN n (L.drop (n - 1) xs)


### PR DESCRIPTION
Adds the following new features:
* Stability checking of the elastic buffers, where
  * the stability is highlighted within the plots, and
  * the return value captures the stability of all buffers at the end of the simulation.
* Running the simulation is now separated from the simulation entity (see [`Bittide.Toplogy`](https://github.com/bittide/bittide-hardware/blob/stability-check/elastic-buffer-sim/src/Bittide/Topology.hs)), where the entity captures all synthesizable parts of the simulation architecture.
* More CLI options have been added (use `--help` for details), featuring
  * topology generation via CLI arguments,
  * reproduction of the experiment from a generated JSON file and DOT graph

---------------------

TODOs:

- [x] fix CI build problem
- [x] add the random offsets to the `simulation.json`
- [x] rebase after the nix branch has been merged
- [x] add a CLI flag for stopping simulation as soon as all buffers are stable
- [x] fix the problem of the slowdown
- [x] integrate with `staging`: #247

Other "Nice-to-Have"s:

- [x] _(make CLI arguments optional, if passed via JSON file)_
- [x] _(support passing topologies as files)_
- [x] _(support random topology generation)_