### PR TITLE
Add ELF/DTC interpretation utilities

### DIFF
--- a/bittide/bittide.cabal
+++ b/bittide/bittide.cabal
@@ -76,23 +76,27 @@ library
   import: common-options
   hs-source-dirs: src
   build-depends:
-    aeson,
-    base,
     Cabal,
-    cassava,
-    clash-cores,
+    aeson,
     array,
+    base,
     bittide-extra,
     bytestring,
-    -- clash-prelude will set suitable version bounds for the plugins
+    cassava,
+    clash-cores,
     clash-lib >= 1.6.3 && < 1.8,
     clash-prelude >= 1.6.3 && < 1.8,
     clash-protocols,
     constraints >= 0.13.3 && < 0.15,
     containers >= 0.4.0 && < 0.7,
     clash-vexriscv,
+    directory,
+    elf,
+    exceptions,
+    process,
     random,
     string-interpolate ^>= 0.3,
+    template-haskell,
   exposed-modules:
     Bittide.Arithmetic.Ppm
     Bittide.Arithmetic.Time
@@ -110,6 +114,9 @@ library
     Bittide.Link
     Bittide.Node
     Bittide.ProcessingElement
+    Bittide.ProcessingElement.DeviceTreeCompiler
+    Bittide.ProcessingElement.ReadElf
+    Bittide.ProcessingElement.Util
     Bittide.ScatterGather
     Bittide.SharedTypes
     Bittide.Switch
@@ -118,6 +125,9 @@ library
     Clash.Cores.Xilinx.Extra
     Clash.Sized.Extra
     Data.Constraint.Nat.Extra
+    System.IO.Temp.Extra
+  other-modules:
+    Paths_bittide
 
 executable clash
   import: common-options
@@ -151,25 +161,27 @@ test-suite unittests
     Tests.ElasticBuffer
     Tests.Haxioms
     Tests.Link
+    Tests.ProcessingElement.ReadElf
     Tests.ScatterGather
     Tests.Shared
     Tests.StabilityChecker
     Tests.Switch
     Tests.Wishbone
   build-depends:
+    HUnit,
     base,
     bittide,
+    bytestring,
     clash-cores,
     clash-lib,
-    clash-prelude-hedgehog >= 1.6 && < 1.8,
     clash-prelude,
+    clash-prelude-hedgehog >= 1.6 && < 1.8,
     clash-protocols,
     constraints >= 0.13.3 && < 0.15,
     containers,
+    elf,
     hedgehog >= 1.0 && < 1.1,
     tasty >= 1.4 && < 1.5,
-    tasty-th,
-    HUnit,
-    tasty-hunit,
     tasty-hedgehog >= 1.2 && < 1.3,
     tasty-hunit,
+    tasty-th,

--- a/bittide/src/Bittide/ProcessingElement/DeviceTreeCompiler.hs
+++ b/bittide/src/Bittide/ProcessingElement/DeviceTreeCompiler.hs
@@ -1,0 +1,61 @@
+-- SPDX-FileCopyrightText: 2022 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+
+module Bittide.ProcessingElement.DeviceTreeCompiler
+  ( compileDeviceTreeSource
+  ) where
+
+
+import Prelude
+
+import Data.Char (isSpace)
+import Data.List (dropWhileEnd)
+import System.Exit
+import System.IO (hPutStrLn)
+import System.Process
+
+import System.IO.Temp.Extra
+
+import qualified Data.ByteString as BS
+import qualified System.IO as IO
+
+
+findDtc :: IO (Maybe FilePath)
+findDtc = do
+  let process = shell "which dtc"
+  (exitcode, stdout, _) <- readCreateProcessWithExitCode process ""
+
+  case exitcode of
+    ExitSuccess   -> pure . Just $ dropWhileEnd isSpace stdout
+    ExitFailure _ -> pure Nothing
+
+compileDeviceTreeSource :: FilePath -> IO (Maybe BS.ByteString)
+compileDeviceTreeSource src = withTempBinaryFile "tmp" "fdt.dtb" $ \path _ -> do
+  dtcPathRes <- findDtc
+  case dtcPathRes of
+    Nothing -> do
+      hPutStrLn IO.stderr
+        "Unable to find device tree compiler on the system. Are you in a Nix shell?"
+      pure Nothing
+    Just dtc -> do
+
+      (exitCode, stdout, stderr) <- readProcessWithExitCode
+        dtc
+        ["-O", "dtb", "-b", "0", src, "-o", path] -- args
+        "" -- stdin
+
+      case exitCode of
+        ExitSuccess -> do
+          content <- BS.readFile path
+          pure $ Just content
+        ExitFailure n -> do
+          hPutStrLn IO.stderr $ "devicetree compilation failed with exit code: " <> show n
+          hPutStrLn IO.stderr $ "devicetree-source file: " <> src
+          hPutStrLn IO.stderr ""
+          hPutStrLn IO.stderr "stdout:"
+          hPutStrLn IO.stderr stdout
+          hPutStrLn IO.stderr ""
+          hPutStrLn IO.stderr "stderr:"
+          hPutStrLn IO.stderr stderr
+          pure Nothing

--- a/bittide/src/Bittide/ProcessingElement/ReadElf.hs
+++ b/bittide/src/Bittide/ProcessingElement/ReadElf.hs
@@ -1,0 +1,53 @@
+-- SPDX-FileCopyrightText: 2022 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+{-# LANGUAGE PatternGuards #-}
+
+module Bittide.ProcessingElement.ReadElf (readElf, readElfFromMemory, Address, BinaryData) where
+
+import Clash.Prelude
+
+import Data.Elf
+
+import qualified Data.ByteString    as BS
+import qualified Data.IntMap.Strict as I
+import qualified Data.List          as L
+
+type BinaryData = I.IntMap (BitVector 8)
+type Address = BitVector 32
+
+readElfFromMemory :: BS.ByteString -> (Address, BinaryData, BinaryData)
+readElfFromMemory contents =
+  let elf = parseElf contents
+  in readElf elf
+
+-- | readElf :: elf file -> (initial PC, instructions, data)
+--
+-- TODO Check the ELF header is valid: is this RISCV? Is it RV32IMC?
+-- TODO Binaries output now are SYS V ABI, are others compatible?
+readElf :: Elf -> (Address, BinaryData, BinaryData)
+readElf elf =
+  let (iMem, dMem) = L.foldr go (mempty, mempty) (elfSegments elf)
+   in (fromIntegral (elfEntry elf), iMem, dMem)
+ where
+  go seg acc@(is, ds)
+    -- skip segments that don't need loading
+    | elfSegmentType seg /= PT_LOAD
+    = acc
+
+    | PF_X `elem` elfSegmentFlags seg
+    = (addData (elfSegmentPhysAddr seg) (bytes $ elfSegmentData seg `BS.append` BS.pack [0,0]) is, ds)
+
+    | otherwise
+    = let
+        segData = elfSegmentData seg
+        fileSz  = fromIntegral $ BS.length segData
+        memSz   = fromIntegral $ elfSegmentMemSize seg
+        data'   = bytes segData <> L.replicate (memSz - fileSz) 0
+      in
+        (is, addData (elfSegmentPhysAddr seg) data' ds)
+
+  bytes str = pack <$> BS.unpack str
+
+  addData (fromIntegral -> startAddr) dat mem =
+     I.fromList (L.zip [startAddr..] dat) <> mem

--- a/bittide/src/Bittide/ProcessingElement/Util.hs
+++ b/bittide/src/Bittide/ProcessingElement/Util.hs
@@ -1,0 +1,142 @@
+-- SPDX-FileCopyrightText: 2023 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+{-# LANGUAGE NumericUnderscores #-}
+module Bittide.ProcessingElement.Util where
+
+import Clash.Prelude hiding (Exp)
+
+import Bittide.ProcessingElement.DeviceTreeCompiler
+import Bittide.ProcessingElement.ReadElf
+import Bittide.SharedTypes
+
+import Clash.Explicit.BlockRam.File
+import Control.Monad (when)
+import Data.Maybe
+import Language.Haskell.TH
+import Numeric (showHex)
+import System.Exit
+import System.IO (stderr, hPutStrLn)
+
+import qualified Data.ByteString as BS
+import qualified Data.IntMap as I
+import qualified Data.List as L
+
+-- | Given the path to an elf file, the path to a device tree and a starting address
+--  for the device tree. Return a 3 tuple containing:
+--  (initial program counter, instruction memory blob, data memory blob)
+memBlobsFromElf ::
+  -- | How the words should be ordered in the memBlob
+  ByteOrder ->
+  -- | Source file, assumed to be Little Endian.
+  FilePath ->
+  -- | Optional tuple of starting address and filepath to a device tree.
+  Maybe (I.Key, FilePath) ->
+  -- | (instruction memBlob, data memBlob)
+   Q Exp
+memBlobsFromElf byteOrder elfPath maybeDeviceTree = do
+  (iMemIntMap, dMemIntMap) <- runIO (getBytesMems elfPath maybeDeviceTree)
+  let
+    iResult = intMapToMemBlob byteOrder iMemIntMap
+    dResult = intMapToMemBlob byteOrder dMemIntMap
+
+  [|($iResult, $dResult)|]
+
+-- | Given the path to an elf file, the path to a device tree and a starting address
+--  for the device tree. Return a 3 tuple containing:
+-- Return a 3 tuple containing (initial program counter, instruction memory blob, data memory blob)
+getBytesMems :: FilePath -> Maybe (I.Key, FilePath) -> IO (I.IntMap Byte, I.IntMap Byte)
+getBytesMems elfPath maybeDeviceTree = do
+
+  elfBytes <- BS.readFile elfPath
+  let (entry, iMem, dMem0) = readElfFromMemory elfBytes
+
+  when (entry /= 0x0000_0000) $ do
+    hPutStrLn stderr $
+      "Entry point of ELF file at " <> show elfPath <>
+        " must be 0x00000000. Found 0x" <> showHex entry "" <> " instead"
+    exitFailure
+
+  -- add device tree as a memory mapped component
+  deviceTree <- maybe (pure []) (readDeviceTree . snd) maybeDeviceTree
+  let
+    fdtAddr = maybe 0 fst maybeDeviceTree
+    deviceTreeMap = I.fromList (L.zip [fdtAddr ..] deviceTree)
+    dMem1 = I.unionWithKey (\k _ _ -> error $
+      "Bittide.ProcessingElement.Util: Overlapping element in data memory and device tree at address 0x"
+      <> showHex k "") dMem0 deviceTreeMap
+
+  putStrLn $ "elf file: " <> elfPath <>
+          "\ndevice tree: " <> show (fmap (\(a,b) -> (a,b, L.length b)) maybeDeviceTree)
+
+  pure (iMem, if isJust maybeDeviceTree then dMem1 else dMem0)
+
+-- | Given an IntMap, return a 3 tuple containing:
+-- (starting address, size, memBlob)
+intMapToMemBlob :: ByteOrder -> I.IntMap Byte -> Q Exp
+intMapToMemBlob byteOrder intMap = do
+  let
+    (startAddr, size, mapAsList) = extractIntMapData byteOrder intMap
+    memBlob = memBlobTH Nothing mapAsList
+  [| (startAddr, size :: Integer, $memBlob) |]
+
+-- | Write a list of `Byte`s to a file to be used with `blockRamFile`.
+writeByteListToFile :: FilePath -> [Byte] -> IO ()
+writeByteListToFile filePath byteList = do
+  let fileContent = memFile Nothing byteList
+  writeFile filePath fileContent
+
+-- | Given an IntMap, return the starting address, size and content as @[Bytes 4]@
+extractIntMapData ::
+  ByteOrder ->
+  -- | IntMap
+  I.IntMap (BitVector 8) ->
+  -- |
+  -- 1. Starting address
+  -- 2. Size
+  -- 3. List of words
+  (BitVector 32, Int, [Bytes 4])
+extractIntMapData byteOrder dataMap = (resize . bitCoerce $ startAddr, size, combineFunction content)
+ where
+  combineFunction
+    | LittleEndian <- byteOrder = toWordsLinear
+    | BigEndian    <- byteOrder = toWordsSwapped
+
+  ordList = I.toAscList dataMap
+  startAddr = fst $ L.head ordList
+  size = I.size dataMap
+  content =
+    snd (L.head ordList) : flattenContent startAddr (L.tail ordList)
+
+  flattenContent _ [] = []
+  flattenContent prevAddr ((nextAddr, val):vals) =
+    let
+      n = nextAddr - prevAddr - 1
+      padding = L.replicate n 0
+    in padding L.++ (val : flattenContent nextAddr vals)
+
+  toWordsLinear :: [Bytes 1] -> [Bytes 4]
+  toWordsLinear [] = []
+  toWordsLinear [!a] = [bitCoerce (a, 0 :: Bytes 3)]
+  toWordsLinear [!a, !b] = [bitCoerce (a, b, 0 :: Bytes 2)]
+  toWordsLinear [!a, !b, !c] = [bitCoerce (a, b, c, 0 :: Bytes 1)]
+  toWordsLinear ((!a):(!b):(!c):(!d):rest) = bitCoerce (a, b, c, d) : toWordsLinear rest
+
+  toWordsSwapped :: [Bytes 1] -> [Bytes 4]
+  toWordsSwapped [] = []
+  toWordsSwapped [!a] = [bitCoerce (a, 0 :: Bytes 3)]
+  toWordsSwapped [!a, !b] = [bitCoerce (b, a, 0 :: Bytes 2)]
+  toWordsSwapped [!a, !b, !c] = [bitCoerce (c, b, a, 0 :: Bytes 1)]
+  toWordsSwapped ((!a):(!b):(!c):(!d):rest) = bitCoerce (d, c, b, a) : toWordsSwapped rest
+
+-- | Given the filepath to a device tree, return the divce tree as list of `Byte`.
+readDeviceTree :: FilePath -> IO [Byte]
+readDeviceTree deviceTreePath = do
+    compileRes <- compileDeviceTreeSource deviceTreePath
+
+    deviceTreeRaw <- maybe exitFailure pure compileRes
+
+    let
+      padding = L.replicate (4 - (BS.length deviceTreeRaw `mod` 4)) 0
+
+    pure (fmap pack . BS.unpack $ deviceTreeRaw <> BS.pack padding)

--- a/bittide/src/Bittide/SharedTypes.hs
+++ b/bittide/src/Bittide/SharedTypes.hs
@@ -83,6 +83,7 @@ type Pad a bw  = (Regs a bw * bw) - BitSize a
 type Regs a bw = DivRU (BitSize a) bw
 
 data ByteOrder = LittleEndian | BigEndian
+  deriving Eq
 
 -- | Stores any arbitrary datatype as a vector of registers.
 newtype RegisterBank regSize content (byteOrder :: ByteOrder) =

--- a/bittide/src/System/IO/Temp/Extra.hs
+++ b/bittide/src/System/IO/Temp/Extra.hs
@@ -1,0 +1,34 @@
+-- SPDX-FileCopyrightText: 2023 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+module System.IO.Temp.Extra(withTempBinaryFile) where
+
+import Prelude
+
+import Control.Monad.IO.Class
+import System.Directory
+import System.IO
+
+import qualified Control.Monad.Catch as MC
+
+-- | Create, open, and use a temporary binary file in the given directory.
+--
+-- The temp file is deleted after use.
+withTempBinaryFile ::
+  (MonadIO m, MC.MonadMask m) =>
+  -- | Parent directory to create the file in
+  FilePath ->
+  -- | File name template
+  String ->
+  -- | Callback that can use the file
+  (FilePath -> Handle -> m a) ->
+  -- | Callback result
+  m a
+withTempBinaryFile tmpDir template action =
+  MC.bracket
+    (liftIO (openBinaryTempFile tmpDir template))
+    (\(name, handle) -> liftIO (hClose handle >> ignoringIOErrors (removeFile name)))
+    (uncurry action)
+
+ignoringIOErrors :: MC.MonadCatch m => m () -> m ()
+ignoringIOErrors ioe = ioe `MC.catch` (\e -> const (return ()) (e :: IOError))

--- a/bittide/tests/Tests/ProcessingElement/ReadElf.hs
+++ b/bittide/tests/Tests/ProcessingElement/ReadElf.hs
@@ -1,0 +1,271 @@
+-- SPDX-FileCopyrightText: 2022 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+
+module Tests.ProcessingElement.ReadElf where
+
+import Prelude
+
+import Data.Elf
+import Data.IntMap as I
+import Numeric
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (assertEqual, testCase, (@?=))
+
+import Bittide.ProcessingElement.ReadElf (readElf)
+
+import qualified Data.ByteString as BS
+import qualified Data.List as L
+
+riscvElfEmpty :: Elf
+riscvElfEmpty = Elf
+  { elfClass = ELFCLASS32
+  , elfData = ELFDATA2LSB
+  , elfVersion = 1
+  , elfOSABI = ELFOSABI_SYSV
+  , elfABIVersion = 1
+  , elfType = ET_EXEC
+  , elfMachine = EM_EXT 0xF3 -- RISC-V
+  , elfEntry = 0x80000000
+  , elfSections = []
+  , elfSegments = []
+  }
+
+textSection :: ElfSection
+textSection = ElfSection
+  { elfSectionName = ".text"
+  , elfSectionType = SHT_PROGBITS
+  , elfSectionFlags = [SHF_ALLOC, SHF_EXECINSTR]
+  , elfSectionAddr = 0x80000000
+  , elfSectionSize = 0
+  , elfSectionLink = 0
+  , elfSectionInfo = 0
+  , elfSectionAddrAlign = 0x00010000
+  , elfSectionEntSize = 0
+  , elfSectionData = BS.empty
+  }
+
+dataSection :: ElfSection
+dataSection = ElfSection
+  { elfSectionName = ".data"
+  , elfSectionType = SHT_PROGBITS
+  , elfSectionFlags = [SHF_ALLOC, SHF_WRITE]
+  , elfSectionAddr = 0x80000000
+  , elfSectionSize = 0
+  , elfSectionLink = 0
+  , elfSectionInfo = 0
+  , elfSectionAddrAlign = 0x00010000
+  , elfSectionEntSize = 0
+  , elfSectionData = BS.empty
+  }
+
+rodataSection :: ElfSection
+rodataSection = dataSection
+  { elfSectionName = ".rodata"
+  , elfSectionFlags = [SHF_ALLOC]
+  }
+
+bssSection :: ElfSection
+bssSection = ElfSection
+  { elfSectionName = ".bss"
+  , elfSectionType = SHT_NOBITS
+  , elfSectionFlags = [SHF_ALLOC, SHF_WRITE]
+  , elfSectionAddr = 0x80000000
+  , elfSectionSize = 0
+  , elfSectionLink = 0
+  , elfSectionInfo = 0
+  , elfSectionAddrAlign = 0x00010000
+  , elfSectionEntSize = 0
+  , elfSectionData = BS.empty
+  }
+
+instrSegment :: ElfSegment
+instrSegment = ElfSegment
+  { elfSegmentType = PT_LOAD
+  , elfSegmentFlags = [PF_R, PF_X]
+  , elfSegmentVirtAddr = 0x80000000
+  , elfSegmentPhysAddr = 0x80000000
+  , elfSegmentAlign = 0x00010000
+  , elfSegmentData = BS.empty
+  , elfSegmentMemSize = 0
+  }
+
+dataSegment :: ElfSegment
+dataSegment = ElfSegment
+  { elfSegmentType = PT_LOAD
+  , elfSegmentFlags = [PF_R, PF_W]
+  , elfSegmentVirtAddr = 0x80000000
+  , elfSegmentPhysAddr = 0x80000000
+  , elfSegmentAlign = 0x00010000
+  , elfSegmentData = BS.empty
+  , elfSegmentMemSize = 0
+  }
+
+readElfTestGroup :: TestTree
+readElfTestGroup = testGroup "Read ELF Tests"
+  [ testCase "ELF file empty" $ do
+    let
+      elf = riscvElfEmpty
+      (entry, iMem, dMem) = readElf elf
+
+    elfEntry elf @?= fromIntegral entry
+    iMem @?= I.fromList []
+    dMem @?= I.fromList []
+
+
+  , testCase "ELF file, only .text" $ do
+    let
+      iData = L.replicate 100 0xAB
+      elf = riscvElfEmpty
+        { elfSections =
+          [ textSection
+            { elfSectionAddr = 0x80000000
+            , elfSectionSize = fromIntegral $ L.length iData
+            , elfSectionData = BS.pack iData
+            }
+          ]
+        , elfSegments =
+          [ instrSegment
+            { elfSegmentVirtAddr = 0x80000000
+            , elfSegmentPhysAddr = 0x80000000
+            , elfSegmentData = BS.pack iData
+            , elfSegmentMemSize = fromIntegral $ L.length iData
+            }
+          ]
+        }
+      (entry, iMem, dMem) = readElf elf
+      iDataMap = I.fromList (L.zip [0x80000000..] (fromIntegral <$> iData))
+
+    elfEntry elf @?= fromIntegral entry
+    assertEqual "instruction memory contains instruction data" iDataMap (I.intersection iMem iDataMap)
+    dMem @?= I.fromList []
+
+  , testCase "ELF file, .data and .rodata" $ do
+    let
+      data' = L.replicate 100 0xAB
+      roData = L.replicate 50 0x0F
+      elf = riscvElfEmpty
+        { elfSections =
+          [ dataSection
+            { elfSectionAddr = 0x80000000
+            , elfSectionSize = fromIntegral $ L.length data'
+            , elfSectionData = BS.pack data'
+            }
+          , rodataSection
+            { elfSectionAddr = 0x80000000 + fromIntegral (L.length data')
+            , elfSectionSize = fromIntegral $ L.length roData
+            , elfSectionData = BS.pack roData
+            }
+          ]
+        , elfSegments =
+          [ dataSegment
+            { elfSegmentVirtAddr = 0x80000000
+            , elfSegmentPhysAddr = 0x80000000
+            , elfSegmentData = BS.pack (data' <> roData)
+            , elfSegmentMemSize = fromIntegral $ L.length data' + L.length roData
+            }
+          ]
+        }
+      (entry, iMem, dMem) = readElf elf
+      dataMap = I.fromList (L.zip [0x80000000..] (fromIntegral <$> (data' <> roData)))
+
+    elfEntry elf @?= fromIntegral entry
+    iMem @?= I.fromList []
+    assertEqual "instruction memory contains instruction data" dataMap (I.intersection dMem dataMap)
+
+  ,  testCase "ELF file, .text and .data" $ do
+    let
+      iData = L.replicate 100 0xAB
+      dData = L.replicate 1000 0xB3
+      elf = riscvElfEmpty
+        { elfSections =
+          [ textSection
+            { elfSectionAddr = 0x80000000
+            , elfSectionSize = fromIntegral $ L.length iData
+            , elfSectionData = BS.pack iData
+            }
+          , dataSection
+            { elfSectionAddr = 0x80000000 + fromIntegral (L.length iData)
+            , elfSectionSize = fromIntegral $ L.length dData
+            , elfSectionData = BS.pack dData
+            }
+          ]
+        , elfSegments =
+          [ instrSegment
+            { elfSegmentVirtAddr = 0x80000000
+            , elfSegmentPhysAddr = 0x80000000
+            , elfSegmentData = BS.pack iData
+            , elfSegmentMemSize = fromIntegral $ L.length iData
+            }
+          , dataSegment
+            { elfSegmentVirtAddr = 0x80000000 + fromIntegral (L.length iData)
+            , elfSegmentPhysAddr = 0x80000000 + fromIntegral (L.length iData)
+            , elfSegmentData = BS.pack dData
+            , elfSegmentMemSize = fromIntegral $ L.length dData
+            }
+          ]
+        }
+      (entry, iMem, dMem) = readElf elf
+      iDataMap = I.fromList (L.zip [0x80000000..] (fromIntegral <$> iData))
+      dDataMap = I.fromList (L.zip [(0x80000000 + fromIntegral (L.length iData))..] (fromIntegral <$> dData))
+
+    elfEntry elf @?= fromIntegral entry
+    assertEqual "instruction memory contains instruction data" iDataMap (I.intersection iMem iDataMap)
+    assertEqual "data memory contains data contents" dDataMap (I.intersection dMem dDataMap)
+
+
+  , testCase "ELF file, .text, .data and .bss" $ do
+    let
+      iData = L.replicate 100 0xAB
+      dData = L.replicate 1000 0xB3
+      bssLen = 500
+
+      iStart = 0x80000000
+      dStart = iStart + L.length iData
+      bssStart = dStart + L.length dData
+      elf = riscvElfEmpty
+        { elfSections =
+          [ textSection
+            { elfSectionAddr = fromIntegral iStart
+            , elfSectionSize = fromIntegral $ L.length iData
+            , elfSectionData = BS.pack iData
+            }
+          , dataSection
+            { elfSectionAddr = fromIntegral dStart
+            , elfSectionSize = fromIntegral $ L.length dData
+            , elfSectionData = BS.pack dData
+            }
+          , bssSection
+            { elfSectionAddr = fromIntegral bssStart
+            , elfSectionSize = bssLen
+            , elfSectionData = BS.empty
+            }
+          ]
+        , elfSegments =
+          [ instrSegment
+            { elfSegmentVirtAddr = fromIntegral iStart
+            , elfSegmentPhysAddr = fromIntegral iStart
+            , elfSegmentData = BS.pack iData
+            , elfSegmentMemSize = fromIntegral $ L.length iData
+            }
+          , dataSegment
+              { elfSegmentVirtAddr = fromIntegral dStart
+              , elfSegmentPhysAddr = fromIntegral dStart
+              , elfSegmentData = BS.pack dData
+              , elfSegmentMemSize = fromIntegral (L.length dData) + fromIntegral bssLen
+              }
+          ]
+        }
+      (entry, iMem, dMem) = readElf elf
+      iDataMap = I.fromList (L.zip [iStart..] (fromIntegral <$> iData))
+      dDataMap = I.unionWithKey (\k _ _ -> error $
+        "Tests.ContranomySim.ReadElf : Overlapping elements in `.data` and `.bss` memory at address 0x"
+        <> showHex k "")
+        (I.fromList (L.zip [dStart..] (fromIntegral <$> dData)))
+        (I.fromList (L.zip [bssStart..] (L.replicate (fromIntegral bssLen) 0)))
+
+    elfEntry elf @?= fromIntegral entry
+    assertEqual "instruction memory contains instruction data" iDataMap (I.intersection iMem iDataMap)
+    assertEqual "data memory contains data contents" dDataMap (I.intersection dMem dDataMap)
+
+  ]

--- a/bittide/tests/UnitTests.hs
+++ b/bittide/tests/UnitTests.hs
@@ -15,6 +15,7 @@ import Tests.DoubleBufferedRam
 import Tests.ElasticBuffer
 import Tests.Haxioms
 import Tests.Link
+import Tests.ProcessingElement.ReadElf
 import Tests.ScatterGather
 import Tests.StabilityChecker
 import Tests.Switch
@@ -23,15 +24,16 @@ import Tests.Wishbone
 tests :: TestTree
 tests = testGroup "Unittests"
   [ calGroup
+  , clockGenGroup
   , ebGroup
   , haxiomsGroup
   , linkGroup
   , memMapGroup
   , ramGroup
+  , readElfTestGroup
   , sgGroup
   , stabilityGroup
   , switchGroup
-  , clockGenGroup
   ]
 
 setDefaultHedgehogTestLimit :: HedgehogTestLimit -> HedgehogTestLimit


### PR DESCRIPTION
The added utilities enable us to:
 * Compile device trees (copied from `contranomt-sim`)
 * Read elf binaries (copied from `contranomt-sim`)
 * Create synthesizable  memories for RISC cores based on ELF en FDT.

TODO'S:
- [ ] Add bittide-instance showcasing a risc core with boot program.