### PR TITLE
Make (union dMem fdt) error on overlapping elements

### DIFF
--- a/contranomy-sim/bin/SimContranomy.hs
+++ b/contranomy-sim/bin/SimContranomy.hs
@@ -14,6 +14,7 @@ import qualified Data.List as L
 import Paths_contranomy_sim
 import System.Environment (getArgs)
 import System.Exit
+import Numeric
 
 main :: IO ()
 main = do
@@ -34,7 +35,11 @@ main = do
       deviceTree = fmap pack . BS.unpack $ deviceTreeRaw <> BS.pack padding
       deviceTreeMap = I.fromAscList (L.zip [fdtAddr ..] deviceTree)
 
-  let dMem' = dMem `I.union` deviceTreeMap
+  let
+    dMem' = I.unionWithKey (\k _ _ ->
+      error $ "SimContranomy: Overlapping elements in data memory and device tree at address 0x"
+      <> showHex k "")
+      dMem deviceTreeMap
 
   -- Hook up to print-debugging at uts designated address
   hookPrint characterDeviceAddr $

--- a/contranomy-sim/tests/Tests/ContranomySim/FirmwareIntegrationTests.hs
+++ b/contranomy-sim/tests/Tests/ContranomySim/FirmwareIntegrationTests.hs
@@ -25,7 +25,7 @@ import           Paths_contranomy_sim
 import           ContranomySim.DeviceTreeCompiler
 import           ContranomySim.MemoryMapConsts
 import           System.Exit (exitFailure)
-import Numeric
+import           Numeric
 
 -- | Load an elf binary, inspect the debug output
 elfExpect :: (FilePath -> IO ()) -- ^ Action to place the @.elf@ file in the given 'FilePath'

--- a/contranomy-sim/tests/Tests/ContranomySim/FirmwareIntegrationTests.hs
+++ b/contranomy-sim/tests/Tests/ContranomySim/FirmwareIntegrationTests.hs
@@ -25,6 +25,7 @@ import           Paths_contranomy_sim
 import           ContranomySim.DeviceTreeCompiler
 import           ContranomySim.MemoryMapConsts
 import           System.Exit (exitFailure)
+import Numeric
 
 -- | Load an elf binary, inspect the debug output
 elfExpect :: (FilePath -> IO ()) -- ^ Action to place the @.elf@ file in the given 'FilePath'
@@ -48,7 +49,11 @@ elfExpect act n expected = do
     elfBytes <- BS.readFile fp
     let (entry, iMem, dMem) = readElfFromMemory elfBytes
 
-    let dMem' = dMem `I.union` deviceTreeMap
+    let
+      dMem' = I.unionWithKey (\k _ _ -> error $
+        "Tests.ContranomySim.FirmwareIntegrationTests: Overlapping elements in data memory and device tree at address 0x"
+        <> showHex k "")
+        dMem deviceTreeMap
 
     -- Hook up to println-debugging
     let res = getDataBytes (BS.length expected) characterDeviceAddr $ sampleN n $ fmap snd $

--- a/contranomy-sim/tests/Tests/ContranomySim/ReadElf.hs
+++ b/contranomy-sim/tests/Tests/ContranomySim/ReadElf.hs
@@ -271,7 +271,7 @@ tests = testGroup "Read ELF Tests"
       let iDataMap = I.fromList (L.zip [iStart..] (fromIntegral <$> iData))
       let
         dDataMap = I.unionWithKey (\k _ _ -> error $
-          "Tests.ContranomySim.ReadElf : Overlapping elements in data memory and device tree at address 0x"
+          "Tests.ContranomySim.ReadElf : Overlapping elements in `.data` and `.bss` memory at address 0x"
           <> showHex k "")
           (I.fromList (L.zip [dStart..] (fromIntegral <$> dData)))
           (I.fromList (L.zip [bssStart..] (L.replicate (fromIntegral bssLen) 0)))


### PR DESCRIPTION
Previously, combining data memory and the device tree would silently pick the left element on key collisions.
This is undesired because there should be no overlap. Now we error on overlapping keys.