### PR TITLE
Add test using clash-protocols to wbStorage to check for double-ACKs

### DIFF
--- a/bittide/src/Bittide/DoubleBufferedRam.hs
+++ b/bittide/src/Bittide/DoubleBufferedRam.hs
@@ -250,12 +250,11 @@ wbStorage' initContent wbIn = delayControls wbIn wbOut
 
     -- It takes a single cycle to lookup elements in a block ram. We can therfore
     -- only process a request every other clock cycle.
-    ack = (acknowledge <$> s2m0) .&&. (not <$> delayedAck) .&&. inCycle
+    ack = (acknowledge <$> s2m0) .&&. (not <$> err1) .&&. (not <$> delayedAck) .&&. inCycle
     err1 = (err <$> s2m0) .&&. inCycle
     delayedAck = register False ack
-    delayedErr1 = register False err1
     s2m1 = (\wb newAck newErr-> wb{acknowledge = newAck, err = newErr})
-      <$> s2m0 <*> delayedAck <*> delayedErr1
+      <$> s2m0 <*> delayedAck <*> err1
 
 -- | The double buffered Ram component is a memory component that contains two buffers
 -- and enables the user to write to one buffer and read from the other. 'AorB'

--- a/cabal.project
+++ b/cabal.project
@@ -65,7 +65,7 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/clash-lang/clash-protocols.git
-  tag: 3f3cbb1cec3153b15142d796801eb740961773c8
+  tag: cce5c068bcf95dcd92797d0f284aed0b13eb9e3b
 
 source-repository-package
   type: git

--- a/hie.yaml
+++ b/hie.yaml
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: 2022 Google LLC
+#
+# SPDX-License-Identifier: CC0-1.0
+
+cradle:
+  cabal:


### PR DESCRIPTION
Depends on https://github.com/clash-lang/clash-protocols/pull/52

This test catches the previous errors when double ACKs are not prevented. It also shows that delaying the ERR signal in a "no-downtime" scenario can cause synchronisation issues too.

There's two ways to resolve this ERR issue, either by keeping the signal delayed and making sure no double-ERRs can happen, or by not delaying the ERR signal at all.

For this PR I picked the second solution, that seems like it was the intended behaviour. 