### PR TITLE
Add Axi4Stream scaling components

### DIFF
--- a/bittide/bittide.cabal
+++ b/bittide/bittide.cabal
@@ -100,6 +100,7 @@ library
   exposed-modules:
     Bittide.Arithmetic.Ppm
     Bittide.Arithmetic.Time
+    Bittide.Axi4
     Bittide.Calendar
     Bittide.ClockControl
     Bittide.ClockControl.Callisto
@@ -165,6 +166,7 @@ test-suite unittests
   main-is: UnitTests.hs
   ghc-options: -threaded -with-rtsopts=-N
   other-modules:
+    Tests.Axi4
     Tests.Calendar
     Tests.ClockControl.Si539xSpi
     Tests.Counter
@@ -182,6 +184,7 @@ test-suite unittests
     HUnit,
     base,
     bittide,
+    bittide-extra,
     bytestring,
     clash-cores,
     clash-lib,

--- a/bittide/src/Bittide/Axi4.hs
+++ b/bittide/src/Bittide/Axi4.hs
@@ -1,0 +1,116 @@
+-- SPDX-FileCopyrightText: 2023 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE FlexibleContexts #-}
+
+{-# OPTIONS_GHC -fconstraint-solver-iterations=10 #-}
+
+module Bittide.Axi4 where
+
+import Clash.Prelude
+
+import Protocols
+import Protocols.Axi4.Stream
+
+import Bittide.Extra.Maybe
+
+
+{-# NOINLINE axisFromByteStream #-}
+-- | Transforms an Axi4 stream of 1 byte wide into an Axi4 stream of /n/ bytes
+-- wide. If it encounters '_tlast' or has captured /n/ bytes, it will present
+-- the transaction at the output. Note that if less than /n/ bytes have been
+-- captured, but '_tlast' is set, the component will immediately output the
+-- captured bytes with appropriately set '_tkeep' bits. The '_tuser', _tdest'
+-- and '_tid' signals are blindly routed to the output. This effectively means
+-- that all but the last '_tuser', '_tdest', '_tid' are linked to a valid
+-- transaction.
+axisFromByteStream ::
+  forall dom dataWidth idWidth destWidth userType .
+  ( HiddenClockResetEnable dom
+  , KnownNat dataWidth
+  , 1 <= dataWidth
+  , Eq userType
+  , NFDataX userType) =>
+  Circuit
+    (Axi4Stream dom ('Axi4StreamConfig 1 idWidth destWidth) userType)
+    (Axi4Stream dom ('Axi4StreamConfig dataWidth idWidth destWidth) userType)
+axisFromByteStream = Circuit (mealyB go initState)
+ where
+  initState :: (Index dataWidth, Vec (dataWidth - 1) (Unsigned 8, Bool, Bool))
+  initState = (0, repeat initTempAxi)
+  initTempAxi = (0, False, False)
+  go state (Nothing, _) = (state, (Axi4StreamS2M{_tready = True}, Nothing))
+  go (counter, storedBytes) (Just Axi4StreamM2S{..}, Axi4StreamS2M{_tready}) =
+    ((newCounter, nextStoredBytes), (smallS2M, bigM2S))
+   where
+    smallS2M = Axi4StreamS2M{_tready = smallReady}
+    bigM2S
+      | not upscaleDone = Nothing
+      | otherwise       = Just $ Axi4StreamM2S
+        { _tdata = newData
+        , _tkeep = newKeeps
+        , _tstrb = newStrobes
+        , _tuser = _tuser
+        , _tid   = _tid
+        , _tdest = _tdest
+        , _tlast = _tlast}
+    (newData, newKeeps, newStrobes) = unzip3 intermediateBytes
+
+    upscaleDone = counter == maxBound || _tlast
+    smallReady  = not upscaleDone || _tready
+    newCounter
+      | upscaleDone && _tready && _tready = 0
+      | upscaleDone = counter
+      | otherwise   = satSucc SatWrap counter
+
+    -- TODO: Replace this relatively expensive replace operation with a shift operation
+    intermediateBytes = replace counter (head _tdata, head _tkeep, head _tstrb)
+      (storedBytes :< initTempAxi)
+
+    nextStoredBytes
+      | upscaleDone && _tready = repeat initTempAxi
+      | otherwise              = init intermediateBytes
+
+{-# NOINLINE axisToByteStream #-}
+-- | Transforms an Axi4 stream of /n/ bytes wide into an Axi4 stream of 1 byte
+-- wide. It uses an internal counter to select the bytes of the incoming axi
+-- stream one by one. The incoming stream is acknowledged when the last byte is
+-- acknowledged by the outgoing stream. The '_tuser', '_tdest' and '_tid' are
+-- blindly routed to the output.
+axisToByteStream ::
+  forall dom dataWidth idWidth destWidth userType .
+  ( HiddenClockResetEnable dom
+  , KnownNat dataWidth
+  , 1 <= dataWidth
+  , Eq userType
+  , NFDataX userType) =>
+  Circuit
+    (Axi4Stream dom ('Axi4StreamConfig dataWidth idWidth destWidth) userType)
+    (Axi4Stream dom ('Axi4StreamConfig 1 idWidth destWidth) userType)
+axisToByteStream = Circuit (mealyB go (0 :: Index dataWidth))
+ where
+  go state (Nothing, _) = (state, (Axi4StreamS2M{_tready = True}, Nothing))
+  go counter (Just Axi4StreamM2S{..}, Axi4StreamS2M{_tready}) = (newCounter, (bigS2M, smallM2S))
+   where
+    bigS2M = Axi4StreamS2M{_tready = _tready && lastByte}
+    lastByte = counter == lastValidByteIndex
+    smallM2S = Just $ Axi4StreamM2S
+        { _tdata = outData :> Nil
+        , _tkeep = outKeep :> Nil
+        , _tstrb = outStrb :> Nil
+        , _tuser = _tuser
+        , _tid   = _tid
+        , _tdest = _tdest
+        , _tlast = _tlast && lastByte}
+    -- TODO: The use of !! is typically rather expensive because it produces an n-mux
+    -- Look into optimizing by loading the n bytes in a register and shifting them out
+    -- byte by byte
+    (outData, outKeep, outStrb) = zip3 _tdata _tkeep _tstrb !! counter
+    lastValidByteIndex = fromMaybesR 0 (orNothing <$> _tkeep <*> indicesI)
+    newCounter
+      | _tready && lastByte = 0
+      | _tready = satSucc SatWrap counter
+      | otherwise = counter

--- a/bittide/tests/Tests/Axi4.hs
+++ b/bittide/tests/Tests/Axi4.hs
@@ -1,0 +1,241 @@
+-- SPDX-FileCopyrightText: 2023 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RecordWildCards #-}
+
+{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
+{-# OPTIONS_GHC -fconstraint-solver-iterations=0 #-}
+
+{-# HLINT ignore "Functor law" #-}
+{-# HLINT ignore "Used otherwise as a pattern" #-}
+
+module Tests.Axi4 where
+
+import Clash.Prelude
+
+import Clash.Hedgehog.Sized.Unsigned
+import Clash.Hedgehog.Sized.Vector (genVec)
+import Clash.Sized.Vector(unsafeFromList)
+import Data.Maybe
+import Hedgehog
+import Protocols
+import Protocols.Axi4.Stream
+import Protocols.Wishbone
+import Test.Tasty
+import Test.Tasty.Hedgehog
+
+import Bittide.Axi4
+import Bittide.Extra.Maybe
+import Bittide.SharedTypes
+import Tests.Shared
+
+import qualified Data.List as L
+import qualified GHC.TypeNats as TN
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
+
+axi4Group :: TestTree
+axi4Group = testGroup "Axi4Group"
+  [ testPropertyNamed
+      "Axi4Stream up scaling does not affect packet content"
+      "axisFromByteStreamUnchangedPackets"
+      axisFromByteStreamUnchangedPackets
+  , testPropertyNamed
+      "Axi4Stream down scaling does not affect packet content"
+      "axisToByteStreamUnchangedPackets"
+      axisToByteStreamUnchangedPackets
+  ]
+
+type Packet = [Unsigned 8]
+type BasicAxiConfig nBytes = 'Axi4StreamConfig nBytes 0 0
+
+genAxisM2S ::
+  KnownAxi4StreamConfig conf =>
+  Gen userType ->
+  Gen (Axi4StreamM2S conf userType)
+genAxisM2S genUser = do
+  _tdata <- genVec $ genUnsigned Range.constantBounded
+  _tkeep <- genVec Gen.bool
+  _tstrb <- genVec Gen.bool
+  _tlast <- Gen.bool
+  _tid   <- genUnsigned Range.constantBounded
+  _tdest <- genUnsigned Range.constantBounded
+  _tuser <- genUser
+
+  pure $ Axi4StreamM2S{..}
+
+-- | Generate a `axisToByteStream` component with variable input bus width and
+-- test if a stream of multiple generated `Packet`s can be routed through it
+-- without being changed.
+axisToByteStreamUnchangedPackets :: Property
+axisToByteStreamUnchangedPackets = property $ do
+  busWidth <- forAll @_ @Integer $ Gen.enum 1 8
+  nrOfPackets <- forAll $ Gen.enum 1 4
+  packetLengths <- forAll $ Gen.list (Range.singleton nrOfPackets) $ Gen.enum 1 16
+  packets <- forAll $ traverse
+    (flip Gen.list (genUnsigned @_ @8 Range.constantBounded) . Range.singleton)
+    packetLengths
+  repeatingReadyList <- forAll $ Gen.filter or $ Gen.list (Range.linear 1 8) Gen.bool
+  case TN.someNatVal $ fromIntegral (busWidth - 1) of
+    SomeNat (succSNat . snatProxy -> _ :: SNat busWidth) -> do
+      let
+        axiStream = Nothing : L.concatMap (packetToAxiStream (SNat @busWidth)) packets
+        axiSlave ::
+          Circuit
+            (Axi4Stream System (BasicAxiConfig 1) ())
+            (Axi4Stream System (BasicAxiConfig 1) ())
+        axiSlave = let ackSignal = fromList (cycle repeatingReadyList) in
+          Circuit
+          (\(fwd, _) -> (Axi4StreamS2M <$> ackSignal, mux ackSignal fwd (pure Nothing)))
+        maxSimDuration = 100 + ((1 + sum packetLengths) * L.length repeatingReadyList)
+        axiResult = catMaybes . L.take maxSimDuration $ wcre $
+          sampleC def (driveC def axiStream |> axisToByteStream |> axiSlave)
+        retrievedPackets = axis4ToPackets axiResult
+      packets  === retrievedPackets
+
+
+-- | Generate a 'axisFromByteStream' component with variable output bus width
+-- and test if a stream of multiple generated 'Packet's can be routed through it
+-- without being changed.
+axisFromByteStreamUnchangedPackets :: Property
+axisFromByteStreamUnchangedPackets = property $ do
+  busWidth <- forAll @_ @Integer $ Gen.enum 1 8
+  nrOfPackets <- forAll $ Gen.enum 1 4
+  packetLengths <- forAll $ Gen.list (Range.singleton nrOfPackets) $ Gen.enum 1 16
+  packets <- forAll $ traverse
+    (flip Gen.list (genUnsigned @_ @8 Range.constantBounded) . Range.singleton)
+    packetLengths
+  repeatingReadyList <- forAll $ Gen.filter or $ Gen.list (Range.linear 1 8) Gen.bool
+  case
+    TN.someNatVal $ fromIntegral (busWidth - 1) of
+    SomeNat (succSNat . snatProxy -> _ :: SNat busWidth) -> do
+      let
+        axiStream = Nothing : L.concatMap (packetToAxiStream d1) packets
+
+        axiSlave ::
+          Circuit
+            (Axi4Stream System (BasicAxiConfig busWidth) ())
+            (Axi4Stream System (BasicAxiConfig busWidth) ())
+        axiSlave = let ackSignal = fromList (cycle repeatingReadyList) in
+          Circuit
+          (\(fwd, _) -> (Axi4StreamS2M <$> ackSignal, mux ackSignal fwd (pure Nothing)))
+
+        maxSimDuration = 100 + ((1 + sum packetLengths) * L.length repeatingReadyList)
+        axiResult = catMaybes . L.take maxSimDuration $ wcre $
+          sampleC def (driveC def axiStream |> axisFromByteStream |> axiSlave)
+        retrievedPackets = axis4ToPackets axiResult
+      packets  === retrievedPackets
+
+-- | Extract a 'Packet' by observing an Axi4 Stream.
+axis4ToPackets ::
+  (Show userType, KnownNat (DataWidth conf)) =>
+  [Axi4StreamM2S conf userType] ->
+  [Packet]
+axis4ToPackets transactions = fmap (catMaybes . L.concatMap getKeepBytes) packets
+ where
+  packetEnds = L.findIndices _tlast transactions
+  packets = getPackets packetEnds transactions 0
+
+  getKeepBytes Axi4StreamM2S{..} = toList (orNothing <$> _tkeep <*> _tdata)
+  getPackets [] _  _ = []
+  getPackets (i:iii) list acc = pre : getPackets iii post (acc + toTake)
+   where
+    (pre, post) = L.splitAt toTake list
+    toTake = i - acc + 1
+
+-- | Convert a given 'Packet' to a list of Wishbone master operations that write
+-- the packet to the slave interface as a contiguous blob of memory with the bytes from
+-- the packet arranged in big-endian format. The last operation writes the size
+-- of the packet in words to the provided 'packetSizeAddress'.
+packetsToWb ::
+  forall addrW nBytes .
+  (KnownNat addrW, KnownNat nBytes) =>
+  Int ->
+  Int ->
+  Packet ->
+  [WishboneM2S addrW nBytes (Bytes nBytes)]
+packetsToWb packetSizeAddress packetLength allBytes = f 0 allBytes <>
+  [(emptyWishboneM2S @addrW @(Bytes nBytes))
+      { addr = 4 * fromIntegral packetSizeAddress
+      , strobe = True
+      , busCycle = True
+      , writeData = fromIntegral $ ((packetLength + busWidth - 1) `div` busWidth) - 1
+      , busSelect = maxBound
+      , writeEnable = True}]
+ where
+  busWidth = natToNum @nBytes
+  f i bytes =
+    (emptyWishboneM2S @addrW @(Bytes nBytes))
+      { addr = 4 * i
+      , strobe = True
+      , busCycle = True
+      , writeData
+      , busSelect
+      , writeEnable = True} : if otherBytes == [] then [] else f (succ i) otherBytes
+    where
+    (bytesToSend, otherBytes) = L.splitAt busWidth bytes
+    writeData = pack $ unsafeFromList (L.reverse $ L.take busWidth (bytesToSend <> L.repeat 0))
+    busSelect = pack . unsafeFromList $
+      L.replicate (busWidth - L.length bytesToSend) False <>
+      L.replicate (L.length bytesToSend) True
+
+-- Transform a `Packet` into a list of Axi Stream operations.
+packetToAxiStream ::
+  forall nBytes .
+  SNat nBytes ->
+  Packet ->
+  [Maybe (Axi4StreamM2S (BasicAxiConfig nBytes) ())]
+packetToAxiStream w@SNat !bs
+  | bs /= [] = Just axis : packetToAxiStream w rest
+  | otherwise  = []
+  where
+  busWidth = natToNum @nBytes
+  (firstWords, rest) = L.splitAt busWidth bs
+  word = L.take busWidth (firstWords <> L.replicate (busWidth - 1) 0)
+  axis = Axi4StreamM2S
+    { _tdata = unsafeFromList word
+    , _tkeep = keeps
+    , _tstrb = repeat True
+    , _tlast = null rest
+    , _tid   = 0
+    , _tdest = 0
+    , _tuser = deepErrorX ""
+    }
+  keeps = unsafeFromList $
+       L.replicate (L.length bs) True
+    <> L.replicate (busWidth - L.length bs) False
+
+-- Write a value with Wishbone to a 4 byte aligned address.
+wbWrite::
+  forall addrW nBytes .
+  (KnownNat addrW, KnownNat nBytes) =>
+  Int ->
+  Bytes nBytes ->
+  WishboneM2S addrW nBytes (Bytes nBytes)
+wbWrite a d =
+  (emptyWishboneM2S @addrW @(Bytes nBytes))
+  { busCycle    = True
+  , strobe      = True
+  , addr        = resize . pack $ a * 4
+  , writeEnable = True
+  , busSelect   = maxBound
+  , writeData   = d
+  }
+
+-- Read a value from a 4 byte aligned address.
+wbRead::
+  forall addrW nBytes .
+  (KnownNat addrW, KnownNat nBytes) =>
+  Int ->
+  WishboneM2S addrW nBytes (Bytes nBytes)
+wbRead a =
+  (emptyWishboneM2S @addrW @(Bytes nBytes))
+  { busCycle  = True
+  , strobe    = True
+  , addr      = resize . pack $ a * 4
+  , busSelect = minBound
+  }

--- a/bittide/tests/UnitTests.hs
+++ b/bittide/tests/UnitTests.hs
@@ -9,6 +9,7 @@ import Prelude
 import Test.Tasty
 import Test.Tasty.Hedgehog
 
+import Tests.Axi4
 import Tests.Calendar
 import Tests.ClockControl.Si539xSpi
 import Tests.DoubleBufferedRam
@@ -23,7 +24,8 @@ import Tests.Wishbone
 
 tests :: TestTree
 tests = testGroup "Unittests"
-  [ calGroup
+  [ axi4Group
+  , calGroup
   , clockGenGroup
   , ebGroup
   , haxiomsGroup


### PR DESCRIPTION
The ethernet MAC we have available from the `verilog-ethernet` repository has an API with single byte wide Axi stream interfaces.

To be able to connect these interfaces to wishbone accessible packet buffers, we have to scale them from- and to the 4 byte buswidth we use for wishbone.

To do so, we created adapters to scale byte wide axi stream interfaces to an arbitrary width.

We can combine these to transform any width axi stream into any other width axi stream.
**Do note, this will limit the bandwidth to a single byte!**