### PR TITLE
Fixes `divide-by-zero` and `exhausted heap`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,7 +164,7 @@ jobs:
 
       - name: Plot mesh grid
         run: |
-          cabal run -- elastic-buffer-sim:sim +RTS -M16M -RTS \
+          cabal run -- elastic-buffer-sim:sim +RTS -M32M -RTS \
             --output-mode pdf \
             --steps ${{ matrix.target.steps }} \
             --samples 1000 \
@@ -174,7 +174,7 @@ jobs:
       - name: Upload plots
         uses: actions/upload-artifact@v3
         with:
-          name: gen-plots-hs
+          name: gen-plots-hs-${{ matrix.target.topology }}
           path: _build
           retention-days: 14
 

--- a/bittide/src/Bittide/Arithmetic/Ppm.hs
+++ b/bittide/src/Bittide/Arithmetic/Ppm.hs
@@ -13,6 +13,7 @@ import Clash.Signal.Internal (Femtoseconds (Femtoseconds), hzToFs, fsToHz)
 
 import Data.Int (Int64)
 import Data.Ratio
+import qualified Control.Exception as E (assert)
 import GHC.Stack (HasCallStack)
 import Numeric.Natural
 import System.Random (Random)
@@ -37,7 +38,7 @@ slowDownHz ppm hz = hz - diffHz ppm hz
 
 -- PPM arithmetic on periods
 diffPeriod :: HasCallStack => Ppm -> Femtoseconds -> Femtoseconds
-diffPeriod (Ppm ppm) (Femtoseconds fs) = Femtoseconds absFs
+diffPeriod (Ppm ppm) (Femtoseconds fs) = E.assert (ppm /= 0) $ Femtoseconds absFs
  where
   absFs = fs `div` (1_000_000 `div` ppm)
 

--- a/elastic-buffer-sim/src/Bittide/Plot.hs
+++ b/elastic-buffer-sim/src/Bittide/Plot.hs
@@ -72,7 +72,7 @@ import Bittide.Simulate (Offset)
 import Bittide.Domain (defBittideClockConfig)
 import Bittide.ClockControl (ClockControlConfig(..), clockPeriodFs)
 import Bittide.Topology (simulate, simulationEntity, allStable)
-import Bittide.Arithmetic.Ppm (diffPeriod)
+import Bittide.Arithmetic.Ppm (Ppm(..), diffPeriod)
 import Bittide.Topology.Graph
 
 data OutputMode =
@@ -439,8 +439,9 @@ genOffsets ::
   ClockControlConfig dom n ->
   IO Offset
 genOffsets ClockControlConfig{cccDeviation} = do
-  offsetPpm <- randomRIO (-cccDeviation, cccDeviation)
-  pure (diffPeriod offsetPpm (clockPeriodFs @dom Proxy))
+  Ppm offsetPpm <- randomRIO (-cccDeviation, cccDeviation)
+  let nonZeroOffsetPpm = if offsetPpm == 0 then cccDeviation else Ppm offsetPpm
+  pure (diffPeriod nonZeroOffsetPpm (clockPeriodFs @dom Proxy))
 
 someNat :: Int -> Maybe SomeNat
 someNat = someNatVal . toInteger


### PR DESCRIPTION
Fixes [the issues](https://github.com/bittide/bittide-hardware/actions/runs/4189654924) of the nightly simulation runs.