### PR TITLE
Fix simulation time and memory requirements

### DIFF
--- a/.github/simulation/all.json
+++ b/.github/simulation/all.json
@@ -1,10 +1,10 @@
 [
-  {"topology": "diamond",   "steps": 8000000,  "args": "" },
-  {"topology": "complete",  "steps": 8000000,  "args": "--nodes 3"},
-  {"topology": "line",      "steps": 8000000,  "args": "--nodes 4"},
-  {"topology": "star",      "steps": 20000000, "args": "--nodes 7"},
-  {"topology": "torus2d",   "steps": 20000000, "args": "--rows 2 --cols 3"},
-  {"topology": "cycle",     "steps": 20000000, "args": "--nodes 5"},
-  {"topology": "hypercube", "steps": 50000000, "args": "--dimensions 3"},
-  {"topology": "random",    "steps": 50000000, "args": "--nodes 5"}
+  {"topology": "diamond",   "hmem": 16, "steps": 8000000,  "args": "" },
+  {"topology": "complete",  "hmem": 16, "steps": 8000000,  "args": "--nodes 3"},
+  {"topology": "torus2d",   "hmem": 16, "steps": 20000000, "args": "--rows 2 --cols 3"},
+  {"topology": "cycle",     "hmem": 16, "steps": 20000000, "args": "--nodes 5"},
+  {"topology": "star",      "hmem": 64, "steps": 20000000, "args": "--nodes 7"},
+  {"topology": "line",      "hmem": 64, "steps": 50000000, "args": "--nodes 4"},
+  {"topology": "hypercube", "hmem": 64, "steps": 50000000, "args": "--dimensions 3"},
+  {"topology": "random",    "hmem": 64, "steps": 50000000, "args": "--nodes 5"}
 ]

--- a/.github/simulation/staging.json
+++ b/.github/simulation/staging.json
@@ -1,3 +1,3 @@
 [
-  {"topology": "complete", "steps": 1000000, "args": "--nodes 2 --offsets [-2,2] --frame-size 1500"}
+  {"topology": "complete", "hmem": 16, "steps": 1000000, "args": "--nodes 2 --offsets [-2,2] --frame-size 1500"}
 ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,7 +164,8 @@ jobs:
 
       - name: Plot mesh grid
         run: |
-          cabal run -- elastic-buffer-sim:sim +RTS -M32M -RTS \
+          cabal run -- elastic-buffer-sim:sim \
+            +RTS -M${{ matrix.target.hmem }}M -RTS \
             --output-mode pdf \
             --steps ${{ matrix.target.steps }} \
             --samples 1000 \
@@ -173,6 +174,7 @@ jobs:
 
       - name: Upload plots
         uses: actions/upload-artifact@v3
+        if: always()
         with:
           name: gen-plots-hs-${{ matrix.target.topology }}
           path: _build


### PR DESCRIPTION
This PR (hopefully) the fixes remaining issues with nightly simulation.
 - Always upload artifacts.
 - The linear topology just requires more time until it stabilizes.
 - Heap memory limits are set for each topology individually now to allow more resources for large topologies.