### PR TITLE
Disable formal checks on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -312,11 +312,7 @@ jobs:
 
       - name: Get test matrix
         run: |
-          if [[ "${{ github.event_name }}" == "schedule" || $(.github/scripts/force_expensive_checks.sh) == "true" ]]; then
-            .github/scripts/get_formal_checks.sh
-          else
-            echo '["formal-checks-disabled"]' > checks.json
-          fi
+          echo '["formal-checks-disabled"]' > checks.json
 
       - name: Set test matrix
         id: set-matrix


### PR DESCRIPTION
We're going to switch to VexRiscV soon, which we don't plan to formal test on CI anymore. Given that the formal checks currently fail every night for Nixy reasons, this (crudely) disables them.

TODO: Properly remove.