### PR TITLE
Write settings before simulating

### DIFF
--- a/.github/simulation/all.json
+++ b/.github/simulation/all.json
@@ -1,10 +1,10 @@
 [
-  {"topology": "diamond",   "hmem": 16, "steps": 8000000,  "args": "" },
-  {"topology": "complete",  "hmem": 16, "steps": 8000000,  "args": "--nodes 3"},
-  {"topology": "torus2d",   "hmem": 16, "steps": 20000000, "args": "--rows 2 --cols 3"},
-  {"topology": "cycle",     "hmem": 16, "steps": 20000000, "args": "--nodes 5"},
-  {"topology": "star",      "hmem": 64, "steps": 20000000, "args": "--nodes 7"},
-  {"topology": "line",      "hmem": 64, "steps": 50000000, "args": "--nodes 4"},
-  {"topology": "hypercube", "hmem": 64, "steps": 50000000, "args": "--dimensions 3"},
-  {"topology": "random",    "hmem": 64, "steps": 50000000, "args": "--nodes 5"}
+  {"topology": "diamond",   "hmem": 16,  "steps": 8000000,  "args": "" },
+  {"topology": "complete",  "hmem": 16,  "steps": 8000000,  "args": "--nodes 3"},
+  {"topology": "cycle",     "hmem": 16,  "steps": 20000000, "args": "--nodes 5"},
+  {"topology": "torus2d",   "hmem": 32,  "steps": 20000000, "args": "--rows 2 --cols 3"},
+  {"topology": "star",      "hmem": 64,  "steps": 20000000, "args": "--nodes 7"},
+  {"topology": "line",      "hmem": 64,  "steps": 50000000, "args": "--nodes 4"},
+  {"topology": "random",    "hmem": 64,  "steps": 50000000, "args": "--nodes 5"}
+  {"topology": "hypercube", "hmem": 128, "steps": 50000000, "args": "--dimensions 3"},
 ]


### PR DESCRIPTION
This PR introduces some minor improvements:
* If clocks do not stabilize, a short message is output for better distinguishing the failure from other errors in CI.
* Simulation settings are also written before simulation starts such that they are available even if simulation fails.
* Heap memory limits got increased for the failing nightly simulation runs.