### PR TITLE
Add board programming to Shake

### DIFF
--- a/bittide-instances/README.md
+++ b/bittide-instances/README.md
@@ -22,7 +22,7 @@ The build system automatically generates _false path_ constraints for all input 
 ## Prerequisites
 * We have tested the build system with Vivado 2022.1
 * To change the part for which the instances are synthesized, set the environment variable `SYNTHESIS_PART`. For the part we've bought use `SYNTHESIS_PART=xcku040-ffva1156-2-e`. Note that for this part you need to use Vivado Enterprise.
-* For the step Bitstream generation an XDC file with pinmappings is required. This file must have the same name as the instance, and be located in the `data/constraints/` directory.
+* For the step Bitstream generation and Board programming an XDC file with pinmappings is required. This file must have the same name as the instance, and be located in the `data/constraints/` directory.
 
 
 ## Shake
@@ -77,4 +77,11 @@ Example:
 
 ```
 cabal run -- bittide-instances:shake clockControlDemo0:bitstream
+```
+
+## Board programming
+Example:
+
+```
+cabal run -- bittide-instances:shake clockControlDemo0:program
 ```

--- a/bittide-instances/bin/Shake.hs
+++ b/bittide-instances/bin/Shake.hs
@@ -146,11 +146,12 @@ main = do
         netlistDir = synthesisDir </> "netlist"
         reportDir = synthesisDir </> "reports"
 
-        runSynthTclPath     = synthesisDir </> "run_synth.tcl"
-        runPlaceTclPath     = synthesisDir </> "run_place.tcl"
-        runRouteTclPath     = synthesisDir </> "run_route.tcl"
-        runNetlistTclPath   = synthesisDir </> "run_netlist.tcl"
-        runBitstreamTclPath = synthesisDir </> "run_bitstream.tcl"
+        runSynthTclPath        = synthesisDir </> "run_synth.tcl"
+        runPlaceTclPath        = synthesisDir </> "run_place.tcl"
+        runRouteTclPath        = synthesisDir </> "run_route.tcl"
+        runNetlistTclPath      = synthesisDir </> "run_netlist.tcl"
+        runBitstreamTclPath    = synthesisDir </> "run_bitstream.tcl"
+        runBoardProgramTclPath = synthesisDir </> "run_board_program.tcl"
 
         postSynthCheckpointPath = checkpointsDir </> "post_synth.dcp"
         postPlaceCheckpointPath = checkpointsDir </> "post_place.dcp"
@@ -273,6 +274,10 @@ main = do
           need (runBitstreamTclPath : netlistPaths)
           vivadoFromTcl runBitstreamTclPath
 
+        -- Write bitstream to board
+        runBoardProgramTclPath %> \path -> do
+          writeFileChanged path (mkBoardProgramTcl synthesisDir)
+
       -- User friendly target names
       phony (nameBase target <> ":hdl") $ do
         need [manifestPath]
@@ -291,3 +296,7 @@ main = do
 
       phony (nameBase target <> ":bitstream") $ do
         need [bitstreamPath]
+
+      phony (nameBase target <> ":program") $ do
+        need [bitstreamPath, runBoardProgramTclPath]
+        vivadoFromTcl runBoardProgramTclPath


### PR DESCRIPTION
This PR adds board programming support to Shake. Both bitstream generation and board programming need each input and output pin to be mapped in an XDC file with the same name as the instance. With this PR, only `clockControlDemo0` and `clockControlDemo1` have XDC files with pin mappings, and can thus be flashed on hardware.

Vivado will throw an error when:
- There is no XDC file with pin mappings
- The pin mappings do not match the synthesis part
- Vivado Enterprise is needed for the synthesis part, but not correctly sourced
- No board is connected to the localhost on port 3121 (the default port)

If multiple boards are connected, the board with the lowest `hw_server`-name is chosen (alphabetically sorted). It is recommended to connect just one board to your PC.