### PR TITLE
Update Callisto to algo in `arxiv/2303.11467`

### DIFF
--- a/.github/simulation/all.json
+++ b/.github/simulation/all.json
@@ -1,9 +1,9 @@
 [
-  {"topology": "diamond",   "hmem": 16,  "steps": 8000000,  "args": "" },
-  {"topology": "complete",  "hmem": 16,  "steps": 8000000,  "args": "--nodes 3"},
-  {"topology": "cycle",     "hmem": 16,  "steps": 20000000, "args": "--nodes 5"},
+  {"topology": "diamond",   "hmem": 16,  "steps": 20000000, "args": "" },
+  {"topology": "complete",  "hmem": 16,  "steps": 20000000, "args": "--nodes 3"},
+  {"topology": "cycle",     "hmem": 16,  "steps": 30000000, "args": "--nodes 5"},
   {"topology": "torus2d",   "hmem": 32,  "steps": 20000000, "args": "--rows 2 --cols 3"},
-  {"topology": "star",      "hmem": 64,  "steps": 20000000, "args": "--nodes 7"},
+  {"topology": "star",      "hmem": 64,  "steps": 35000000, "args": "--nodes 7"},
   {"topology": "line",      "hmem": 64,  "steps": 50000000, "args": "--nodes 4"},
   {"topology": "random",    "hmem": 64,  "steps": 50000000, "args": "--nodes 5"},
   {"topology": "hypercube", "hmem": 128, "steps": 50000000, "args": "--dimensions 3"}

--- a/.github/simulation/all.json
+++ b/.github/simulation/all.json
@@ -6,5 +6,5 @@
   {"topology": "star",      "hmem": 64,  "steps": 35000000, "args": "--nodes 7"},
   {"topology": "line",      "hmem": 64,  "steps": 50000000, "args": "--nodes 4"},
   {"topology": "hourglass", "hmem": 64,  "steps": 50000000, "args": "--nodes 3"},
-  {"topology": "random",    "hmem": 64,  "steps": 50000000, "args": "--nodes 5"},
+  {"topology": "random",    "hmem": 64,  "steps": 50000000, "args": "--nodes 5"}
 ]

--- a/.github/simulation/all.json
+++ b/.github/simulation/all.json
@@ -1,10 +1,10 @@
 [
-  {"topology": "diamond",   "hmem": 16,  "steps": 20000000, "args": "" },
-  {"topology": "complete",  "hmem": 16,  "steps": 20000000, "args": "--nodes 3"},
-  {"topology": "cycle",     "hmem": 16,  "steps": 30000000, "args": "--nodes 5"},
-  {"topology": "torus2d",   "hmem": 32,  "steps": 20000000, "args": "--rows 2 --cols 3"},
-  {"topology": "star",      "hmem": 64,  "steps": 35000000, "args": "--nodes 7"},
-  {"topology": "line",      "hmem": 64,  "steps": 50000000, "args": "--nodes 4"},
-  {"topology": "hourglass", "hmem": 64,  "steps": 50000000, "args": "--nodes 3"},
-  {"topology": "random",    "hmem": 64,  "steps": 50000000, "args": "--nodes 5"}
+  {"topology": "diamond",   "hmem": 16,  "steps": 60000000, "args": "" },
+  {"topology": "complete",  "hmem": 16,  "steps": 60000000, "args": "--nodes 3"},
+  {"topology": "cycle",     "hmem": 16,  "steps": 70000000, "args": "--nodes 5"},
+  {"topology": "torus2d",   "hmem": 32,  "steps": 60000000, "args": "--rows 2 --cols 3"},
+  {"topology": "star",      "hmem": 64,  "steps": 70000000, "args": "--nodes 7"},
+  {"topology": "line",      "hmem": 64,  "steps": 80000000, "args": "--nodes 4"},
+  {"topology": "hourglass", "hmem": 64,  "steps": 80000000, "args": "--nodes 3"},
+  {"topology": "random",    "hmem": 64,  "steps": 80000000, "args": "--nodes 5"}
 ]

--- a/.github/simulation/all.json
+++ b/.github/simulation/all.json
@@ -5,6 +5,6 @@
   {"topology": "torus2d",   "hmem": 32,  "steps": 20000000, "args": "--rows 2 --cols 3"},
   {"topology": "star",      "hmem": 64,  "steps": 35000000, "args": "--nodes 7"},
   {"topology": "line",      "hmem": 64,  "steps": 50000000, "args": "--nodes 4"},
+  {"topology": "hourglass", "hmem": 64,  "steps": 50000000, "args": "--nodes 3"},
   {"topology": "random",    "hmem": 64,  "steps": 50000000, "args": "--nodes 5"},
-  {"topology": "hypercube", "hmem": 128, "steps": 50000000, "args": "--dimensions 3"}
 ]

--- a/.github/simulation/all.json
+++ b/.github/simulation/all.json
@@ -1,10 +1,10 @@
 [
-  {"topology": "diamond",   "hmem": 16,  "steps": 60000000, "args": "" },
-  {"topology": "complete",  "hmem": 16,  "steps": 60000000, "args": "--nodes 3"},
-  {"topology": "cycle",     "hmem": 16,  "steps": 70000000, "args": "--nodes 5"},
-  {"topology": "torus2d",   "hmem": 32,  "steps": 60000000, "args": "--rows 2 --cols 3"},
-  {"topology": "star",      "hmem": 64,  "steps": 70000000, "args": "--nodes 7"},
-  {"topology": "line",      "hmem": 64,  "steps": 80000000, "args": "--nodes 4"},
-  {"topology": "hourglass", "hmem": 64,  "steps": 80000000, "args": "--nodes 3"},
-  {"topology": "random",    "hmem": 64,  "steps": 80000000, "args": "--nodes 5"}
+  {"topology": "diamond",   "hmem": 16,  "steps": 80000000, "args": "--frame-size 15000000" },
+  {"topology": "complete",  "hmem": 16,  "steps": 80000000, "args": "--nodes 3 --frame-size 15000000"},
+  {"topology": "cycle",     "hmem": 16,  "steps": 100000000, "args": "--nodes 5 --frame-size 15000000 "},
+  {"topology": "torus2d",   "hmem": 32,  "steps": 100000000, "args": "--rows 2 --cols 3 --frame-size 15000000 "},
+  {"topology": "star",      "hmem": 64,  "steps": 100000000, "args": "--nodes 7 --frame-size 15000000 "},
+  {"topology": "line",      "hmem": 64,  "steps": 100000000, "args": "--nodes 4 --frame-size 15000000 "},
+  {"topology": "hourglass", "hmem": 64,  "steps": 130000000, "args": "--nodes 3 --frame-size 15000000 "},
+  {"topology": "random",    "hmem": 64,  "steps": 100000000, "args": "--nodes 5 --frame-size 15000000"}
 ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,7 +178,6 @@ jobs:
             --output-mode pdf \
             --steps ${{ matrix.target.steps }} \
             --samples 1000 \
-            --stop-when-stable \
             ${{ matrix.target.topology }} ${{ matrix.target.args }}
 
       - name: Generate report

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,6 +178,7 @@ jobs:
             --output-mode pdf \
             --steps ${{ matrix.target.steps }} \
             --samples 1000 \
+            --frame-size 15000000 \
             --stop-after-stable ${{ matrix.target.steps }} \
             ${{ matrix.target.topology }} ${{ matrix.target.args }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,7 @@ jobs:
   elastic-buffer-sim-topologies:
     name: Simulate network
     runs-on: self-hosted
+    timeout-minutes: 840
     defaults:
       run:
         shell: git-nix-shell {0} --pure
@@ -178,7 +179,6 @@ jobs:
             --output-mode pdf \
             --steps ${{ matrix.target.steps }} \
             --samples 1000 \
-            --frame-size 15000000 \
             --stop-after-stable ${{ matrix.target.steps }} \
             ${{ matrix.target.topology }} ${{ matrix.target.args }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,6 +178,7 @@ jobs:
             --output-mode pdf \
             --steps ${{ matrix.target.steps }} \
             --samples 1000 \
+            --stop-after-stable ${{ matrix.target.steps }} \
             ${{ matrix.target.topology }} ${{ matrix.target.args }}
 
       - name: Generate report

--- a/bittide-instances/src/Bittide/Instances/ClockControl.hs
+++ b/bittide-instances/src/Bittide/Instances/ClockControl.hs
@@ -20,7 +20,7 @@ callisto3 ::
   -- | Data counts from elastic buffers
   Vec 3 (Signal Basic200 (DataCount 12)) ->
   -- | Speed change requested from clock multiplier
-  Signal Basic200 SpeedChange
+  Signal Basic200 (SpeedChange, AllStable, AllSettled)
 callisto3 clk rst ena dataCounts =
   callistoClockControl clk rst ena config availableLinkMask dataCounts
  where

--- a/bittide-instances/src/Bittide/Instances/ClockControl.hs
+++ b/bittide-instances/src/Bittide/Instances/ClockControl.hs
@@ -20,7 +20,7 @@ callisto3 ::
   -- | Data counts from elastic buffers
   Vec 3 (Signal Basic200 (DataCount 12)) ->
   -- | Speed change requested from clock multiplier
-  Signal Basic200 (SpeedChange, AllStable, AllSettled)
+  Signal Basic200 (CallistoResult 3)
 callisto3 clk rst ena dataCounts =
   callistoClockControl clk rst ena config availableLinkMask dataCounts
  where

--- a/bittide-instances/src/Bittide/Instances/ClockControl.hs
+++ b/bittide-instances/src/Bittide/Instances/ClockControl.hs
@@ -10,7 +10,7 @@ import Bittide.ClockControl.Callisto
 import Bittide.Instances.Domains
 import Bittide.ClockControl
 
-config :: ClockControlConfig Basic200 12
+config :: ClockControlConfig Basic200 12 8 1500000
 config = $(lift (defClockConfig @Basic200))
 
 callisto3 ::

--- a/bittide-instances/src/Bittide/Instances/ElasticBuffer.hs
+++ b/bittide-instances/src/Bittide/Instances/ElasticBuffer.hs
@@ -9,6 +9,7 @@ import Clash.Prelude
 import Clash.Annotations.TH
 
 import Bittide.ElasticBuffer
+import Bittide.ClockControl (DataCount)
 
 createDomain vXilinxSystem{vPeriod=hzToPeriod 201e6, vName="Fast"}
 createDomain vXilinxSystem{vPeriod=hzToPeriod 199e6, vName="Slow"}
@@ -18,7 +19,7 @@ elasticBuffer5 ::
   "clkWriteSlow" :::Clock Slow ->
   "resetRead" ::: Reset Fast ->
   "writeData" ::: Signal Slow (Unsigned 8) ->
-  ( "dataCount" ::: Signal Fast (Unsigned 5)
+  ( "dataCount" ::: Signal Fast (DataCount 5)
   , "underflow" ::: Signal Fast Underflow
   , "overrflow" ::: Signal Fast Overflow
   , "ebMode" ::: Signal Fast EbMode

--- a/bittide-instances/src/Bittide/Instances/MVPs.hs
+++ b/bittide-instances/src/Bittide/Instances/MVPs.hs
@@ -95,11 +95,11 @@ genericClockControlDemo0 config clkRecovered clkControlled rstControlled drainFi
  where
   speedChangeSticky =
     withClockResetEnable clkControlled rstControlled enableGen $
-      stickyBits d15 (speedChangeToPins <$> speedChange)
+      stickyBits d15 (speedChangeToPins . speedChange <$> callistoResult)
   availableLinkMask = pure $ complement 0 -- all links available
-  (speedChange, _allStable, _allCentered) = unbundle
-    $ callistoClockControl @1 clkControlled clockControlReset enableGen
-        config availableLinkMask (bufferOccupancy :> Nil)
+  callistoResult =
+    callistoClockControl @1 clkControlled clockControlReset enableGen
+      config availableLinkMask (bufferOccupancy :> Nil)
   clockControlReset = unsafeFromLowPolarity $ (==Pass) <$> ebMode
 
   writeData = pure (0 :: DataCount 8)

--- a/bittide-instances/src/Bittide/Instances/MVPs.hs
+++ b/bittide-instances/src/Bittide/Instances/MVPs.hs
@@ -101,7 +101,7 @@ genericClockControlDemo0 config clkRecovered clkControlled rstControlled drainFi
     config availableLinkMask (bufferOccupancy :> Nil)
   clockControlReset = unsafeFromLowPolarity $ (==Pass) <$> ebMode
 
-  writeData = pure (0 :: Unsigned 8)
+  writeData = pure (0 :: DataCount 8)
 
   (bufferOccupancy, underFlowed, overFlowed, ebMode, _) =
     withReset rstControlled $

--- a/bittide-instances/src/Bittide/Instances/Si539xSpi.hs
+++ b/bittide-instances/src/Bittide/Instances/Si539xSpi.hs
@@ -93,8 +93,9 @@ callistoSpi clk125 clkRecovered clkControlled rst125 locked miso =
     clk125 rst125 enableGen speedChange200 spiBusy
 
   -- Produce a SpeedChange based on the elastic buffer's datacount.
-  speedChange200 = callistoClockControl @1 @12 clkControlled clockControlReset enableGen
-    clockConfig (pure maxBound) (bufferOccupancy :> Nil)
+  (speedChange200, _allStable, _allCentered) = unbundle
+    $ callistoClockControl @1 @12 clkControlled clockControlReset enableGen
+        clockConfig (pure maxBound) (bufferOccupancy :> Nil)
 
   -- ALl circuitry in the controlled domain should be in reset while the the PLL is not locked.
   rstControlled = unsafeFromLowPolarity locked
@@ -110,7 +111,7 @@ callistoSpi clk125 clkRecovered clkControlled rst125 locked miso =
   -- Determine if the controlled clock is synchronized "enough" with the static clock.
   isStable =
     withClockResetEnable clkControlled (unsafeFromLowPolarity $ pure True) enableGen $
-      snd <$> stabilityChecker d5 (SNat @1_000_000) bufferOccupancy
+      settled <$> stabilityChecker d5 (SNat @1_000_000) bufferOccupancy
 
   -- Configuration for Callisto
   clockConfig :: ClockControlConfig External 12 8 1500000

--- a/bittide-instances/src/Bittide/Instances/Si539xSpi.hs
+++ b/bittide-instances/src/Bittide/Instances/Si539xSpi.hs
@@ -110,10 +110,10 @@ callistoSpi clk125 clkRecovered clkControlled rst125 locked miso =
   -- Determine if the controlled clock is synchronized "enough" with the static clock.
   isStable =
     withClockResetEnable clkControlled (unsafeFromLowPolarity $ pure True) enableGen $
-      stabilityChecker d5 (SNat @1_000_000) bufferOccupancy
+      snd <$> stabilityChecker d5 (SNat @1_000_000) bufferOccupancy
 
   -- Configuration for Callisto
-  clockConfig :: ClockControlConfig External 12
+  clockConfig :: ClockControlConfig External 12 8 1500000
   clockConfig = $(lift ((defClockConfig @External){cccPessimisticSettleCycles = 20000} ))
 
 makeTopEntity 'callistoSpi

--- a/bittide-instances/src/Bittide/Instances/Si539xSpi.hs
+++ b/bittide-instances/src/Bittide/Instances/Si539xSpi.hs
@@ -93,8 +93,9 @@ callistoSpi clk125 clkRecovered clkControlled rst125 locked miso =
     clk125 rst125 enableGen speedChange200 spiBusy
 
   -- Produce a SpeedChange based on the elastic buffer's datacount.
-  (speedChange200, _allStable, _allCentered) = unbundle
-    $ callistoClockControl @1 @12 clkControlled clockControlReset enableGen
+  speedChange200 =
+    speedChange <$>
+      callistoClockControl @1 @12 clkControlled clockControlReset enableGen
         clockConfig (pure maxBound) (bufferOccupancy :> Nil)
 
   -- ALl circuitry in the controlled domain should be in reset while the the PLL is not locked.

--- a/bittide-instances/src/Bittide/Instances/StabilityChecker.hs
+++ b/bittide-instances/src/Bittide/Instances/StabilityChecker.hs
@@ -10,11 +10,12 @@ import Clash.Prelude
 
 import Bittide.ClockControl.StabilityChecker
 import Bittide.Instances.Domains (Basic200)
+import Bittide.ClockControl (DataCount)
 
 stabilityChecker_3_1M ::
   Clock Basic200 ->
   Reset Basic200 ->
-  Signal Basic200 (Unsigned 16) ->
+  Signal Basic200 (DataCount 16) ->
   Signal Basic200 (Bool, Bool)
 stabilityChecker_3_1M clk rst =
   withClockResetEnable clk rst enableGen $

--- a/bittide-instances/src/Bittide/Instances/StabilityChecker.hs
+++ b/bittide-instances/src/Bittide/Instances/StabilityChecker.hs
@@ -16,7 +16,7 @@ stabilityChecker_3_1M ::
   Clock Basic200 ->
   Reset Basic200 ->
   Signal Basic200 (DataCount 16) ->
-  Signal Basic200 (Bool, Bool)
+  Signal Basic200 StabilityIndication
 stabilityChecker_3_1M clk rst =
   withClockResetEnable clk rst enableGen $
     stabilityChecker d3 (SNat @1_000_000)

--- a/bittide-instances/src/Bittide/Instances/StabilityChecker.hs
+++ b/bittide-instances/src/Bittide/Instances/StabilityChecker.hs
@@ -15,7 +15,7 @@ stabilityChecker_3_1M ::
   Clock Basic200 ->
   Reset Basic200 ->
   Signal Basic200 (Unsigned 16) ->
-  Signal Basic200 Bool
+  Signal Basic200 (Bool, Bool)
 stabilityChecker_3_1M clk rst =
   withClockResetEnable clk rst enableGen $
     stabilityChecker d3 (SNat @1_000_000)

--- a/bittide/src/Bittide/ClockControl.hs
+++ b/bittide/src/Bittide/ClockControl.hs
@@ -74,9 +74,15 @@ data ClockControlConfig dom n m c = ClockControlConfig
   , cccStepSize :: Femtoseconds
 
     -- | Size of elastic buffers. Used to observe bounds and 'targetDataCount'.
-    --
   , cccBufferSize :: SNat n
+
+    -- | Bound on the number of elements the elastic buffer is allowed
+    -- to deviate from while still being considered "stable".
   , cccStabilityCheckerMargin :: SNat m
+
+    -- | The minimum number of clock cycles an elastic buffer must
+    -- remain within the @cccStabilityCheckerMargin@ to be considered
+    -- "stable".
   , cccStabilityCheckerFramesize :: SNat c
   } deriving (Lift)
 

--- a/bittide/src/Bittide/ClockControl.hs
+++ b/bittide/src/Bittide/ClockControl.hs
@@ -84,6 +84,11 @@ data ClockControlConfig dom n m c = ClockControlConfig
     -- remain within the @cccStabilityCheckerMargin@ to be considered
     -- "stable".
   , cccStabilityCheckerFramesize :: SNat c
+
+    -- | Enable reframing. Reframing allows a system to resettle buffers around
+    -- their midpoints, without dropping any frames. For more information, see
+    -- [arXiv:2303.11467](https://arxiv.org/abs/2303.11467).
+  , cccEnableReframing :: Bool
   } deriving (Lift)
 
 -- | The (virtual) type of the FIFO's data counter. Setting this to
@@ -146,6 +151,7 @@ defClockConfig = ClockControlConfig
   , cccDeviation                 = Ppm 100
   , cccStabilityCheckerMargin    = SNat
   , cccStabilityCheckerFramesize = SNat
+  , cccEnableReframing           = True
   }
  where
   self = defClockConfig @dom

--- a/bittide/src/Bittide/ClockControl.hs
+++ b/bittide/src/Bittide/ClockControl.hs
@@ -89,6 +89,11 @@ data ClockControlConfig dom n m c = ClockControlConfig
     -- their midpoints, without dropping any frames. For more information, see
     -- [arXiv:2303.11467](https://arxiv.org/abs/2303.11467).
   , cccEnableReframing :: Bool
+
+    -- | Number of cycles to wait until reframing takes place after
+    -- stability has been detected, as it is used by the "detect,
+    -- store, and wait" reframing approach
+  , cccReframingWaitTime :: Unsigned 32
   } deriving (Lift)
 
 -- | The (virtual) type of the FIFO's data counter. Setting this to
@@ -152,6 +157,7 @@ defClockConfig = ClockControlConfig
   , cccStabilityCheckerMargin    = SNat
   , cccStabilityCheckerFramesize = SNat
   , cccEnableReframing           = True
+  , cccReframingWaitTime         = 20000000
   }
  where
   self = defClockConfig @dom

--- a/bittide/src/Bittide/ClockControl/Callisto.hs
+++ b/bittide/src/Bittide/ClockControl/Callisto.hs
@@ -16,7 +16,6 @@ import Data.Constraint.Nat.Extra (euclid3, useLowerLimit)
 import Bittide.ClockControl
 import Bittide.ClockControl.Callisto.Util
 import Bittide.ClockControl.StabilityChecker
-import Clash.Sized.Extra
 
 import qualified Clash.Cores.Xilinx.Floating as F
 import qualified Clash.Signal.Delayed as D
@@ -171,7 +170,7 @@ callisto margin framesize targetCount updateEveryNCycles mask allDataCounts =
       targetCountSigned =
         case euclid3 @n @m @32 of
           Dict ->
-            extend @_ @_ @(32 - m - 1) (unsignedToSigned targetCount)
+            extend @_ @_ @(32 - m - 1) (dataCountToSigned targetCount)
     in
       measuredSum - (pure targetCountSigned * nBuffers)
 

--- a/bittide/src/Bittide/ClockControl/StabilityChecker.hs
+++ b/bittide/src/Bittide/ClockControl/StabilityChecker.hs
@@ -6,8 +6,8 @@ module Bittide.ClockControl.StabilityChecker where
 
 import Clash.Prelude
 
-import Bittide.ClockControl (targetDataCount)
-import Clash.Sized.Extra
+import Bittide.ClockControl (DataCount, targetDataCount)
+import Bittide.ClockControl.Callisto.Util (dataCountToSigned)
 
 -- | Checks whether the @Signal@ of buffer occupancies from an elastic
 -- buffer is stable and close to the target data counter. The @Signal@
@@ -28,7 +28,7 @@ stabilityChecker ::
   -- must remain within the @margin@ for it to be considered "stable".
   SNat framesize ->
   -- | Incoming buffer occupancy.
-  Signal dom (Unsigned n) ->
+  Signal dom (DataCount n) ->
   -- | Stability indicators. The first tuple element indicates
   -- stability of the signal over time, while the second element
   -- indicates whether the signal is close to 'targetDataCount'.
@@ -38,9 +38,9 @@ stabilityChecker SNat SNat = mealy go (0, targetDataCount)
   go (!cnt, !target) input = (newState, (isStable, isCloseToTarget))
    where
     withinMargin !x !y =
-      abs (unsignedToSigned x `sub` unsignedToSigned y) <= (natToNum @margin)
+      abs (dataCountToSigned x `sub` dataCountToSigned y) <= (natToNum @margin)
 
-    newState :: (Index (framesize + 1), Unsigned n)
+    newState :: (Index (framesize + 1), DataCount n)
     newState
       | withinMargin target input = (satSucc SatBound cnt, target)
       | otherwise                 = (0, input)

--- a/bittide/src/Bittide/ClockControl/StabilityChecker.hs
+++ b/bittide/src/Bittide/ClockControl/StabilityChecker.hs
@@ -2,6 +2,7 @@
 --
 -- SPDX-License-Identifier: Apache-2.0
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE RecordWildCards #-}
 module Bittide.ClockControl.StabilityChecker where
 
 import Clash.Prelude
@@ -9,14 +10,25 @@ import Clash.Prelude
 import Bittide.ClockControl (DataCount, targetDataCount)
 import Bittide.ClockControl.Callisto.Util (dataCountToSigned)
 
+-- | Stability results to be returned by the 'stabilityChecker'.
+data StabilityIndication =
+  StabilityIndication
+    { stable :: Bool
+      -- ^ Indicates stability of the signal over time.
+    , settled :: Bool
+      -- ^ Indicates whether the signal is stable and close to
+      -- 'targetDataCount'.
+    }
+  deriving (Generic, NFDataX)
+
 -- | Checks whether the @Signal@ of buffer occupancies from an elastic
--- buffer is stable and close to the target data counter. The @Signal@
--- is considered stable if it stays within a @margin@ of the target
--- buffer occupancy for @framesize@ number of cycles. If the
--- current buffer occupancies exceed that margin, then the target is
--- updated to the current buffer occupancy. The @Signal@ is considered
--- to be close to the target data counter, if it is stable and close
--- (within the @margin@) to the global target data count.
+-- buffer is stable and settled. The @Signal@ is considered to be
+-- stable, if it stays within a @margin@ of the target buffer
+-- occupancy for @framesize@ number of cycles. If the current buffer
+-- occupancies exceed that margin, then the target is updated to the
+-- current buffer occupancy. The @Signal@ is considered to be settled,
+-- if it is stable and close (within @margin@) to the global target
+-- data count.
 stabilityChecker ::
   forall dom margin framesize n .
   (HiddenClockResetEnable dom, 1 <= framesize, KnownNat n) =>
@@ -29,13 +41,11 @@ stabilityChecker ::
   SNat framesize ->
   -- | Incoming buffer occupancy.
   Signal dom (DataCount n) ->
-  -- | Stability indicators. The first tuple element indicates
-  -- stability of the signal over time, while the second element
-  -- indicates whether the signal is close to 'targetDataCount'.
-  Signal dom (Bool, Bool)
+  -- | Stability indicators
+  Signal dom StabilityIndication
 stabilityChecker SNat SNat = mealy go (0, targetDataCount)
  where
-  go (!cnt, !target) input = (newState, (isStable, isCloseToTarget))
+  go (!cnt, !target) input = (newState, StabilityIndication{..})
    where
     withinMargin !x !y =
       abs (dataCountToSigned x `sub` dataCountToSigned y) <= (natToNum @margin)
@@ -45,5 +55,5 @@ stabilityChecker SNat SNat = mealy go (0, targetDataCount)
       | withinMargin target input = (satSucc SatBound cnt, target)
       | otherwise                 = (0, input)
 
-    isStable = withinMargin target input && cnt == maxBound
-    isCloseToTarget = isStable && withinMargin targetDataCount input
+    stable = withinMargin target input && cnt == maxBound
+    settled = stable && withinMargin targetDataCount input

--- a/bittide/src/Bittide/ClockControl/StabilityChecker.hs
+++ b/bittide/src/Bittide/ClockControl/StabilityChecker.hs
@@ -9,34 +9,41 @@ import Clash.Prelude
 import Bittide.ClockControl (targetDataCount)
 import Clash.Sized.Extra
 
--- | Checks whether the @Signal@ of buffer occupancies from an elastic buffer is stable.
--- The @Signal@ is considered stable if it stays within a @margin@ of the target buffer
--- occupancy for @cyclesStable@ number of cycles. The next target is set to the current
--- buffer occupancy when the current buffer occupancy is not within margin of
--- the target.
+-- | Checks whether the @Signal@ of buffer occupancies from an elastic
+-- buffer is stable and close to the target data counter. The @Signal@
+-- is considered stable if it stays within a @margin@ of the target
+-- buffer occupancy for @framesize@ number of cycles. If the
+-- current buffer occupancies exceed that margin, then the target is
+-- updated to the current buffer occupancy. The @Signal@ is considered
+-- to be close to the target data counter, if it is stable and close
+-- (within the @margin@) to the global target data count.
 stabilityChecker ::
-  forall dom margin cyclesStable n .
-  (HiddenClockResetEnable dom, 1 <= cyclesStable, KnownNat n) =>
-  -- | Maximum number of elements the incoming buffer occupancy is allowed to deviate
-  -- from the current @target@ for it to be considered "stable".
+  forall dom margin framesize n .
+  (HiddenClockResetEnable dom, 1 <= framesize, KnownNat n) =>
+  -- | Maximum number of elements the incoming buffer occupancy is
+  -- allowed to deviate from the current @target@ for it to be
+  -- considered "stable".
   SNat margin ->
-  -- | Minimum number of clock cycles the incoming buffer occupancy must remain within the
-  -- @margin@ for it to be considered "stable".
-  SNat cyclesStable ->
+  -- | Minimum number of clock cycles the incoming buffer occupancy
+  -- must remain within the @margin@ for it to be considered "stable".
+  SNat framesize ->
   -- | Incoming buffer occupancy.
   Signal dom (Unsigned n) ->
-  -- | Stability indicator.
-  Signal dom Bool
+  -- | Stability indicators. The first tuple element indicates
+  -- stability of the signal over time, while the second element
+  -- indicates whether the signal is close to 'targetDataCount'.
+  Signal dom (Bool, Bool)
 stabilityChecker SNat SNat = mealy go (0, targetDataCount)
  where
-  go (cnt, target) input = (newState, isStable)
+  go (!cnt, !target) input = (newState, (isStable, isCloseToTarget))
    where
-    withinMargin =
-      abs (unsignedToSigned target `sub` unsignedToSigned input) <= (natToNum @margin)
+    withinMargin !x !y =
+      abs (unsignedToSigned x `sub` unsignedToSigned y) <= (natToNum @margin)
 
-    newState :: (Index (cyclesStable + 1), Unsigned n)
+    newState :: (Index (framesize + 1), Unsigned n)
     newState
-      | withinMargin = (satSucc SatBound cnt, target)
-      | otherwise    = (0, input)
+      | withinMargin target input = (satSucc SatBound cnt, target)
+      | otherwise                 = (0, input)
 
-    isStable = withinMargin && cnt == maxBound
+    isStable = withinMargin target input && cnt == maxBound
+    isCloseToTarget = isStable && withinMargin targetDataCount input

--- a/bittide/src/Bittide/Counter.hs
+++ b/bittide/src/Bittide/Counter.hs
@@ -24,9 +24,9 @@ data DdcState
 type Active = Bool
 
 -- | Determine speed differences between two domains. If the source domain is
--- faster than the destination domain, the result will become smaller. Vice versa,
+-- faster than the destination domain, the result will become larger. Vice versa,
 -- if the source domain is slower than the destination domain, the result will
--- become larger. This is analogous to what would happen to a FIFO's data count
+-- become smaller. This is analogous to what would happen to a FIFO's data count
 -- when continuously written to by the source domain and read from by the
 -- destination domain. To ease integration in control algorithms, this component
 -- makes sure it starts counting at zero. It also waits for the incoming counter
@@ -78,7 +78,7 @@ domainDiffCounter clkSrc rstSrc clkDst rstDst =
   go DdcInReset c1
     | c1 == 0   = (DdcInReset,          (0, False))
     | otherwise = (DdcRunning (c1 + 1), (0, True))
-  go (DdcRunning c0) c1 = (DdcRunning (c0 + 1), (c0 `subAndTruncate` c1, True))
+  go (DdcRunning c0) c1 = (DdcRunning (c0 + 1), (c1 `subAndTruncate` c0, True))
 
   subAndTruncate :: Unsigned 64 -> Unsigned 64 -> Signed 32
   subAndTruncate c0 c1 = truncateB (unsignedToSigned c0 - unsignedToSigned c1)

--- a/bittide/tests/Tests/ElasticBuffer.hs
+++ b/bittide/tests/Tests/ElasticBuffer.hs
@@ -14,7 +14,7 @@ import Test.Tasty
 import Test.Tasty.HUnit
 
 import Bittide.ElasticBuffer
-import Bittide.ClockControl (targetDataCount)
+import Bittide.ClockControl (DataCount, targetDataCount)
 
 import qualified Data.List as L
 
@@ -95,7 +95,7 @@ case_resettableXilinxElasticBufferEq = do
     (dataCounts, underflows, overflows, ebModes, _) = L.unzip5 .
       L.dropWhile (\(_, _, _, eb, _)-> eb == Drain || eb == Fill) $ sampleN 256
         (bundle (resettableXilinxElasticBuffer @5 (clockGen @Slow) (clockGen @Slow) resetGen wData))
-    dataCountBounds = L.all ((< 3) . abs . subtract (toInteger (targetDataCount :: Unsigned 5)) . toInteger) dataCounts
+    dataCountBounds = L.all ((< 3) . abs . subtract (toInteger (targetDataCount :: DataCount 5)) . toInteger) dataCounts
 
   assertBool "elastic buffer should get out of its Fill state" ((>0) $ L.length ebModes)
   assertBool "elastic buffer should not overflow after stabalising" (not $ or overflows)

--- a/bittide/tests/Tests/StabilityChecker.hs
+++ b/bittide/tests/Tests/StabilityChecker.hs
@@ -54,7 +54,7 @@ stabilityCheckerTest = property $ do
     dataCounts <- forAll $ Gen.list (Range.singleton simLength)
       (genSigned @_ @dataCountBits Range.constantBounded)
     let
-      topEntity = wcre $ fmap fst . stabilityChecker @System sMargin sCyclesStable
+      topEntity = wcre $ fmap stable . stabilityChecker @System sMargin sCyclesStable
       simOut = simulateN simLength topEntity dataCounts
 
     simOut === golden (snatToNum sMargin) (snatToNum sCyclesStable) dataCounts

--- a/bittide/tests/Tests/StabilityChecker.hs
+++ b/bittide/tests/Tests/StabilityChecker.hs
@@ -10,7 +10,7 @@ module Tests.StabilityChecker where
 import Clash.Prelude hiding ((^), someNatVal)
 import Prelude ((^))
 
-import Clash.Hedgehog.Sized.Unsigned (genUnsigned)
+import Clash.Hedgehog.Sized.Signed (genSigned)
 import Hedgehog
 import Test.Tasty
 import Test.Tasty.Hedgehog
@@ -52,7 +52,7 @@ stabilityCheckerTest = property $ do
   prop SNat sCyclesStable@SNat sMargin@SNat = do
     simLength <- forAll $ Gen.integral (Range.linear 4 1024)
     dataCounts <- forAll $ Gen.list (Range.singleton simLength)
-      (genUnsigned @_ @dataCountBits Range.constantBounded)
+      (genSigned @_ @dataCountBits Range.constantBounded)
     let
       topEntity = wcre $ fmap fst . stabilityChecker @System sMargin sCyclesStable
       simOut = simulateN simLength topEntity dataCounts
@@ -60,10 +60,10 @@ stabilityCheckerTest = property $ do
     simOut === golden (snatToNum sMargin) (snatToNum sCyclesStable) dataCounts
 
   -- 'stabilityChecker' reference design
-  golden :: forall n . KnownNat n => Integer -> Integer -> [Unsigned n] -> [Bool]
+  golden :: forall n . KnownNat n => Integer -> Integer -> [DataCount n] -> [Bool]
   golden margin cyclesStable dataCounts =
     f
-    (0, fromIntegral (targetDataCount :: Unsigned n))
+    (0, fromIntegral (targetDataCount :: DataCount n))
     (fmap fromIntegral dataCounts)
    where
     f _ [] = []

--- a/bittide/tests/Tests/StabilityChecker.hs
+++ b/bittide/tests/Tests/StabilityChecker.hs
@@ -54,7 +54,7 @@ stabilityCheckerTest = property $ do
     dataCounts <- forAll $ Gen.list (Range.singleton simLength)
       (genUnsigned @_ @dataCountBits Range.constantBounded)
     let
-      topEntity = wcre $ stabilityChecker @System sMargin sCyclesStable
+      topEntity = wcre $ fmap fst . stabilityChecker @System sMargin sCyclesStable
       simOut = simulateN simLength topEntity dataCounts
 
     simOut === golden (snatToNum sMargin) (snatToNum sCyclesStable) dataCounts

--- a/elastic-buffer-sim/elastic-buffer-sim.cabal
+++ b/elastic-buffer-sim/elastic-buffer-sim.cabal
@@ -81,7 +81,6 @@ library
     cassava,
     clash-cores,
     containers,
-    deepseq,
     directory,
     filepath,
     matplotlib,

--- a/elastic-buffer-sim/exe/Main.hs
+++ b/elastic-buffer-sim/exe/Main.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ImplicitParams #-}
 
 module Main (main) where
 
@@ -409,6 +410,8 @@ data Options =
     , simulationSamples  :: Int
     , stabilityMargin    :: Int
     , stabilityFrameSize :: Int
+    , disableReframing   :: Bool
+    , waitTime           :: Int
     , stopWhenStable     :: Bool
     , stopAfterStable    :: Maybe Int
     , offsets            :: [Int64]
@@ -466,6 +469,22 @@ optionParser =
           <> help
                (  "Minimum number of clock cycles a buffer occupancy "
                <> "must remain within to be considered stable"
+               )
+          )
+    <*> flag False True
+          (  long "disable-reframing"
+          <> short 'e'
+          <> help "Disables clock control reframing"
+          )
+    <*> option auto
+          (  long "wait-time"
+          <> short 'w'
+          <> metavar "NUM"
+          <> value 20000000
+          <> showDefault
+          <> help
+               (  "Number of clock cycles to wait until reframing takes place "
+               <> "(after stability has been detected, for all elastic buffers)"
                )
           )
     <*> flag False True
@@ -553,6 +572,8 @@ main = do
         , framesize  = stabilityFrameSize
         , samples    = simulationSamples
         , periodsize = simulationSteps `quot` simulationSamples
+        , reframe    = not disableReframing
+        , waittime   = waitTime
         , mode       = outMode
         , dir        = outDir
         , stopStable =
@@ -565,22 +586,24 @@ main = do
 
   isStable <- case topology of
     Just t -> do
-      let simSettings = settings { save = safeToFile $ ttype t }
+      let ?settings = settings { save = safeToFile $ ttype t }
       case t of
-        Diamond       -> plotDiamond simSettings
-        Line n        -> plotLine simSettings n
-        HyperCube n   -> plotHyperCube simSettings n
-        Grid r c      -> plotGrid simSettings r c
-        Torus2D r c   -> plotTorus2D simSettings r c
-        Torus3D r c p -> plotTorus3D simSettings r c p
-        Tree d c      -> plotTree simSettings d c
-        Star n        -> plotStar simSettings n
-        Cycle n       -> plotCyclic simSettings n
-        Complete n    -> plotComplete simSettings n
-        Hourglass n   -> plotHourglass simSettings n
-        Random n      -> randomGraph n >>= plotGraph simSettings
+        Diamond       -> plotDiamond
+        Line n        -> plotLine n
+        HyperCube n   -> plotHyperCube n
+        Grid r c      -> plotGrid r c
+        Torus2D r c   -> plotTorus2D r c
+        Torus3D r c p -> plotTorus3D r c p
+        Tree d c      -> plotTree d c
+        Star n        -> plotStar n
+        Cycle n       -> plotCyclic n
+        Complete n    -> plotComplete n
+        Hourglass n   -> plotHourglass n
+        Random n      -> randomGraph n >>= plotGraph
         DotFile f     -> (fromDot <$> readFile f) >>= \case
-          Right (g, name) -> plotGraph settings { save = safeToFile name } g
+          Right (g, name) ->
+            let ?settings = ?settings { save = safeToFile name }
+            in plotGraph g
           Left err -> die $ "ERROR: Invalid DOT file - " <> f <> "\n" <> err
     Nothing ->
       handleParseResult $ Failure
@@ -710,7 +733,7 @@ fromDot cnt = do
 -- | Successive overlapping pairs.
 --
 -- >>> pairwise [1, 2, 3, 4]
--- [(1,2), (2, 3), (3, 4), (4, 5)]
+-- [(1, 2), (2, 3), (3, 4), (4, 5)]
 -- >>> pairwise []
 -- []
 pairwise :: [a] -> [(a,a)]

--- a/elastic-buffer-sim/exe/Main.hs
+++ b/elastic-buffer-sim/exe/Main.hs
@@ -383,6 +383,7 @@ data Options =
     , stabilityMargin    :: Int
     , stabilityFrameSize :: Int
     , stopWhenStable     :: Bool
+    , stopAfterStable    :: Maybe Int
     , offsets            :: [Int64]
     , outDir             :: FilePath
     , jsonArgs           :: Maybe FilePath
@@ -444,6 +445,17 @@ optionParser =
           (  long "stop-when-stable"
           <> short 'x'
           <> help "Stop simulation as soon as all buffers get stable"
+          )
+    <*> optional
+          ( option auto
+              (  long "stop-after-stable"
+              <> short 'X'
+              <> metavar "NUM"
+              <> help
+                   (  "Stop simulation after all buffers have been stable for "
+                   <> " at least the given number of simulation steps"
+                   )
+              )
           )
     <*> option auto
           (  long "offsets"
@@ -516,7 +528,10 @@ main = do
         , periodsize = simulationSteps `quot` simulationSamples
         , mode       = outMode
         , dir        = outDir
-        , stopStable = stopWhenStable
+        , stopStable =
+            if stopWhenStable
+            then Just 0
+            else (`quot` simulationSamples) <$> stopAfterStable
         , fixOffsets = offsets
         , save       = \_ _ _ -> return ()
         }

--- a/elastic-buffer-sim/src/Bittide/ClockControl/ElasticBuffer.hs
+++ b/elastic-buffer-sim/src/Bittide/ClockControl/ElasticBuffer.hs
@@ -5,53 +5,18 @@
 module Bittide.ClockControl.ElasticBuffer where
 
 import Clash.Prelude
-import Clash.Signal.Internal
 import GHC.Stack
 
+import Bittide.Counter
 import Bittide.ClockControl
-
-
--- | Determines how 'elasticBuffer' should respond to underflow/overflow.
-data OverflowMode
-  -- | Saturate at empty/full boundaries. Useful for testing purposes.
-  = Saturate
-  -- | Error on write-when-full, or read-when-empty. This mode should be used in
-  -- practice. Overflowing elastic buffer cannot happen in a real Bittide system.
-  | Error
 
 -- | Simple model of a FIFO that only models the interesting part for conversion:
 -- data counts.
 elasticBuffer ::
   forall n readDom writeDom.
   (HasCallStack, KnownDomain readDom, KnownDomain writeDom, KnownNat n) =>
-  -- | What behavior to pick on underflow/overflow
-  OverflowMode ->
   Clock readDom ->
   Clock writeDom ->
   Signal readDom (DataCount n)
-elasticBuffer mode clkRead clkWrite =
-  go (clockTicks clkWrite clkRead) targetDataCount
- where
-  go (tick:ticks) !fillLevel =
-    case tick of
-      ClockA  -> goWrite ticks fillLevel
-      ClockB  -> goRead ticks fillLevel
-      ClockAB -> go (ClockB:ClockA:ticks) fillLevel
-  go [] _ =
-    error "elasticBuffer.go: `ticks` should have been an infinite list"
-
-  goWrite ticks fillLevel = go ticks newFillLevel
-   where
-    newFillLevel
-      | fillLevel == maxBound = case mode of
-          Saturate -> fillLevel
-          Error -> error "elasticBuffer: overflow"
-      | otherwise = fillLevel + 1
-
-  goRead ticks fillLevel = newFillLevel :- go ticks newFillLevel
-   where
-    newFillLevel
-      | fillLevel == minBound = case mode of
-          Saturate -> fillLevel
-          Error -> error "elasticBuffer: underflow"
-      | otherwise = fillLevel - 1
+elasticBuffer clkRead clkWrite = resize . fst
+  <$> domainDiffCounter clkWrite resetGen clkRead resetGen

--- a/elastic-buffer-sim/src/Bittide/ClockControl/ElasticBuffer.hs
+++ b/elastic-buffer-sim/src/Bittide/ClockControl/ElasticBuffer.hs
@@ -51,7 +51,7 @@ elasticBuffer mode clkRead clkWrite =
   goRead ticks fillLevel = newFillLevel :- go ticks newFillLevel
    where
     newFillLevel
-      | fillLevel <= 0 = case mode of
-          Saturate -> 0
+      | fillLevel == minBound = case mode of
+          Saturate -> fillLevel
           Error -> error "elasticBuffer: underflow"
       | otherwise = fillLevel - 1

--- a/elastic-buffer-sim/src/Bittide/Domain.hs
+++ b/elastic-buffer-sim/src/Bittide/Domain.hs
@@ -16,5 +16,5 @@ createDomain vSystem{
   , vResetKind=Synchronous
   }
 
-defBittideClockConfig :: ClockControlConfig Bittide 12
+defBittideClockConfig :: ClockControlConfig Bittide 12 8 1500000
 defBittideClockConfig = defClockConfig

--- a/elastic-buffer-sim/src/Bittide/Plot.hs
+++ b/elastic-buffer-sim/src/Bittide/Plot.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE ImplicitParams #-}
 
 module Bittide.Plot
   ( OutputMode(..)
@@ -73,6 +74,7 @@ import Bittide.Simulate (Offset)
 import Bittide.Domain (Bittide, defBittideClockConfig)
 import Bittide.ClockControl (ClockControlConfig(..), clockPeriodFs)
 import Bittide.ClockControl.StabilityChecker qualified as SC (StabilityIndication(..))
+import Bittide.ClockControl.Callisto (ReframingState(..))
 import Bittide.Topology (simulate, simulationEntity, allSettled)
 import Bittide.Arithmetic.Ppm (Ppm(..), diffPeriod)
 import Bittide.Topology.Graph
@@ -109,6 +111,8 @@ data SimulationSettings =
     , framesize  :: Int
     , samples    :: Int
     , periodsize :: Int
+    , reframe    :: Bool
+    , waittime   :: Int
     , mode       :: OutputMode
     , dir        :: FilePath
     , stopStable :: Maybe Int
@@ -116,19 +120,20 @@ data SimulationSettings =
     , save       :: G.Graph -> [Int64] -> Maybe Bool -> IO ()
     }
 
-plotDiamond :: SimulationSettings -> IO Bool
-plotDiamond settings@SimulationSettings{..} =
+plotDiamond :: (?settings :: SimulationSettings) => IO Bool
+plotDiamond =
   case ( someNat margin
        , somePositiveNat framesize
        ) of
     (  Just (SomeNat (_ :: Proxy margin))
      , Just (SomePositiveNat (_ :: Proxy framesize))
-     ) -> simulateTopology clockControlConfig
-            (SNat @margin) (SNat @framesize) diamond settings
+     ) -> simulateTopology (clockControlConfig @margin @framesize) diamond
     (x, y) -> invalidArgs False (isNothing x) $ isNothing y
+ where
+  SimulationSettings{..} = ?settings
 
-plotCyclic :: SimulationSettings -> Int -> IO Bool
-plotCyclic settings@SimulationSettings{..} nodes =
+plotCyclic :: (?settings :: SimulationSettings) => Int -> IO Bool
+plotCyclic nodes =
   case ( simulatableG (SomeGraph . cyclic) nodes
        , someNat margin
        , somePositiveNat framesize
@@ -136,12 +141,13 @@ plotCyclic settings@SimulationSettings{..} nodes =
     (  Just (SomeSimulatableGraph graph)
      , Just (SomeNat (_ :: Proxy margin))
      , Just (SomePositiveNat (_ :: Proxy framesize))
-     ) -> simulateTopology clockControlConfig
-            (SNat @margin) (SNat @framesize) graph settings
+     ) -> simulateTopology (clockControlConfig @margin @framesize) graph
     (x, y, z) -> invalidArgs (isNothing x) (isNothing y) (isNothing z)
+ where
+  SimulationSettings{..} = ?settings
 
-plotComplete :: SimulationSettings -> Int -> IO Bool
-plotComplete settings@SimulationSettings{..} nodes =
+plotComplete :: (?settings :: SimulationSettings) => Int -> IO Bool
+plotComplete nodes =
   case ( simulatableG (SomeGraph . complete) nodes
        , someNat margin
        , somePositiveNat framesize
@@ -149,12 +155,13 @@ plotComplete settings@SimulationSettings{..} nodes =
     (  Just (SomeSimulatableGraph graph)
      , Just (SomeNat (_ :: Proxy margin))
      , Just (SomePositiveNat (_ :: Proxy framesize))
-     ) -> simulateTopology clockControlConfig
-            (SNat @margin) (SNat @framesize) graph settings
+     ) -> simulateTopology (clockControlConfig @margin @framesize) graph
     (x, y, z) -> invalidArgs (isNothing x) (isNothing y) (isNothing z)
+ where
+  SimulationSettings{..} = ?settings
 
-plotHourglass :: SimulationSettings -> Int -> IO Bool
-plotHourglass settings@SimulationSettings{..} nodes =
+plotHourglass :: (?settings :: SimulationSettings) => Int -> IO Bool
+plotHourglass nodes =
   case ( simulatableG (SomeGraph . hourglass) nodes
        , someNat margin
        , somePositiveNat framesize
@@ -162,12 +169,13 @@ plotHourglass settings@SimulationSettings{..} nodes =
     (  Just (SomeSimulatableGraph graph)
      , Just (SomeNat (_ :: Proxy margin))
      , Just (SomePositiveNat (_ :: Proxy framesize))
-     ) -> simulateTopology clockControlConfig
-            (SNat @margin) (SNat @framesize) graph settings
+     ) -> simulateTopology (clockControlConfig @margin @framesize) graph
     (x, y, z) -> invalidArgs (isNothing x) (isNothing y) (isNothing z)
+ where
+  SimulationSettings{..} = ?settings
 
-plotGrid :: SimulationSettings -> Int -> Int -> IO Bool
-plotGrid settings@SimulationSettings{..} rows cols =
+plotGrid :: (?settings :: SimulationSettings) => Int -> Int -> IO Bool
+plotGrid rows cols =
   case ( simulatableG2 ((SomeGraph .) . grid) rows cols
        , someNat margin
        , somePositiveNat framesize
@@ -175,12 +183,13 @@ plotGrid settings@SimulationSettings{..} rows cols =
     (  Just (SomeSimulatableGraph graph)
      , Just (SomeNat (_ :: Proxy margin))
      , Just (SomePositiveNat (_ :: Proxy framesize))
-     ) -> simulateTopology clockControlConfig
-            (SNat @margin) (SNat @framesize) graph settings
+     ) -> simulateTopology (clockControlConfig @margin @framesize) graph
     (x, y, z) -> invalidArgs (isNothing x) (isNothing y) (isNothing z)
+ where
+  SimulationSettings{..} = ?settings
 
-plotStar :: SimulationSettings -> Int -> IO Bool
-plotStar settings@SimulationSettings{..} nodes =
+plotStar :: (?settings :: SimulationSettings) => Int -> IO Bool
+plotStar nodes =
   case ( simulatableG (SomeGraph . star) nodes
        , someNat margin
        , somePositiveNat framesize
@@ -188,12 +197,13 @@ plotStar settings@SimulationSettings{..} nodes =
     (  Just (SomeSimulatableGraph graph)
      , Just (SomeNat (_ :: Proxy margin))
      , Just (SomePositiveNat (_ :: Proxy framesize))
-     ) -> simulateTopology clockControlConfig
-            (SNat @margin) (SNat @framesize) graph settings
+     ) -> simulateTopology (clockControlConfig @margin @framesize) graph
     (x, y, z) -> invalidArgs (isNothing x) (isNothing y) (isNothing z)
+ where
+  SimulationSettings{..} = ?settings
 
-plotTorus2D :: SimulationSettings -> Int -> Int -> IO Bool
-plotTorus2D settings@SimulationSettings{..} rows cols =
+plotTorus2D :: (?settings :: SimulationSettings) => Int -> Int -> IO Bool
+plotTorus2D rows cols =
   case ( simulatableG2 ((SomeGraph .) . torus2d) rows cols
        , someNat margin
        , somePositiveNat framesize
@@ -201,12 +211,13 @@ plotTorus2D settings@SimulationSettings{..} rows cols =
     (  Just (SomeSimulatableGraph graph)
      , Just (SomeNat (_ :: Proxy margin))
      , Just (SomePositiveNat (_ :: Proxy framesize))
-     ) -> simulateTopology clockControlConfig
-           (SNat @margin) (SNat @framesize) graph settings
+     ) -> simulateTopology (clockControlConfig @margin @framesize) graph
     (x, y, z) -> invalidArgs (isNothing x) (isNothing y) (isNothing z)
+ where
+  SimulationSettings{..} = ?settings
 
-plotTorus3D :: SimulationSettings -> Int -> Int -> Int -> IO Bool
-plotTorus3D settings@SimulationSettings{..} rows cols planes =
+plotTorus3D :: (?settings :: SimulationSettings) => Int -> Int -> Int -> IO Bool
+plotTorus3D rows cols planes =
   case ( simulatableG3 (((SomeGraph .) .) . torus3d) rows cols planes
        , someNat margin
        , somePositiveNat framesize
@@ -214,12 +225,13 @@ plotTorus3D settings@SimulationSettings{..} rows cols planes =
     (  Just (SomeSimulatableGraph graph)
      , Just (SomeNat (_ :: Proxy margin))
      , Just (SomePositiveNat (_ :: Proxy framesize))
-     ) -> simulateTopology clockControlConfig
-            (SNat @margin) (SNat @framesize) graph settings
+     ) -> simulateTopology (clockControlConfig @margin @framesize) graph
     (x, y, z) -> invalidArgs (isNothing x) (isNothing y) (isNothing z)
+ where
+  SimulationSettings{..} = ?settings
 
-plotTree :: SimulationSettings -> Int -> Int -> IO Bool
-plotTree settings@SimulationSettings{..} depth childs =
+plotTree :: (?settings :: SimulationSettings) => Int -> Int -> IO Bool
+plotTree depth childs =
   case ( simulatableG2 ((SomeGraph .) . tree) depth childs
        , someNat margin
        , somePositiveNat framesize
@@ -227,12 +239,13 @@ plotTree settings@SimulationSettings{..} depth childs =
     (  Just (SomeSimulatableGraph graph)
      , Just (SomeNat (_ :: Proxy margin))
      , Just (SomePositiveNat (_ :: Proxy framesize))
-     ) -> simulateTopology clockControlConfig
-            (SNat @margin) (SNat @framesize) graph settings
+     ) -> simulateTopology (clockControlConfig  @margin @framesize) graph
     (x, y, z) -> invalidArgs (isNothing x) (isNothing y) (isNothing z)
+ where
+  SimulationSettings{..} = ?settings
 
-plotLine :: SimulationSettings -> Int -> IO Bool
-plotLine settings@SimulationSettings{..} nodes =
+plotLine :: (?settings :: SimulationSettings) => Int -> IO Bool
+plotLine nodes =
   case ( simulatableG (SomeGraph . line) nodes
        , someNat margin
        , somePositiveNat framesize
@@ -240,12 +253,13 @@ plotLine settings@SimulationSettings{..} nodes =
     (  Just (SomeSimulatableGraph graph)
      , Just (SomeNat (_ :: Proxy margin))
      , Just (SomePositiveNat (_ :: Proxy framesize))
-     ) -> simulateTopology clockControlConfig
-            (SNat @margin) (SNat @framesize) graph settings
+     ) -> simulateTopology (clockControlConfig @margin @framesize) graph
     (x, y, z) -> invalidArgs (isNothing x) (isNothing y) (isNothing z)
+ where
+  SimulationSettings{..} = ?settings
 
-plotHyperCube :: SimulationSettings -> Int -> IO Bool
-plotHyperCube settings@SimulationSettings{..} nodes =
+plotHyperCube :: (?settings :: SimulationSettings) => Int -> IO Bool
+plotHyperCube nodes =
   case ( simulatableG (SomeGraph . hypercube) nodes
        , someNat margin
        , somePositiveNat framesize
@@ -253,13 +267,13 @@ plotHyperCube settings@SimulationSettings{..} nodes =
     (  Just (SomeSimulatableGraph graph)
      , Just (SomeNat (_ :: Proxy margin))
      , Just (SomePositiveNat (_ :: Proxy framesize))
-     ) -> simulateTopology clockControlConfig
-            (SNat @margin) (SNat @framesize) graph settings
+     ) -> simulateTopology (clockControlConfig @margin @framesize) graph
     (x, y, z) -> invalidArgs (isNothing x) (isNothing y) (isNothing z)
+ where
+  SimulationSettings{..} = ?settings
 
-
-plotGraph :: SimulationSettings -> G.Graph -> IO Bool
-plotGraph settings@SimulationSettings{..} g =
+plotGraph :: (?settings :: SimulationSettings) => G.Graph -> IO Bool
+plotGraph g =
   case ( simulatableG (SomeGraph . givenGraph) n
        , someNat margin
        , somePositiveNat framesize
@@ -267,27 +281,29 @@ plotGraph settings@SimulationSettings{..} g =
     (  Just (SomeSimulatableGraph graph)
      , Just (SomeNat (_ :: Proxy margin))
      , Just (SomePositiveNat (_ :: Proxy framesize))
-     ) -> simulateTopology clockControlConfig
-            (SNat @margin) (SNat @framesize) graph settings
+     ) -> simulateTopology (clockControlConfig @margin @framesize) graph
     (x, y, z) -> invalidArgs (isNothing x) (isNothing y) (isNothing z)
  where
-
+  SimulationSettings{..} = ?settings
   n = let (l, u) = bounds g in u - l + 1
   givenGraph :: KnownNat n => SNat n -> Graph n
   givenGraph = const $ boundGraph g
 
 clockControlConfig ::
   forall margin framesize.
-  (KnownNat margin, KnownNat framesize) =>
+  (?settings :: SimulationSettings, KnownNat margin, KnownNat framesize) =>
   ClockControlConfig Bittide 12 margin framesize
 clockControlConfig =
   ClockControlConfig
     { cccStabilityCheckerMargin    = SNat @margin
     , cccStabilityCheckerFramesize = SNat @framesize
+    , cccEnableReframing           = reframe
+    , cccReframingWaitTime         = fromInteger $ toInteger waittime
     , ..
     }
   where
     ClockControlConfig{..} = defBittideClockConfig
+    SimulationSettings{..} = ?settings
 
 invalidArgs :: Bool -> Bool -> Bool -> IO Bool
 invalidArgs invalidGraph invalidMargin invalidFramesize
@@ -300,7 +316,9 @@ invalidArgs invalidGraph invalidMargin invalidFramesize
 -- given output mode.
 simulateTopology ::
   forall dom nodes dcount margin framesize.
-  ( KnownDomain dom
+  ( ?settings :: SimulationSettings
+  -- ^ simulation settings
+  , KnownDomain dom
   -- ^ domain
   , KnownNat nodes
   -- ^ the size of the topology is know
@@ -323,17 +341,11 @@ simulateTopology ::
   ) =>
   ClockControlConfig dom dcount margin framesize ->
   -- ^ clock control configuration
-  SNat margin ->
-  -- ^ margin of the stability checker
-  SNat framesize ->
-  -- ^ frame size of cycles within the margins required
   Graph nodes ->
   -- ^ the topology
-  SimulationSettings ->
-  -- ^ simulation settings
   IO Bool
   -- ^ stability result
-simulateTopology ccc margin framesize graph settings = do
+simulateTopology ccc graph = do
   offsets <- V.zipWith (maybe id const) givenOffsets <$> genOffs ccc
   let
     simResult = sim offsets
@@ -359,11 +371,11 @@ simulateTopology ccc margin framesize graph settings = do
     , stopStable
     , fixOffsets
     , save
-    } = settings
+    } = ?settings
 
   sim =
    simulate graph stopStable samples periodsize
-    . simulationEntity graph ccc margin framesize
+    . simulationEntity graph ccc
 
   plotTopology =
     uncurry (matplotWrite dir) . V.unzip . V.map plotDats
@@ -373,7 +385,7 @@ simulateTopology ccc margin framesize graph settings = do
         (uncurry plot . unzip)
         (foldPlots . fmap plotEbData . transpose)
     . unzip
-    . fmap (\(x,y,z) -> ((x,y), (x,) <$> z))
+    . fmap (\(a,b,c,d) -> ((a,b), ((a,c),) <$> d))
 
   givenOffsets =
       V.unsafeFromList
@@ -393,40 +405,54 @@ simulateTopology ccc margin framesize graph settings = do
       [(0 :: Int)..]
 
   filename i = dir </> "clocks" <> "_" <> show i <> ".csv"
-  flatten (a, b, v) = toField a : toField b : (toField . fst <$> v)
+  flatten (a, b, _, v) = toField a : toField b : (toField . fst <$> v)
   (0, n) = bounds $ unboundGraph $ graph
+
+data Marking = Waiting | Stable | Settled | None deriving (Eq)
 
 -- | Plots the datacount of an elastic buffer and marks those parts of
 -- the plots that are reported to be stable/settled by the stability
--- checker for the repsective buffer.
+-- checker as well as the time frames at which the reframing detector
+-- is in the waiting state.
 plotEbData ::
-  (ToJSON t, ToJSON d) => [(t, (d, SC.StabilityIndication))] -> Matplotlib
+  (ToJSON t, ToJSON d) =>
+  [((t, ReframingState), (d, SC.StabilityIndication))] ->
+  Matplotlib
 plotEbData xs = foldPlots markedIntervals % ebPlot
  where
-  mGr = (@@ [ o1 "g-", o2 "linewidth" (10 :: Int)]) -- green marking
-  mBl = (@@ [ o1 "b-", o2 "linewidth" (10 :: Int)]) -- blue marking
-  ebPlot = uncurry plot $ unzip ((\(t, (d, _)) -> (t, d)) <$> xs)
+  mGr = (@@ [ o1 "g-", o2 "linewidth" (8 :: Int)]) -- green marking
+  mBl = (@@ [ o1 "b-", o2 "linewidth" (8 :: Int)]) -- blue marking
+  mRe = (@@ [ o1 "r-", o2 "linewidth" (8 :: Int)]) -- red marking
+  ebPlot = uncurry plot $ unzip ((\((t, _), (d, _)) -> (t, d)) <$> xs)
+
+  mindMarking ys ms = \case
+    Waiting -> (mRe, reverse ys) : ms
+    Stable  -> (mBl, reverse ys) : ms
+    Settled -> (mGr, reverse ys) : ms
+    None    -> ms
 
   markedIntervals =
     (\(mark, ys) -> mark $ uncurry plot $ unzip ys)
-      <$> stableIvs [] False False xs
+      <$> collectIntervals ((None, []), []) xs
 
-  stableIvs a _  _  []     = a
-  stableIvs a as ac ((t, (d, sci)):xr) = stableIvs a' stable settled xr
+  collectIntervals ((previous, ys), markings) [] =
+    mindMarking ys markings previous
+
+  collectIntervals ((previous, ys), markings) (((t, rfState), (d, sci)) : xr) =
+    collectIntervals a' xr
    where
-    stable  = SC.stable sci
-    settled = SC.settled sci
-    pData   = (t, d)
+    current = case rfState of
+      Wait {}            -> Waiting
+      _
+        | SC.settled sci -> Settled
+        | SC.stable sci  -> Stable
+        | otherwise      -> None
 
-    (m, y) : yr = a
-    rya = (m, reverse y) : yr
+    markings' = mindMarking ys markings previous
 
-    a' |     stable  && not settled && not as           = (mBl, [pData]  ) : a
-       |     stable  &&     settled &&           not ac = (mGr, [pData]  ) : a
-       |     stable  && not settled &&     as &&     ac = (mBl, [pData]  ) : rya
-       |     stable                 &&     as           = (m,   pData : y) : yr
-       | not stable                 &&     as           = rya
-       | otherwise                                      = a
+    a' | current == previous = ((current, (t, d) : ys), markings )
+       | current == None     = ((None,    []         ), markings')
+       | otherwise           = ((current, [(t, d)]   ), markings')
 
 -- | Folds the vectors of generated plots and writes the results to
 -- the disk.

--- a/elastic-buffer-sim/src/Bittide/Plot.hs
+++ b/elastic-buffer-sim/src/Bittide/Plot.hs
@@ -13,6 +13,7 @@ module Bittide.Plot
   , plotDiamond
   , plotCyclic
   , plotComplete
+  , plotHourglass
   , plotGrid
   , plotStar
   , plotTorus2D
@@ -141,6 +142,19 @@ plotCyclic settings@SimulationSettings{..} nodes =
 plotComplete :: SimulationSettings -> Int -> IO Bool
 plotComplete settings@SimulationSettings{..} nodes =
   case ( simulatableG (SomeGraph . complete) nodes
+       , someNat margin
+       , somePositiveNat framesize
+       ) of
+    (  Just (SomeSimulatableGraph graph)
+     , Just (SomeNat (_ :: Proxy margin))
+     , Just (SomePositiveNat (_ :: Proxy framesize))
+     ) -> simulateTopology clockControlConfig
+            (SNat @margin) (SNat @framesize) graph settings
+    (x, y, z) -> invalidArgs (isNothing x) (isNothing y) (isNothing z)
+
+plotHourglass :: SimulationSettings -> Int -> IO Bool
+plotHourglass settings@SimulationSettings{..} nodes =
+  case ( simulatableG (SomeGraph . hourglass) nodes
        , someNat margin
        , somePositiveNat framesize
        ) of

--- a/elastic-buffer-sim/src/Bittide/Topology.hs
+++ b/elastic-buffer-sim/src/Bittide/Topology.hs
@@ -86,7 +86,7 @@ simulationEntity topology ccc margin framesize !offsets =
   !ebs = imap ebv clocks
   ebv x = flip imap clocks . eb x
   eb x xClk y yClk
-    | hasEdge topology x y = elasticBuffer Error xClk yClk
+    | hasEdge topology x y = elasticBuffer xClk yClk
     | otherwise            = pure 0
   -- stability checkers
   !scs = imap (\i (v, clk) -> imap (sc i clk) v) $ zip ebs clocks

--- a/elastic-buffer-sim/src/Bittide/Topology/Graph.hs
+++ b/elastic-buffer-sim/src/Bittide/Topology/Graph.hs
@@ -25,6 +25,7 @@ module Bittide.Topology.Graph
   , tree
   , line
   , hypercube
+  , hourglass
   )
 where
 
@@ -228,3 +229,21 @@ complete (snatToNum -> n) =
  where
   bounds = (0, n-1)
   others i = [ j | j <- [0..(n-1)], j /= i ]
+
+-- | A hourglass shaped graph consisting of two independent complete
+-- sub-graphs, only connected via a single edge between two distinct
+-- nodes of each sub-graph.
+hourglass :: KnownNat n => SNat n -> Graph (2 * n)
+hourglass (snatToNum -> n)
+  | n == 0    = boundGraph $ A.array (0,-1) []
+  | otherwise = boundGraph $ A.array bounds
+                  $ fmap (\i -> (i, neighbours i)) [0..2*n-1]
+ where
+  bounds = (0, 2*n-1)
+  neighbours i
+    | even i    =
+      (if i == 0 then (1 :) else id)
+        [ 2*j   | j <- [0..n-1], 2*j   /= i ]
+    | otherwise =
+      (if i == 1 then (0 :) else id)
+        [ 2*j+1 | j <- [0..n-1], 2*j+1 /= i ]

--- a/elastic-buffer-sim/tests/Tests/Bittide/Simulate.hs
+++ b/elastic-buffer-sim/tests/Tests/Bittide/Simulate.hs
@@ -34,7 +34,7 @@ case_clockControlMaxBound = do
     dataCounts = pure maxBound :> Nil
     mask = pure $ pack (repeat high)
     changes =
-      fmap (\(x, _, _) -> x) $ sampleN
+      fmap speedChange $ sampleN
         -- +10_000 assumes callisto's pipeline less than 10_000 deep
         (fromIntegral (cccPessimisticSettleCycles config + 10_000))
         (callistoClockControl @_ @_ @Fast clockGen resetGen enableGen config mask dataCounts)
@@ -50,7 +50,7 @@ case_clockControlMinBound = do
     dataCounts = pure minBound :> Nil
     mask = pure $ pack (repeat high)
     changes =
-      fmap (\(x, _, _) -> x) $ sampleN
+      fmap speedChange $ sampleN
         -- +100 assumes callisto's pipeline less than 100 deep
         (fromIntegral (cccPessimisticSettleCycles config + 100))
         (callistoClockControl @_ @_ @Fast clockGen resetGen enableGen config mask dataCounts)

--- a/elastic-buffer-sim/tests/Tests/Bittide/Simulate.hs
+++ b/elastic-buffer-sim/tests/Tests/Bittide/Simulate.hs
@@ -51,7 +51,7 @@ case_clockControlMinBound :: Assertion
 case_clockControlMinBound = do
   let
     config = defClockConfig
-    dataCounts = pure 0 :> Nil
+    dataCounts = pure minBound :> Nil
     mask = pure $ pack (repeat high)
     changes =
       sampleN
@@ -71,14 +71,14 @@ case_elasticBufferMaxBound = do
   -- it never hits exactly the maximum because the occupancy is in the read
   -- domain, i.e. we have to look for one less than the max
   assertBool "elastic buffer should reach its near maximum (read domain)" ((maxBound-1) `elem` dataCounts)
-  assertBool "elastic buffer should not reach its minimum" (0 `notElem` dataCounts)
+  assertBool "elastic buffer should not reach its minimum" (minBound `notElem` dataCounts)
 
 -- | When the elasticBuffer is read from more quickly than it is being written to,
 -- its data count should reach 'minBound'.
 case_elasticBufferMinBound :: Assertion
 case_elasticBufferMinBound = do
   let dataCounts = sampleN 1024 (elasticBuffer @5 Saturate (clockGen @Fast) (clockGen @Slow))
-  assertBool "elastic buffer should reach its minimum" (0 `elem` dataCounts)
+  assertBool "elastic buffer should reach its minimum" (minBound `elem` dataCounts)
   assertBool "elastic buffer should not reach its maximum" (maxBound `notElem` dataCounts)
 
 -- | When the elasticBuffer is written to as quickly to as it is read from, it should
@@ -86,5 +86,5 @@ case_elasticBufferMinBound = do
 case_elasticBufferEq :: Assertion
 case_elasticBufferEq = do
   let dataCounts = sampleN 1024 (elasticBuffer @5 Saturate (clockGen @Slow) (clockGen @Slow))
-  assertBool "elastic buffer should not reach its minimum" (0 `notElem` dataCounts)
+  assertBool "elastic buffer should not reach its minimum" (minBound `notElem` dataCounts)
   assertBool "elastic buffer should not reach its maximum" (maxBound `notElem` dataCounts)

--- a/elastic-buffer-sim/tests/Tests/Bittide/Simulate.hs
+++ b/elastic-buffer-sim/tests/Tests/Bittide/Simulate.hs
@@ -34,7 +34,7 @@ case_clockControlMaxBound = do
     dataCounts = pure maxBound :> Nil
     mask = pure $ pack (repeat high)
     changes =
-      sampleN
+      fmap (\(x, _, _) -> x) $ sampleN
         -- +10_000 assumes callisto's pipeline less than 10_000 deep
         (fromIntegral (cccPessimisticSettleCycles config + 10_000))
         (callistoClockControl @_ @_ @Fast clockGen resetGen enableGen config mask dataCounts)
@@ -50,7 +50,7 @@ case_clockControlMinBound = do
     dataCounts = pure minBound :> Nil
     mask = pure $ pack (repeat high)
     changes =
-      sampleN
+      fmap (\(x, _, _) -> x) $ sampleN
         -- +100 assumes callisto's pipeline less than 100 deep
         (fromIntegral (cccPessimisticSettleCycles config + 100))
         (callistoClockControl @_ @_ @Fast clockGen resetGen enableGen config mask dataCounts)

--- a/elastic-buffer-sim/tests/Tests/Bittide/Simulate.hs
+++ b/elastic-buffer-sim/tests/Tests/Bittide/Simulate.hs
@@ -15,7 +15,6 @@ import Test.Tasty.HUnit
 
 import Bittide.ClockControl
 import Bittide.ClockControl.Callisto
-import Bittide.ClockControl.ElasticBuffer
 
 createDomain vXilinxSystem{vPeriod=hzToPeriod 200e6, vName="Fast"}
 createDomain vXilinxSystem{vPeriod=hzToPeriod 20e6, vName="Slow"}
@@ -23,10 +22,7 @@ createDomain vXilinxSystem{vPeriod=hzToPeriod 20e6, vName="Slow"}
 tests :: TestTree
 tests = testGroup "Simulate"
   [ testGroup "elasticBuffer"
-    [ testCase "case_elasticBufferMaxBound" case_elasticBufferMaxBound
-    , testCase "case_elasticBufferMinBound" case_elasticBufferMinBound
-    , testCase "case_elasticBufferEq" case_elasticBufferEq
-    , testCase "case_caseClockControlMaxBound" case_clockControlMaxBound
+    [ testCase "case_caseClockControlMaxBound" case_clockControlMaxBound
     , testCase "case_caseClockControlMinBound" case_clockControlMinBound
     ]
   ]
@@ -62,29 +58,3 @@ case_clockControlMinBound = do
   assertBool
     "only requests slow down"
     (SlowDown `elem` changes && SpeedUp `notElem` changes)
-
--- | When the elasticBuffer is written to more quickly than it is being read from,
--- its data count should reach 'maxBound'.
-case_elasticBufferMaxBound :: Assertion
-case_elasticBufferMaxBound = do
-  let dataCounts = sampleN 2048 (elasticBuffer @5 Saturate (clockGen @Slow) (clockGen @Fast))
-  -- it never hits exactly the maximum because the occupancy is in the read
-  -- domain, i.e. we have to look for one less than the max
-  assertBool "elastic buffer should reach its near maximum (read domain)" ((maxBound-1) `elem` dataCounts)
-  assertBool "elastic buffer should not reach its minimum" (minBound `notElem` dataCounts)
-
--- | When the elasticBuffer is read from more quickly than it is being written to,
--- its data count should reach 'minBound'.
-case_elasticBufferMinBound :: Assertion
-case_elasticBufferMinBound = do
-  let dataCounts = sampleN 1024 (elasticBuffer @5 Saturate (clockGen @Fast) (clockGen @Slow))
-  assertBool "elastic buffer should reach its minimum" (minBound `elem` dataCounts)
-  assertBool "elastic buffer should not reach its maximum" (maxBound `notElem` dataCounts)
-
--- | When the elasticBuffer is written to as quickly to as it is read from, it should
--- reach neiher its maxBound nor minBound.
-case_elasticBufferEq :: Assertion
-case_elasticBufferEq = do
-  let dataCounts = sampleN 1024 (elasticBuffer @5 Saturate (clockGen @Slow) (clockGen @Slow))
-  assertBool "elastic buffer should not reach its minimum" (minBound `notElem` dataCounts)
-  assertBool "elastic buffer should not reach its maximum" (maxBound `notElem` dataCounts)


### PR DESCRIPTION
Adds a variation of the reframing model of https://arxiv.org/abs/2303.11467 to the Callisto controller.

Instead of some global time `T_0`, which is implicitly shared among all nodes in the paper, the current implementation uses a local stability checker for each elastic buffer to determine whether the buffer occupancies have been stablized and centered, or not. If all of the elastic buffers of a node are stable, but not all are centered, then the controller of that node reframes. This process repeats until all elastic buffers are stable and centered eventually.

----

### TODOs:
  * [x] Fix the memory leak
  * [x] Verify that simulation produces the expected results
  * [x] Integrate #289
  * [x] ~~Enable the real FIFOs after everything has stablizied~~
  * [x] _Add a hourglass topology generator (optional)_
  * [x] ~~Reduce the size of the simulated examples to fit within github's 6h bound~~ The bounds have been exeeded to 14h.
  * [x] Add the "detect, store and wait" reframing approach