### PR TITLE
Add `Bittide.Counter`: a way of measuring domain speed differences

### DIFF
--- a/.github/synthesis/all.json
+++ b/.github/synthesis/all.json
@@ -1,5 +1,6 @@
 [
   {"top": "callisto3",                   "stage": "netlist"},
+  {"top": "counterReducedPins",          "stage": "netlist"},
   {"top": "clockControlDemo0",           "stage": "bitstream"},
   {"top": "clockControlDemo1",           "stage": "bitstream"},
   {"top": "elasticBuffer5",              "stage": "netlist"},

--- a/bittide-instances/bin/Shake.hs
+++ b/bittide-instances/bin/Shake.hs
@@ -26,6 +26,7 @@ import Development.Shake.Extra
 
 import qualified Bittide.Instances.Calendar as Calendar
 import qualified Bittide.Instances.ClockControl as ClockControl
+import qualified Bittide.Instances.Counter as Counter
 import qualified Bittide.Instances.ElasticBuffer as ElasticBuffer
 import qualified Bittide.Instances.MVPs as MVPs
 import qualified Bittide.Instances.ScatterGather as ScatterGather
@@ -80,6 +81,7 @@ targets =
   [ 'Calendar.switchCalendar1k
   , 'Calendar.switchCalendar1kReducedPins
   , 'ClockControl.callisto3
+  , 'Counter.counterReducedPins
   , 'ElasticBuffer.elasticBuffer5
   , 'MVPs.clockControlDemo0
   , 'MVPs.clockControlDemo1

--- a/bittide-instances/bittide-instances.cabal
+++ b/bittide-instances/bittide-instances.cabal
@@ -94,6 +94,7 @@ library
   exposed-modules:
     Bittide.Instances.Calendar
     Bittide.Instances.ClockControl
+    Bittide.Instances.Counter
     Bittide.Instances.Domains
     Bittide.Instances.ElasticBuffer
     Bittide.Instances.Hacks

--- a/bittide-instances/src/Bittide/Instances/Counter.hs
+++ b/bittide-instances/src/Bittide/Instances/Counter.hs
@@ -1,0 +1,28 @@
+-- SPDX-FileCopyrightText: 2022 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+
+module Bittide.Instances.Counter where
+
+import Clash.Explicit.Prelude
+import Clash.Prelude (withClock)
+
+import Bittide.Counter
+import Bittide.Instances.Domains
+import Bittide.Instances.Hacks
+
+counter ::
+  Clock Basic200 -> Reset Basic200 ->
+  Clock Basic200 -> Reset Basic200 ->
+  Signal Basic200 () ->
+  Signal Basic200 (Signed 32, Bool)
+counter clk0 rst0 clk1 rst1 _ =
+  domainDiffCounter clk0 rst0 clk1 rst1
+
+counterReducedPins ::
+  Clock Basic200 -> Reset Basic200 ->
+  Clock Basic200 -> Reset Basic200 ->
+  Signal Basic200 Bit
+counterReducedPins clk0 rst0 clk1 rst1 =
+  withClock clk1 $
+    reducePins (counter clk0 rst0 clk1 rst1) (pure 0)

--- a/bittide/bittide.cabal
+++ b/bittide/bittide.cabal
@@ -104,6 +104,7 @@ library
     Bittide.ClockControl.Si5395J
     Bittide.ClockControl.Si539xSpi
     Bittide.ClockControl.StabilityChecker
+    Bittide.Counter
     Bittide.DoubleBufferedRam
     Bittide.ElasticBuffer
     Bittide.Link
@@ -145,6 +146,7 @@ test-suite unittests
   other-modules:
     Tests.Calendar
     Tests.ClockControl.Si539xSpi
+    Tests.Counter
     Tests.DoubleBufferedRam
     Tests.ElasticBuffer
     Tests.Haxioms
@@ -166,6 +168,7 @@ test-suite unittests
     containers,
     hedgehog >= 1.0 && < 1.1,
     tasty >= 1.4 && < 1.5,
+    tasty-th,
     HUnit,
     tasty-hunit,
     tasty-hedgehog >= 1.2 && < 1.3,

--- a/bittide/src/Bittide/Counter.hs
+++ b/bittide/src/Bittide/Counter.hs
@@ -1,0 +1,142 @@
+-- SPDX-FileCopyrightText: 2022 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+
+module Bittide.Counter
+  ( Active
+  , domainDiffCounter
+  ) where
+
+import Clash.Explicit.Prelude
+
+import Clash.Cores.Xilinx.Xpm (xpmCdcGray)
+import Clash.Sized.Extra (unsignedToSigned, concatUnsigneds)
+
+-- | State of 'domainDiffCounter'
+data DdcState
+  -- | In reset, or waiting for the incoming counter to change
+  = DdcInReset
+  -- | Counting and comparing with incoming domain
+  | DdcRunning (Unsigned 64)
+  deriving (Generic, NFDataX)
+
+-- | Indicates whether 'domainDiffCounter' is actively counting or still in reset.
+type Active = Bool
+
+-- | Determine speed differences between two domains. If the source domain is
+-- faster than the destination domain, the result will become smaller. Vice versa,
+-- if the source domain is slower than the destination domain, the result will
+-- become larger. This is analogous to what would happen to a FIFO's data count
+-- when continuously written to by the source domain and read from by the
+-- destination domain. To ease integration in control algorithms, this component
+-- makes sure it starts counting at zero. It also waits for the incoming counter
+-- to become active, i.e. non-zero, before starting to count itself.
+--
+-- If both domains support initial values, 'domainDiffCounter' does not need to
+-- be reset.
+--
+-- To reset this component, the reset should be asserted for at least one cycle in
+-- the source domain _plus_ four cycles in the destination domain. The reset in the
+-- destination domain should be deasserted at the same time or *after* the one in
+-- the source domain for glitchless operation.
+--
+-- __N.B.__:
+--   This function will only work properly if the given domains are pretty close
+--   to another for a number of reasons:
+--
+--     1. It uses an 8-bit Gray counter internally for CDC
+--
+--     2. It uses one 64-bit counter in each domain
+--
+--     3. Its output is constrained to @Signed 32@
+--
+--   These values have been chosen such that:
+--
+--     * The 64-bit counter only overflows once every 3000 years at 200 MHz
+--
+--     * The 32-bit output only overflows after running at maximum divergence
+--       rate (100 ppm) at 200 MHz for 2 days. We expect systems to stabilize
+--       after a few milliseconds and reframing should nudge counters back to
+--       zero ever so often.
+--
+domainDiffCounter ::
+  forall src dst .
+  ( KnownDomain src
+  , KnownDomain dst
+  ) =>
+  Clock src -> Reset src ->
+  Clock dst -> Reset dst ->
+  -- | Counter and boolean indicating whether the component is currently active
+  Signal dst (Signed 32, Active)
+domainDiffCounter clkSrc rstSrc clkDst rstDst =
+  mealy clkDst rstDst enableGen go DdcInReset counter
+ where
+  -- 64 bits is enough for approximately 3 millenia @ 200 MHz
+  counter = synchronizedSuccCounter @64 clkSrc rstSrc clkDst rstDst
+
+  go :: DdcState -> Unsigned 64 -> (DdcState, (Signed 32, Bool))
+  go DdcInReset c1
+    | c1 == 0   = (DdcInReset,          (0, False))
+    | otherwise = (DdcRunning (c1 + 1), (0, True))
+  go (DdcRunning c0) c1 = (DdcRunning (c0 + 1), (c0 `subAndTruncate` c1, True))
+
+  subAndTruncate :: Unsigned 64 -> Unsigned 64 -> Signed 32
+  subAndTruncate c0 c1 = truncateB (unsignedToSigned c0 - unsignedToSigned c1)
+
+-- | A counter that counts /up/, synchronized from the domain @src@ to domain @dst@. To
+-- reset this component, the reset should be asserted for at least one cycle in the
+-- source domain _plus_ four cycles in the destination domain.
+--
+-- __N.B.__: This function uses an 8-bit Gray counter internally, and will therefore
+--           only work properly if both clock speeds are pretty close to one another.
+synchronizedSuccCounter ::
+  forall n src dst .
+  ( KnownDomain src
+  , KnownDomain dst
+  , KnownNat n
+  , 8 <= n
+  ) =>
+  Clock src -> Reset src ->
+  Clock dst -> Reset dst ->
+  Signal dst (Unsigned n)
+synchronizedSuccCounter clkSrc rstSrc clkDst rstDst =
+  extendSuccCounter @8 @(n - 8) clkDst rstDst $
+    xpmCdcGray @8 clkSrc clkDst counter
+ where
+  counter :: Signal src (Unsigned 8)
+  counter = register clkSrc rstSrc enableGen 0 (counter + 1)
+
+-- | State of 'extendSuccCounter'
+data EscState m
+  -- | In reset, or waiting for an overflow
+  = EscInReset
+  -- | Counting - whenever an overflow occurs, this constructors field is upped
+  | EscRunning (Unsigned m)
+  deriving (Generic, NFDataX)
+
+-- | Given a counter that counts /up/, extend the size of the counter. After its
+-- reset is deasserted, it will wait until it sees an overflow to ensure the
+-- counter is glitchless and always starts at 0.
+--
+-- This can be used to extend computationally complex counter components, such as
+-- Gray counters.
+extendSuccCounter ::
+  forall n m dom .
+  ( KnownDomain dom
+  , KnownNat n
+  , KnownNat m ) =>
+  Clock dom -> Reset dom ->
+  Signal dom (Unsigned n) ->
+  Signal dom (Unsigned (m + n))
+extendSuccCounter clk rst counterLower =
+  mealyB clk rst enableGen go EscInReset
+    ( isFalling clk rst enableGen 0 (msb <$> counterLower)
+    , counterLower )
+ where
+  go :: EscState m -> (Bool, Unsigned n) -> (EscState m, Unsigned (m + n))
+  go EscInReset      (False,    _)  = (EscInReset,    0)
+  go EscInReset      (True,     n0) = (EscRunning 0,  extend n0)
+  go (EscRunning m0) (overflow, n0) = (EscRunning m1, n1)
+   where
+    m1 = if overflow then m0 + 1 else m0
+    n1 = concatUnsigneds m1 n0

--- a/bittide/src/Clash/Sized/Extra.hs
+++ b/bittide/src/Clash/Sized/Extra.hs
@@ -6,6 +6,27 @@ module Clash.Sized.Extra where
 
 import Clash.Prelude
 
+{- $setup
+>>> import Clash.Prelude
+-}
+
 -- | Safe 'Unsigned' to 'Signed' conversion
 unsignedToSigned :: forall n. KnownNat n => Unsigned n -> Signed (n + 1)
 unsignedToSigned n = bitCoerce (zeroExtend n)
+
+-- | Combine two 'Unsigned's by concatenating them together. I.e., the first
+-- argument is prepended to the second.
+--
+-- >>> pack (concatUnsigneds (0b1100 :: Unsigned 4) (0b1111 :: Unsigned 4))
+-- 0b1100_1111
+concatUnsigneds ::
+  forall a b .
+  (KnownNat a, KnownNat b) =>
+  -- | Most significant bits of result
+  Unsigned a ->
+  -- | Least significant bits of result
+  Unsigned b ->
+  -- | First and second argument concatenated
+  Unsigned (a + b)
+concatUnsigneds a b =
+  shiftL (extend a) (natToNum @b) .|. extend b

--- a/bittide/tests/Tests/Counter.hs
+++ b/bittide/tests/Tests/Counter.hs
@@ -1,0 +1,80 @@
+-- SPDX-FileCopyrightText: 2022 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+
+{-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Tests.Counter where
+
+import Clash.Explicit.Prelude
+import qualified Prelude as P
+
+import Control.Monad (forM_)
+
+import Test.Tasty
+import Test.Tasty.HUnit
+import Test.Tasty.TH
+
+import Bittide.Counter (domainDiffCounter)
+
+createDomain vXilinxSystem{vName="D10", vPeriod=hzToPeriod 100e6}
+createDomain vXilinxSystem{vName="D17", vPeriod=hzToPeriod 170e6}
+createDomain vXilinxSystem{vName="D20", vPeriod=hzToPeriod 200e6}
+
+noRst :: KnownDomain dom => Reset dom
+noRst = unsafeFromHighPolarity (pure False)
+
+rst :: KnownDomain dom => Reset dom
+rst = unsafeFromHighPolarity (pure True)
+
+rstN :: KnownDomain dom => Int -> Reset dom
+rstN n = unsafeFromHighPolarity (fromList (P.replicate n True <> P.repeat False))
+
+top ::
+  forall src dst .
+  ( KnownDomain src
+  , KnownDomain dst
+  ) =>
+  Reset src ->
+  Reset dst ->
+  Signal dst (Signed 32)
+top rstSrc rstDst = fst <$> domainDiffCounter clockGen rstSrc clockGen rstDst
+
+-- | 'domainDiffCounter' should continuously emit zeros when applied to the same domain
+case_zeroSameDomain :: Assertion
+case_zeroSameDomain = sampleN 1000 (top @D10 @D10 noRst noRst) @?= P.replicate 1000 0
+
+-- | 'domainDiffCounter' should continuously emit zeros when src reset is kept asserted
+case_zeroSrcRst :: Assertion
+case_zeroSrcRst = sampleN 1000 (top @D10 @D17 rst noRst) @?= P.replicate 1000 0
+
+-- | 'domainDiffCounter' should continuously emit zeros when dst reset is kept asserted
+case_zeroDstRst :: Assertion
+case_zeroDstRst = sampleN 1000 (top @D10 @D17 noRst rst) @?= P.replicate 1000 0
+
+-- | No matter when we release the destination reset, we should zeros followed by counting
+case_glitchless :: Assertion
+case_glitchless = --
+  forM_ [0..512] $ \n -> do
+    let
+      sampled = sampleN 1000 (dut (rstN n))
+      sampledNonZero = P.dropWhile (==0) sampled
+      len = P.length sampledNonZero
+    assertBool (">1 @ " <> show n) (len > 1)
+    assertEqual ("exp @ " <> show n) sampledNonZero (P.take len expected)
+ where
+  dut = top @D10 @D20 noRst
+  expected = P.concat [[n, n] | n <- [1..]]
+
+tests :: TestTree
+tests = $(testGroupGenerator)
+
+-- Run with:
+--
+--    ghcid -c cabal repl bittide:unittests -T Tests.Counter.main
+--
+-- Add -W if you want to run tests in spite of warnings
+--
+main :: IO ()
+main = defaultMain tests

--- a/cabal.project
+++ b/cabal.project
@@ -28,37 +28,38 @@ package clash-prelude
 -- index state, to go along with the cabal.project.freeze file. update the index
 -- state by running `cabal update` twice and looking at the index state it
 -- displays to you (as the second update will be a no-op)
-index-state: 2023-01-09T23:37:48Z
+index-state: 2023-05-02T21:48:25Z
 
--- Needed to simulate dynamic clocks.
+-- We need an up-to-date Clash and libraries. Among other features, this adds
+-- support for dynamic clocks and Xilinx primitive support.
 source-repository-package
   type: git
   location: https://github.com/clash-lang/clash-compiler.git
-  tag: 5aa81561fda1d9c5cdcdab5e90343442e26d779a
+  tag: a97cf28929a509a08d2285f83e52891664379641
   subdir: clash-prelude
 
 source-repository-package
   type: git
   location: https://github.com/clash-lang/clash-compiler.git
-  tag: 5aa81561fda1d9c5cdcdab5e90343442e26d779a
+  tag: a97cf28929a509a08d2285f83e52891664379641
   subdir: clash-ghc
 
 source-repository-package
   type: git
   location: https://github.com/clash-lang/clash-compiler.git
-  tag: 5aa81561fda1d9c5cdcdab5e90343442e26d779a
+  tag: a97cf28929a509a08d2285f83e52891664379641
   subdir: clash-lib
 
 source-repository-package
   type: git
   location: https://github.com/clash-lang/clash-compiler.git
-  tag: 5aa81561fda1d9c5cdcdab5e90343442e26d779a
+  tag: a97cf28929a509a08d2285f83e52891664379641
   subdir: clash-prelude-hedgehog
 
 source-repository-package
   type: git
   location: https://github.com/clash-lang/clash-compiler.git
-  tag: 5aa81561fda1d9c5cdcdab5e90343442e26d779a
+  tag: a97cf28929a509a08d2285f83e52891664379641
   subdir: clash-cores
 
 source-repository-package


### PR DESCRIPTION
Exposes a single function, `domainDiffCounter`, that we can use to measure speed differences between two domains. These can in turn be used to eliminate the need for using FIFOs directly to measure clock divergence.

TODO: 

 - [x] Tests
 - [x] Instance?