### PR TITLE
Small shake fixes

### DIFF
--- a/bittide-instances/src/Clash/Shake/Vivado.hs
+++ b/bittide-instances/src/Clash/Shake/Vivado.hs
@@ -192,7 +192,7 @@ mkBitstreamTcl outputDir = [__i|
     open_checkpoint {#{outputDir </> "checkpoints" </> "post_route.dcp"}}
 
     \# Generate bitstream
-    write_bitstream {#{outputDir </> "bitstream.bit"}}
+    write_bitstream -force {#{outputDir </> "bitstream.bit"}}
 
     report_drc -file {#{outputDir </> "reports" </> "post_bitstream_drc.rpt"}}
 |]


### PR DESCRIPTION
For now this only adds `-force` to `write_bitstream`, I thought about maybe adding a new target that also produces the file containing the probe information. However, we might need another solution for hardware in the loop