### PR TITLE
Add hardware in the loop testing to Shake

### DIFF
--- a/.github/synthesis/all.json
+++ b/.github/synthesis/all.json
@@ -6,6 +6,7 @@
   {"top": "elasticBuffer5",              "stage": "netlist"},
   {"top": "gatherUnit1K",                "stage": "hdl"    },
   {"top": "gatherUnit1KReducedPins",     "stage": "netlist"},
+  {"top": "simpleHardwareInTheLoopTest", "stage": "test"},
   {"top": "safeDffSynchronizer",         "stage": "netlist"},
   {"top": "scatterUnit1K",               "stage": "hdl"    },
   {"top": "scatterUnit1KReducedPins",    "stage": "netlist"},

--- a/.github/synthesis/staging.json
+++ b/.github/synthesis/staging.json
@@ -1,1 +1,4 @@
-[{"top": "clockControlDemo0", "stage": "bitstream"}]
+[
+  {"top": "clockControlDemo0",           "stage": "bitstream"},
+  {"top": "simpleHardwareInTheLoopTest", "stage": "test"}
+]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Google LLC
+# SPDX-FileCopyrightText: 2022-2023 Google LLC
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -567,8 +567,13 @@ jobs:
   bittide-instances-hdl-matrix:
     name: bittide-instances synthesis matrix generation
     runs-on: [self-hosted, compute]
+    defaults:
+      run:
+        shell: git-nix-shell {0} --pure --keep "GITHUB_OUTPUT"
+
     container:
       image: ghcr.io/clash-lang/nixos-bittide-hardware:2023-06-23
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -580,6 +585,39 @@ jobs:
           else
             cp .github/synthesis/staging.json checks.json
           fi
+
+      - name: Set test matrix
+        id: set-matrix
+        run: |
+          echo "check_matrix=$(cat checks.json | tr '\n' ' ')" | tee -a "$GITHUB_OUTPUT"
+
+    outputs:
+      check_matrix: ${{ steps.set-matrix.outputs.check_matrix }}
+
+  bittide-instances-hardware-in-the-loop-test-matrix:
+    name: bittide-instances hardware-in-the-loop test matrix generation
+    runs-on: [self-hosted, compute]
+    defaults:
+      run:
+        shell: git-nix-shell {0} --pure --keep "GITHUB_OUTPUT"
+
+    container:
+      image: ghcr.io/clash-lang/nixos-bittide-hardware:2023-06-23
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Generate matrix
+        run: |
+          if [[ "${{ github.event_name }}" == "schedule" || $(.github/scripts/force_expensive_checks.sh) == "true" ]]; then
+            cp .github/synthesis/all.json checks.json
+          else
+            cp .github/synthesis/staging.json checks.json
+          fi
+
+          jq '[.[] | select(.stage=="test")]' checks.json > checks.json.filtered
+          cp checks.json.filtered checks.json
 
       - name: Set test matrix
         id: set-matrix
@@ -643,21 +681,96 @@ jobs:
 
       - name: HDL generation and synthesis
         run : |
-          .github/scripts/with_vivado.sh cabal run -- bittide-instances:shake ${{ matrix.target.top }}:${{ matrix.target.stage }}
+          target="${{ matrix.target.stage }}"
 
-      - name: Archive synthesis artifacts
+          if [[ "${target}" == "program" ]]; then
+            echo "Illegal Shake target on CI: program"
+            exit 1
+          fi
+
+          # Only the local runner connected to the bittide demonstrator (hoeve)
+          # should perform the jobs which need hardware access. And that runner
+          # should do only that, so we let other 'compute' runners do the
+          # bitstream generation.
+          if [[ "${{ matrix.target.stage }}" == "test" ]]; then
+            target="bitstream"
+          fi
+
+          .github/scripts/with_vivado.sh cabal run -- \
+            bittide-instances:shake \
+              ${{ matrix.target.top }}:"${target}"
+
+          # Explicitly generate the Tcl scripts needed for programming and
+          # hardware testing.
+          if [[ "${{ matrix.target.stage }}" == "test" ]]; then
+            # Local machine connected to the bittide demonstrator is called
+            # 'hoeve'. But the docker container of the runner cannot resolve
+            # DNS, so we use its local IP address instead.
+            export HW_SERVER_URL="192.168.102.130:3121"
+            dir=$(ls _build/vivado | grep -E '\.${{ matrix.target.top }}$')
+            tcl_test=_build/vivado/"${dir}"/run_hardware_test.tcl
+            tcl_program=_build/vivado/"${dir}"/run_board_program.tcl
+            cabal run shake -- "${tcl_test}" "${tcl_program}" --hardware-targets=All
+          fi
+
+      - name: Archive build artifacts
         uses: actions/upload-artifact@v3
         with:
           name: _build
-          path: _build
+          # We don't pack `ip`, as it is generally useless for debugging while
+          # also taking up a lot of space.
+          path: |
+            _build
+            !_build/vivado/*/ip
           retention-days: 14
 
+  bittide-instances-hardware-in-the-loop:
+    name: bittide-instances hardware-in-the-loop tests
+    runs-on: [self-hosted, hardware-access]
+    defaults:
+      run:
+        # We leave out '--pure', as 'with_vivado.sh' relies on basic Ubuntu
+        shell: git-nix-shell {0}
+    needs: [bittide-instances-hdl, bittide-instances-hardware-in-the-loop-test-matrix]
+
+    strategy:
+      matrix:
+        target: ${{ fromJson(needs.bittide-instances-hardware-in-the-loop-test-matrix.outputs.check_matrix) }}
+      fail-fast: false
+
+    container:
+      image: ghcr.io/clash-lang/nixos-bittide-hardware:2023-06-23
+      volumes:
+        - /opt/tools:/opt/tools
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: _build
+          path: _build
+
+      - name: Run tests on hardware
+        run : |
+          dir=$(ls _build/vivado | grep -E '\.${{ matrix.target.top }}$')
+          tcl_test=_build/vivado/"${dir}"/run_hardware_test.tcl
+          tcl_program=_build/vivado/"${dir}"/run_board_program.tcl
+
+          .github/scripts/with_vivado.sh \
+            vivado -mode batch -source "${tcl_program}"
+
+          .github/scripts/with_vivado.sh \
+            vivado -mode batch -source "${tcl_test}"
 
   all:
     name: All jobs finished
     if: always()
     needs: [
         bittide-instances-doctests,
+        bittide-instances-hardware-in-the-loop-test-matrix,
+        bittide-instances-hardware-in-the-loop,
         bittide-instances-hdl-matrix,
         bittide-instances-hdl,
         bittide-instances-unittests,
@@ -666,11 +779,11 @@ jobs:
         elastic-buffer-sim-tests,
         elastic-buffer-sim-topologies-matrix,
         elastic-buffer-sim-topologies,
-        generate-full-clock-control-simulation-report,
         firmware-build-examples,
         firmware-limit-checks,
         firmware-lints,
         firmware-unit-tests,
+        generate-full-clock-control-simulation-report,
         license-check,
         lint,
       ]

--- a/bittide-instances/README.md
+++ b/bittide-instances/README.md
@@ -22,20 +22,22 @@ The build system automatically generates _false path_ constraints for all input 
 ## Prerequisites
 * We have tested the build system with Vivado 2022.1
 * To change the part for which the instances are synthesized, set the environment variable `SYNTHESIS_PART`. For the part we've bought use `SYNTHESIS_PART=xcku040-ffva1156-2-e`. Note that for this part you need to use Vivado Enterprise.
-* For the step Bitstream generation and Board programming an XDC file with pinmappings is required. This file must have the same name as the instance, and be located in the `data/constraints/` directory.
+* Only targets which have the flag `targetHasXdc` can be used to generate a bitstream. This XDC file must have the same name as the instance, and be located in the `data/constraints/` directory.
+* For targets which have the flag `targetHasVio`, a probes file is generated alongside the bitstream.
+* Only targets which have the flag `targetHasTest` can be used to perform hardware tests.
 
 
 ## Shake
 The build rules are defined in `bin/Shake.hs`. Shake can be called using:
 
 ```
-cabal run -- bittide-instances:shake
+cabal run -- shake
 ```
 
 You can list all build targets like this:
 
 ```
-cabal run -- bittide-instances:shake --help
+cabal run -- shake --help
 ```
 
 All build results end up in `_build`.
@@ -44,14 +46,14 @@ All build results end up in `_build`.
 Example:
 
 ```
-cabal run -- bittide-instances:shake scatterUnitWb:hdl
+cabal run -- shake scatterUnitWb:hdl
 ```
 
 ## Synthesis
 Example:
 
 ```
-cabal run -- bittide-instances:shake scatterUnitWb:synth
+cabal run -- shake scatterUnitWb:synth
 ```
 
 ## Implementation
@@ -59,29 +61,36 @@ Example:
 
 ```bash
 # For just placement:
-cabal run -- bittide-instances:shake scatterUnitWb:place
+cabal run -- shake scatterUnitWb:place
 
 # For place & route:
-cabal run -- bittide-instances:shake scatterUnitWb:route
+cabal run -- shake scatterUnitWb:route
 ```
 
 ## Netlist
 Example:
 
 ```
-cabal run -- bittide-instances:shake scatterUnitWb:netlist
+cabal run -- shake scatterUnitWb:netlist
 ```
 
 ## Bitstream generation
 Example:
 
 ```
-cabal run -- bittide-instances:shake clockControlDemo0:bitstream
+cabal run -- shake clockControlDemo0:bitstream
 ```
 
 ## Board programming
 Example:
 
 ```
-cabal run -- bittide-instances:shake clockControlDemo0:program
+cabal run -- shake clockControlDemo0:program --hardware-targets=FirstOfKnown
+```
+
+## Hardware testing
+Example:
+
+```
+cabal run -- shake hardwareTest:test --hardware-targets=FirstOfKnown
 ```

--- a/bittide-instances/bittide-instances.cabal
+++ b/bittide-instances/bittide-instances.cabal
@@ -68,6 +68,7 @@ common common-options
     base,
     bittide-extra,
     bittide,
+    clash-cores,
     clash-lib,
     clash-prelude,
     clash-protocols,
@@ -92,6 +93,7 @@ library
   import: common-options
   hs-source-dirs: src
   exposed-modules:
+    Bittide.Instances.BoardTest
     Bittide.Instances.Calendar
     Bittide.Instances.ClockControl
     Bittide.Instances.Counter
@@ -105,6 +107,7 @@ library
     Bittide.Instances.Synchronizer
 
     Clash.Shake.Extra
+    Clash.Shake.Flags
     Clash.Shake.Vivado
     Development.Shake.Extra
     Language.Haskell.TH.Extra

--- a/bittide-instances/data/constraints/simpleHardwareInTheLoopTest.xdc
+++ b/bittide-instances/data/constraints/simpleHardwareInTheLoopTest.xdc
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: 2022-2023 Google LLC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# CLK_125MHZ_P
+set_property PACKAGE_PIN G10 [get_ports "CLK_125MHZ_P"]
+set_property IOSTANDARD LVDS [get_ports "CLK_125MHZ_P"]
+# CLK_125MHZ_P
+set_property PACKAGE_PIN F10 [get_ports "CLK_125MHZ_N"]
+set_property IOSTANDARD LVDS [get_ports "CLK_125MHZ_N"]
+
+
+# GPIO_LED_0_LS
+set_property PACKAGE_PIN AP8      [get_ports "done"]
+set_property IOSTANDARD  LVCMOS18 [get_ports "done"]
+# GPIO_LED_1_LS
+set_property PACKAGE_PIN H23      [get_ports "success"]
+set_property IOSTANDARD  LVCMOS18 [get_ports "success"]

--- a/bittide-instances/data/tcl/HardwareTest.tcl
+++ b/bittide-instances/data/tcl/HardwareTest.tcl
@@ -1,0 +1,159 @@
+# SPDX-FileCopyrightText: 2023 Google LLC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# The IDs of the Digilent chips on each FPGA board. The indices match the
+# position of each FPGA in the mining rig.
+set fpga_ids {
+  210308B3B272
+  210308B0992E
+  210308B0AE73
+  210308B0AE6D
+  210308B0AFD4
+  210308B0AE65
+  210308B3A22D
+  210308B0B0C2
+}
+
+proc get_part_name {url id} {
+  return ${url}/xilinx_tcf/Digilent/${id}
+}
+
+# Open the hardware manager and connect to the hardware server at the given url.
+# Checks whether the expected number of hardware targets or more are connected,
+# if not exit.
+proc connect_expected_targets {url expected} {
+  open_hw_manager
+  connect_hw_server -url $url
+
+  after 1000 refresh_hw_server
+  set hw_targets [get_hw_targets -quiet]
+  set hw_target_count [llength $hw_targets]
+  if {$hw_target_count < $expected} {
+    puts "Expected $expected hardware targets, but found $hw_target_count:"
+    puts "$hw_targets"
+    exit 1
+  }
+  puts "Hardware server at ${url} hosts ${hw_target_count} hardware targets:"
+  puts "$hw_targets"
+}
+
+# Set the first board found as the current hardware target and return its device
+proc load_first_device {} {
+  set target [lindex [get_hw_targets] 0]
+  return [load_target_device $target]
+}
+
+# Set the target board as the current hardware target and return its device
+proc load_target_device {target_name} {
+  close_hw_target
+  current_hw_target [get_hw_targets $target_name]
+  open_hw_target [current_hw_target]
+  current_hw_device [lindex [get_hw_devices] 0]
+  set device [current_hw_device]
+  return $device
+}
+
+# Program the current hardware device with the given program and probes file.
+proc program_fpga {program_file probes_file} {
+  set device [current_hw_device]
+  set_property PROGRAM.FILE ${program_file} $device
+  set_property PROBES.FILE ${probes_file} $device
+  # Program the device and close properly
+  program_hw_devices $device
+  refresh_hw_device $device
+}
+
+# Test one FPGA and returns as list with two flags: test_done and test_success
+proc run_test {} {
+  # Set the radix of each probe
+  set_property INPUT_VALUE_RADIX BINARY [get_hw_probes probe_test_done]
+  set_property INPUT_VALUE_RADIX BINARY [get_hw_probes probe_test_success]
+  set_property OUTPUT_VALUE_RADIX BINARY [get_hw_probes probe_start_test]
+
+  # Verify that `done` is not set before starting the test
+  set_property OUTPUT_VALUE 0 [get_hw_probes probe_start_test]
+  commit_hw_vio [get_hw_vios hw_vio_1]
+  refresh_hw_vio [get_hw_vios hw_vio_1]
+
+  set done [get_property INPUT_VALUE [get_hw_probes probe_test_done]]
+  if {$done != 0} {
+    puts "\tERROR: test is done before starting the test"
+    exit 1
+  }
+
+  # Start the test
+  set_property OUTPUT_VALUE 1 [get_hw_probes probe_start_test]
+  commit_hw_vio [get_hw_vios hw_vio_1]
+
+  # Refresh the input probes until the done flag is set. Retries for up to 1
+  # second.
+  set start_time [clock milliseconds]
+  set timestamp [format "%s.%03d" \
+                    [clock format [expr {$start_time / 1000}] -format %T] \
+                    [expr {$start_time % 1000}] \
+                ]
+  puts "Start time:\t$timestamp"
+  while 1 {
+    set current_time [clock milliseconds]
+    if {{$current_time - $start_time} > 1000} {
+      break
+    }
+    refresh_hw_vio [get_hw_vios hw_vio_1]
+    set done [get_property INPUT_VALUE [get_hw_probes probe_test_done]]
+    set success [get_property INPUT_VALUE [get_hw_probes probe_test_success]]
+    if {$done == 1} {
+      break
+    }
+  }
+  set current_time [clock milliseconds]
+  set timestamp [format "%s.%03d" \
+                    [clock format [expr {$current_time / 1000}] -format %T] \
+                    [expr {$current_time % 1000}] \
+                ]
+  puts "End time:\t$timestamp"
+  return [list $done $success]
+}
+
+# Test all FPGAs one-by-one
+proc run_test_all {probes_file fpga_nrs url} {
+  global fpga_ids
+  set successfull_tests 0
+  foreach fpga_nr $fpga_nrs {
+    if {$fpga_nr == -1} {
+      set device [load_first_device]
+    } else {
+      set target_id [lindex $fpga_ids $fpga_nr]
+      set target_name [get_part_name $url $target_id]
+      set device [load_target_device $target_name]
+    }
+
+    set_property PROBES.FILE ${probes_file} $device
+    refresh_hw_device $device
+    set target [current_hw_target]
+    puts "Testing FPGA ${fpga_nr} with target ID ${target}"
+
+    set test_results [run_test]
+    set done [lindex $test_results 0]
+    set success [lindex $test_results 1]
+    if {$done == 0} {
+      puts "\tTest not finished: done flag not set after 5 tries"
+    }
+    if {$success == 0} {
+      puts "\tTest failed"
+    } else {
+      puts "\tTest passed"
+      incr successfull_tests 1
+    }
+  }
+
+  set total_tests [llength $fpga_nrs]
+  if {$successfull_tests != $total_tests} {
+    set failed {$total_tests - $successfull_tests}
+    puts "Tests failed for ${failed} targets"
+    exit 1
+  } else {
+    puts "Test passed for all targets"
+    exit 0
+  }
+}

--- a/bittide-instances/src/Bittide/Instances/BoardTest.hs
+++ b/bittide-instances/src/Bittide/Instances/BoardTest.hs
@@ -1,0 +1,88 @@
+-- SPDX-FileCopyrightText: 2023 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+
+-- | Checks whether `+` works as expected, though its real purpose is to check
+-- whether we can run hardware-in-the-loop tests.
+module Bittide.Instances.BoardTest where
+
+import Clash.Explicit.Prelude
+
+import Clash.Annotations.TH (makeTopEntity)
+import Clash.Cores.Xilinx.VIO
+import Clash.Cores.Xilinx.Extra (ibufds)
+
+import Bittide.Instances.Domains
+
+type StartTest = Bool
+data TestState = Busy | Done TestSuccess
+data TestSuccess = TestFailed | TestSuccess deriving (Generic, Eq, NFDataX)
+
+toDoneSuccess :: TestState -> (Bool, Bool)
+toDoneSuccess Busy = (False, False)
+toDoneSuccess (Done s) = (True, s == TestSuccess)
+
+data CheckState n
+  = CsChecking (Index n)
+  | CsDone TestSuccess
+  deriving (Generic, NFDataX)
+
+check ::
+  forall n a b c dom .
+  ( KnownDomain dom
+  , KnownNat n
+  , Eq c
+  ) =>
+  Clock dom ->
+  Reset dom ->
+  (a -> b -> c) ->
+  Vec n (a, b, c) ->
+  Signal dom TestState
+check clk rst dut stimuli =
+  mealy clk rst enableGen go (CsChecking 0 :: CheckState n) (pure ())
+ where
+  go :: CheckState n -> () -> (CheckState n, TestState)
+  go s@(CsDone testSuccess) () = (s, Done testSuccess)
+  go (CsChecking n) () = (s, Busy)
+   where
+    (a, b, c) = stimuli !! n
+    testResult = dut a b == c
+    s | not testResult = CsDone TestFailed
+      | n == maxBound = CsDone TestSuccess
+      | otherwise = CsChecking (n + 1)
+
+-- | Testing circuit for `plus`. Feeds the circuit with inputs and checks
+-- the received output against the expected output.
+simpleHardwareInTheLoopTest ::
+  "CLK_125MHZ_P" ::: Clock Basic125 ->
+  "CLK_125MHZ_N" ::: Clock Basic125 ->
+  "" ::: Signal Basic125
+    ( "done" ::: Bool
+    , "success" ::: Bool
+    )
+simpleHardwareInTheLoopTest clkP clkN = bundle (testDone, testSuccess)
+ where
+  clk = ibufds clkP clkN
+  rst = unsafeFromLowPolarity startTest
+
+  testState = check clk rst (+) stimuli
+  (testDone, testSuccess) = unbundle $ toDoneSuccess <$> testState
+
+  startTest =
+    vioProbe
+      ("probe_test_done" :> "probe_test_success" :> Nil)
+      ("probe_start_test" :> Nil)
+      False
+      clk
+      testDone
+      testSuccess
+
+  stimuli :: Vec 4 (Unsigned 8, Unsigned 8, Unsigned 8)
+  stimuli = (
+       (  0,   0,   0)
+    :> (  1,   2,   3)
+    :> (255,   0, 255)
+    :> (255,   1,   0)
+    :> Nil
+    )
+makeTopEntity 'simpleHardwareInTheLoopTest

--- a/bittide-instances/src/Clash/Shake/Flags.hs
+++ b/bittide-instances/src/Clash/Shake/Flags.hs
@@ -1,0 +1,54 @@
+-- SPDX-FileCopyrightText: 2023 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+
+-- | Flags used by Shake
+module Clash.Shake.Flags where
+
+import Prelude
+
+import Data.Maybe (fromMaybe)
+import Text.Read (readMaybe)
+import System.Console.GetOpt (OptDescr(Option), ArgDescr(ReqArg))
+
+-- | Number of hardware targets to program and optionally test
+data HardwareTargets
+  -- | Program first FPGA found by Vivado
+  = FirstOfAny
+  -- | Program the first FPGA from a list of hardcoded IDs (FGPA IDs), see
+  -- @HardwareTest.tcl@
+  | FirstOfKnown
+  -- | Program all connected FPGAs. Note that we currently hardcode a list of all
+  -- FPGAs in our possesion. If we can't find them all, the program will exit with
+  -- and error code.
+  | All
+  deriving (Read)
+
+-- | Like 'last', but returns 'Nothing' if given list is empty
+lastMaybe :: [a] -> Maybe a
+lastMaybe [] = Nothing
+lastMaybe (x:xs) = Just $ last (x:xs)
+
+-- | Parse string to 'HardwareTargets'. Return 'Left' if given string could not
+-- be parsed.
+parseHardwareTargetsFlag :: String -> Either String HardwareTargets
+parseHardwareTargetsFlag s =
+  case readMaybe s of
+    Just f -> Right f
+    Nothing -> Left ("Not a valid hardware target: " ++ s)
+
+-- | Get hardware flag based on a list of parsed flags. Defaults to 'FirstOfAny'. If
+-- multiple options are given, the last one is picked.
+getHardwareTargetsFlag :: [HardwareTargets] -> HardwareTargets
+getHardwareTargetsFlag = fromMaybe FirstOfAny . lastMaybe
+
+-- | List of custom flags supported by us. Note that we currently support only
+-- one flag, 'HardwareTargets'.
+customFlags :: [OptDescr (Either String HardwareTargets)]
+customFlags =
+  [ Option
+      "" -- no short flags
+      ["hardware-targets"] -- long name of flag
+      (ReqArg parseHardwareTargetsFlag "TARGET")
+      "Options: FirstOfAny, FirstOfKnown, All. See 'HardwareTargets' in 'Flags.hs'."
+  ]

--- a/cabal.project
+++ b/cabal.project
@@ -35,31 +35,31 @@ index-state: 2023-05-02T21:48:25Z
 source-repository-package
   type: git
   location: https://github.com/clash-lang/clash-compiler.git
-  tag: a97cf28929a509a08d2285f83e52891664379641
+  tag: 06f8c5cfce0cb54e7818cc400cee01e4f88cd4b7
   subdir: clash-prelude
 
 source-repository-package
   type: git
   location: https://github.com/clash-lang/clash-compiler.git
-  tag: a97cf28929a509a08d2285f83e52891664379641
+  tag: 06f8c5cfce0cb54e7818cc400cee01e4f88cd4b7
   subdir: clash-ghc
 
 source-repository-package
   type: git
   location: https://github.com/clash-lang/clash-compiler.git
-  tag: a97cf28929a509a08d2285f83e52891664379641
+  tag: 06f8c5cfce0cb54e7818cc400cee01e4f88cd4b7
   subdir: clash-lib
 
 source-repository-package
   type: git
   location: https://github.com/clash-lang/clash-compiler.git
-  tag: a97cf28929a509a08d2285f83e52891664379641
+  tag: 06f8c5cfce0cb54e7818cc400cee01e4f88cd4b7
   subdir: clash-prelude-hedgehog
 
 source-repository-package
   type: git
   location: https://github.com/clash-lang/clash-compiler.git
-  tag: a97cf28929a509a08d2285f83e52891664379641
+  tag: 06f8c5cfce0cb54e7818cc400cee01e4f88cd4b7
   subdir: clash-cores
 
 source-repository-package


### PR DESCRIPTION
This PR adds:
- Keep Tcl scripts generated by Shake clear by using helper functions and global variables in `HardwareTest.tcl`
- Program multiple FPGA boards with one command via a command line flag
- Run tests on hardware


### Updates to Shake
Shake generates Tcl script which are exectuted by Vivado. These scripts are written as strings in Haskell, and therefore lack Tcl syntax highlighting. Interactions with hardware, such as reading and writing from VIOs, quickly leads to long scripts. To keep the Tcl generated by Shake clear, `HardwareTest.tcl` was introduced. This script contains some global variables such as the IDs of the FPGAs in our office, was well as functions to program an FPGA, and run hardware tests. The script is sourced by the last targets in Shake: `:program` and `:test`.

A command line flag is introduced to specify which FPGA targets are programmed or tested. `FirstOfKnown` and `All` specify FPGA boards in our office. Example usage:
`cabal run shake -- hardwareTest:program --hardware-targets={FirstOfAny, FirstOfKnown, All}`

This PR also adds a generalized infrastructure for hardware-in-the-loop tests. The testing circuit should generate input for the design under test, and verify its output with a reference. The circuit should have exactly one VIO with 2 input and 1 output probe: `probe_test_done`, `probe_test_success`, and `probe_start_test` respectively. Initially, the test checks that `done` is not set before the test is started. It then starts the test and checks whether the done flag is set, which it tries 5 times. For now, Vivado does not wait in between tries. It is assumed the communication with VIOs is slow enough. 


### TODO:
- [x] ~~Always rebuild `run_board_program.tcl` and `run_hardware_test.tcl` (target FPGAs can very per command line run)~~
- [x] Add hardware testing to CI
- [x] Update copyright licenses
- [x] Clean up commits