### PR TITLE
Update Docker images to contain latest Nix additions

### DIFF
--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -28,6 +28,7 @@ ENV \
   PATH="/root/.nix-profile/bin:$PATH"
 
 WORKDIR /build
+COPY rust-toolchain.toml rust-toolchain.toml
 COPY default.nix default.nix
 COPY shell.nix shell.nix
 COPY nix /build/nix

--- a/.github/docker/build-and-publish.sh
+++ b/.github/docker/build-and-publish.sh
@@ -15,6 +15,7 @@ cd "${HERE}"
 
 cp "${ROOT}/default.nix" .
 cp "${ROOT}/shell.nix" .
+cp "${ROOT}/rust-toolchain.toml" .
 cp -ap "${ROOT}/nix" .
 
 docker build -t "${REPO}/${NAME}:$TODAY" -t "${REPO}/${NAME}:latest" .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
         shell: git-nix-shell {0} --pure
 
     container:
-      image: ghcr.io/clash-lang/nixos-bittide-hardware:2023-02-01
+      image: ghcr.io/clash-lang/nixos-bittide-hardware:2023-06-22
 
     steps:
       - name: Checkout
@@ -108,7 +108,7 @@ jobs:
         shell: git-nix-shell {0} --pure --keep "GITHUB_OUTPUT"
 
     container:
-      image: ghcr.io/clash-lang/nixos-bittide-hardware:2023-02-01
+      image: ghcr.io/clash-lang/nixos-bittide-hardware:2023-06-22
 
     steps:
       - name: Checkout
@@ -147,7 +147,7 @@ jobs:
       fail-fast: false
 
     container:
-      image: ghcr.io/clash-lang/nixos-bittide-hardware:2023-02-01
+      image: ghcr.io/clash-lang/nixos-bittide-hardware:2023-06-22
 
     steps:
       - name: Checkout
@@ -215,7 +215,7 @@ jobs:
     needs: [build, lint, elastic-buffer-sim-topologies-matrix, elastic-buffer-sim-topologies]
 
     container:
-      image: ghcr.io/clash-lang/nixos-bittide-hardware:2023-02-01
+      image: ghcr.io/clash-lang/nixos-bittide-hardware:2023-06-22
 
     steps:
       - name: Download simulation artifacts
@@ -252,7 +252,7 @@ jobs:
     needs: [build, lint]
 
     container:
-      image: ghcr.io/clash-lang/nixos-bittide-hardware:2023-02-01
+      image: ghcr.io/clash-lang/nixos-bittide-hardware:2023-06-22
 
     steps:
       - name: Checkout
@@ -290,7 +290,7 @@ jobs:
     needs: [build, lint]
 
     container:
-      image: ghcr.io/clash-lang/nixos-bittide-hardware:2023-02-01
+      image: ghcr.io/clash-lang/nixos-bittide-hardware:2023-06-22
 
     steps:
       - name: Checkout
@@ -336,7 +336,7 @@ jobs:
       run:
         shell: git-nix-shell {0} --pure
     container:
-      image: ghcr.io/clash-lang/nixos-bittide-hardware:2023-02-01
+      image: ghcr.io/clash-lang/nixos-bittide-hardware:2023-06-22
 
     steps:
       - name: Checkout
@@ -367,7 +367,7 @@ jobs:
       run:
         shell: git-nix-shell {0} --pure
     container:
-      image: ghcr.io/clash-lang/nixos-bittide-hardware:2023-02-01
+      image: ghcr.io/clash-lang/nixos-bittide-hardware:2023-06-22
     needs: [build]
 
     steps:
@@ -419,7 +419,7 @@ jobs:
       run:
         shell: git-nix-shell {0} --pure
     container:
-      image: ghcr.io/clash-lang/nixos-bittide-hardware:2023-02-01
+      image: ghcr.io/clash-lang/nixos-bittide-hardware:2023-06-22
 
     steps:
       - name: Checkout
@@ -449,7 +449,7 @@ jobs:
       run:
         shell: git-nix-shell {0} --pure
     container:
-      image: ghcr.io/clash-lang/nixos-bittide-hardware:2023-02-01
+      image: ghcr.io/clash-lang/nixos-bittide-hardware:2023-06-22
 
     steps:
       - name: Checkout
@@ -488,7 +488,7 @@ jobs:
     needs: [build, lint]
 
     container:
-      image: ghcr.io/clash-lang/nixos-bittide-hardware:2023-02-01
+      image: ghcr.io/clash-lang/nixos-bittide-hardware:2023-06-22
 
     steps:
       - name: Checkout
@@ -526,7 +526,7 @@ jobs:
     needs: [build, lint]
 
     container:
-      image: ghcr.io/clash-lang/nixos-bittide-hardware:2023-02-01
+      image: ghcr.io/clash-lang/nixos-bittide-hardware:2023-06-22
 
     steps:
       - name: Checkout
@@ -596,7 +596,7 @@ jobs:
       fail-fast: false
 
     container:
-      image: ghcr.io/clash-lang/nixos-bittide-hardware:2023-02-01
+      image: ghcr.io/clash-lang/nixos-bittide-hardware:2023-06-22
       volumes:
         - /opt/tools:/opt/tools
       options: --mac-address="6c:5a:b0:6c:13:0b"

--- a/.gitignore
+++ b/.gitignore
@@ -79,5 +79,6 @@ tight_setup_hold_pins.txt
 .Xil
 
 # Docker builds
+.github/docker/rust-toolchain.toml
 .github/docker/*.nix
 .github/docker/nix


### PR DESCRIPTION
We've changed our Nix setup quite a bit. While CI is happy to download this setup every time a job is run, this slows down our flow. The new images contain all the dependencies, removing the need to re-download them.