### PR TITLE
Add initial startup offsets to simulation

### DIFF
--- a/.github/simulation/all.json
+++ b/.github/simulation/all.json
@@ -1,10 +1,10 @@
 [
-  {"topology": "diamond",   "hmem": 16,  "steps": 80000000, "args": "--frame-size 15000000" },
-  {"topology": "complete",  "hmem": 16,  "steps": 80000000, "args": "--nodes 3 --frame-size 15000000"},
-  {"topology": "cycle",     "hmem": 16,  "steps": 100000000, "args": "--nodes 5 --frame-size 15000000 "},
-  {"topology": "torus2d",   "hmem": 32,  "steps": 100000000, "args": "--rows 2 --cols 3 --frame-size 15000000 "},
-  {"topology": "star",      "hmem": 64,  "steps": 100000000, "args": "--nodes 7 --frame-size 15000000 "},
-  {"topology": "line",      "hmem": 64,  "steps": 100000000, "args": "--nodes 4 --frame-size 15000000 "},
-  {"topology": "hourglass", "hmem": 64,  "steps": 130000000, "args": "--nodes 3 --frame-size 15000000 "},
-  {"topology": "random",    "hmem": 64,  "steps": 100000000, "args": "--nodes 5 --frame-size 15000000"}
+  {"topology": "diamond",   "hmem": 16,  "steps": 100000000, "args": "--frame-size 15000000" },
+  {"topology": "complete",  "hmem": 16,  "steps": 100000000, "args": "--nodes 3 --frame-size 15000000"},
+  {"topology": "cycle",     "hmem": 16,  "steps": 120000000, "args": "--nodes 5 --frame-size 15000000 "},
+  {"topology": "torus2d",   "hmem": 32,  "steps": 120000000, "args": "--rows 2 --cols 3 --frame-size 15000000 "},
+  {"topology": "star",      "hmem": 64,  "steps": 120000000, "args": "--nodes 7 --frame-size 15000000 "},
+  {"topology": "line",      "hmem": 64,  "steps": 120000000, "args": "--nodes 4 --frame-size 15000000 "},
+  {"topology": "hourglass", "hmem": 64,  "steps": 150000000, "args": "--nodes 3 --frame-size 15000000 "},
+  {"topology": "random",    "hmem": 64,  "steps": 150000000, "args": "--nodes 5 --frame-size 15000000"}
 ]

--- a/.github/simulation/report-template.tex
+++ b/.github/simulation/report-template.tex
@@ -20,7 +20,8 @@
 
 \newcommand{\printlua}[1]{\luaexec{tex.sprint(#1)}}
 \newcommand{\printtype}[1]{\luaexec{if #1 == "dotfile" then tex.sprint("random") else tex.sprint(#1) end}}
-\newcommand{\printoffsets}[1]{\luaexec{tex.sprint(table.concat(#1, "\\,\\textit{fs}, "))}\,\textit{fs}}
+\newcommand{\printclockoffsets}[1]{\luaexec{tex.sprint(table.concat(#1, "\\,\\textit{fs}, "))}\,\textit{fs}}
+\newcommand{\printstartupoffsets}[1]{\luaexec{tex.sprint(table.concat(#1, ", "))}}
 \newcommand{\printbool}[1]{\luaexec{if #1 then tex.sprint("\\textcolor{green!50!black}{\\ding{51}}") else tex.sprint("\\textcolor{red!50!black}{\\ding{55}}") end}}
 \newcommand{\printnumber}[1]{\printlua{string.format("\%d", #1)}}
 \newcommand{\printafter}[1]{\luaexec{if #1 ~= nil then tex.sprint(string.format("\%d", #1) .. " steps") else tex.sprint("not used") end}}
@@ -42,7 +43,7 @@
 \ \vspace{3em}
 
 \begin{center}
-  \begin{tikzpicture}[overlay, xshift=0.25\textwidth]
+  \begin{tikzpicture}[overlay, xshift=0.30\textwidth]
     \node {\resizebox{!}{10em}{\input{topology.tikz}}};
   \end{tikzpicture}
 \end{center}
@@ -61,6 +62,10 @@
       & \textpm\,\printnumber{data['stabilityMargin']} elements \\
     when stable, automatically stop after:
       & \printafter{data['stopAfterStable']}                    \\
+    clock offsets:
+      & \printclockoffsets{data['clockOffsets']}                \\
+    startup offsets (\# clock cycles):
+      & \printstartupoffsets{data['startupOffsets']}            \\
     stable at the end of simulation:
       & \printbool{data['stable']}                              \\
   \end{tabular}
@@ -69,7 +74,6 @@
 \vfill
 
 \begin{center}
-  clock offsets: \printoffsets{data['offsets']}
   \begin{tikzpicture}
     \node (clocks) at (0,0) {
       \includegraphics[width=.5\textwidth]{clocks.pdf}

--- a/.github/simulation/staging.json
+++ b/.github/simulation/staging.json
@@ -1,3 +1,3 @@
 [
-  {"topology": "complete", "hmem": 16, "steps": 1000000, "args": "--nodes 2 --offsets [-2,2] --frame-size 1500"}
+  {"topology": "complete", "hmem": 16, "steps": 1000000, "args": "--nodes 2 --clock-offsets [-2,2] --frame-size 1500"}
 ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,6 +187,7 @@ jobs:
             --output-mode pdf \
             --steps ${{ matrix.target.steps }} \
             --samples 1000 \
+            --max-startup-offset 2000 \
             --stop-after-stable ${{ matrix.target.steps }} \
             ${{ matrix.target.topology }} ${{ matrix.target.args }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,11 +194,12 @@ jobs:
       - name: Generate report
         if: always()
         run: |
+          sed -i -e "s/n\([0-9]*\)/\1/g" _build/topology.gv
           dot2tex \
             -f tikz \
             --figonly \
             --progoptions "-K neato" \
-            --nodeoptions "every node/.style={fill, text opacity=0,minimum size=1.5em,inner sep=0pt,text width=0pt}" \
+            --nodeoptions "every node/.style={fill,text=white,font=\Large\tt,minimum size=2em,inner sep=0pt}" \
             --edgeoptions "line width=0.3em" \
             _build/topology.gv > _build/topology.tikz
           cp .github/simulation/report-template.tex _build/report.tex

--- a/elastic-buffer-sim/src/Bittide/Plot.hs
+++ b/elastic-buffer-sim/src/Bittide/Plot.hs
@@ -107,17 +107,19 @@ instance FromJSON OutputMode where
 
 data SimulationSettings =
   SimulationSettings
-    { margin     :: Int
-    , framesize  :: Int
-    , samples    :: Int
-    , periodsize :: Int
-    , reframe    :: Bool
-    , waittime   :: Int
-    , mode       :: OutputMode
-    , dir        :: FilePath
-    , stopStable :: Maybe Int
-    , fixOffsets :: [Int64]
-    , save       :: G.Graph -> [Int64] -> Maybe Bool -> IO ()
+    { margin       :: Int
+    , framesize    :: Int
+    , samples      :: Int
+    , periodsize   :: Int
+    , reframe      :: Bool
+    , waittime     :: Int
+    , mode         :: OutputMode
+    , dir          :: FilePath
+    , stopStable   :: Maybe Int
+    , fixClockOffs :: [Int64]
+    , fixStartOffs :: [Int]
+    , maxStartOff  :: Int
+    , save         :: G.Graph -> [Int64] -> [Int] -> Maybe Bool -> IO ()
     }
 
 plotDiamond :: (?settings :: SimulationSettings) => IO Bool
@@ -346,12 +348,18 @@ simulateTopology ::
   IO Bool
   -- ^ stability result
 simulateTopology ccc graph = do
-  offsets <- V.zipWith (maybe id const) givenOffsets <$> genOffs ccc
+  clockOffsets <-
+    V.zipWith (maybe id const) givenClockOffsets
+      <$> genClockOffsets ccc
+  startupOffsets <-
+    V.zipWith (maybe id const) givenStartupOffsets
+      <$> genStartupOffsets maxStartOff
   let
-    simResult = sim offsets
+    simResult = sim clockOffsets startupOffsets
     saveSettings =
       save (unboundGraph graph)
-        $ (\(Femtoseconds x) -> x) <$> V.toList offsets
+        ((\(Femtoseconds x) -> x) <$> V.toList clockOffsets)
+        (V.toList startupOffsets)
 
   saveSettings Nothing
 
@@ -369,13 +377,15 @@ simulateTopology ccc graph = do
     , mode
     , dir
     , stopStable
-    , fixOffsets
+    , fixClockOffs
+    , fixStartOffs
+    , maxStartOff
     , save
     } = ?settings
 
-  sim =
+  sim o =
    simulate graph stopStable samples periodsize
-    . simulationEntity graph ccc
+    . simulationEntity graph ccc o
 
   plotTopology =
     uncurry (matplotWrite dir) . V.unzip . V.map plotDats
@@ -387,10 +397,15 @@ simulateTopology ccc graph = do
     . unzip
     . fmap (\(a,b,c,d) -> ((a,b), ((a,c),) <$> d))
 
-  givenOffsets =
+  givenClockOffsets =
       V.unsafeFromList
     $ take (natToNum @nodes)
-    $ (Just . Femtoseconds <$> fixOffsets) <> repeat Nothing
+    $ (Just . Femtoseconds <$> fixClockOffs) <> repeat Nothing
+
+  givenStartupOffsets =
+      V.unsafeFromList
+    $ take (natToNum @nodes)
+    $ (Just <$> fixStartOffs) <> repeat Nothing
 
   dumpCsv simulationResult = do
     forM_ [0..n] $ \i -> do
@@ -482,24 +497,24 @@ matplotWrite dir clockDats ebDats = do
 foldPlots :: [Matplotlib] -> Matplotlib
 foldPlots = foldl' (%) mp
 
--- | Generates a vector of random offsets.
-genOffs ::
+-- | Generates a vector of random clock offsets.
+genClockOffsets ::
+  forall dom k n m c.
   (KnownDomain dom, KnownNat k, KnownNat n) =>
   ClockControlConfig dom n m c ->
   IO (V.Vec k Offset)
-genOffs = V.traverse# genOffsets . V.replicate SNat
+genClockOffsets ClockControlConfig{cccDeviation} =
+  V.traverse# (const genOffset) $ V.repeat ()
+ where
+  genOffset = do
+    Ppm offsetPpm <- randomRIO (-cccDeviation, cccDeviation)
+    let nonZeroOffsetPpm = if offsetPpm == 0 then cccDeviation else Ppm offsetPpm
+    pure (diffPeriod nonZeroOffsetPpm (clockPeriodFs @dom Proxy))
 
--- | Randomly generate an 'Offset', how much a real clock's period may
--- differ from its spec.
-genOffsets ::
-  forall dom n m c.
-  KnownDomain dom =>
-  ClockControlConfig dom n m c ->
-  IO Offset
-genOffsets ClockControlConfig{cccDeviation} = do
-  Ppm offsetPpm <- randomRIO (-cccDeviation, cccDeviation)
-  let nonZeroOffsetPpm = if offsetPpm == 0 then cccDeviation else Ppm offsetPpm
-  pure (diffPeriod nonZeroOffsetPpm (clockPeriodFs @dom Proxy))
+-- | Generates a vector of random startup offsets.
+genStartupOffsets :: KnownNat k => Int -> IO (V.Vec k Int)
+genStartupOffsets limit =
+  V.traverse# (const ((+1) <$> randomRIO (0, limit))) $ V.repeat ()
 
 someNat :: Int -> Maybe SomeNat
 someNat = someNatVal . toInteger


### PR DESCRIPTION
Adds the generation and configuration of some initial startup offsets (per node) to the simulation and a legend to the plots in the reports.