### PR TITLE
Add `.envrc`

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: 2023 Google LLC
+#
+# SPDX-License-Identifier: CC0-1.0
+use_nix -j8


### PR DESCRIPTION
After allowing this specific script with `direnv allow`, users of direnv will be auto-dropped to a Nix shell every time they enter a (sub)directory of this repository.