### PR TITLE
Specify individual hardware targets with Shake

### DIFF
--- a/bittide-instances/data/tcl/HardwareTest.tcl
+++ b/bittide-instances/data/tcl/HardwareTest.tcl
@@ -240,6 +240,9 @@ proc run_device_tests {} {
 proc run_test_all {probes_file fpga_nrs url} {
     global fpga_ids
     set successful_devices 0
+    if {[expr [llength $fpga_nrs] == 0]} {
+        set fpga_nrs [list -1]
+    }
     foreach fpga_nr $fpga_nrs {
         if {$fpga_nr == -1} {
             set device [load_first_device]

--- a/bittide-instances/src/Clash/Shake/Flags.hs
+++ b/bittide-instances/src/Clash/Shake/Flags.hs
@@ -13,11 +13,12 @@ import System.Console.GetOpt (OptDescr(Option), ArgDescr(ReqArg))
 
 -- | Number of hardware targets to program and optionally test
 data HardwareTargets
-  -- | Program first FPGA found by Vivado
-  = FirstOfAny
-  -- | Program the first FPGA from a list of hardcoded IDs (FGPA IDs), see
-  -- @HardwareTest.tcl@
-  | FirstOfKnown
+  -- | Program the first FPGA found by Vivado. This is not necessarily the first
+  -- FPGA in the demo rack.
+  = OneAny
+  -- | Program the FPGAs in the demo rack at the specific indices. The actual
+  -- IDs of the FPGAs in the demo rack are specified in @HardwareTest.tcl@.
+  | Specific [Int]
   -- | Program all connected FPGAs. Note that we currently hardcode a list of all
   -- FPGAs in our possesion. If we can't find them all, the program will exit with
   -- and error code.
@@ -34,13 +35,16 @@ lastMaybe (x:xs) = Just $ last (x:xs)
 parseHardwareTargetsFlag :: String -> Either String HardwareTargets
 parseHardwareTargetsFlag s =
   case readMaybe s of
-    Just f -> Right f
+    Just f ->
+      case f of
+        Specific [] -> Left ("Specify at least one index from the demo rack, or use OneAny")
+        _ -> Right f
     Nothing -> Left ("Not a valid hardware target: " ++ s)
 
--- | Get hardware flag based on a list of parsed flags. Defaults to 'FirstOfAny'. If
+-- | Get hardware flag based on a list of parsed flags. Defaults to 'OneAny'. If
 -- multiple options are given, the last one is picked.
 getHardwareTargetsFlag :: [HardwareTargets] -> HardwareTargets
-getHardwareTargetsFlag = fromMaybe FirstOfAny . lastMaybe
+getHardwareTargetsFlag = fromMaybe OneAny . lastMaybe
 
 -- | List of custom flags supported by us. Note that we currently support only
 -- one flag, 'HardwareTargets'.
@@ -50,5 +54,5 @@ customFlags =
       "" -- no short flags
       ["hardware-targets"] -- long name of flag
       (ReqArg parseHardwareTargetsFlag "TARGET")
-      "Options: FirstOfAny, FirstOfKnown, All. See 'HardwareTargets' in 'Flags.hs'."
+      "Options: OneAny, Specific, All. See 'HardwareTargets' in 'Flags.hs'."
   ]


### PR DESCRIPTION
Specify individual hardware targets with Shake

Renamed the options for the `--hardware-targets` flag to: `OneAny`,  `Specific {FPGA indices}` and `All`. Defaults to `OneAny`.

Some examples:

```--hardware-targets=OneAny``` -> First FPGA Vivado can find
```--hardware-targets=All``` -> All FPGAs in the demo rack
```--hardware-targets="Specific [1,2,5]"``` -> Only FPGAs 1, 2 and 5 in demo rack
```--hardware-targets="Specific [-1,-2]"``` -> Only the last 2 FPGAs in the demo rack