### PR TITLE
Don't cache Shake's `_build` on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -689,17 +689,6 @@ jobs:
           restore-keys: packages-cachebust-3-
           fail-on-cache-miss: true
 
-      - name: Cache Shake build directory
-        uses: actions/cache@v3
-        with:
-          path: |
-            _build
-
-          key: shake-build-cachebust-3-${{ matrix.target.top }}-${{ steps.extract_branch.outputs.branch }}-${{ github.sha }}
-          restore-keys: |
-            shake-build-cachebust-3-${{ matrix.target.top }}-${{ steps.extract_branch.outputs.branch }}-
-            shake-build-cachebust-3-${{ matrix.target.top }}-
-
       - name: HDL generation and synthesis
         run : |
           target="${{ matrix.target.stage }}"


### PR DESCRIPTION
It crashes CI in case of deleted files. See #356.