### PR TITLE
Remove auto clock group code

### DIFF
--- a/bittide-instances/data/constraints/clockControlDemo0.xdc
+++ b/bittide-instances/data/constraints/clockControlDemo0.xdc
@@ -18,6 +18,13 @@ set_property IOSTANDARD  LVDS     [get_ports "USER_SMA_CLOCK_p"]
 set_property PACKAGE_PIN C23      [get_ports "USER_SMA_CLOCK_n"]
 set_property IOSTANDARD  LVDS     [get_ports "USER_SMA_CLOCK_n"]
 
+# Vivado marks all clocks as related by default. Our external clocks are not
+# though, which means that we need to explicitly mark them as unrelated (or
+# "asynchronous").
+set_clock_groups \
+    -asynchronous \
+    -group [get_clocks -include_generated_clocks {SYSCLK_300_p}] \
+    -group [get_clocks -include_generated_clocks {USER_SMA_CLOCK_p}]
 
 # GPIO_SW_E
 set_property PACKAGE_PIN AE8      [get_ports "drainFifo"]

--- a/bittide-instances/data/constraints/clockControlDemo1.xdc
+++ b/bittide-instances/data/constraints/clockControlDemo1.xdc
@@ -18,6 +18,14 @@ set_property PACKAGE_PIN D25      [get_ports "FMC_HPC_CLK1_M2C_n"]
 set_property IOSTANDARD  LVDS     [get_ports "FMC_HPC_CLK1_M2C_n"]
 set_property DIFF_TERM   TRUE     [get_ports "FMC_HPC_CLK1_M2C_n"]
 
+# Vivado marks all clocks as related by default. Our external clocks are not
+# though, which means that we need to explicitly mark them as unrelated (or
+# "asynchronous").
+set_clock_groups \
+    -asynchronous \
+    -group [get_clocks -include_generated_clocks {SYSCLK_300_p}] \
+    -group [get_clocks -include_generated_clocks {USER_SMA_CLOCK_p}] \
+    -group [get_clocks -include_generated_clocks {FMC_HPC_CLK1_M2C_p}]
 
 # GPIO_SW_E
 set_property PACKAGE_PIN AE8      [get_ports "drainFifoA"]

--- a/bittide-instances/data/constraints/fincFdecTests.xdc
+++ b/bittide-instances/data/constraints/fincFdecTests.xdc
@@ -28,6 +28,14 @@ set_property BOARD_PART_PIN sysclk_125_n [get_ports {CLK_125MHZ_n}]
 set_property -dict {IOSTANDARD LVDS PACKAGE_PIN D23} [get_ports {USER_SMA_CLOCK_p}]
 set_property -dict {IOSTANDARD LVDS PACKAGE_PIN C23} [get_ports {USER_SMA_CLOCK_n}]
 
+# Vivado marks all clocks as related by default. Our external clocks are not
+# though, which means that we need to explicitly mark them as unrelated (or
+# "asynchronous").
+set_clock_groups \
+    -asynchronous \
+    -group [get_clocks -include_generated_clocks {CLK_125MHZ_p}] \
+    -group [get_clocks -include_generated_clocks {USER_SMA_CLOCK_p}]
+
 # GPIO_LED_0_LS
 set_property BOARD_PART_PIN GPIO_LED_0_LS [get_ports {done}]
 # GPIO_LED_1_LS

--- a/bittide-shake/src/Clash/Shake/Vivado.hs
+++ b/bittide-shake/src/Clash/Shake/Vivado.hs
@@ -201,13 +201,6 @@ mkPlaceTcl outputDir = [__i|
     \# Pick up where synthesis left off
     open_checkpoint {#{outputDir </> "checkpoints" </> "post_synth.dcp"}}
 
-    \# Place all clocks in individual clock groups and make them asynchronous
-    set clkArgs {}
-    foreach clk [get_clocks] {
-      lappend clkArgs -group $clk
-    }
-    set_clock_groups -asynchronous {*}$clkArgs
-
     \# Run optimization & placement
     opt_design
     place_design


### PR DESCRIPTION
This code sets _all_ clocks in the design (including generated ones) as asynchronous. This is undesirable for components that derive clocks, including PLLs and GTH transceivers. Developers should explicitly mark clocks as asynchronous, using a construction such as:

    set_clock_groups \
       -asynchronous \
       -group [get_clocks -include_generated_clocks {SYSCLK_300_p}] \
       -group [get_clocks -include_generated_clocks {SMA_MGT_REFCLK_C_p}]