### PR TITLE
Use 'done' signals as clock locks in tranceiver logic

### DIFF
--- a/bittide-instances/src/Bittide/Instances/Tests/FullMeshHwCc.hs
+++ b/bittide-instances/src/Bittide/Instances/Tests/FullMeshHwCc.hs
@@ -103,14 +103,12 @@ goTransceiversUpTest refClk sysClk rst rxns rxps miso =
       si539xSpi testConfig6_200_on_0a (SNat @(Microseconds 10)) (pure Nothing) miso
 
   -- Transceiver setup
-  gthAllReset  = E.holdReset sysClk enableGen d1024 (unsafeFromActiveLow spiDone)
-  gthChanReset = E.holdReset sysClk enableGen d1024 gthAllReset
-  gthStimReset = E.holdReset sysClk enableGen d1024 gthChanReset
+  gthAllReset = unsafeFromActiveLow spiDone
 
   (head -> (txClock :: Clock GthTx), rxClocks, txns, txps, linkUpsRx, stats) = unzip6 $
     transceiverPrbsN
       @GthTx @GthRx @Basic200 @Basic125 @GthTx @GthRx
-      refClk sysClk gthAllReset gthStimReset gthChanReset
+      refClk sysClk gthAllReset
       c_CHANNEL_NAMES c_CLOCK_PATHS rxns rxps
 
   syncLink rxClock linkUp = xpmCdcSingle rxClock sysClk linkUp

--- a/bittide-instances/src/Bittide/Instances/Tests/Transceivers.hs
+++ b/bittide-instances/src/Bittide/Instances/Tests/Transceivers.hs
@@ -86,14 +86,12 @@ goTransceiversUpTest refClk sysClk rst rxns rxps miso =
       si539xSpi testConfig6_200_on_0a (SNat @(Microseconds 10)) (pure Nothing) miso
 
   -- Transceiver setup
-  gthAllReset  = E.holdReset sysClk enableGen d1024 (unsafeFromActiveLow spiDone)
-  gthChanReset = E.holdReset sysClk enableGen d1024 gthAllReset
-  gthStimReset = E.holdReset sysClk enableGen d1024 gthChanReset
+  gthAllReset = unsafeFromActiveLow spiDone
 
   (_txClocks, rxClocks, txns, txps, linkUpsRx, stats) = unzip6 $
     transceiverPrbsN
       @GthTx @GthRx @Basic200 @Basic125 @GthTx @GthRx
-      refClk sysClk gthAllReset gthStimReset gthChanReset
+      refClk sysClk gthAllReset
       c_CHANNEL_NAMES c_CLOCK_PATHS rxns rxps
 
   syncLink rxClock linkUp = xpmCdcSingle rxClock sysClk linkUp


### PR DESCRIPTION
Greatly increases the reliability of transceiver bring-up. We accidentally used unstable clocks before. After this PR they're guarded by clock locks.

A second commit piggy-backed to this PR removes resets tied to internals from the public API. These were originally added for debugging purposes.

## TODO
- [ ] Add @leonschoorl as co-author before merging