### PR TITLE
Only use one clock for `counterReducedPins`

### DIFF
--- a/bittide-instances/src/Bittide/Instances/Counter.hs
+++ b/bittide-instances/src/Bittide/Instances/Counter.hs
@@ -19,10 +19,7 @@ counter ::
 counter clk0 rst0 clk1 rst1 _ =
   domainDiffCounter clk0 rst0 clk1 rst1
 
-counterReducedPins ::
-  Clock Basic200 -> Reset Basic200 ->
-  Clock Basic200 -> Reset Basic200 ->
-  Signal Basic200 Bit
-counterReducedPins clk0 rst0 clk1 rst1 =
-  withClock clk1 $
-    reducePins (counter clk0 rst0 clk1 rst1) (pure 0)
+counterReducedPins :: Clock Basic200 -> Signal Basic200 Bit
+counterReducedPins clk =
+  withClock clk $
+    reducePins (counter clk noReset clk noReset) (pure 0)

--- a/nix/bin/shake
+++ b/nix/bin/shake
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+cabal run shake -- $@

--- a/shell.nix
+++ b/shell.nix
@@ -49,5 +49,8 @@ pkgs.mkShell {
 
     # Mixing Nix Cabal and non-Nix Cabal yields some weird linking errors.
     export CABAL_DIR="$HOME/.cabal-nix";
+
+    # Allow writing 'shake ...' instead of 'cabal run shake -- ...'
+    export PATH="$(git rev-parse --show-toplevel)/nix/bin:$PATH";
   '';
 }


### PR DESCRIPTION
Sneaked in:

 * Use `shake` directly in your Nix shell, instead of having to use `cabal run shake -- ..`