### PR TITLE
ILA based plot generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,12 +225,37 @@ jobs:
     name: Generate clock control simulation report
     runs-on: [self-hosted, compute]
     if: always()
-    needs: [build, lint, elastic-buffer-sim-topologies-matrix, elastic-buffer-sim-topologies]
+    defaults:
+      run:
+        shell: git-nix-shell {0} --pure
+    needs: [build, lint, elastic-buffer-sim-topologies-matrix, elastic-buffer-sim-topologies, bittide-instances-hardware-in-the-loop]
 
     container:
       image: ghcr.io/clash-lang/nixos-bittide-hardware:2023-06-30
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set CI flags
+        run: |
+          cp .github/cabal.project cabal.project.local
+
+      - name: Update Cabal index info
+        run: |
+          cabal update
+          cabal freeze
+
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cabal-nix/store
+
+          key: packages-cachebust-4-${{ hashFiles('cabal.project.freeze', 'cabal.project') }}
+          restore-keys: packages-cachebust-3-
+          fail-on-cache-miss: true
+
       - name: Download simulation artifacts
         uses: actions/download-artifact@v3
         with:
@@ -244,17 +269,28 @@ jobs:
           # the required artifacts instead.
           path: artifacts
 
-      - name: Generate final report
-        shell: git-nix-shell {0} --pure
+      - name: Generate final simulation report
         run: |
           set +f # Enable globbing
           pdfunite artifacts/*/report.pdf report.pdf
 
-      - name: Upload report
+      - name: Upload simulation report
         uses: actions/upload-artifact@v3
         with:
           name: Clock Control Simulation Report
           path: report.pdf
+          retention-days: 14
+
+      - name: Generate HITL based plots
+        run: |
+          mkdir hitl-plots
+          ./cargo.sh build --release && cabal run -- elastic-buffer-sim:plot artifacts/_build-fullMeshHwCcTest-debug/Bittide.Instances.Tests.FullMeshHwCc.fullMeshHwCcTest/ila-data/probe_test_start/ hitl-plots Bittide_Instances_Tests_FullMeshHwCc_fullMeshHwCcTest_callistoClockControlWithIla
+
+      - name: Upload HITL based plots
+        uses: actions/upload-artifact@v3
+        with:
+          name: Clock Control HITL Plots
+          path: hitl-plots
           retention-days: 14
 
   elastic-buffer-sim-tests:

--- a/bittide-extra/bittide-extra.cabal
+++ b/bittide-extra/bittide-extra.cabal
@@ -76,6 +76,7 @@ library
     Bittide.Extra.Maybe
     Bittide.Extra.Wishbone
     Clash.Sized.Vector.Extra
+    Clash.Explicit.Signal.Extra
 
 test-suite doctests
   type:             exitcode-stdio-1.0

--- a/bittide-extra/src/Clash/Explicit/Signal/Extra.hs
+++ b/bittide-extra/src/Clash/Explicit/Signal/Extra.hs
@@ -1,0 +1,19 @@
+-- SPDX-FileCopyrightText: 2022-2023 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+
+module Clash.Explicit.Signal.Extra where
+
+import Clash.Explicit.Prelude
+
+-- | Give a pulse whenever the signal changes.
+changepoints ::
+  forall dom a.
+  (KnownDomain dom, NFDataX a, Eq a) =>
+  Clock dom ->
+  Reset dom ->
+  Enable dom ->
+  Signal dom a ->
+  Signal dom Bool
+changepoints clk rst ena =
+  mealy clk rst ena (\s i -> (Just i, maybe False (/= i) s)) Nothing

--- a/bittide-instances/bittide-instances.cabal
+++ b/bittide-instances/bittide-instances.cabal
@@ -76,13 +76,13 @@ common common-options
     containers,
     cryptohash-sha256,
     directory,
-    elastic-buffer-sim,
     extra,
     filepath,
     ghc-typelits-extra,
     ghc-typelits-knownnat,
     ghc-typelits-natnormalise,
     Glob,
+    lift-type,
     MissingH,
     pretty-simple,
     process,
@@ -114,6 +114,7 @@ library
     Bittide.Instances.Tests.BoardTest
     Bittide.Instances.Tests.FincFdec
     Bittide.Instances.Tests.FullMeshHwCc
+    Bittide.Instances.Tests.FullMeshHwCc.IlaPlot
     Bittide.Instances.Tests.SyncInSyncOut
     Bittide.Instances.Tests.Transceivers
     Bittide.Instances.Tests.VexRiscv

--- a/bittide-instances/src/Bittide/Instances/Domains.hs
+++ b/bittide-instances/src/Bittide/Instances/Domains.hs
@@ -27,7 +27,7 @@ createDomain vXilinxSystem{vName="GthTx", vPeriod= hzToPeriod 125e6}
 createDomain vXilinxSystem{vName="Internal", vPeriod=hzToPeriod 200e6}
 
 type CccBufferSize = 25 :: Nat
-type CccStabilityCheckerMargin = 10 :: Nat
+type CccStabilityCheckerMargin = 16 :: Nat
 type CccStabilityCheckerFramesize dom = PeriodToCycles dom (Seconds 2)
 type CccReframingWaitTime dom = PeriodToCycles dom (Seconds 5)
 

--- a/bittide-instances/src/Bittide/Instances/Tests/FullMeshHwCc/IlaPlot.hs
+++ b/bittide-instances/src/Bittide/Instances/Tests/FullMeshHwCc/IlaPlot.hs
@@ -1,0 +1,271 @@
+-- SPDX-FileCopyrightText: 2023 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+{-# LANGUAGE MultiWayIf #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE FlexibleContexts #-}
+
+{-# OPTIONS_GHC -fconstraint-solver-iterations=20 #-}
+module Bittide.Instances.Tests.FullMeshHwCc.IlaPlot
+  ( PlotData(..)
+  , IlaControl(..)
+  , RfStageChange(..)
+  , CaptureCondition(..)
+  , GlobalTimestamp
+  , LocalTimestamp
+  , AccWindowHeight
+  , SyncPulsePeriod
+  , syncOutGenerator
+  , callistoClockControlWithIla
+  ) where
+
+import Clash.Explicit.Prelude
+import Clash.Explicit.Signal.Extra
+
+import Bittide.Arithmetic.Time (Milliseconds, PeriodToCycles)
+import Bittide.ClockControl (SpeedChange(..), DataCount, ClockControlConfig)
+import Bittide.ClockControl.Callisto
+  (CallistoResult(..), ReframingState(..), callistoClockControl)
+import Bittide.ClockControl.StabilityChecker
+import Bittide.Extra.Maybe (orNothing)
+
+import Clash.Cores.Xilinx.Xpm.Cdc.Handshake.Extra (xpmCdcMaybeLossy)
+import Clash.Cores.Xilinx.Xpm.Cdc.Gray (xpmCdcGray)
+import Clash.Cores.Xilinx.Ila (IlaConfig(..), Depth(..), ila, ilaConfig)
+
+import Data.Maybe (isJust, fromMaybe)
+
+type AccWindowHeight = 3 :: Nat
+type SyncPulsePeriod = Milliseconds 5
+type SyncPulseIndex dom = Index (PeriodToCycles dom SyncPulsePeriod)
+
+-- | A global timestamp consists of the number of synchronized pulses
+-- received and the number of cycles of the local stable clock
+-- (starting with 'syncStart').
+type GlobalTimestamp = (Unsigned 32, Unsigned 32)
+
+-- | The local timestamp counts the cycles of the dynamic clock
+-- (starting with clock control).
+type LocalTimestamp = Unsigned 32
+
+-- | Indicator for signaling a change in the stage of 'ReframingState'.
+data RfStageChange = Stable | ToDetect | ToWait | ToDone
+  deriving (Eq, Generic, BitPack, NFDataX)
+
+-- | Indicator for stating the reason of an ILA capture.
+data CaptureCondition = UntilTrigger | CalibrationDone | DataChange | TheEnd
+  deriving (Eq, Generic, NFDataX, BitPack)
+
+-- | Conglomerate of signals, as they are required by the ILA trigger
+-- and capture conditions.
+data IlaControl dom =
+  IlaControl
+    { syncStart :: Signal dom Bool
+      -- ^ Synchronized test start trigger
+    , syncEnd :: Signal dom Bool
+      -- ^ Synchronized test end trigger
+    , calibrate :: Signal dom Bool
+      -- ^ Calibration interval
+    , calibrationDone :: Signal dom Bool
+      -- ^ Calibration end trigger
+    , globalTimestamp :: Signal dom GlobalTimestamp
+      -- ^ Synchronized pulse counter
+    }
+
+-- | A single data type for covering all of the non-clock related data
+-- to be included into a capture.
+data PlotData (n :: Nat) (m :: Nat) =
+  PlotData
+    { dEBData       :: Vec n (DataCount m, Maybe Bool, Maybe Bool)
+    , dSpeedChange  :: SpeedChange
+    , dRfStageChange :: RfStageChange
+    }
+  deriving (Generic, NFDataX, BitPack)
+
+-- | Accumulates over multiple @FINC@/@FDEC@s to reduce the number of
+-- captures recorded by the ILA (which are mostly jitter otherwise).
+--
+-- The compression technique works as follows: if both @FINC@ and
+-- @FDEC@ are requested after each other, then they cancel each other
+-- out and are not reported. Hence, only @FINC@/@FDEC@s are reported
+-- that haven't canceled out before they exceed the @n@
+-- boundary. Thus, for example @FINC@, @FINC@, @FDEC@, @FDEC@, ... is
+-- not reported for @n > 2@ as the first two @FINC@s don't exceed the
+-- boundary @n@.
+accwindow ::
+  forall height dom.
+  (KnownNat height, KnownDomain dom) =>
+  SNat height ->
+  Clock dom ->
+  Reset dom ->
+  Enable dom ->
+  Signal dom SpeedChange ->
+  Signal dom SpeedChange
+accwindow _ clk rst ena =
+  flip (mealy clk rst ena) (True, minBound :: Index height)
+    $ \(d,s) -> \case
+         NoChange -> ((d, s), NoChange)
+         x        -> let d' = if x == SpeedUp then d else not d in if
+           |     d' && s == maxBound -> ((not d, minBound), x       )
+           | not d' && s == minBound -> ((not d, minBound), NoChange)
+           |     d'                  -> ((d,     s + 1),    NoChange)
+           | otherwise               -> ((d,     s - 1),    NoChange)
+
+
+-- Wrapper on 'Bittide.ClockControl.Callisto.callistoClockControl'
+-- additionally dumping all the data that is required for producing
+-- plots of the clock control behavior.
+{-# NOINLINE callistoClockControlWithIla #-}
+callistoClockControlWithIla ::
+  forall n m dom domIla margin framesize.
+  ( KnownDomain dom
+  , KnownDomain domIla
+  , KnownNat n
+  , KnownNat m
+  , KnownNat margin
+  , KnownNat framesize
+  , 1 <= n
+  , 1 <= m
+  , n + m <= 32
+  , 1 <= framesize
+  , 4 + n * (m + 4) <= 1024
+  ) =>
+  Clock domIla ->
+  Clock dom ->
+  Reset dom ->
+  Enable dom ->
+  -- | Configuration for this component, see individual fields for more info.
+  ClockControlConfig dom m margin framesize ->
+  -- | Ila trigger and capture conditions
+  IlaControl domIla ->
+  -- | Link availability mask
+  Signal dom (BitVector n) ->
+  -- | Statistics provided by elastic buffers.
+  Vec n (Signal dom (DataCount m)) ->
+  Signal dom (CallistoResult n)
+callistoClockControlWithIla sysClk clk rst ena ccc IlaControl{..} mask ebs =
+  hwSeqX ilaInstance result
+ where
+  result = callistoClockControl clk rst ena ccc mask ebs
+
+  -- local timestamp on the stable clock
+  localTs :: Signal domIla LocalTimestamp
+  localTs =
+    let lts :: Signal dom LocalTimestamp
+        lts = register clk rst ena 0 ((+1) <$> lts)
+     in xpmCdcGray clk sysClk lts
+
+  rfStageChange CallistoResult{..} = case reframingState of
+    Detect {} -> ToDetect
+    Wait {}   -> ToWait
+    Done {}   -> ToDone
+
+  localData =
+    let
+      height = SNat :: SNat AccWindowHeight
+      indicators = unbundle (stability <$> result)
+
+      -- get the points in time where the monitored values change
+      stableUpdates = changepoints clk rst ena <$> (fmap stable <$> indicators)
+      settledUpdates = changepoints clk rst ena <$> (fmap settled <$> indicators)
+      modeUpdate = changepoints clk rst ena (rfStageChange <$> result)
+
+      combine eb stU seU ind = (,,)
+        <$> eb
+        <*> (orNothing <$> stU <*> (stable  <$> ind))
+        <*> (orNothing <$> seU <*> (settled <$> ind))
+    in PlotData
+      <$> bundle (zipWith4 combine ebs stableUpdates settledUpdates indicators)
+      <*> accwindow height clk rst ena (speedChange <$> result)
+      <*> mux modeUpdate (rfStageChange <$> result) (pure Stable)
+
+  plotData = mux calibrate (pure Nothing)
+    $ xpmCdcMaybeLossy clk sysClk
+      ((\x -> orNothing (dataChange x) x) <$> localData)
+
+  dataChange PlotData{..} =
+       any (\(_, x, y) -> isJust x || isJust y) dEBData
+    || dSpeedChange /= NoChange
+    || dRfStageChange /= Stable
+
+  -- Note that we always need to capture everything before the trigger
+  -- fires, because the data that ILA captures is undefined
+  -- otherwise. Moreover, @syncStart@ does not hold at the trigger,
+  -- but only after it. Hence, if the trigger position is at 0, then
+  -- we store exactly one capture that is marked with the
+  -- @UntilTrigger@ flag this way.
+  captureCond :: Signal domIla (Maybe CaptureCondition)
+  captureCond =
+      mux (not <$> syncStart)   (pure $ Just UntilTrigger)
+    $ mux calibrationDone       (pure $ Just CalibrationDone)
+    $ mux syncEnd               (pure $ Just TheEnd)
+    $ mux (isJust <$> plotData) (pure $ Just DataChange)
+    $ pure Nothing
+
+  ilaInstance :: Signal domIla ()
+  ilaInstance =
+    ila
+      ( ilaConfig
+           $ "trigger_1"
+          :> "capture_1"
+          :> "condition"
+          :> "global"
+          :> "local"
+          :> "data"
+          :> Nil
+      ) { depth = D16384 }
+      -- the ILA must run on a stable clock
+      sysClk
+      -- trigger as soon as we start
+      syncStart
+      -- capture on relevant data changes
+      (isJust <$> captureCond)
+      -- capture the capture condition
+      (fromMaybe UntilTrigger <$> captureCond)
+      -- capture the globally synchronized timestamp
+      globalTimestamp
+      -- capture the local timestamp
+      localTs
+      -- capture all relevant plot data
+      (fromMaybe dummy <$> plotData)
+
+  dummy = PlotData
+    { dEBData        = repeat (0, Nothing, Nothing)
+    , dSpeedChange   = NoChange
+    , dRfStageChange = Stable
+    }
+
+-- | The state space of the mealy machine for producing @SYNC_OUT@.
+data SyncOutGen dom =
+    WaitForStart
+  | WaitAtLeast (SyncPulseIndex dom)
+  | WaitForTransceivers
+  | SyncPulse Bool (SyncPulseIndex dom)
+  | Freeze Bool
+  deriving (Generic, NFDataX)
+
+-- | The signal transformer for producing @SYNC_OUT@.
+syncOutGenerator ::
+  forall dom.
+  KnownDomain dom =>
+  Clock dom ->
+  Reset dom ->
+  Enable dom ->
+  (Signal dom Bool, Signal dom Bool) ->
+  Signal dom Bool
+syncOutGenerator clk rst ena =
+  mealyB clk rst ena transF (WaitForStart :: SyncOutGen dom)
+ where
+  transF WaitForStart        (True, _   ) = (WaitAtLeast maxBound,       True )
+  transF WaitForStart        (_   , _   ) = (WaitForStart,               False)
+  transF (WaitAtLeast 0)     (True, True) = (SyncPulse False maxBound,   False)
+  transF (WaitAtLeast 0)     (True, _   ) = (WaitForTransceivers,        True )
+  transF (WaitAtLeast n)     (True, _   ) = (WaitAtLeast (n - 1),        True )
+  transF (WaitAtLeast _)     _            = (Freeze True,                True )
+  transF WaitForTransceivers (True, True) = (SyncPulse False maxBound,   False)
+  transF WaitForTransceivers (True, _   ) = (WaitForTransceivers,        True )
+  transF WaitForTransceivers _            = (Freeze True,                True )
+  transF (SyncPulse o 0)     (True, True) = (SyncPulse (not o) maxBound, not o)
+  transF (SyncPulse o n)     (True, True) = (SyncPulse o (n - 1),        o    )
+  transF (SyncPulse o _)     _            = (Freeze o,                   o    )
+  transF (Freeze o)          _            = (Freeze o,                   o    )

--- a/bittide-shake/data/tcl/HardwareTest.tcl
+++ b/bittide-shake/data/tcl/HardwareTest.tcl
@@ -543,6 +543,9 @@ proc run_test_group {probes_file target_dict url ila_data_dir} {
                 set capture_probe [get_hw_probes [dict get $ila_dict capture_probe]]
                 set_property capture_compare_value eq1'b1 $capture_probe
 
+                # Set the trigger position
+                set_property control.trigger_position 0 $ila
+
                 run_hw_ila $ila
             }
 

--- a/bittide/src/Bittide/ClockControl.hs
+++ b/bittide/src/Bittide/ClockControl.hs
@@ -18,6 +18,7 @@ module Bittide.ClockControl
   , targetDataCount
   , clockPeriodFs
   , speedChangeToFincFdec
+  , sign
   )
 where
 
@@ -124,10 +125,10 @@ targetDataCount = 0
 
 -- | Safer version of FINC/FDEC signals present on the Si5395/Si5391 clock multipliers.
 data SpeedChange
-  = SpeedUp
+  = NoChange
   | SlowDown
-  | NoChange
-  deriving (Eq, Show, Generic, ShowX, NFDataX, Enum)
+  | SpeedUp
+  deriving (Eq, Show, Generic, BitPack, ShowX, NFDataX)
 
 type instance SizeOf SpeedChange =
   SizeOf CUInt
@@ -154,6 +155,14 @@ instance (SizeOf SpeedChange ~ 4, Alignment SpeedChange ~ 4)
       SpeedUp  -> 0
       SlowDown -> 1
       NoChange -> 2
+
+-- | Converts speed changes into a normalized scalar, which reflects
+-- their effect on clock control.
+sign :: Num a => SpeedChange -> a
+sign = \case
+  SpeedUp  -> 1
+  NoChange -> 0
+  SlowDown -> -1
 
 data ToFincFdecState dom
   = Wait (Index (PeriodToCycles dom (Microseconds 1)))

--- a/bittide/src/Bittide/ClockControl.hs
+++ b/bittide/src/Bittide/ClockControl.hs
@@ -144,17 +144,17 @@ instance (SizeOf SpeedChange ~ 4, Alignment SpeedChange ~ 4)
   peek p = from <$> peek (castPtr p :: Ptr CUInt)
    where
     from = \case
-      0 -> SpeedUp
+      0 -> NoChange
       1 -> SlowDown
-      2 -> NoChange
+      2 -> SpeedUp
       _ -> error "out of range"
 
   poke p = poke (castPtr p :: Ptr CUInt) . to
    where
     to = \case
-      SpeedUp  -> 0
+      NoChange -> 0
       SlowDown -> 1
-      NoChange -> 2
+      SpeedUp  -> 2
 
 -- | Converts speed changes into a normalized scalar, which reflects
 -- their effect on clock control.

--- a/bittide/src/Bittide/ClockControl/Callisto.hs
+++ b/bittide/src/Bittide/ClockControl/Callisto.hs
@@ -193,11 +193,6 @@ callisto ControlConfig{..} mask scs dataCounts state =
       -- TODO: Propagate errors upwards?
       F.NaN -> NoChange
 
-  sign = \case
-    NoChange -> 0
-    SpeedUp  -> 1
-    SlowDown -> -1
-
   rfStateUpdate stable target st@ControlSt{..}
     | not reframingEnabled = st
     | otherwise = case rfState of

--- a/elastic-buffer-sim/elastic-buffer-sim.cabal
+++ b/elastic-buffer-sim/elastic-buffer-sim.cabal
@@ -115,6 +115,28 @@ executable sim
   -- enable rtsopts so we can setup memory limits
   ghc-options: -Wall -Wcompat -threaded -rtsopts -with-rtsopts=-xm20000000 +RTS -xm20000000 -RTS
 
+executable plot
+  import: common-options
+  main-is: plot/Main.hs
+  build-depends:
+    array,
+    bittide,
+    bittide-instances,
+    bytestring,
+    cassava,
+    cassava-conduit,
+    conduit,
+    containers,
+    directory,
+    elastic-buffer-sim,
+    filepath,
+    text,
+    vector
+  default-language: Haskell2010
+  default-extensions: ImplicitPrelude
+  -- enable rtsopts so we can setup memory limits
+  ghc-options: -Wall -Wcompat -threaded -rtsopts -with-rtsopts=-xm20000000 +RTS -xm20000000 -RTS
+
 test-suite unittests
   import:           common-options
   type:             exitcode-stdio-1.0

--- a/elastic-buffer-sim/plot/Main.hs
+++ b/elastic-buffer-sim/plot/Main.hs
@@ -1,0 +1,307 @@
+-- SPDX-FileCopyrightText: 2023 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE FlexibleInstances #-}
+
+{-# OPTIONS_GHC -Wno-orphans #-}
+module Main (main) where
+
+import Clash.Prelude
+  ( BitPack(..), SNat(..), BitSize, Nat, KnownNat, Vec
+  , type (*), type (-), type (<=), (.&&.), (.|.)
+  , natToNum, shift
+  )
+import Clash.Signal.Internal (Femtoseconds(..))
+import qualified Clash.Sized.Vector as Vec
+  ( unsafeFromList, toList, repeat, zip, zipWith
+  )
+
+import Conduit
+  ( ConduitT, Void, (.|)
+  , runConduit, sourceHandle, scanlC, dropC, mapC, sinkList, yield, await
+  )
+import Control.Exception (Exception, throw)
+import Control.Monad (when, forM, foldM, filterM)
+import Data.ByteString.Internal (w2c)
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as BSC
+import Data.Char (isHexDigit, digitToInt)
+import Data.Csv
+  ( FromField(..), FromRecord(..), HasHeader(..), (.!)
+  , defaultDecodeOptions
+  )
+import Data.Csv.Conduit
+  ( CsvStreamRecordParseError, CsvStreamHaltParseError(..)
+  , fromCsvStreamError
+  )
+import Data.List (uncons)
+import Data.Maybe (fromMaybe)
+import Data.Proxy (Proxy(..))
+import qualified Data.Text as Text (unpack)
+import qualified Data.Vector as Vector (length)
+import GHC.IO.Exception (IOException(..), IOErrorType(..))
+import System.IO (IOMode(..), Handle, openFile, hClose)
+import System.Directory (listDirectory, doesDirectoryExist, createDirectoryIfMissing)
+import System.Environment (getArgs, getProgName)
+import System.FilePath ((</>), takeExtensions, takeBaseName)
+
+import Bittide.Plot
+import Bittide.ClockControl
+import Bittide.ClockControl.StabilityChecker
+import Bittide.Instances.Tests.FullMeshHwCc
+import Bittide.Instances.Tests.FullMeshHwCc.IlaPlot
+import Bittide.Instances.Domains
+import Bittide.Topology.Graph
+
+-- A newtype wrapper for working with hex encoded types.
+newtype Hex a = Hex { fromHex :: a }
+  deriving newtype (BitPack)
+
+instance BitPack a => FromField (Hex a) where
+  parseField bs = (unpack <$>) $ foldM pHex 0
+    $ reverse $ zip [0,1..] $ reverse (w2c <$> BS.unpack bs)
+   where
+    pHex !a (i, c)
+      | not (isHexDigit c) =
+          fail $ "Non-hexadecimal digit: " <> [c]
+      | i * 4 + log2 (digitToNum c) > natToNum @(BitSize a) =
+          fail $ "Value is out of range: " <> BSC.unpack bs
+      | otherwise =
+          return $ shift a 4 .|. digitToNum c
+
+    -- 'digitToInt' produces only 16 different values. Hence, it can be
+    --  extended to work for any 'Num' instance.
+    digitToNum x = case digitToInt x of
+      { 0 -> 0; 1 -> 1; 2 -> 2; 3 -> 3; 4 -> 4; 5 -> 5; 6 -> 6; 7 -> 7; 8 -> 8
+      ; 9 -> 9; 10 -> 10; 11 -> 11; 12 -> 12; 13 -> 13; 14 -> 14; 15 -> 15
+      ; y | y < 0     -> error "digitToInt returned some negative value"
+          | otherwise -> error "digitToInt returned some value greater than 15"
+      }
+
+    log2 :: Int -> Int
+    log2 =
+      let log2' !a 0 = a
+          log2' !a n = log2' (a + 1) $ n `div` 2
+      in  log2' 0
+
+-- | The captured data entries, as they are dumped by the ILA of
+-- 'Bittide.Instances.Tests.FullMeshHwCc.callistoClockControlWithIla'.
+data Capture (n :: Nat) (m :: Nat) =
+  Capture
+    { sampleInBuffer  :: Int
+    , sampleInWindow  :: Int
+    , trigger         :: Hex Bool
+    , triggerSignal   :: Hex Bool
+    , capture         :: Hex Bool
+    , captureCond     :: Hex CaptureCondition
+    , globalTimestamp :: Hex GlobalTimestamp
+    , localTimestamp  :: Hex LocalTimestamp
+    , plotData        :: Hex (PlotData n m)
+    }
+
+instance (KnownNat n, KnownNat m) => FromRecord (Capture n m) where
+  parseRecord v =
+    if Vector.length v /= 9
+    then fail $ "Row with more than 9 fields" <> show v
+    else Capture
+      <$> v .! 0 <*> v .! 1 <*> v .! 2 <*> v .! 3 <*> v .! 4
+      <*> v .! 5 <*> v .! 6 <*> v .! 7 <*> v .! 8
+
+-- | A data point resulting from post processing the captured data.
+data DataPoint (n :: Nat) (m :: Nat) =
+  DataPoint
+    { dpIndex       :: Int
+      -- ^ the index of the corresponding sample of the dump
+    , dpLocalStamp  :: LocalTimestamp
+      -- ^ the local time stamp counting the cycles of the dynamic clock
+    , dpGlobalTime  :: Femtoseconds
+      -- ^ the absolute number of femtoseconds since the start of the
+      -- dump according to the global synchronized clock
+    , dpLocalTime   :: Femtoseconds
+      -- ^ the absolute number of femtoseconds since the start of the
+      -- dump according to the local dynamic clock
+    , dpDrift       :: Double
+      -- ^ the drift between the global an the local clocks in
+      -- femtoseconds per cycle of the global clock
+    , dpCCChanges   :: Int
+      -- ^ the accumulated number FINC/FDECs integrated over time
+    , dpDataCounts  :: Vec n (DataCount m)
+      -- ^ the elastic buffer data counts
+    , dpStability   :: Vec n StabilityIndication
+      -- ^ the stability indicators for each of the elastic buffers
+    , dpRfStage      :: ReframingStage
+      -- ^ the reframing stage
+    }
+
+-- | Multiplies some 'Femtoseconds' with any numerical value. Note
+-- that this operation can produce negative values, which is
+-- intentional.
+infix 9 ~*
+(~*) :: Integral a => a -> Femtoseconds -> Femtoseconds
+a ~* (Femtoseconds b) = Femtoseconds $ fromInteger (toInteger a) * b
+
+deriving newtype instance Num Femtoseconds
+deriving newtype instance Real Femtoseconds
+deriving newtype instance Enum Femtoseconds
+deriving newtype instance Integral Femtoseconds
+
+newtype CsvParseError e = CsvParseError e deriving newtype (Show)
+instance Exception (CsvParseError CsvStreamRecordParseError)
+
+-- | Data post processor.
+postProcess ::
+  (KnownNat n, KnownNat k, Monad m) =>
+  ConduitT (Capture n k) (DataPoint n k) m ()
+postProcess = scanlC process initDummy
+  -- finally drop the dummy, the trigger and the calibration entry
+  .| (dropC 3 >> mapC id)
+ where
+  process prevDP Capture{..} =
+    let PlotData{..}    = fromHex plotData
+        captureType     = fromHex captureCond
+        localStamp      = fromHex localTimestamp
+        ccChanges       = dpCCChanges prevDP
+                        + natToNum @AccWindowHeight * sign dSpeedChange
+        globalTime      = globalTsToFs $ fromHex globalTimestamp
+        globalTimeDelta = globalTime - dpGlobalTime prevDP
+        localTime       = case captureType of
+          UntilTrigger -> 0
+          _            ->  (+) (dpLocalTime prevDP)
+                        $ (~*) (localStamp - dpLocalStamp prevDP)
+                        $  (+) (clockPeriodFs (Proxy @GthTx))
+                        $ (~*) (dpCCChanges prevDP)
+                               (cccStepSize clockControlConfig)
+        localTimeDelta  = localTime - dpLocalTime prevDP
+        driftPerCycle   = fromIntegral (globalTimeDelta - localTimeDelta)
+                        / fromIntegral globalTimeDelta
+    in DataPoint
+         { dpIndex      = sampleInBuffer
+         , dpLocalStamp = localStamp
+         , dpGlobalTime = globalTime
+         , dpLocalTime  = localTime
+         , dpDrift      = driftPerCycle
+         , dpCCChanges  = ccChanges
+         , dpDataCounts = (\(x,_,_) -> x) <$> dEBData
+         , dpStability  =
+             let combine (_, st, se) StabilityIndication{..} =
+                   StabilityIndication
+                     { stable  = fromMaybe stable st
+                     , settled = fromMaybe settled se
+                     }
+              in Vec.zipWith combine dEBData $ dpStability prevDP
+         , dpRfStage = case dRfStageChange of
+             Stable   -> dpRfStage prevDP
+             ToDetect -> RSDetect
+             ToWait   -> RSWait
+             ToDone   -> RSDone
+         }
+
+  globalTsToFs :: GlobalTimestamp -> Femtoseconds
+  globalTsToFs (pulses, cycles) =
+    (pulses ~* syncPulsePeriodFs) +
+    (cycles ~* clockPeriodFs (Proxy @Basic125))
+   where
+    syncPulsePeriodFs = Femtoseconds $ natToNum @(1000 * SyncPulsePeriod)
+
+  initDummy = DataPoint
+    { dpIndex      = -1
+    , dpLocalStamp = 0
+    , dpGlobalTime = 0
+    , dpLocalTime  = 0
+    , dpDrift      = 0
+    , dpCCChanges  = 0
+    , dpDataCounts = Vec.repeat 0
+    , dpStability  = Vec.repeat $ StabilityIndication
+        { stable  = False
+        , settled = False
+        }
+    , dpRfStage    = RSDetect
+    }
+
+fromCsvDump ::
+  (KnownNat n, KnownNat m, 1 <= n) =>
+  (Handle, FilePath) ->
+  ConduitT () Void IO [DataPoint (n - 1) m]
+fromCsvDump  (csvHandle, csvFile) =
+     -- turn the input file into a conduit source
+     sourceHandle csvHandle
+     -- plugin the CSV parser
+  .| fromCsvStreamError defaultDecodeOptions NoHeader toIOE
+     -- drop the first two header lines and ensure that the remaining
+     -- data entries are valid
+  .| (dropC 2 >> checkForErrors)
+     -- post process the data
+  .| postProcess
+     -- return as a list
+  .| sinkList
+ where
+  toIOE (HaltingCsvParseError _ msg) = IOError
+    { ioe_handle      = Just csvHandle
+    , ioe_type        = SystemError
+    , ioe_location    = csvFile
+    , ioe_description = Text.unpack msg
+    , ioe_errno       = Nothing
+    , ioe_filename    = Just csvFile
+    }
+
+  checkForErrors = await >>= \case
+    Nothing        -> return ()
+    Just (Left e)  -> throw $ CsvParseError e
+    Just (Right x) -> yield x >> checkForErrors
+
+main :: IO ()
+main = getArgs >>= \case
+  []          -> wrongNumberOfArguments
+  ilaDir : xr -> do
+    let (outDir, yr) = fromMaybe (".", []) $ uncons xr
+    prefix <- case yr of
+      []  -> return $ "Bittide_Instances_Tests_FullMeshHwCc_fullMeshHwCcTest_"
+                   <> "callistoClockControlWithIla"
+      [x] -> return x
+      _   -> wrongNumberOfArguments
+    postProcessData <- do
+      dirs <- listDirectory ilaDir
+        >>= filterM doesDirectoryExist
+          . fmap (ilaDir </>)
+      when (length dirs /= nodeCount) $
+        error $ "There are "
+             <> (if length dirs > nodeCount then "more" else "less")
+             <> " than " <> show nodeCount <> " directories in "
+             <> ilaDir <> ". Aborting"
+      forM dirs $ \d -> listDirectory d
+        >>= fmap fst
+          . maybe
+              (error $ d <> " does not contain a matching .csv file. Aborting.")
+              return
+          . uncons
+          . filter (isIlaDumpFile prefix)
+          . fmap (d </>)
+        >>= \file -> do
+          h <- openFile file ReadMode
+          rs <- runConduit $ fromCsvDump @NodeCount @DataCountSize (h, file)
+          hClose h
+          return (toPlotData <$> rs)
+    createDirectoryIfMissing True outDir
+    plotTopology outDir (complete (SNat :: SNat NodeCount))
+      $ Vec.unsafeFromList postProcessData
+ where
+  nodeCount = natToNum @NodeCount
+
+  isIlaDumpFile prefix =
+         (== ".csv") . takeExtensions
+    .&&. and . zipWith (==) prefix . takeBaseName
+
+  wrongNumberOfArguments = do
+    name <- getProgName
+    error $ "Wrong number of arguments. Aborting.\n\nUsage: " <> name
+         <> " <ila plot directory> [<output directory>] [<csv file prefix>]"
+
+  toPlotData DataPoint{..} =
+    ( dpGlobalTime
+    , dpDrift
+    , dpRfStage
+    , Vec.toList $ Vec.zip dpDataCounts dpStability
+    )


### PR DESCRIPTION
Implementation for #345.

A short overview of how data collection for the plots and how plotting works:

#### Setup
  * Clock control starts synchronized for all nodes `5s` after all the transceivers of the last node are up.
  * If the transceivers of the other nodes are not ready then, they fail the test.
  * The last node uses its stable clock to produce a synchronization trigger every `5ms` (output via `SYNC_OUT`)
  * All nodes synchronize on these triggers via `SYNC_IN`.
  * The time between these triggers is measured using each node's individual stable clock.
  * This offers a `global timestamp` consisting of the number of global triggers received and the clock cycles of the stable clock in between.
  * Additionally, each node produces a `local timestamp` that counts the cycles of the dynamic clock (starting with clock control).
  * During the first second, `FINC`/`FDEC`s are suppressed (i,e., not passed to the clock boards). This serves as a calibration period to measure the initial drift of the dynamic clocks  versus the "global clock". Clock control should not be affected by this.
  * Data is dumped via an ILA, which stores up to `16384` captures (more does not fit currently)

#### Each capture of the ILA dump includes
  * the `capture condition flag` indicating whether it is
    * the initial trigger (synchronized),
    * the calibration end (synchronized),
    * or a data change (not synchronized),
  * the `global timestamp`,
  * the `local timestamp`,
  * the `datacounts` of the elastic buffers including their `stable` and `settled` status,
  * the "`SpeedChange`", and
  * every change of the `reframing mode` (`detect`, `wait`, or `done`).

#### Data changes are triggered by
  * changes of the `stable` or `settled` indicators for any of the elastic buffers
  * `n` accumulated `FINC`/`FDEC`s (currently `n = 3`)
     _("accumulated" here means that if both `FINC` and `FDEC` are requested after each other, then they cancel each other out and are not reported. Only `FINC`/`FDEC`s are reported that haven't canceled out before they exceed the `n` boundary. Thus, for example `FINC`, `FINC`, `FDEC`, `FDEC`, ... is not reported for `n > 2` as the first two `FINC`s don't exceed the boundary `n`.)_
  * changes in the `reframing mode`.

#### Plots are produced as follows
* the elastic buffer plots are generated the same way as for the software based simulation report using the "global timestamp" (converted to femtoseconds) as the time reference (x-axis).
* the clock plots are also generated with the `global timestamp` as a time reference (x-axis) and report clock drift of the local timestamp against the global on calculated via 
$$\frac{\Delta t_G - (\Delta c_L \cdot (p_L + a_{\uparrow / \downarrow} \cdot t_S))}{\Delta t_G}$$
where
    * $\Delta t_G$ is the time difference of the "global static clock" between two captures in femtoseconds,
    * $\Delta c_L$ is the number of cycles that have been counted on the "local dynamic clock" between two captures,
    * $p_L$ is the default period of a local clock cycle in femtoseconds (aka `clockPeriodFs (Proxy @GthTx)`),
    * $a_{\uparrow / \downarrow}$ is the accumulated number of all `FINC`/`FDEC`s obtained via assigning `FINC ↦ 1` and `FDEC ↦ -1` and integrating them up to the current capture, and
    * $t_S$ is the step size per `FINC`/`FDEC` (aka `cccStepSize clockControlConfig`).

   This gets us the drift of the local clock against the global one per clock cycle of the global clock in femtoseconds.