### PR TITLE
Use `cabal.project` in cache key calculation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
           path: |
             ~/.cabal-nix/store
 
-          key: packages-cachebust-3-${{ hashFiles('cabal.project.freeze') }}
+          key: packages-cachebust-4-${{ hashFiles('cabal.project.freeze', 'cabal.project') }}
           restore-keys: packages-
 
       - name: Build
@@ -178,7 +178,7 @@ jobs:
           path: |
             ~/.cabal-nix/store
 
-          key: packages-cachebust-3-${{ hashFiles('cabal.project.freeze') }}
+          key: packages-cachebust-4-${{ hashFiles('cabal.project.freeze', 'cabal.project') }}
           restore-keys: packages-cachebust-3-
           fail-on-cache-miss: true
 
@@ -287,7 +287,7 @@ jobs:
           path: |
             ~/.cabal-nix/store
 
-          key: packages-cachebust-3-${{ hashFiles('cabal.project.freeze') }}
+          key: packages-cachebust-4-${{ hashFiles('cabal.project.freeze', 'cabal.project') }}
           restore-keys: packages-cachebust-3-
           fail-on-cache-miss: true
 
@@ -325,7 +325,7 @@ jobs:
           path: |
             ~/.cabal-nix/store
 
-          key: packages-cachebust-3-${{ hashFiles('cabal.project.freeze') }}
+          key: packages-cachebust-4-${{ hashFiles('cabal.project.freeze', 'cabal.project') }}
           restore-keys: packages-cachebust-3-
           fail-on-cache-miss: true
 
@@ -394,7 +394,7 @@ jobs:
           path: |
             ~/.cabal-nix/store
 
-          key: packages-cachebust-3-${{ hashFiles('cabal.project.freeze') }}
+          key: packages-cachebust-4-${{ hashFiles('cabal.project.freeze', 'cabal.project') }}
           restore-keys: packages-cachebust-3-
           fail-on-cache-miss: true
 
@@ -566,7 +566,7 @@ jobs:
           path: |
             ~/.cabal-nix/store
 
-          key: packages-cachebust-3-${{ hashFiles('cabal.project.freeze') }}
+          key: packages-cachebust-4-${{ hashFiles('cabal.project.freeze', 'cabal.project') }}
           restore-keys: packages-cachebust-3-
           fail-on-cache-miss: true
 
@@ -609,7 +609,7 @@ jobs:
           path: |
             ~/.cabal-nix/store
 
-          key: packages-cachebust-3-${{ hashFiles('cabal.project.freeze') }}
+          key: packages-cachebust-4-${{ hashFiles('cabal.project.freeze', 'cabal.project') }}
           restore-keys: packages-cachebust-3-
           fail-on-cache-miss: true
 
@@ -739,7 +739,7 @@ jobs:
           path: |
             ~/.cabal-nix/store
 
-          key: packages-cachebust-3-${{ hashFiles('cabal.project.freeze') }}
+          key: packages-cachebust-4-${{ hashFiles('cabal.project.freeze', 'cabal.project') }}
           restore-keys: packages-cachebust-3-
           fail-on-cache-miss: true
 


### PR DESCRIPTION
Cabal's freeze file doesn't include version hashes, just version numbers. This means that updates to dependencies specified in `cabal.project`'s `source-repository-package` field don't get taken into account properly. This in turn causes a bunch of rebuilds, as GitHub Actions caches are immutable.