### PR TITLE
Fix `FullMeshHwCc` resets

### DIFF
--- a/bittide-instances/src/Bittide/Instances/Tests/FullMeshHwCc.hs
+++ b/bittide-instances/src/Bittide/Instances/Tests/FullMeshHwCc.hs
@@ -327,57 +327,67 @@ fullMeshHwCcTest refClkDiff sysClkDiff syncIn rxns rxps miso =
   (sysClk, sysLock0) = clockWizardDifferential (SSymbol @"SysClk") sysClkDiff noReset
   sysLock1 = xpmCdcSingle sysClk sysClk sysLock0 -- improvised reset syncer
   sysRst = unsafeFromActiveLow sysLock1
+    `orReset` unsafeFromActiveLow startTest
+  --
+  -- 'syncOutGenerator' is used to drive the 'SYNC_OUT' signal, which
+  -- is only connected for the last node in the network and wired back
+  -- to 'SYNC_IN' of all nodes from there.
+  --
+  -- Note that all nodes are in reset before their local 'startTest' VIO
+  -- signal gets asserted, as 'startTest' is directly driving 'sysRst'.
+  -- Thus, for the other nodes to capture the 'SYNC_OUT' signal correctly,
+  -- the node receiving the `startTest` rising edge last must be the one
+  -- with it's 'SYNC_OUT' physically connected to the 'SYNC_IN' of all
+  -- nodes in the network. This assumption is tested by
+  -- 'Bittide.Instances.Tests.SyncInSyncOut'.
+  syncOut =
+      dflipflop sysClk
+    $ syncOutGenerator sysClk startTest
+    $ trueFor5s sysClk testRst allUp
 
-  syncIn1 = (startTest .&&.)
-    $ unsafeToActiveLow
+  -- first synchronize SYNC_IN to the local clock and filter from
+  -- potential glitches
+  syncIn1 =
+      unsafeToActiveLow
     $ resetGlitchFilter (SNat @1024) sysClk
     $ unsafeFromActiveLow
     $ xpmCdcSingle sysClk sysClk syncIn
 
+  -- generate a pulse on every change of SYNC_IN
   syncInChangepoints =
-    changepoints sysClk syncStartRst enableGen syncIn1
+    changepoints sysClk sysRst enableGen syncIn1
 
-  syncInRst =
-      unsafeFromActiveLow
-    $ sticky sysClk sysRst
-    $ isRising sysClk sysRst enableGen False
-      syncIn1
+  -- recover the activity and readiness states from SYNC_IN
+  (syncActive, syncStart) = unbundle $ syncInRecover sysClk sysRst syncIn1
 
-  testRst = sysRst `orReset` syncInRst
+  -- tests are reset with on `sysRst` or if not synchronously active
+  testRst = sysRst `orReset` unsafeFromActiveLow syncActive
 
-  syncStart =
-      sticky sysClk sysRst
-    $ isFalling sysClk sysRst enableGen False
-      syncIn1
-
-  syncStartRst = unsafeFromActiveLow syncStart
-
-  startBeforeAllUp = sticky sysClk sysRst
+  -- checks that tests are not synchronously start before all
+  -- transceivers are up
+  startBeforeAllUp = sticky sysClk testRst
     (syncStart .&&. ((not <$> allUp) .||. transceiversFailedAfterUp))
 
-  syncOut =
-    syncOutGenerator sysClk sysRst enableGen
-      (startTest, trueFor5s sysClk sysRst allUp)
-
+  -- generate the global timestamp from the synchronous rising and
+  -- falling edges of SYNC_IN
   globalTimestamp :: Signal Basic125 GlobalTimestamp
-  globalTimestamp = register sysClk syncStartRst enableGen (0,0) $
+  globalTimestamp = register sysClk testRst enableGen (0,0) $
     mux syncInChangepoints
       (((+1) *** const 0) <$> globalTimestamp)
       (second (+1) <$> globalTimestamp)
 
   -- calibrate over the first 200 sync pulses
   calibrate =
-    moore sysClk syncStartRst enableGen
+    moore sysClk testRst enableGen
       (\s -> bool s $ satSucc SatBound s)
       (/= maxBound)
       (minBound :: Index 200)
       syncInChangepoints
 
   calibrationDone =
-    isFalling sysClk sysRst enableGen False calibrate
+    isFalling sysClk testRst enableGen False calibrate
 
-  -- TODO: not implemented yet
-  syncEnd = pure False
+  syncEnd = isFalling sysClk testRst enableGen False syncActive
 
   (txns, txps, fincFdecs, stats, spiDone, spiOut
     , transceiversFailedAfterUp, allUp, allStable) =


### PR DESCRIPTION
This PR introduces a reset line for the `FullMeshHwCC` tests, which is synchronized among all nodes via `SYNC_OUT` and `SYNC_IN`. 

The components of `FullMeshHwCc` are now reset in two stages. The first stage is driven by `startTest` (such that it is reset on `startTest` being low) and is used to produce the `SYNC_OUT` signal and read it back via `SYNC_IN`. The communicated data then is used to establish the **synchronized** reset, which is asserted whenever `SYNC_IN` is low for more than `5ms`. If not, then `SYNC_IN` also synchronizes the global time stamp via flipping every `5ms`. The reset line that gets recovered from `SYNC_IN` then drives test components themselves via offering the reset line for the second stage.

By that, the implementation also offers a synchronized end trigger, which can be used to finalize the tests simultaneously.