### PR TITLE
Add `+RTS -xp -RTS` to `clash-vexriscv-sim`.

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -46,6 +46,9 @@ package bittide-shake
 package clash-vexriscv
   ghc-options: +RTS -xp -RTS
 
+package clash-vexriscv-sim
+  ghc-options: +RTS -xp -RTS
+
 package elastic-buffer-sim
   ghc-options: +RTS -xp -RTS
 


### PR DESCRIPTION
This package is part of `clash-vexriscv-sim` and we have to build it to be able to simulate VexRisc.