### PR TITLE
Fix Simulation Plots

### DIFF
--- a/host-tools/callisto-lib/src/lib.rs
+++ b/host-tools/callisto-lib/src/lib.rs
@@ -325,7 +325,7 @@ pub unsafe extern "C" fn __c_callisto_rust(
                 mask |= 1 << i;
             }
         }
-        mask
+        mask & availability_mask
     };
 
     callisto::callisto(


### PR DESCRIPTION
The elastic buffer data counts of disabled links default to `0`, which is why they automatically turn to be stable and settled after some time. _(Note that there always are elastic buffers and stability checkers for all links of the complete topology in order to support enabling and disabling links at runtime at some point)._

This is why the [old check](https://github.com/bittide/bittide-hardware/blob/a0e4f271efb30500bda95c19fe6d2ee1b40885eb/firmware-support/bittide-sys/src/callisto.rs#L154)
```haskell
stability_checks.iter().all(|x| x.stable())
```
was working (unintentionally) without considering the availability mask. The [new check](https://github.com/bittide/bittide-hardware/blob/3b2ad4858bf9073b11aa05f953f197e198bc56f3/firmware-support/bittide-sys/src/callisto.rs#L137)
```haskell
links_stable.count_ones() == n_buffers
```
however breaks if the stability mask also contains stability indicators for disabled links.

This PR fixes the error by removing the disabled links from the stability mask, i.e., their indicator values are ignored.

----

* Successfully reverts simulation to the old behavior (cf. [#3128](https://github.com/bittide/bittide-hardware/actions/runs/6559343030)).
* Fixes #418.
* Depends on #419 to be fixed first.