### PR TITLE
Add selective synth and test CI runs for debugging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,6 @@ jobs:
       - name: Update Cabal index info
         run: |
           cabal update
-          cabal freeze
 
       - name: Cache
         uses: actions/cache@v3
@@ -104,7 +103,6 @@ jobs:
             ~/.cabal-nix/store
 
           key: packages-cachebust-4-${{ hashFiles('cabal.project.freeze', 'cabal.project') }}
-          restore-keys: packages-
 
       - name: Build
         run: |
@@ -170,7 +168,6 @@ jobs:
       - name: Update Cabal index info
         run: |
           cabal update
-          cabal freeze
 
       - name: Cache
         uses: actions/cache@v3
@@ -179,7 +176,6 @@ jobs:
             ~/.cabal-nix/store
 
           key: packages-cachebust-4-${{ hashFiles('cabal.project.freeze', 'cabal.project') }}
-          restore-keys: packages-cachebust-3-
           fail-on-cache-miss: true
 
       - name: Plot mesh grid
@@ -244,7 +240,6 @@ jobs:
       - name: Update Cabal index info
         run: |
           cabal update
-          cabal freeze
 
       - name: Cache
         uses: actions/cache@v3
@@ -253,7 +248,6 @@ jobs:
             ~/.cabal-nix/store
 
           key: packages-cachebust-4-${{ hashFiles('cabal.project.freeze', 'cabal.project') }}
-          restore-keys: packages-cachebust-3-
           fail-on-cache-miss: true
 
       - name: Download simulation artifacts
@@ -318,7 +312,6 @@ jobs:
       - name: Update Cabal index info
         run: |
           cabal update
-          cabal freeze
 
       - name: Cache
         uses: actions/cache@v3
@@ -327,7 +320,6 @@ jobs:
             ~/.cabal-nix/store
 
           key: packages-cachebust-4-${{ hashFiles('cabal.project.freeze', 'cabal.project') }}
-          restore-keys: packages-cachebust-3-
           fail-on-cache-miss: true
 
       - name: Run unittests
@@ -356,7 +348,6 @@ jobs:
       - name: Update Cabal index info
         run: |
           cabal update
-          cabal freeze
 
       - name: Cache
         uses: actions/cache@v3
@@ -365,7 +356,6 @@ jobs:
             ~/.cabal-nix/store
 
           key: packages-cachebust-4-${{ hashFiles('cabal.project.freeze', 'cabal.project') }}
-          restore-keys: packages-cachebust-3-
           fail-on-cache-miss: true
 
       - name: Unittests
@@ -425,7 +415,6 @@ jobs:
       - name: Update Cabal index info
         run: |
           cabal update
-          cabal freeze
 
       - name: Cabal Cache
         uses: actions/cache@v3
@@ -434,7 +423,6 @@ jobs:
             ~/.cabal-nix/store
 
           key: packages-cachebust-4-${{ hashFiles('cabal.project.freeze', 'cabal.project') }}
-          restore-keys: packages-cachebust-3-
           fail-on-cache-miss: true
 
       - uses: actions/cache@v3
@@ -598,7 +586,6 @@ jobs:
       - name: Update Cabal index info
         run: |
           cabal update
-          cabal freeze
 
       - name: Cache
         uses: actions/cache@v3
@@ -607,7 +594,6 @@ jobs:
             ~/.cabal-nix/store
 
           key: packages-cachebust-4-${{ hashFiles('cabal.project.freeze', 'cabal.project') }}
-          restore-keys: packages-cachebust-3-
           fail-on-cache-miss: true
 
       - name: Doctests
@@ -641,7 +627,6 @@ jobs:
       - name: Update Cabal index info
         run: |
           cabal update
-          cabal freeze
 
       - name: Cache
         uses: actions/cache@v3
@@ -650,7 +635,6 @@ jobs:
             ~/.cabal-nix/store
 
           key: packages-cachebust-4-${{ hashFiles('cabal.project.freeze', 'cabal.project') }}
-          restore-keys: packages-cachebust-3-
           fail-on-cache-miss: true
 
       - name: Unit tests
@@ -775,7 +759,6 @@ jobs:
       - name: Update Cabal index info
         run: |
           cabal update
-          cabal freeze
 
       - name: Cache Cabal store
         uses: actions/cache@v3
@@ -784,7 +767,6 @@ jobs:
             ~/.cabal-nix/store
 
           key: packages-cachebust-4-${{ hashFiles('cabal.project.freeze', 'cabal.project') }}
-          restore-keys: packages-cachebust-3-
           fail-on-cache-miss: true
 
       - name: HDL generation and synthesis

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -675,6 +675,8 @@ jobs:
         run: |
           if [[ "${{ github.event_name }}" == "schedule" || $(.github/scripts/force_expensive_checks.sh) == "true" ]]; then
             cp .github/synthesis/all.json checks.json
+          elif [[ -f .github/synthesis/debug.json ]]; then
+            cp .github/synthesis/debug.json checks.json
           else
             cp .github/synthesis/staging.json checks.json
           fi
@@ -705,6 +707,8 @@ jobs:
         run: |
           if [[ "${{ github.event_name }}" == "schedule" || $(.github/scripts/force_expensive_checks.sh) == "true" ]]; then
             cp .github/synthesis/all.json checks.json
+          elif [[ -f .github/synthesis/debug.json ]]; then
+            cp .github/synthesis/debug.json checks.json
           else
             cp .github/synthesis/staging.json checks.json
           fi
@@ -922,6 +926,12 @@ jobs:
           # Test whether success/fail variables contain sane values
           if [[ "${success}" != "true" && "${success}" != "false" ]]; then exit 1; fi
           if [[ "${fail}"    != "true" && "${fail}"    != "false" ]]; then exit 1; fi
+
+          # If this is a debug run, fail even when all dependencies succeeded.
+          if [[ -f .github/synthesis/debug.json ]]; then
+            echo "This is a debug run, which may never succeed. Remove '.github/synthesis/debug.json' before trying to merge."
+            exit 1
+          fi
 
           # We want to fail if one or more dependencies fail. For safety, we introduce
           # a second check: if no dependencies succeeded something weird is going on.


### PR DESCRIPTION
While debugging, we often only want one bittide instance to be tested with our hardware-in-the-loop infrastructure. With the increasing number of bittide instances with are synthesized and tested, these CI runs take a long time. With this commit you can add a file `.github/synthesis/debug.json`, with only the instances you want CI to synthesize/test. The CI run will always fail on the 'all' job when this file exists to prevent a premature merge.

---
This PR currently fails due to the job `generate-ful-clock-control-simulation-report`, which expects both `fullMeshHwCcTest` and `fullMeshSwCcTest` to have run. Since this job does not matter for most debugging purposes where we would use the `debug.json` this _can_ be overlooked for this PR.
See this [CI run](https://github.com/bittide/bittide-hardware/actions/runs/6612030661).
