### PR TITLE
Bounded clock control

### DIFF
--- a/bittide/bittide.cabal
+++ b/bittide/bittide.cabal
@@ -115,6 +115,7 @@ library
     Bittide.ClockControl.Callisto.Util
     Bittide.ClockControl.Foreign.Rust.Callisto
     Bittide.ClockControl.Foreign.Sizes
+    Bittide.ClockControl.QuotaControl
     Bittide.ClockControl.Registers
     Bittide.ClockControl.Si5391A
     Bittide.ClockControl.Si5395J
@@ -190,6 +191,7 @@ test-suite unittests
     Tests.Axi4
     Tests.Calendar
     Tests.ClockControl.Si539xSpi
+    Tests.ClockControl.QuotaControl
     Tests.Counter
     Tests.DoubleBufferedRam
     Tests.ElasticBuffer

--- a/bittide/src/Bittide/ClockControl/QuotaControl.hs
+++ b/bittide/src/Bittide/ClockControl/QuotaControl.hs
@@ -1,0 +1,124 @@
+-- SPDX-FileCopyrightText: 2023 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+
+{-# LANGUAGE RecordWildCards #-}
+
+module Bittide.ClockControl.QuotaControl
+  ( CostDelayBits
+  , QuotaControlState(..)
+  , quotaControl
+  , quotaControlTF
+  ) where
+
+import Clash.Prelude
+import Bittide.ClockControl
+
+-- | The number of bits required for measuring the cost delay.
+type CostDelayBits = 64 :: Nat
+
+-- | The internal state of the controller's state machine.
+data QuotaControlState =
+  QuotaControlState
+    { speedChangeRequest :: SpeedChange
+    , remainingCost :: Unsigned CostDelayBits
+    , incDecCounter :: Signed 17
+    }
+  deriving (Generic, NFDataX)
+
+-- | Adds a cost function to clock control, which imposes bounds on
+-- the maximal number of monotone clock modifications. The cost is
+-- applied in terms of a temporal delay, which causes @FINC@ and
+-- @FDEC@ requests of the clock controller to take longer to be passed
+-- to the clock boards the closer the clock gets adpated towards the
+-- physical limits.
+quotaControl ::
+  HiddenClockResetEnable dom =>
+  Signal dom SpeedChange ->
+  Signal dom (Maybe SpeedChange)
+quotaControl =
+  mealy quotaControlTF QuotaControlState
+    { speedChangeRequest = NoChange
+    , remainingCost = 0
+    , incDecCounter = 0
+    }
+
+-- | The transition function of the controller's state machine.
+quotaControlTF ::
+  QuotaControlState ->
+  SpeedChange ->
+  (QuotaControlState, Maybe SpeedChange)
+quotaControlTF (forceX -> qcs@QuotaControlState{..}) !newSpeedChangeRequest =
+  -- the following pattern match look a bit unusual, but is the most
+  -- effective way to ensure meeting timing constraints
+  case (sameSpeedChangeRequest, remainingCost == 0, hasZeroCost) of
+    -- new speed change request and non-zero cost
+    (False, _, False) ->
+      ( qcs { speedChangeRequest = newSpeedChangeRequest
+            , remainingCost = satPred SatBound nonZeroCost
+            }
+      , Nothing
+      )
+    -- still the same request and non-zero cost
+    (True, False, _) ->
+      ( qcs { remainingCost = satPred SatBound remainingCost
+            }
+      , Nothing
+      )
+    -- zero cost or running cost reached zero
+    _ ->
+      ( QuotaControlState
+          { speedChangeRequest = NoChange
+          , remainingCost = 0
+          , incDecCounter = case newSpeedChangeRequest of
+              SpeedUp  -> satSucc SatBound incDecCounter
+              SlowDown -> satPred SatBound incDecCounter
+              _        -> incDecCounter
+          }
+      , Just newSpeedChangeRequest
+      )
+
+ where
+  sameSpeedChangeRequest =
+    newSpeedChangeRequest == speedChangeRequest
+
+  -- clock shifts back to the center and below the first 2^14 changes
+  -- are for free
+  hasZeroCost =
+    opposite newSpeedChangeRequest incDecCounter
+      || abs incDecCounter < natToNum @(2^12)
+   where
+    opposite = \case
+      SpeedUp  -> (<= 0)
+      SlowDown -> (>= 0)
+      _        -> const True
+
+  nonZeroCost
+    -- very slowly increase cost for the first 2^14 changes
+    | abs incDecCounter < natToNum @(2^14) = 1
+    -- linearly increase cost for the next 2^14 changes
+    | abs incDecCounter < natToNum @(2^15) =
+          satSucc SatBound
+        $ bitCoerce @(Index (2^CostDelayBits))
+        $ extend $ countLeadingOnes $ pack
+        $ checkedTruncateB @15 @_ @Unsigned
+        $ bitCoerce $ abs incDecCounter
+    -- exponentially increase on any further change
+    | otherwise =
+          shift 1
+        $ fromEnum
+        $ checkedTruncateB @CostDelayBits
+        $ bitCoerce @_ @(Index (2^17))
+        $ min (natToNum @(CostDelayBits - 1))
+        $ abs incDecCounter - natToNum @(2^15 - 5)
+
+  -- counts the number of consecutive 1s in a bit vector starting at
+  -- the MSB
+  countLeadingOnes :: KnownNat n => BitVector (n + 1) -> Index (n + 2)
+  countLeadingOnes = fst . fold rAdd . map toIB . bv2v
+   where
+    rAdd (n, True) _      = (n,     True)
+    rAdd (n,    _) (m, y) = (n + m, y   )
+
+    toIB 0 = (0, True)
+    toIB _ = (1, False)

--- a/bittide/tests/Tests/ClockControl/QuotaControl.hs
+++ b/bittide/tests/Tests/ClockControl/QuotaControl.hs
@@ -1,0 +1,96 @@
+-- SPDX-FileCopyrightText: 2022-2023 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+
+{-# LANGUAGE ImplicitParams #-}
+
+module Tests.ClockControl.QuotaControl where
+
+import Prelude
+
+import Bittide.ClockControl (SpeedChange(..))
+import Bittide.ClockControl.QuotaControl (QuotaControlState(..), quotaControlTF)
+
+import Control.Monad (forM_)
+import Control.Arrow (second)
+import Data.Maybe (catMaybes)
+
+import Test.Tasty
+import Test.Tasty.HUnit
+
+quotaControlGroup :: TestTree
+quotaControlGroup = testGroup "Clock Quota Controller"
+ [ testCase "Cost Function (SpeedUp)"
+     $ let ?speedChange = SpeedUp  in costFunctionTest
+ , testCase "Cost Function (SlowDown)"
+     $ let ?speedChange = SlowDown in costFunctionTest
+ , testCase "Reverse is for free (SpeedUp)"
+     $ let ?speedChange = SpeedUp  in towardsCenterIsFreeTest
+ , testCase "Reverse is for free (SpeedDown)"
+     $ let ?speedChange = SlowDown in towardsCenterIsFreeTest
+ ]
+
+costFunctionTest :: (?speedChange :: SpeedChange) => Assertion
+costFunctionTest =
+  forM_ (zip3 golden outcome [0,1..n-1]) $ \(g,o,i) -> do
+    assertEqual ("Mismatch at position " <> show i) g o
+ where
+  n = length golden
+
+  outcome :: [Maybe SpeedChange]
+  outcome = reverse $ snd $ foldl
+    (\(s, ys) x -> second (:ys) $ quotaControlTF s x)
+    (QuotaControlState NoChange 0 0, [])
+    (replicate n ?speedChange)
+
+towardsCenterIsFreeTest :: (?speedChange :: SpeedChange) => Assertion
+towardsCenterIsFreeTest =
+  assertEqual "Re-centering has costs" 0
+    $ incDecCounter
+    $ foldl
+        (\s -> fst . quotaControlTF s)
+        (QuotaControlState NoChange 0 0)
+        (replicate n ?speedChange <> replicate ops oppositeDir)
+
+ where
+  n = length golden
+  ops = length $ catMaybes golden
+
+  oppositeDir = case ?speedChange of
+    SpeedUp  -> SlowDown
+    NoChange -> NoChange
+    SlowDown -> SpeedUp
+
+golden :: (?speedChange :: SpeedChange) => [Maybe SpeedChange]
+golden = concatMap
+  (\(n, d) ->
+      concat $ replicate n $ reverse $ Just ?speedChange : replicate d Nothing
+  )
+  --  #INC/DECs      cost
+  [ ( p2 12,         0     )
+  , ( p2 14 - p2 12, 1     )
+  , ( p2 13,         2     )
+  , ( p2 12,         3     )
+  , ( p2 11,         4     )
+  , ( p2 10,         5     )
+  , ( p2 9,          6     )
+  , ( p2 8,          7     )
+  , ( p2 7,          8     )
+  , ( p2 6,          9     )
+  , ( p2 5,          10    )
+  , ( p2 4,          11    )
+  , ( p2 3,          12    )
+  , ( p2 2,          13    )
+  , ( p2 1,          14    )
+  , ( p2 0,          15    )
+  , ( 1,             p2 4  )
+  , ( 1,             p2 5  )
+  , ( 1,             p2 6  )
+  , ( 1,             p2 7  )
+  , ( 1,             p2 8  )
+  , ( 1,             p2 9  )
+  , ( 1,             p2 10 )
+  ]
+ where
+  p2 :: Int -> Int
+  p2 = (2^)

--- a/bittide/tests/UnitTests.hs
+++ b/bittide/tests/UnitTests.hs
@@ -12,6 +12,7 @@ import Test.Tasty.Hedgehog
 import Tests.Axi4
 import Tests.Calendar
 import Tests.ClockControl.Si539xSpi
+import Tests.ClockControl.QuotaControl
 import Tests.DoubleBufferedRam
 import Tests.ElasticBuffer
 import Tests.Haxioms
@@ -27,6 +28,7 @@ tests = testGroup "Unittests"
   [ axi4Group
   , calGroup
   , clockGenGroup
+  , quotaControlGroup
   , ebGroup
   , haxiomsGroup
   , linkGroup

--- a/elastic-buffer-sim/tests/Tests/Bittide/Simulate.hs
+++ b/elastic-buffer-sim/tests/Tests/Bittide/Simulate.hs
@@ -52,8 +52,8 @@ case_clockControlMinBound = do
     mask = pure $ pack (repeat high)
     changes =
       fmap (fromMaybe NoChange . maybeSpeedChange) $ sampleN
-        -- +100 assumes callisto's pipeline less than 100 deep
-        (fromIntegral (cccPessimisticSettleCycles config + 100))
+        -- +10_000 assumes callisto's pipeline less than 10_000 deep
+        (fromIntegral (cccPessimisticSettleCycles config + 10_000))
         (callistoClockControl @_ @_ @Fast clockGen resetGen enableGen config mask dataCounts)
 
   assertBool


### PR DESCRIPTION
This PR adds a cost function to clock control, which imposes bounds on the maximal number of monotone clock modifications. The cost is applied in terms of a temporal delay, which causes `FINC` and `FDEC` requests of the clock controller to take longer to be passed to the clock boards the closer the clock gets adpated towards the physical limits.

In terms of clock control a temporal delay is always applicable, as clock modifcations are only measured indirectly via buffer occupancies used exclusively for feedback control. Hence, as long as the measured feedback of the controller stays the same it will continue to request the same clock modification.

Consequently, imposing a temporal cost can only delays clock operations, but cannot mix things up. We need to consider, however, that the more inert the clock operations are, the more time the elastic buffers will fill or drain. This is why we impose costs in one direction only, e.g., if clock speed mostly increases such that the upper limit gets reached, then further increments come at a higher price, but decrements are still free. The same applies in the other direction, where we assume that clock speeds are between the limits at the center initially. This way, we add an implicit feedback for clock control, which endorses the controller to stay within the limits.

An exponentially increasing cost-function is best suited for this. However, it's implementation requires a counter for implementing the delay, which increases linearly in bit-width according to number of exponential steps. We observed that clock control peaks at about `8k` of `FINC`/`FDEC`s in most of our simulated examples, which is why we cannot apply an exponential cost immediately. Instead, we use a softer scheme to give clock control more freedom as long as it stays within the limits.

In particular, we use a mixed scheme that increases cost logarithmically for the first $2^{14}$ monotone modifications. Hence, clock control is almost not affected by the cost within this region. Beyond, we use a linear increasing scheme for the next $2^{14}$ monotone modifications and then finally switch to an exponential scheme in the end.  The cost function is summarized in the table below, where $w_0 = 0$ and the second column denotes the integral weight of the applied increments and decrements according to their sign function $\sigma$, i.e., for

* $\sigma(x) = -1 $, if clock speed gets decreased,
* $\sigma(x) = 0 $, if clock speed keeps unchanged, and
* $\sigma(x) = 1 $, if clock speed gets increased.

<table>
  <tr>
    <th>$i$</th>
    <th>Weight: $w_{i}=|\sum\limits_{t=t_{init}}^{t_{now}} \sigma(t)|$</th>
    <th>Cost: $c(x)$ for $w_{i-1} \leq x < w_{i}$</th>
    <th>Mode</th>
  </tr>
  <tr><td colspan=4></td></tr>
  <tr>
    <td>$1$</td>
    <td>$2^{12}$</td>
    <td>$0$</td>
    <td rowspan=2>negligible</td>
  </tr>
  <tr>
    <td>$2$</td>
    <td>$2^{14}$</td>
    <td>$1$</td>
  </tr>
  <tr><td colspan=4></td></tr>
  <tr>
    <td>$3$</td>
    <td>$\sum\limits_{n=13}^{14}2^n$</td>
    <td>$2$</td>
    <td rowspan=4>logarithmic</td>
  </tr>
  <tr>
    <td>$4$</td>
    <td>$\sum\limits_{n=12}^{14}2^n$</td>
    <td>$3$</td>
  </tr>
  <tr>
    <td>...</td>
    <td>...</td>
    <td>...</td>
  </tr>
  <tr>
    <td>$16$</td>
    <td>$\sum\limits_{n=0}^{14}2^n$</td>
    <td>$15$</td>
  </tr>
  <tr><td colspan=4></td></tr>
  <tr>
    <td>$17$</td>
    <td>$2^{15}$</td>
    <td>$16$</td>
    <td rowspan=4>linear</td>
  </tr>
  <tr>
    <td>$18$</td>
    <td>$2^{15}+1$</td>
    <td>$17$</td>
  </tr>
  <tr>
    <td>$19$</td>
    <td>$2^{15}+2$</td>
    <td>$18$</td>
  </tr>
  <tr>
    <td>...</td>
    <td>...</td>
    <td>...</td>
  </tr>
</table>

We use 64-bit counter for measuring the delay in terms of clock ticks, so it never should run into it's limits in practice.

Tracking and application of the temporal cost is implemented in hardware, as it easly allows the precise execution of the temporal delay. This approach is also more modular, because it just gets plugged after the clock controller. Moreover, if the process of controlling the clock speed changes in the future, then this module can be easily adapted without additional modifications of clock control.

------

### TODOs:

 - [x] Simulation encounters a memory leak due to the cost based delay. Hopefully an easy one, which only requires some strictness annotations.
 - [x] Timing constraints are violated on some of the builds. The cost function itself imposes certain gate-level depth, but this does not seem to be the limiting factor (as some first tests indicated). Wrongly latching the output of clock control may be the issue as well.
 - [ ] ~~Add SW implementation and disable the HW one.~~
 - [ ] Code cleanup and more code documentation.