### PR TITLE
Increase refraiming wait time

### DIFF
--- a/bittide/src/Bittide/ClockControl.hs
+++ b/bittide/src/Bittide/ClockControl.hs
@@ -241,7 +241,7 @@ defClockConfig = ClockControlConfig
   , cccStabilityCheckerMargin    = SNat
   , cccStabilityCheckerFramesize = SNat
   , cccEnableReframing           = True
-  , cccReframingWaitTime         = 100000
+  , cccReframingWaitTime         = 160000
   , cccEnableRustySimulation     = False
   }
  where


### PR DESCRIPTION
Nightlies sometimes fail due to the reframing wait time being to short. This PR fixes this by increasing the wait time.