### PR TITLE
Fix Ext200A/B reset kind

### DIFF
--- a/bittide-instances/src/Bittide/Instances/Domains.hs
+++ b/bittide-instances/src/Bittide/Instances/Domains.hs
@@ -19,8 +19,8 @@ createDomain vXilinxSystem{vName="Basic25", vPeriod= hzToPeriod 25e6}
 createDomain vXilinxSystem{vName="Basic199", vPeriod=hzToPeriod 199e6}
 createDomain vXilinxSystem{vName="Basic200", vPeriod=hzToPeriod 200e6}
 createDomain vXilinxSystem{vName="Ext200", vPeriod=hzToPeriod 200e6, vResetKind=Asynchronous}
-createDomain vXilinxSystem{vName="Ext200A", vPeriod=hzToPeriod 200e6, vResetKind=Asynchronous}
-createDomain vXilinxSystem{vName="Ext200B", vPeriod=hzToPeriod 200e6, vResetKind=Asynchronous}
+createDomain vXilinxSystem{vName="Ext200A", vPeriod=hzToPeriod 200e6}
+createDomain vXilinxSystem{vName="Ext200B", vPeriod=hzToPeriod 200e6}
 createDomain vXilinxSystem{vName="Basic300", vPeriod=hzToPeriod 300e6}
 createDomain vXilinxSystem{vName="Ext300", vPeriod=hzToPeriod 300e6, vResetKind=Asynchronous}
 createDomain vXilinxSystem{vName="Basic50", vPeriod= hzToPeriod 50e6}


### PR DESCRIPTION
`ClockControlDemo1` currently fails to build on CI. The reason is a miss-match of the reset kind. The cause was introduced with #444 and it is still under consideration how to correctly define the reset behavior of differential inputs (cf. https://github.com/bittide/bittide-hardware/pull/444#issuecomment-1874029429). 

This PR reverts the changes of #444 for the `EXT200A` and `Ext200B` domains (as used by `ClockControlDemo1`) to avoid the build failure.  