### PR TITLE
Move clock control to the stable clock

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,7 +263,7 @@ jobs:
           mkdir -p reports
           mkdir -p hitl-plots/hw
           ./cargo.sh build --frozen --release
-          cabal run -- elastic-buffer-sim:plot artifacts/_build-fullMeshHwCcTest-debug/Bittide.Instances.Hitl.FullMeshHwCc.fullMeshHwCcTest/ila-data/probe_test_start/ hitl-plots/hw Bittide_Instances_Hitl_FullMeshHwCc_fullMeshHwCcTest_callistoClockControlWithIla
+          cabal run -- elastic-buffer-sim:plot artifacts/_build-fullMeshHwCcTest-debug/Bittide.Instances.Hitl.FullMeshHwCc.fullMeshHwCcTest/ila-data/probe_test_start/ hitl-plots/hw
           cp .github/hitl/FullMeshHwCcReportTemplate.tex hitl-plots/hw/report.tex
           cp .github/hitl/topology.tikz hitl-plots/hw/topology.tikz
           export RUNREF="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
@@ -275,7 +275,7 @@ jobs:
           cd ../..
           mv hitl-plots/hw/report.pdf reports/HITL-FullMeshHwCc-Report.pdf
           mkdir -p hitl-plots/sw
-          cabal run -- elastic-buffer-sim:plot artifacts/_build-fullMeshSwCcTest-debug/Bittide.Instances.Hitl.FullMeshSwCc.fullMeshSwCcTest/ila-data/probe_test_start/ hitl-plots/sw Bittide_Instances_Hitl_FullMeshSwCc_fullMeshSwCcTest_callistoClockControlWithIla
+          cabal run -- elastic-buffer-sim:plot artifacts/_build-fullMeshSwCcTest-debug/Bittide.Instances.Hitl.FullMeshSwCc.fullMeshSwCcTest/ila-data/probe_test_start/ hitl-plots/sw
           cp .github/hitl/FullMeshSwCcReportTemplate.tex hitl-plots/sw/report.tex
           cp .github/hitl/topology.tikz hitl-plots/sw/topology.tikz
           mv hitl-plots/hw/datetime hitl-plots/sw/datetime

--- a/bittide-instances/src/Bittide/Instances/Hitl/FullMeshSwCc.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/FullMeshSwCc.hs
@@ -60,9 +60,7 @@ import Clash.Class.Counter
 import Clash.Cores.Xilinx.GTH
 import Clash.Cores.Xilinx.VIO (vioProbe)
 import Clash.Cores.Xilinx.Xpm.Cdc.Single
-import Clash.Cores.Xilinx.Xpm.Cdc.Gray
 import Clash.Cores.Xilinx.Ila (IlaConfig(..), Depth(..), ila, ilaConfig)
-import Clash.Explicit.Reset.Extra
 import Clash.Sized.Extra (unsignedToSigned)
 import Clash.Xilinx.ClockGen
 
@@ -72,9 +70,9 @@ import Protocols.Internal
 type NodeCount = 8 :: Nat
 
 clockControlConfig ::
-  $(case (instancesClockConfig (Proxy @GthTx)) of { (_ :: t) -> liftTypeQ @t })
+  $(case (instancesClockConfig (Proxy @Basic125)) of { (_ :: t) -> liftTypeQ @t })
 clockControlConfig =
-  $(lift (instancesClockConfig (Proxy @GthTx)))
+  $(lift (instancesClockConfig (Proxy @Basic125)))
 
 c_CHANNEL_NAMES :: Vec 7 String
 c_CHANNEL_NAMES =
@@ -163,11 +161,10 @@ fullMeshHwTest ::
   "MISO" ::: Signal Basic125 Bit ->
   ( "GTH_TX_NS" ::: TransceiverWires GthTx
   , "GTH_TX_PS" ::: TransceiverWires GthTx
-  , "FINC_FDEC" ::: Signal GthTx (FINC, FDEC)
-  , "CALLISTO_CLOCK" ::: Clock GthTx
-  , "CALLISTO_RESULT" ::: Signal GthTx (CallistoResult 7)
-  , "CALLISTO_RESET" ::: Reset GthTx
-  , "DATA_COUNTERS" ::: Vec 7 (Signal GthTx (DataCount 32))
+  , "FINC_FDEC" ::: Signal Basic125 (FINC, FDEC)
+  , "CALLISTO_RESULT" ::: Signal Basic125 (CallistoResult 7)
+  , "CALLISTO_RESET" ::: Reset Basic125
+  , "DATA_COUNTERS" ::: Vec 7 (Signal Basic125 (DataCount 32))
   , "stats" ::: Vec 7 (Signal Basic125 GthResetStats)
   , "spiDone" ::: Signal Basic125 Bool
   , "" :::
@@ -184,7 +181,6 @@ fullMeshHwTest refClk sysClk IlaControl{syncRst = rst, ..} rxns rxps miso =
   ( txns
   , txps
   , frequencyAdjustments
-  , txClock
   , callistoResult
   , clockControlReset
   , domainDiffs
@@ -193,7 +189,7 @@ fullMeshHwTest refClk sysClk IlaControl{syncRst = rst, ..} rxns rxps miso =
   , spiOut
   , transceiversFailedAfterUp
   , allUp
-  , allStable1
+  , allStable0
   )
  where
   syncRst = rst `orReset` (unsafeFromActiveLow (fmap not spiErr))
@@ -212,7 +208,7 @@ fullMeshHwTest refClk sysClk IlaControl{syncRst = rst, ..} rxns rxps miso =
   -- Transceiver setup
   gthAllReset = unsafeFromActiveLow spiDone
 
-  (head -> (txClock :: Clock GthTx), rxClocks, txns, txps, linkUpsRx, stats) = unzip6 $
+  (txClocks, rxClocks, txns, txps, linkUpsRx, stats) = unzip6 $
     transceiverPrbsN
       @GthTx @GthRx @Ext200 @Basic125 @GthTx @GthRx
       refClk sysClk gthAllReset
@@ -230,10 +226,9 @@ fullMeshHwTest refClk sysClk IlaControl{syncRst = rst, ..} rxns rxps miso =
 
   -- Clock control
   clockControlReset =
-    xpmResetSynchronizer Asserted sysClk txClock
-      $ orReset (unsafeFromActiveLow allUp)
-      $ orReset (unsafeFromActiveHigh transceiversFailedAfterUp)
-                (unsafeFromActiveLow syncStart)
+      orReset (unsafeFromActiveLow allUp)
+    $ orReset (unsafeFromActiveHigh transceiversFailedAfterUp)
+              (unsafeFromActiveLow syncStart)
 
   availableLinkMask = pure maxBound
 
@@ -243,11 +238,9 @@ fullMeshHwTest refClk sysClk IlaControl{syncRst = rst, ..} rxns rxps miso =
       callistoResult
 
   callistoResult =
-    callistoClockControlWithIla @(NodeCount - 1) @CccBufferSize @GthTx
-      sysClk txClock clockControlReset enableGen clockControlConfig
+    callistoClockControlWithIla @(NodeCount - 1) @CccBufferSize
+      (head txClocks) sysClk clockControlReset clockControlConfig
       IlaControl{..} availableLinkMask (fmap (fmap resize) domainDiffs)
-
-  allStable1 = xpmCdcSingle txClock sysClk allStable0
 
   -- Capture every 100 microseconds - this should give us a window of about 5
   -- seconds. Or: when we're in reset. If we don't do the latter, the VCDs get
@@ -260,7 +253,7 @@ fullMeshHwTest refClk sysClk IlaControl{syncRst = rst, ..} rxns rxps miso =
          "trigger_0"
       :> "capture_0"
       :> "probe_milliseconds"
-      :> "probe_allStable1"
+      :> "probe_allStable0"
       :> "probe_transceiversFailedAfterUp"
       :> "probe_nFincs"
       :> "probe_nFdecs"
@@ -276,38 +269,35 @@ fullMeshHwTest refClk sysClk IlaControl{syncRst = rst, ..} rxns rxps miso =
 
     -- Debug probes
     milliseconds1
-    allStable1
+    allStable0
     transceiversFailedAfterUp
-    nFincsSynced
-    nFdecsSynced
-    (fmap unsignedToSigned nFincsSynced - fmap unsignedToSigned nFdecsSynced)
-
-  nFincsSynced = xpmCdcGray txClock sysClk nFincs
-  nFdecsSynced = xpmCdcGray txClock sysClk nFdecs
+    nFincs
+    nFdecs
+    (fmap unsignedToSigned nFincs - fmap unsignedToSigned nFdecs)
 
   captureFlag = riseEvery sysClk syncRst enableGen
     (SNat @(PeriodToCycles Basic125 (Milliseconds 1)))
 
-  nFincs = regEn txClock clockControlReset enableGen
+  nFincs = regEn sysClk clockControlReset enableGen
     (0 :: Unsigned 32)
     ((== Just SpeedUp) <$> clockMod)
     (satSucc SatBound <$> nFincs)
 
-  nFdecs = regEn txClock clockControlReset enableGen
+  nFdecs = regEn sysClk clockControlReset enableGen
     (0 :: Unsigned 32)
     ((== Just SlowDown) <$> clockMod)
     (satSucc SatBound <$> nFdecs)
 
-  frequencyAdjustments :: Signal GthTx (FINC, FDEC)
+  frequencyAdjustments :: Signal Basic125 (FINC, FDEC)
   frequencyAdjustments =
-    E.delay txClock enableGen minBound {- glitch filter -} $
-      withClockResetEnable txClock clockControlReset enableGen $
-        stickyBits @GthTx d20 (speedChangeToPins . fromMaybe NoChange <$> clockMod)
+    E.delay sysClk enableGen minBound {- glitch filter -} $
+      withClockResetEnable sysClk clockControlReset enableGen $
+        stickyBits @Basic125 d20 (speedChangeToPins . fromMaybe NoChange <$> clockMod)
 
-  (domainDiffs, _domainActives) =
-    unzip $ fmap unbundle $ rxDiffCounter <$> rxClocks <*> linkUpsRx
-  rxDiffCounter rxClk linkUp =
-    domainDiffCounter rxClk (unsafeFromActiveLow linkUp) txClock clockControlReset
+  domainDiffs =
+    domainDiffCounterExt sysClk clockControlReset
+      <$> rxClocks
+      <*> txClocks
 
 -- | Top entity for this test. See module documentation for more information.
 fullMeshSwCcTest ::
@@ -320,8 +310,8 @@ fullMeshSwCcTest ::
   ( "GTH_TX_NS" ::: TransceiverWires GthTx
   , "GTH_TX_PS" ::: TransceiverWires GthTx
   , "" :::
-      ( "FINC"      ::: Signal GthTx Bool
-      , "FDEC"      ::: Signal GthTx Bool
+      ( "FINC"      ::: Signal Basic125 Bool
+      , "FDEC"      ::: Signal Basic125 Bool
       )
   , "SYNC_OUT" ::: Signal Basic125 Bool
   , "spiDone" ::: Signal Basic125 Bool
@@ -338,12 +328,12 @@ fullMeshSwCcTest refClkDiff sysClkDiff syncIn rxns rxps miso =
   (sysClk, sysRst) = clockWizardDifferential sysClkDiff noReset
   ilaControl@IlaControl{..} = ilaPlotSetup IlaPlotSetup{..}
 
-  (   txns, txps, _hwFincFdecs, callistoClock, _callistoResult, callistoReset
+  (   txns, txps, _hwFincFdecs, _callistoResult, callistoReset
     , dataCounts, stats, spiDone, spiOut, transceiversFailedAfterUp, allUp
     , allStable ) = fullMeshHwTest refClk sysClk ilaControl rxns rxps miso
 
   (riscvFinc, riscvFdec) =
-    fullMeshRiscvTest callistoClock callistoReset dataCounts
+    fullMeshRiscvTest sysClk callistoReset dataCounts
 
   stats0 :> stats1 :> stats2 :> stats3 :> stats4 :> stats5 :> stats6 :> Nil = stats
 

--- a/bittide-instances/src/Bittide/Instances/Hitl/IlaPlot.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/IlaPlot.hs
@@ -82,7 +82,7 @@ type family DDivCheck (a :: Nat) (b :: Nat) (c :: Nat) :: Nat where
 
 -- | The window high of 'accWindow' for reducing the number of
 -- reported clock modifications.
-type AccWindowHeight = 3 :: Nat
+type AccWindowHeight = 5 :: Nat
 
 -- | The period of the sync pulse used to share a synchronized time
 -- stamp between the nodes.

--- a/bittide-instances/src/Bittide/Instances/Hitl/IlaPlot.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/IlaPlot.hs
@@ -58,10 +58,10 @@ import Bittide.ClockControl.Callisto
 import Bittide.ClockControl.StabilityChecker
 import Bittide.Extra.Maybe (orNothing)
 
-import Clash.Cores.Xilinx.Xpm.Cdc.Handshake.Extra (xpmCdcMaybeLossy)
 import Clash.Cores.Xilinx.Xpm.Cdc.Gray (xpmCdcGray)
 import Clash.Cores.Xilinx.Xpm.Cdc.Single (xpmCdcSingle)
 import Clash.Cores.Xilinx.Ila (IlaConfig(..), Depth(..), ila, ilaConfig)
+import Clash.Explicit.Reset.Extra
 
 import Control.Arrow ((***), second)
 import Data.Bool (bool)
@@ -401,91 +401,46 @@ data DiffResult a =
     -- reference got to large to fit into the output type.
   deriving (Generic, BitPack, NFDataX, Functor, Eq, Ord, Show)
 
--- | Turns a signal with single clock cycle pulses into an inverting
--- one, which flips its polarity on every incoming pulse. The
--- conversion is used to work around the missing XPM_CDC_PULSE via
--- XPM_CDC_SINGLE.
-fromPulse ::
-  KnownDomain dom =>
-  Clock dom ->
-  Reset dom ->
-  Enable dom ->
-  Signal dom Bool ->
-  Signal dom Bool
-fromPulse clk rst ena inp = out
- where
-  out = register clk rst ena False $ mux inp (not <$> out) out
-
--- | Turns an Boolean signal into a pulsing one delivering a one clock
--- cycle pulse on every polarity change. The conversion is used to
--- work around the missing XPM_CDC_PULSE via XPM_CDC_SINGLE.
-toPulse ::
-  KnownDomain dom =>
-  Clock dom ->
-  Reset dom ->
-  Enable dom ->
-  Signal dom Bool ->
-  Signal dom Bool
-toPulse clk rst ena = mealy clk rst ena transF Nothing
- where
-  transF s i = (Just i, maybe False (i /=) s)
-
--- | Implements the missing XPM_CDC_PULSE via XPM_CDC_SINGLE. This
--- workaround suffices here, as we only need to deliver pulses on a
--- low frequency compared to the one of the source and destination
--- clocks.
-xpmCdcPulseWorkaround ::
-  (KnownDomain src, KnownDomain dst) =>
-  Clock src ->
-  Reset src ->
-  Clock dst ->
-  Reset dst ->
-  Signal src Bool ->
-  Signal dst Bool
-xpmCdcPulseWorkaround srcClk srcRst dstClk dstRst =
-    toPulse dstClk dstRst enableGen
-  . xpmCdcSingle srcClk dstClk
-  . fromPulse srcClk srcRst enableGen
-
 {-# NOINLINE callistoClockControlWithIla #-}
 -- | Wrapper on 'Bittide.ClockControl.Callisto.callistoClockControl'
 -- additionally dumping all the data that is required for producing
 -- plots of the clock control behavior.
 callistoClockControlWithIla ::
-  forall n m dom domIla margin framesize. HasCallStack =>
-  (KnownDomain dom , KnownDomain domIla) =>
+  forall n m sys dyn margin framesize. HasCallStack =>
+  (KnownDomain dyn , KnownDomain sys, HasSynchronousReset sys) =>
   (KnownNat n, KnownNat m, KnownNat margin, KnownNat framesize) =>
   (1 <= n, 1 <= m, n + m <= 32, 1 <= framesize, 6 + n * (m + 4) <= 1024) =>
   CompressedBufferSize <= m =>
-  Clock domIla ->
-  Clock dom ->
-  Reset dom ->
-  Enable dom ->
-  ClockControlConfig dom m margin framesize ->
-  IlaControl domIla ->
+  Clock dyn ->
+  Clock sys ->
+  Reset sys ->
+  ClockControlConfig sys m margin framesize ->
+  IlaControl sys ->
   -- ^ Ila trigger and capture conditions
-  Signal dom (BitVector n) ->
+  Signal sys (BitVector n) ->
   -- ^ Link availability mask
-  Vec n (Signal dom (DataCount m)) ->
+  Vec n (Signal sys (DataCount m)) ->
   -- ^ Statistics provided by elastic buffers.
-  Signal dom (CallistoResult n)
-callistoClockControlWithIla sysClk clk ccRst ena ccc IlaControl{..} mask ebs =
+  Signal sys (CallistoResult n)
+callistoClockControlWithIla dynClk clk rst ccc IlaControl{..} mask ebs =
   hwSeqX ilaInstance (muteDuringCalibration <$> calibrating <*> result)
  where
-  result = callistoClockControl clk ccRst ena ccc mask ebs
+  result = callistoClockControl clk rst enableGen ccc mask ebs
 
   maxGeqPlusApp = maxGeqPlus @1
-    @(DivRU ScheduledCapturePeriod (Max 1 (DomainPeriod dom)))
-    @(Div (ScheduledCaptureCycles dom) 10)
+    @(DivRU ScheduledCapturePeriod (Max 1 (DomainPeriod dyn)))
+    @(Div (ScheduledCaptureCycles dyn) 10)
 
   -- local timestamp on the stable clock
-  localTs :: Signal domIla (DiffResult (LocalTimestamp dom))
+  localTs :: Signal sys (DiffResult (LocalTimestamp dyn))
   localTs = case maxGeqPlusApp of
-    Dict -> overflowResistantDiff sysClk syncRst
-              (delay sysClk enableGen False (isJust <$> captureCond))
-          $ let lts :: Signal dom (Unsigned 8)
-                lts = register clk ccRst ena minBound (satSucc SatWrap <$> lts)
-             in xpmCdcGray clk sysClk lts
+    Dict -> overflowResistantDiff clk rst
+              (delay clk enableGen False (isJust <$> captureCond))
+          $ let ccRst = xpmResetSynchronizer Asserted clk dynClk rst
+                lts :: Signal dyn (Unsigned 8)
+                lts = register dynClk ccRst enableGen minBound
+                    $ satSucc SatWrap <$> lts
+             in xpmCdcGray dynClk clk lts
 
   -- collect all plot data
   localData =
@@ -497,12 +452,12 @@ callistoClockControlWithIla sysClk clk ccRst ena ccc IlaControl{..} mask ebs =
         height = SNat @AccWindowHeight
         idcs = unbundle (stability <$> result)
 
-        ebsC = ebsDiffCompress scheduledTrigger <$> ebs
+        ebsC = ebsDiffCompress scheduledCapture <$> ebs
 
         -- get the points in time where the monitored values change
-        stableUpdates  = changepoints clk ccRst ena <$> (fmap stable <$> idcs)
-        settledUpdates = changepoints clk ccRst ena <$> (fmap settled <$> idcs)
-        modeUpdate     = changepoints clk ccRst ena (rfStageChange <$> result)
+        stableUpdates  = changepoints clk rst enableGen <$> (fmap stable <$> idcs)
+        settledUpdates = changepoints clk rst enableGen <$> (fmap settled <$> idcs)
+        modeUpdate     = changepoints clk rst enableGen (rfStageChange <$> result)
 
         combine eb stU seU ind = (,,)
           <$> eb
@@ -513,7 +468,7 @@ callistoClockControlWithIla sysClk clk ccRst ena ccc IlaControl{..} mask ebs =
 
      in PlotData
           <$> bundle (zipWith4 combine ebsC stableUpdates settledUpdates idcs)
-          <*> accWindow height clk ccRst ena (noChange <$> result)
+          <*> accWindow height clk rst enableGen (noChange <$> result)
           <*> mux modeUpdate (rfStageChange <$> result) (pure Stable)
 
   -- compress the elastic buffer data via only reporting the
@@ -532,23 +487,15 @@ callistoClockControlWithIla sysClk clk ccRst ena ccc IlaControl{..} mask ebs =
            in (, truncDiff)
             $ bool lastDataCount curDataCount
             $ trigger || abs diff > half
-     in mealyB clk ccRst enableGen transF (0 :: DataCount m)
-
-  -- This is a quick workaround to send single pulses from one clock
-  -- domain to another. Eventually, we should use an XPM_CDC_PULSE
-  -- instead. Note that pulses may get lost if directly send through a
-  -- XPM_CDC_SINGLE instead.
-  scheduledTrigger =
-    xpmCdcPulseWorkaround sysClk syncRst clk ccRst
-      scheduledCapture
+     in mealyB clk rst enableGen transF (0 :: DataCount m)
 
   -- produce at least two calibration captures
-  calibrating = unsafeToActiveLow ccRst .&&.
-    moore clk ccRst enableGen
+  calibrating = unsafeToActiveLow rst .&&.
+    moore clk rst enableGen
       (\s -> bool s $ satSucc SatBound s)
       (/= maxBound)
       (minBound :: Index 3)
-      scheduledTrigger
+      scheduledCapture
 
   -- do not forward clock modifications during calibration
   muteDuringCalibration active ccResult = ccResult
@@ -561,7 +508,7 @@ callistoClockControlWithIla sysClk clk ccRst ena ccc IlaControl{..} mask ebs =
   -- but only after it. Hence, if the trigger position is at 0, then
   -- we store exactly one capture that is marked with the
   -- @UntilTrigger@ flag this way.
-  captureCond :: Signal domIla (Maybe CaptureCondition)
+  captureCond :: Signal sys (Maybe CaptureCondition)
   captureCond = mux (not <$> syncStart)
     (pure $ Just UntilTrigger)
     (fmap fst <$> plotData)
@@ -578,10 +525,9 @@ callistoClockControlWithIla sysClk clk ccRst ena ccc IlaControl{..} mask ebs =
           || dSpeedChange /= NoChange
           || dRfStageChange /= Stable
 
-     in xpmCdcMaybeLossy clk sysClk
-          (captureType <$> calibrating <*> scheduledTrigger <*> localData)
+     in captureType <$> calibrating <*> scheduledCapture <*> localData
 
-  ilaInstance :: Signal domIla ()
+  ilaInstance :: Signal sys ()
   ilaInstance =
     ila
       ( ilaConfig
@@ -594,7 +540,7 @@ callistoClockControlWithIla sysClk clk ccRst ena ccc IlaControl{..} mask ebs =
           :> Nil
       ) { depth = D16384 }
       -- the ILA must run on a stable clock
-      sysClk
+      clk
       -- trigger as soon as we start
       syncStart
       -- capture on relevant data changes


### PR DESCRIPTION
This PR moves clock control from the dynamic to the stable system clock for the HITL tests. Furthermore, the following updates have been applied as consequence:

* Simplification of the test setup, as many of the previously used CDC components are not required any more.
* `AccWindowHeight` gets increased from `3` to `5`, as the system clock runs at 300Mhz, thus producing more base noise then the dynamic clock running at 200Mhz. Without this change, the ILA buffers would fill up too fast.
*  An extended variant of `domainDiffCounter` gets introduced, which allows to capture the domain difference in a different domain than the source and destination domain of the diff counter.
* The CLI of the `plot` executable gets simplified due to some strange CI error, complaining that the provided prefix won't match any more. The updated version automatically scans for suitable files, so passing the prefix as an argument turns obsolete. _(Note that this change gets only introduced to get CI working again)_