### PR TITLE
Fix ILA short name

### DIFF
--- a/bittide-instances/src/Bittide/Instances/Hitl/Post/BoardTestExtended.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/Post/BoardTestExtended.hs
@@ -11,8 +11,10 @@ module Bittide.Instances.Hitl.Post.BoardTestExtended (postBoardTestExtended) whe
 import Prelude
 
 import Data.Csv
+import Data.List (isSuffixOf)
 import System.Exit (ExitCode(..))
 import Test.Tasty.HUnit
+import System.FilePath
 
 import Bittide.Instances.Hitl.Post.PostProcess
 
@@ -61,7 +63,9 @@ processCsv csvPath_ = do
 postBoardTestExtended :: ExitCode -> [FlattenedIlaCsvPath] -> Assertion
 postBoardTestExtended _exitCode ilaCsvPaths = do
   let
-    csvToProcess = filter ((== "boardTestIla") . ilaName) ilaCsvPaths
+    csvToProcess = filter ((baseNameEndsWith "boardTestIla") . ilaName) ilaCsvPaths
   assertBool "Expected at least 1 CSV file, but got 0" $ not (null csvToProcess)
   mapM_ (processCsv . csvPath) csvToProcess
   putStrLn $ "Successfully performed post processing of " <> show (length csvToProcess) <> " ILA CSV dumps"
+ where
+  baseNameEndsWith x = isSuffixOf x . takeBaseName

--- a/bittide-shake/data/tcl/HardwareTest.tcl
+++ b/bittide-shake/data/tcl/HardwareTest.tcl
@@ -220,9 +220,8 @@ proc get_ila_dicts {} {
         set ila_dict {}
 
         set cell_name [get_property CELL_NAME $hw_ila]
-        set idx_start [expr {[string first _ $cell_name] + 1}]
-        set idx_end [expr {[string first / $cell_name] - 1}]
-        set short_name [string range $cell_name $idx_start $idx_end]
+        set after_last [expr [string last "/" $cell_name] + 1]
+        set short_name [string range $cell_name $after_last end]
         dict set ila_dict name $short_name
         dict set ila_dict cell_name $cell_name
 


### PR DESCRIPTION
Fixes the short name extraction of the ILA cell name to line up with the name, as it is set with Clash's `setName`.