### PR TITLE
HITL infra for parameter configuration via YAML

### DIFF
--- a/.github/synthesis/all.json
+++ b/.github/synthesis/all.json
@@ -17,10 +17,11 @@
 
   {"top": "boardTestExtended",             "stage": "test",   "targets": "All"          },
   {"top": "boardTestSimple",               "stage": "test",   "targets": "All"          },
+  {"top": "extraProbesTest",               "stage": "test",   "targets": "Specific [0]"       },
   {"top": "fincFdecTests",                 "stage": "test",   "targets": "Specific [-1]"},
   {"top": "fullMeshHwCcTest",              "stage": "test",   "targets": "All"          },
-  {"top": "fullMeshSwCcTest",              "stage": "test",   "targets": "All"          },
   {"top": "fullMeshHwCcWithRiscvTest",     "stage": "test",   "targets": "All"          },
+  {"top": "fullMeshSwCcTest",              "stage": "test",   "targets": "All"          },
   {"top": "syncInSyncOut",                 "stage": "test",   "targets": "All"          },
   {"top": "transceiversUpTest",            "stage": "test",   "targets": "All"          },
   {"top": "vexRiscvTest",                  "stage": "test",   "targets": "Specific [-1]"}

--- a/.github/synthesis/staging.json
+++ b/.github/synthesis/staging.json
@@ -4,6 +4,7 @@
 
   {"top": "boardTestExtended",             "stage": "test", "targets": "All"},
   {"top": "boardTestSimple",               "stage": "test", "targets": "All"},
+  {"top": "extraProbesTest",               "stage": "test", "targets": "Specific [0]"},
   {"top": "fincFdecTests",                 "stage": "test", "targets": "Specific [-1]"},
   {"top": "fullMeshHwCcTest",              "stage": "test", "targets": "All"},
   {"top": "fullMeshSwCcTest",              "stage": "test", "targets": "All"},

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,7 +292,7 @@ jobs:
           mkdir -p reports
           mkdir -p hitl-plots/hw
           ./cargo.sh build --frozen --release
-          cabal run -- elastic-buffer-sim:plot artifacts/_build-fullMeshHwCcTest-debug/Bittide.Instances.Hitl.FullMeshHwCc.fullMeshHwCcTest/ila-data/probe_test_start/ hitl-plots/hw
+          cabal run -- elastic-buffer-sim:plot artifacts/_build-fullMeshHwCcTest-debug/Bittide.Instances.Hitl.FullMeshHwCc.fullMeshHwCcTest/ila-data/single_test/ hitl-plots/hw
           cp .github/hitl/FullMeshHwCcReportTemplate.tex hitl-plots/hw/report.tex
           cp .github/hitl/topology.tikz hitl-plots/hw/topology.tikz
           export RUNREF="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
@@ -304,7 +304,7 @@ jobs:
           cd ../..
           mv hitl-plots/hw/report.pdf reports/HITL-FullMeshHwCc-Report.pdf
           mkdir -p hitl-plots/sw
-          cabal run -- elastic-buffer-sim:plot artifacts/_build-fullMeshSwCcTest-debug/Bittide.Instances.Hitl.FullMeshSwCc.fullMeshSwCcTest/ila-data/probe_test_start/ hitl-plots/sw
+          cabal run -- elastic-buffer-sim:plot artifacts/_build-fullMeshSwCcTest-debug/Bittide.Instances.Hitl.FullMeshSwCc.fullMeshSwCcTest/ila-data/single_test/ hitl-plots/sw
           cp .github/hitl/FullMeshSwCcReportTemplate.tex hitl-plots/sw/report.tex
           cp .github/hitl/topology.tikz hitl-plots/sw/topology.tikz
           mv hitl-plots/hw/datetime hitl-plots/sw/datetime

--- a/.vscode/schemas/hitl-test-schema.json
+++ b/.vscode/schemas/hitl-test-schema.json
@@ -1,0 +1,79 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "$defs": {
+    "probes": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "integer"
+      }
+    },
+    "defaults": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "probes": {
+          "$ref": "#/$defs/probes"
+        }
+      }
+    },
+    "target": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "index": {
+              "type": "integer"
+            }
+          },
+          "required": [
+            "index"
+          ]
+        }
+      ]
+    }
+  },
+  "properties": {
+    "defaults": {
+      "$ref": "#/$defs/defaults"
+    },
+    "tests": {
+      "type": "object",
+      "additionalProperties": {
+        "oneOf": [
+          {
+            "type": "null"
+          },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "probes": {
+                "$ref": "#/$defs/probes"
+              },
+              "targets": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "target": {
+                      "$ref": "#/$defs/target"
+                    },
+                    "probes": {
+                      "$ref": "#/$defs/probes"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "required": [
+    "tests"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -30,6 +30,12 @@
   "[haskell]": {
     "editor.formatOnSave": false
   },
+  "yaml.schemas": {
+    ".vscode/schemas/hitl-test-schema.json": [
+      "_build/hitl/*.yml",
+      "bittide-instances/data/test_configs/*.yml"
+    ]
+  },
   "rust-analyzer.linkedProjects": [
     "firmware-support/Cargo.toml",
     "firmware-binaries/Cargo.toml",

--- a/bittide-instances/bin/GetDataFileName.hs
+++ b/bittide-instances/bin/GetDataFileName.hs
@@ -1,25 +1,34 @@
--- SPDX-FileCopyrightText: 2023 Google LLC
+-- SPDX-FileCopyrightText: 2023-2024 Google LLC
 --
 -- SPDX-License-Identifier: Apache-2.0
 
 import Prelude
 
 import Control.Exception
+import Control.Monad (unless)
+import Control.Monad.Extra (unlessM)
 import Paths_bittide_instances
+import System.Console.GetOpt
 import System.Directory
 import System.Environment
+
+data Flag = NoCheck deriving Eq
+
+options :: [OptDescr Flag]
+options = [ Option [] ["no-check"] (NoArg NoCheck) "Do not check if the file exists" ]
 
 main :: IO ()
 main = do
   args <- getArgs
-  case args of
+  let (flags, files, _) = getOpt Permute options args
+  case files of
     [file] -> do
       fPath <- getDataFileName file
-      fileExists <- doesFileExist fPath
-      if fileExists
-      then putStrLn fPath
-      else throwIO (userError $ unwords
-             ["File", show file, "does not exist in bittide-instances."])
+      unless (NoCheck `elem` flags)
+        $ unlessM (doesFileExist fPath)
+          $ throwIO $ userError $ unwords
+            ["File", show file, "does not exist in bittide-instances."]
+      putStrLn fPath
     [] -> throwIO (userError "Expected one file argument, got none")
-    _  -> throwIO (userError $ "Expected one file argument, got: " <> unwords args)
+    _  -> throwIO (userError $ "Expected one file argument, got: " <> unwords files)
   pure ()

--- a/bittide-instances/bittide-instances.cabal
+++ b/bittide-instances/bittide-instances.cabal
@@ -109,6 +109,7 @@ library
     Bittide.Instances.Hitl.FullMeshSwCc
     Bittide.Instances.Hitl.IlaPlot
     Bittide.Instances.Hitl.SyncInSyncOut
+    Bittide.Instances.Hitl.Tcl.ExtraProbes
     Bittide.Instances.Hitl.Transceivers
     Bittide.Instances.Hitl.VexRiscv
 

--- a/bittide-instances/data/constraints/extraProbesTest.xdc
+++ b/bittide-instances/data/constraints/extraProbesTest.xdc
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: 2022-2024 Google LLC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# CLK_125MHZ_P
+set_property PACKAGE_PIN G10 [get_ports "CLK_125MHZ_p"]
+set_property IOSTANDARD LVDS [get_ports "CLK_125MHZ_p"]
+# CLK_125MHZ_P
+set_property PACKAGE_PIN F10 [get_ports "CLK_125MHZ_n"]
+set_property IOSTANDARD LVDS [get_ports "CLK_125MHZ_n"]
+
+# GPIO_LED_1_LS
+set_property PACKAGE_PIN H23      [get_ports "success"]
+set_property IOSTANDARD  LVCMOS18 [get_ports "success"]

--- a/bittide-instances/data/test_configs/boardTestExtended.yml
+++ b/bittide-instances/data/test_configs/boardTestExtended.yml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: 2024 Google LLC
+#
+# SPDX-License-Identifier: Apache-2.0
+default:
+  probes:
+    testSelect: false
+
+tests:
+  testA:
+    probes:
+      testSelect: false
+
+  testB:
+    probes:
+      testSelect: true

--- a/bittide-instances/data/test_configs/default.yml
+++ b/bittide-instances/data/test_configs/default.yml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: 2024 Google LLC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Tcl can not handle empty lists pr dicts, so we supply a null values instead.
+default:
+  probes: null
+
+tests:
+  single_test: null

--- a/bittide-instances/data/test_configs/extraProbesTest.yml
+++ b/bittide-instances/data/test_configs/extraProbesTest.yml
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: 2024 Google LLC
+#
+# SPDX-License-Identifier: Apache-2.0
+default:
+  probes:
+    testState: 0
+    extraProbe: 0
+
+tests:
+  testDefaultProbes: null
+  testSpecificProbes:
+    probes:
+      testState: 1
+      extraProbe: 0xDEADABBA
+  testFpgaSpecificProbes:
+    # We set the extraProbes to the DNA identifier of the respective FPGA
+    probes:
+      testState: 2
+    targets:
+      - target: { index:  0 }
+        probes:
+          extraProbe: 0x00000000400200010169c040044164c5
+      - target: { index:  1 }
+        probes:
+          extraProbe: 0x0000000040020001815160e805108285
+      - target: { index:  2 }
+        probes:
+          extraProbe: 0x000000004002000101695ce72c808445
+      - target: { index:  3 }
+        probes:
+          extraProbe: 0x000000004002000101695ce72c702305
+      - target: { index:  4 }
+        probes:
+          extraProbe: 0x0000000040020001016ba8e52581a285
+      - target: { index:  5 }
+        probes:
+          extraProbe: 0x00000000400200010157f4862d01c345
+      - target: { index:  6 }
+        probes:
+          extraProbe: 0x00000000400200010169c04004308185
+      - target: { index:  7 }
+        probes:
+          extraProbe: 0x0000000040020001015664862d20e405

--- a/bittide-instances/data/test_configs/fincFdecTests.yml
+++ b/bittide-instances/data/test_configs/fincFdecTests.yml
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: 2024 Google LLC
+#
+# SPDX-License-Identifier: Apache-2.0
+default:
+  probes:
+    testType: 0
+
+tests:
+  FDec:
+    probes:
+      testType: 0
+  FInc:
+    probes:
+      testType: 1
+  FDecFInc:
+    probes:
+      testType: 2
+  FIncFDec:
+    probes:
+      testType: 3

--- a/bittide-instances/src/Bittide/Instances/Hitl/Post/BoardTestExtended.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/Post/BoardTestExtended.hs
@@ -1,4 +1,4 @@
--- SPDX-FileCopyrightText: 2023 Google LLC
+-- SPDX-FileCopyrightText: 2023-2024 Google LLC
 --
 -- SPDX-License-Identifier: Apache-2.0
 
@@ -25,8 +25,7 @@ data Row = Row
   , sampleInWindow :: Int
   , trigger :: Bool
   , capture :: Bool
-  , testStartA :: Bool
-  , testStartB :: Bool
+  , testSelect :: Bool
   , testDone :: Bool
   , testSuccess :: Bool
   } deriving Show
@@ -37,10 +36,9 @@ instance FromNamedRecord Row where
     m .: "Sample in Window" <*>
     (toEnum <$> m .: "trigger_AorB") <*>
     (toEnum <$> m .: "capture") <*>
-    (toEnum <$> m .: "testStartA") <*>
-    (toEnum <$> m .: "testStartB") <*>
-    (toEnum <$> m .: "testDone") <*>
-    (toEnum <$> m .: "testSuccess")
+    (toEnum <$> m .: "ilaTestSelect") <*>
+    (toEnum <$> m .: "ilaTestDone") <*>
+    (toEnum <$> m .: "ilaTestSuccess")
 
 
 assertTriggerAtStart :: [Row] -> Assertion
@@ -62,6 +60,6 @@ postBoardTestExtended :: ExitCode -> [FlattenedIlaCsvPath] -> Assertion
 postBoardTestExtended _exitCode ilaCsvPaths = do
   let
     csvToProcess = filter ((== "boardTestIla") . ilaName) ilaCsvPaths
-  assertBool "Expected at least 1 CSV file, but got 0" $ ((length csvToProcess) > 0)
-  _ <- sequence $ map (processCsv . csvPath) csvToProcess
+  assertBool "Expected at least 1 CSV file, but got 0" $ not (null csvToProcess)
+  mapM_ (processCsv . csvPath) csvToProcess
   putStrLn $ "Successfully performed post processing of " <> show (length csvToProcess) <> " ILA CSV dumps"

--- a/bittide-instances/src/Bittide/Instances/Hitl/Post/PostProcess.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/Post/PostProcess.hs
@@ -1,4 +1,4 @@
--- SPDX-FileCopyrightText: 2023 Google LLC
+-- SPDX-FileCopyrightText: 2023-2024 Google LLC
 --
 -- SPDX-License-Identifier: Apache-2.0
 
@@ -62,7 +62,7 @@ toFpgaNum fpgaName =
 -- | Create NestedIlaCsvPaths using a list of filepaths of CSV dumps and the
 -- base directory of ILA data.
 toNestedIlaCsvPaths :: HasCallStack => FilePath -> [FilePath] -> NestedIlaCsvPaths
-toNestedIlaCsvPaths ilaDir = foldl addIlaCsvPath Map.empty . (toFlattenedIlaCsvPathList ilaDir)
+toNestedIlaCsvPaths ilaDir = foldl addIlaCsvPath Map.empty . toFlattenedIlaCsvPathList ilaDir
 
 -- | Create a list of FlattenedIlaCsvPath using a list of filepaths of CSV dumps
 -- and the base directory of ILA data.

--- a/bittide-instances/src/Bittide/Instances/Hitl/SyncInSyncOut.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/SyncInSyncOut.hs
@@ -1,4 +1,4 @@
--- SPDX-FileCopyrightText: 2023 Google LLC
+-- SPDX-FileCopyrightText: 2023-2024 Google LLC
 --
 -- SPDX-License-Identifier: Apache-2.0
 
@@ -136,7 +136,7 @@ syncInSyncOut ::
 syncInSyncOut sysClkDiff syncIn0 = syncOut
  where
   (sysClk, sysRst) = clockWizardDifferential sysClkDiff noReset
-  testRst = sysRst `orReset` (unsafeFromActiveLow startTest)
+  testRst = sysRst `orReset` unsafeFromActiveLow startTest
   syncIn1 =
       unsafeToActiveHigh
     $ resetGlitchFilter (SNat @1024) sysClk

--- a/bittide-instances/src/Bittide/Instances/Hitl/Tcl/ExtraProbes.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/Tcl/ExtraProbes.hs
@@ -1,0 +1,56 @@
+-- SPDX-FileCopyrightText: 2024 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+module Bittide.Instances.Hitl.Tcl.ExtraProbes where
+
+import Clash.Prelude
+
+import Clash.Cores.Xilinx.Dna
+import Bittide.Instances.Domains
+import Clash.Annotations.TH ( makeTopEntity )
+import Clash.Cores.Xilinx.Extra
+import Clash.Cores.Xilinx.VIO
+import Data.Maybe
+
+-- | A circuit that verifies the correct behavior of the TCL infrastructure for
+-- setting extra probes in Hitl tests.
+extraProbesTest ::
+  "CLK_125MHZ" ::: DiffClock Ext125 ->
+  "success" ::: Signal Ext125 Bool
+extraProbesTest diffClk = testSuccess
+ where
+  clk = ibufds diffClk
+
+  testSuccess = testResult <$> testState <*> extraProbe <*> fpgaId
+  testDone = testStart .&&. fmap isJust fpgaId
+  rst = unsafeFromActiveLow testStart
+  fpgaId = withClockResetEnable clk rst enableGen deviceDna defaultSimDNA
+  (testStart, testState, extraProbe) =
+    unbundle $
+    setName @"vioHitlt" $
+    vioProbe
+      ("probe_test_done" :> "probe_test_success" :> "fpgaId" :> Nil)
+      ("probe_test_start" :> "testState" :> "extraProbe" :> Nil)
+      (False, SetDefaultProbes, maxBound)
+      clk
+      testDone
+      testSuccess
+      fpgaId
+{-# NOINLINE extraProbesTest #-}
+
+-- | Produce the test result based on the test state and the extra probe value.
+-- These values should correspond to the yaml configuration.
+testResult :: TestState -> BitVector 96 -> Maybe (BitVector 96) -> Bool
+testResult s extraProbe fpgaId = case (s, extraProbe) of
+  (SetDefaultProbes, 0) -> True
+  (SetTestProbes, 0xDEADABBA) -> True
+  (SetFpgaSpecificProbes, _) -> extraProbe == fromMaybe defaultSimDNA fpgaId
+  _ -> False
+
+data TestState
+  = SetDefaultProbes -- Check if the default probes from the yaml file are set
+  | SetTestProbes -- Check if the test specific probe values are set
+  | SetFpgaSpecificProbes -- Check if the DNA device identifier is set
+  deriving (Generic, NFDataX)
+
+makeTopEntity 'extraProbesTest

--- a/bittide-shake/bin/Shake.hs
+++ b/bittide-shake/bin/Shake.hs
@@ -1,4 +1,4 @@
--- SPDX-FileCopyrightText: 2022-2023 Google LLC
+-- SPDX-FileCopyrightText: 2022-2024 Google LLC
 --
 -- SPDX-License-Identifier: Apache-2.0
 
@@ -15,7 +15,11 @@ module Main where
 
 import Prelude
 
-import Control.Applicative (liftA2)
+import Clash.Shake.Extra
+import Clash.Shake.Flags
+import Clash.Shake.Vivado
+import Control.Applicative (liftA2, Alternative ((<|>)))
+import Control.Exception (throw)
 import Control.Monad (forM_, unless, when)
 import Control.Monad.Extra (ifM, unlessM)
 import Data.Char(isSpace)
@@ -26,19 +30,15 @@ import Data.Maybe (fromJust, isJust)
 import Development.Shake
 import Development.Shake.Classes
 import GHC.Stack (HasCallStack)
+import Paths_bittide_shake (getDataFileName)
 import System.Console.ANSI (setSGR)
 import System.Directory
 import System.Exit (ExitCode(..), exitWith)
 import System.FilePath
 import System.FilePath.Glob (glob)
 import System.Process (readProcess, callProcess)
+import System.Process.Extra (readProcessWithExitCode)
 import Test.Tasty.HUnit (Assertion)
-
-import Paths_bittide_shake (getDataFileName)
-
-import Clash.Shake.Extra
-import Clash.Shake.Flags
-import Clash.Shake.Vivado
 
 import qualified Clash.Util.Interpolate as I
 import qualified System.Directory as Directory
@@ -88,29 +88,30 @@ vivadoBuildDir = buildDir </> "vivado"
 watchFilesPath :: FilePath
 watchFilesPath = buildDir </> "watch_files.txt"
 
--- | Get absolute path to a constraint file based on a target name. Target name
--- example: @Bittide.Instances.Tests.FincFdec.fincFdecTests@.
-getConstraintFilePathFromTarget :: String -> IO FilePath
-getConstraintFilePathFromTarget target =
-  getConstraintFilePath (entityName target <> ".xdc")
-
--- | Get absolute path to a constraint file based on a relative file path. For
--- example: @features/jtag.xdc@ would resolve to
--- @$REPO_ROOT/bittide-instances/data/constraints/features/jtag.xdc@.
-getConstraintFilePath :: String -> IO FilePath
-getConstraintFilePath relativePath = do
-  let binName = "get-data-file-name"
+data CheckExists = CheckExists | NoCheckExists
+  deriving (Eq, Show)
+-- | Get the absolute path to a data file in `bittide-instances` based on a relative
+-- file path.
+getInstanceDataFileName :: CheckExists -> FilePath -> IO (Maybe FilePath)
+getInstanceDataFileName check relativePath = do
+  let
+    binName = "get-data-file-name"
+    flags = (["--no-check" | check == NoCheckExists])
+    cabalArgs = ["run", "-v0", "--", binName, relativePath] ++ flags
   callProcess "cabal" ["-v0", "build", binName]
-  out <- readProcess "cabal"
-    [ "run", "-v0", binName, "data/constraints" </> relativePath] ""
-  pure $ dropWhileEnd isSpace $ dropWhile isSpace out
+  (exitCode, stdOut, stdErr) <- readProcessWithExitCode "cabal" cabalArgs ""
+  case (check, exitCode) of
+    (_, ExitSuccess) -> pure $ Just $ dropWhileEnd isSpace $ dropWhile isSpace stdOut
+    (NoCheckExists, ExitFailure _) ->
+      throw $ userError $ unwords
+      [unwords $ "cabal":cabalArgs, "failed with exit code", show exitCode, ":\n", stdErr]
+    _ -> pure Nothing
 
 -- | Build and run the executable for post processing of ILA data
 doPostProcessing :: String -> FilePath -> ExitCode -> Assertion
 doPostProcessing postProcessMain ilaDir testExitCode = do
   callProcess "cabal" ["build", postProcessMain]
   callProcess "cabal" ["run", postProcessMain, ilaDir, show testExitCode]
-
 
 -- | Searches for a file called @cabal.project@ It will look for it in the
 -- current working directory. If it can't find it there, it will traverse up
@@ -415,13 +416,15 @@ main = do
 
             -- Synthesis
             runSynthTclPath %> \path -> do
-
+              let
+                xdcNames = entityName targetName <> ".xdc" : targetExtraXdc
+                relativeXdcPaths = map ("data/constraints" </>) xdcNames
               constraints <-
                 if targetHasXdc then do
-                  constraintFilePath <- liftIO (getConstraintFilePathFromTarget targetName)
-                  extraConstraintFilePaths <- liftIO (mapM getConstraintFilePath targetExtraXdc)
-                  need (constraintFilePath : extraConstraintFilePaths)
-                  pure (constraintFilePath : extraConstraintFilePaths)
+                  constraintPaths <- liftIO $ mapM
+                    (fmap fromJust . getInstanceDataFileName CheckExists) relativeXdcPaths
+                  need constraintPaths
+                  pure constraintPaths
                 else
                   pure []
 

--- a/bittide-shake/bin/Shake.hs
+++ b/bittide-shake/bin/Shake.hs
@@ -214,6 +214,7 @@ targets = map enforceValidTarget
   , testTarget "Bittide.Instances.Hitl.FullMeshHwCc.fullMeshHwCcWithRiscvTest"
   , testTarget "Bittide.Instances.Hitl.FullMeshSwCc.fullMeshSwCcTest"
   , testTarget "Bittide.Instances.Hitl.SyncInSyncOut.syncInSyncOut"
+  , testTarget "Bittide.Instances.Hitl.Tcl.ExtraProbes.extraProbesTest"
   , testTarget "Bittide.Instances.Hitl.Transceivers.transceiversUpTest"
   , testTarget "Bittide.Instances.Hitl.VexRiscv.vexRiscvTest"
   ]

--- a/bittide-shake/data/tcl/HardwareTest.tcl
+++ b/bittide-shake/data/tcl/HardwareTest.tcl
@@ -2,6 +2,45 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+# Tools to run hardware-in-the-loop (HITL) tests. Most users should consider
+# `runTestGroup` as the main entry point. This function runs a group of tests
+# according to a test configuration file. The test configuration file is defined
+# in YAML, and looks like the following:
+#
+# ```yaml
+# defaults:
+#   probes:
+#     $probe1: 0
+#     $probe2: 0
+#
+# tests:
+#   $test_name:
+#     probes:
+#       $probe1: 1
+#       $probe2: 0xDEADABBA
+#
+#     targets:
+#       - target: { index:  $fpga_index }
+#         probes:
+#           $probe1: 1
+#           $probe2: 0xDEADABBA
+# ```
+#
+# The `defaults` section contains default values for the probes. The `tests`
+# section contains a list of tests, each with a list of targets and a list of
+# probes. The `targets` section contains a list of targets, each with an index
+# that corresponds to the index of the FPGA in the demo rig. Note that the defaults
+# can be overridden by the test specific values, and the test specific values can
+# be overridden by the target specific values.
+#
+# In the example posted above, the strings prefixed by a dollar sign are meant to
+# illustrate that these are arbitrary values to be set by the user. For example,
+# `$test_name` could be `test1`, and `$probe2` could be `device_id`.
+#
+# TODO: Allow the user to specify the timeout for the test.
+#
+# TODO: Allow multiple ways of specifying FPGA targets. E.g., device ID.
+
 package require yaml
 
 # The IDs of the Digilent chips on each FPGA board. The indices match the
@@ -599,6 +638,24 @@ proc set_extra_probes {yaml_dict fpga_index test_name} {
     }
 }
 
+# Run a group of tests according to a test configuration file. See module documentation.
+#
+# Arguments:
+#
+#   probes_file: The path to the probes file - an LTX file produced by Vivado.
+#
+#   test_config_path:
+#     The path to the test configuration file, see the module documentation for
+#     more information.
+#
+#   target_dict:
+#     An ordered dictionary which maps indices of FPGAs in the demo rack to
+#     their FPGA device IDs.
+#
+#   url: The URL of the hardware server.
+#
+#   ila_data_dir: The directory where the ILA data will be stored.
+#
 proc run_test_group {probes_file test_config_path target_dict url ila_data_dir} {
     # Load the device of the first target
     set target_id [lindex [dict values $target_dict] 0]

--- a/bittide-shake/data/tcl/HardwareTest.tcl
+++ b/bittide-shake/data/tcl/HardwareTest.tcl
@@ -37,8 +37,7 @@ proc set_vio_prefix {} {
     # Use `probe_test_done` as the probe to find full probe names
     set probe_done [get_hw_probes *vioHitlt/probe_test_done]
     if {[expr [llength $probe_done] != 1]} {
-        puts "Exactly 1 VIO core with the prefix '*vioHitlt' must be present"
-        exit 1
+        error "Exactly 1 VIO core with the prefix '*vioHitlt' must be present"
     }
     set vio_prefix [lindex [split [get_property name $probe_done] "/"] 0]
 }
@@ -77,7 +76,6 @@ proc verify_extra_vio_probes {test_config} {
         puts "Done"
     } else {
         puts "Failed"
-        puts "There are unmatched extra probes:"
         foreach probe $extra_probes {
             puts $probe
         }
@@ -85,7 +83,7 @@ proc verify_extra_vio_probes {test_config} {
         foreach probe_name $probe_names {
             puts $probe_name
         }
-        exit 1
+        error "There are unmatched extra probes in the design"
     }
 }
 # For the Hardware-in-the-Loop test (hitlt) at least 3 specific probes need to
@@ -103,58 +101,49 @@ proc verify_required_vio_probes {} {
     set done_probe_count [llength $done_probe]
     if {$done_probe_count != 1} {
         set done_probe_count [llength $done_probe]
-        puts "Exactly one probe named '$vio_prefix/probe_test_done' must be present, but ${done_probe_count} were found"
         print_all_probe_names
-        exit 1
+        error "Exactly one probe named '$vio_prefix/probe_test_done' must be present, but ${done_probe_count} were found"
     } elseif {[expr {[get_property type $done_probe] != "vio_input"}]} {
         set probe_name [get_property name.short $done_probe]
-        puts "Probe '${probe_name}' must have type 'vio_input'"
         print_all_probe_names
-        exit 1
+        error "Probe '${probe_name}' must have type 'vio_input'"
     } elseif {[expr {[get_property width $done_probe] != 1}]} {
         set probe_name [get_property name.short $done_probe]
-        puts "Probe '${probe_name}' must have a width of 1 bit"
         print_all_probe_names
-        exit 1
+        error "Probe '${probe_name}' must have a width of 1 bit"
     }
 
     set success_probe [get_hw_probes ${vio_prefix}/probe_test_success]
     set success_probe_count [llength $success_probe]
     if {$success_probe_count != 1} {
         set success_probe_count [llength $success_probe]
-        puts "Exactly one probe named '$vio_prefix/probe_test_success' must be present, but ${success_probe_count} were found"
         print_all_probe_names
-        exit 1
+        error "Exactly one probe named '$vio_prefix/probe_test_success' must be present, but ${success_probe_count} were found"
     }
     if {[expr {[get_property type $success_probe] != "vio_input"}]} {
         set probe_name [get_property name.short $success_probe]
-        puts "Probe '${probe_name}' must have type 'vio_input'"
         print_all_probe_names
-        exit 1
+        error "Probe '${probe_name}' must have type 'vio_input'"
     } elseif {[expr {[get_property width $success_probe] != 1}]} {
         set probe_name [get_property name.short $success_probe]
-        puts "Probe '${probe_name}' must have a width of 1 bit"
         print_all_probe_names
-        exit 1
+        error "Probe '${probe_name}' must have a width of 1 bit"
     }
 
     set start_probe [get_hw_probes ${vio_prefix}/probe_test_start]
     set start_probe_count [llength $start_probe]
     if {$start_probe_count != 1} {
-        puts "Exactly one probe named '$vio_prefix/probe_test_start' must be present, but ${start_probe_count} were found"
         print_all_probe_names
-        exit 1
+        error "Exactly one probe named '$vio_prefix/probe_test_start' must be present, but ${start_probe_count} were found"
     }
     if {[expr {[get_property type $start_probe] != "vio_output"}]} {
         set probe_name [get_property name.short $start_probe]
-        puts "Probe '$probe_name' must have type 'vio_output'"
         print_all_probe_names
-        exit 1
+        error "Probe '$probe_name' must have type 'vio_output'"
     } elseif {[expr {[get_property width $start_probe] != 1}]} {
         set probe_name [get_property name.short $start_probe]
-        puts "Probe '$probe_name' must have a width of 1 bit"
         print_all_probe_names
-        exit 1
+        error "Probe '$probe_name' must have a width of 1 bit"
     }
     puts "Done"
 }
@@ -191,19 +180,16 @@ proc get_ila_dicts {} {
         set trigger_probe [get_hw_probes -of_objects $hw_ila */trigger*]
         set trigger_probe_count [llength $trigger_probe]
         if {[expr {$trigger_probe_count != 1}]} {
-            puts "Exactly one probe named 'trigger*' must be present, but $trigger_probe_count were found"
             print_all_probe_names
-            exit 1
+            error "Exactly one probe named 'trigger*' must be present, but $trigger_probe_count were found"
         } elseif {[expr {[get_property is_trigger $trigger_probe] != 1}]} {
             set probe_name_short [get_property name.short $trigger_probe]
-            puts "Probe '$probe_name_short' should have probeType Trigger or DataAndTrigger"
             print_all_probe_names
-            exit 1
+            error "Probe '$probe_name_short' should have probeType Trigger or DataAndTrigger"
         } elseif {[expr {[get_property width $trigger_probe] != 1}]} {
             set probe_name_short [get_property name.short $trigger_probe]
-            puts "Probe '$probe_name_short' must have a width of 1 bit"
             print_all_probe_names
-            exit 1
+            error "Probe '$probe_name_short' must have a width of 1 bit"
         } else {
             dict set ila_dict trigger_probe [get_property name $trigger_probe]
         }
@@ -212,19 +198,16 @@ proc get_ila_dicts {} {
         set capture_probe [get_hw_probes -of_objects $hw_ila */capture*]
         set capture_probe_count [llength $capture_probe]
         if {[expr {$capture_probe_count != 1}]} {
-            puts "Exactly one probe named 'capture*' must be present, but $capture_probe_count were found"
             print_all_probe_names
-            exit 1
+            error "Exactly one probe named 'capture*' must be present, but $capture_probe_count were found"
         } elseif {[expr {[get_property is_trigger $capture_probe] != 1}]} {
             set probe_name_short [get_property name.short $capture_probe]
-            puts "Probe '$probe_name_short' should have probeType Trigger or DataAndTrigger"
             print_all_probe_names
-            exit 1
+            error "Probe '$probe_name_short' should have probeType Trigger or DataAndTrigger"
         } elseif {[expr {[get_property width $capture_probe] != 1}]} {
             set probe_name_short [get_property name.short $capture_probe]
-            puts "Probe '$probe_name_short' must have a width of 1 bit"
             print_all_probe_names
-            exit 1
+            error "Probe '$probe_name_short' must have a width of 1 bit"
         } else {
             dict set ila_dict capture_probe [get_property name $capture_probe]
         }
@@ -232,9 +215,8 @@ proc get_ila_dicts {} {
         # Get all data probes and verify each conforms with ILA framework
         set all_probes [get_hw_probes -of_objects $hw_ila]
         if {[expr {[llength $all_probes] < 3}]} {
-            puts "ILA '$short_name' has no data probes, at least 1 data probe is required"
             print_all_probe_names
-            exit 1
+            error "ILA '$short_name' has no data probes, at least 1 data probe is required"
         }
         dict set ila_dict data_probes [list]
         foreach probe $all_probes {
@@ -242,9 +224,8 @@ proc get_ila_dicts {} {
                 continue
             } elseif {[expr {[get_property is_data $probe] != 1}]} {
                 set probe_name_short [get_property name.short $probe]
-                puts "Probe '$probe_name_short' should have probeType Data or DataAndTrigger"
                 print_all_probe_names
-                exit 1
+                error "Probe '$probe_name_short' should have probeType Data or DataAndTrigger"
             } else {
                 dict update ila_dict data_probes probe_list {
                     lappend probe_list [get_property name $probe]
@@ -425,7 +406,7 @@ proc has_expected_targets {url expected_target_dict} {
                     puts $tgt
                 }
             }
-            exit 1
+            error "Could not find all expected hardware targets"
         }
 
         puts "Attempt ${i} : Found ${found_targets_count} out of expected ${expected_count} hardware targets"
@@ -471,10 +452,8 @@ proc verify_before_start {} {
     refresh_hw_vio [get_hw_vios]
     set done [get_property INPUT_VALUE [get_hw_probes ${vio_prefix}/probe_test_done]]
     if {$done != 0} {
-        puts "\tERROR: test is done before starting the test"
         print_all_vios
-        exit 1
-    }
+        error "Test is done before starting the test"
 }
 
 # Refresh the input probes until the done flag is set. Retries for up to
@@ -726,7 +705,6 @@ proc run_test_group {probes_file test_config_path target_dict url ila_data_dir} 
         exit 0
     } else {
         set failed_tests [expr ${test_count} - ${successful_tests}]
-        puts "\nFailed for ${failed_tests}/${test_count} tests"
-        exit 1
+        error "\nFailed for ${failed_tests}/${test_count} tests"
     }
 }

--- a/bittide-shake/src/Clash/Shake/Vivado.hs
+++ b/bittide-shake/src/Clash/Shake/Vivado.hs
@@ -1,4 +1,4 @@
--- SPDX-FileCopyrightText: 2022-2023 Google LLC
+-- SPDX-FileCopyrightText: 2022-2024 Google LLC
 --
 -- SPDX-License-Identifier: Apache-2.0
 
@@ -322,6 +322,7 @@ mkHardwareTestTcl outputDir hwTargets url ilaDataPath = do
 
     set fpga_nrs #{toTclTarget hwTargets}
     set probes_file {#{outputDir </> "probes.ltx"}}
+    set test_config_file {#{outputDir </> "test_config.yml"}}
     set url {#{url}}
 
     open_hw_manager
@@ -329,5 +330,5 @@ mkHardwareTestTcl outputDir hwTargets url ilaDataPath = do
     set target_dict [get_target_dict ${url} ${fpga_nrs}]
     has_expected_targets ${url} ${target_dict}
 
-    run_test_group $probes_file $target_dict $url {#{ilaDataPath}}
+    run_test_group $probes_file $test_config_file $target_dict $url {#{ilaDataPath}}
   |]


### PR DESCRIPTION
The PR allows us to write YAML files that describe tests.
Whenever we want to use execute multiple HITL tests on a single DUT, we always want to change some parameters per run.

Now we have the infra where we hard-code extra starting probes and based on that choose different parameters, but a better way would be to set the parameters with a configuration file free from the testbench.

This way we can easily run N tests on a design without changing the testbench.
In the future this infra enables us to simply generate these yaml files for extra flexibility.