### PR TITLE
Use `--locked` flag when calling `cargo install`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -490,7 +490,7 @@ jobs:
       - run: cache pull build
 
       - name: Install `elf-limits`
-        run: cargo install --git https://github.com/cuddlefishie/elf-limits
+        run: cargo install --locked --git https://github.com/cuddlefishie/elf-limits
 
       - name: Checking firmware binary limits
         run: |


### PR DESCRIPTION
Cargo will, by default, ignore any `Cargo.lock` files when invoked using `install`. This behavior is "documented" here:

https://github.com/rust-lang/cargo/issues/7169

It _also_ seems to ignore verion constraints in `Cargo.toml` files, making `elf-limits` uninstallable with an older Rust compiler, as Cargo will resolve `clap` to its latest version instead of the version specified in the `elf-limits`'s `Cargo.toml`. I couldn't find any information on this, but adding `--locked` works around this..