### PR TITLE
Add embedded std

### DIFF
--- a/firmware-support/Cargo.lock
+++ b/firmware-support/Cargo.lock
@@ -20,6 +20,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-polyfill"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
+dependencies = [
+ "critical-section",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -89,6 +98,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "critical-section"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7059fff8937831a9ae6f0fe4d658ffabf58f2ca96aa9dec1c889f936f705f216"
+
+[[package]]
+name = "embedded-std"
+version = "0.1.0"
+dependencies = [
+ "heapless",
+ "lazy_static",
+ "libc",
+ "object",
+ "proptest",
+ "rand",
+ "tempfile",
+ "test-strategy",
+ "ufmt",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -152,6 +182,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -165,6 +204,19 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "heapless"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
+dependencies = [
+ "atomic-polyfill",
+ "hash32",
+ "rustc_version",
+ "spin",
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -225,6 +277,16 @@ name = "linux-raw-sys"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
+
+[[package]]
+name = "lock_api"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
 
 [[package]]
 name = "memchr"
@@ -375,6 +437,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "0.37.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -399,6 +470,33 @@ dependencies = [
  "tempfile",
  "wait-timeout",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "structmeta"

--- a/firmware-support/Cargo.toml
+++ b/firmware-support/Cargo.toml
@@ -1,9 +1,10 @@
-# SPDX-FileCopyrightText: 2022 Google LLC
+# SPDX-FileCopyrightText: 2022-2024 Google LLC
 #
 # SPDX-License-Identifier: CC0-1.0
 
 [workspace]
 members = [
   "bittide-sys",
+  "embedded-std",
 ]
 resolver = "2"

--- a/firmware-support/embedded-std/Cargo.toml
+++ b/firmware-support/embedded-std/Cargo.toml
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: 2024 Google LLC
+#
+# SPDX-License-Identifier: CC0-1.0
+
+[package]
+name = "embedded-std"
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0"
+authors = ["Google LLC"]
+resolver = "2"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[features]
+panic-handler = []
+default = []
+
+[dependencies]
+ufmt = "0.2.0"
+heapless = { version = "0.7", default-features = false}
+
+[dev-dependencies]
+proptest = "1.0"
+object = { version = "0.28", features = ["write"] }
+libc = "0.2"
+test-strategy = "0.2.0"
+rand = "0.8"
+lazy_static = "1.0"
+tempfile = "3"

--- a/firmware-support/embedded-std/src/lib.rs
+++ b/firmware-support/embedded-std/src/lib.rs
@@ -1,0 +1,7 @@
+// SPDX-FileCopyrightText: 2024 Google LLC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#![no_std]
+
+pub mod string;

--- a/firmware-support/embedded-std/src/string.rs
+++ b/firmware-support/embedded-std/src/string.rs
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: 2024 Google LLC
+//
+// SPDX-License-Identifier: Apache-2.0
+use ufmt::{uDisplay, uWrite};
+
+#[derive(Clone)]
+pub struct String<const SIZE: usize>(pub heapless::String<SIZE>);
+
+impl <const SIZE: usize> String<SIZE> {
+    pub fn new() -> Self {
+        String(heapless::String::new())
+    }
+}
+
+impl<const SIZE: usize> uDisplay for String<SIZE> {
+    #[inline(always)]
+    fn fmt<W>(&self, f: &mut ufmt::Formatter<'_, W>) -> Result<(), W::Error>
+    where
+        W: uWrite + ?Sized,
+    {
+        f.write_str(&self.0.as_str())
+    }
+}
+
+impl <const SIZE: usize>  ufmt::uWrite for String<SIZE> {
+    fn write_str(&mut self, s: &str) -> Result<(), Self::Error> {
+        self.0.push_str(s)?;
+        Ok(())
+    }
+    type Error = ();
+}


### PR DESCRIPTION
Rust's [orphan rules](https://github.com/Ixrec/rust-orphan-rules) prevent us from deriving traits like `uDisplay`, `uDebug` and `uWrite` from the `ufmt` package, effectively preventing us from formatting strings with existing types.

Therefore I propose to create an `std` like package that contains newtype wrappers for commonly used datatypes.
A first example is `string.rs` that uses `String` from `heapless`. 