### PR TITLE
Bump to NixOS 23.11

### DIFF
--- a/.github/scripts/cache.py
+++ b/.github/scripts/cache.py
@@ -51,18 +51,20 @@ CLEAR_AFTER_DAYS=7
 CLEAR_AFTER=f"{CLEAR_AFTER_DAYS}d00h00m00s"
 TOUCH_AFTER=datetime.timedelta(days=1)
 
+GLOBAL_CACHE_BUST = 0
+
 CARGO_CACHE_BUST = 2
-CARGO_KEY_PREFIX = f"cargo-{CARGO_CACHE_BUST}-"
+CARGO_KEY_PREFIX = f"cargo-g{GLOBAL_CACHE_BUST}-l{CARGO_CACHE_BUST}-"
 CARGO_KEY_PATTERNS = ("**/Cargo.lock", "**/Cargo.toml", "**/rust-toolchain.toml")
 CARGO_CACHE_PATTERNS = ("~/.cargo",)
 
 CABAL_CACHE_BUST = 2
-CABAL_KEY_PREFIX = f"cabal-{CABAL_CACHE_BUST}-"
+CABAL_KEY_PREFIX = f"cabal-g{GLOBAL_CACHE_BUST}-l{CABAL_CACHE_BUST}-"
 CABAL_KEY_PATTERNS = ("**/cabal.project", "**/cabal.project.freeze")
 CABAL_CACHE_PATTERNS = ("~/.cabal-nix",)
 
 BUILD_CACHE_BUST = 2
-BUILD_KEY_PREFIX = f"build-products-{BUILD_CACHE_BUST}-"
+BUILD_KEY_PREFIX = f"build-products-g{GLOBAL_CACHE_BUST}-l{BUILD_CACHE_BUST}-"
 BUILD_CACHE_PATTERNS = (
     f"{PWD}/_build/",
     f"{PWD}/clash-vexriscv/clash-vexriscv/build_out_dir/",

--- a/.github/scripts/check_copyright_years.py
+++ b/.github/scripts/check_copyright_years.py
@@ -23,6 +23,10 @@ COPYRIGHT_RES = [
 
 YEAR_RE = re.compile(r"\d{4}")
 
+IGNORE_COMMTIS_STARTSWITH = (
+    "Squashed 'clash-vexriscv/' changes",
+)
+
 IGNORE_STARTSWITH = (
     "clash-vexriscv",
 )
@@ -31,7 +35,7 @@ def iter_change_types(diff_index, change_types):
     for change_type in change_types:
         yield from diff_index.iter_change_type(change_type)
 
-def get_pr_commits(repo, common_ancestor):
+def get_pr_commits(repo, common_ancestor, ignore=IGNORE_COMMTIS_STARTSWITH):
     """
     Gets all commits from the current one to (but not including) a common ancestor
     given as an argument.
@@ -39,6 +43,10 @@ def get_pr_commits(repo, common_ancestor):
     for commit in repo.iter_commits():
         if commit.binsha == common_ancestor.binsha:
             break
+
+        if commit.message.startswith(ignore):
+            continue
+
         yield commit
 
 def get_relevant_files_from_diff_index(diff_index):

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
       run:
         shell: git-nix-shell {0} --option connect-timeout 360 --pure --keep "GITHUB_SHA" --keep "S3_PASSWORD"
     container:
-      image: ghcr.io/clash-lang/nixos-bittide-hardware:2023-11-30
+      image: ghcr.io/clash-lang/nixos-bittide-hardware:2024-03-08
       options: --memory=11g
     steps:
       - name: Checkout
@@ -114,7 +114,7 @@ jobs:
         shell: git-nix-shell {0} --option connect-timeout 360 --pure --keep "GITHUB_SHA" --keep "S3_PASSWORD"
 
     container:
-      image: ghcr.io/clash-lang/nixos-bittide-hardware:2023-11-30
+      image: ghcr.io/clash-lang/nixos-bittide-hardware:2024-03-08
       options: --memory=11g
 
     steps:
@@ -154,7 +154,7 @@ jobs:
         shell: git-nix-shell {0} --option connect-timeout 360 --pure --keep "GITHUB_OUTPUT"
 
     container:
-      image: ghcr.io/clash-lang/nixos-bittide-hardware:2023-11-30
+      image: ghcr.io/clash-lang/nixos-bittide-hardware:2024-03-08
       options: --memory=11g
 
     steps:
@@ -194,7 +194,7 @@ jobs:
       fail-fast: false
 
     container:
-      image: ghcr.io/clash-lang/nixos-bittide-hardware:2023-11-30
+      image: ghcr.io/clash-lang/nixos-bittide-hardware:2024-03-08
       options: --memory=11g
 
     steps:
@@ -259,7 +259,7 @@ jobs:
     needs: [build, lint, elastic-buffer-sim-topologies-matrix, elastic-buffer-sim-topologies, bittide-instances-hardware-in-the-loop]
 
     container:
-      image: ghcr.io/clash-lang/nixos-bittide-hardware:2023-11-30
+      image: ghcr.io/clash-lang/nixos-bittide-hardware:2024-03-08
       options: --memory=11g
 
     steps:
@@ -337,7 +337,7 @@ jobs:
     needs: [build, lint]
 
     container:
-      image: ghcr.io/clash-lang/nixos-bittide-hardware:2023-11-30
+      image: ghcr.io/clash-lang/nixos-bittide-hardware:2024-03-08
       options: --memory=11g
 
     steps:
@@ -364,7 +364,7 @@ jobs:
     needs: [build, lint]
 
     container:
-      image: ghcr.io/clash-lang/nixos-bittide-hardware:2023-11-30
+      image: ghcr.io/clash-lang/nixos-bittide-hardware:2024-03-08
       options: --memory=11g
 
     steps:
@@ -399,7 +399,7 @@ jobs:
       run:
         shell: git-nix-shell {0} --option connect-timeout 360 --pure --keep "GITHUB_SHA" --keep "S3_PASSWORD"
     container:
-      image: ghcr.io/clash-lang/nixos-bittide-hardware:2023-11-30
+      image: ghcr.io/clash-lang/nixos-bittide-hardware:2024-03-08
       options: --memory=11g
     needs: [build]
 
@@ -424,7 +424,7 @@ jobs:
       run:
         shell: git-nix-shell {0} --option connect-timeout 360 --pure --keep "GITHUB_SHA" --keep "S3_PASSWORD"
     container:
-      image: ghcr.io/clash-lang/nixos-bittide-hardware:2023-11-30
+      image: ghcr.io/clash-lang/nixos-bittide-hardware:2024-03-08
       options: --memory=11g
     needs: [build]
 
@@ -452,7 +452,7 @@ jobs:
       run:
         shell: git-nix-shell {0} --option connect-timeout 360 --pure --keep "GITHUB_SHA" --keep "S3_PASSWORD"
     container:
-      image: ghcr.io/clash-lang/nixos-bittide-hardware:2023-11-30
+      image: ghcr.io/clash-lang/nixos-bittide-hardware:2024-03-08
       options: --memory=11g
     needs: [build]
 
@@ -478,7 +478,7 @@ jobs:
       run:
         shell: git-nix-shell {0} --option connect-timeout 360 --pure --keep "GITHUB_SHA" --keep "S3_PASSWORD"
     container:
-      image: ghcr.io/clash-lang/nixos-bittide-hardware:2023-11-30
+      image: ghcr.io/clash-lang/nixos-bittide-hardware:2024-03-08
       options: --memory=11g
     needs: [build]
 
@@ -511,7 +511,7 @@ jobs:
     needs: [build, lint]
 
     container:
-      image: ghcr.io/clash-lang/nixos-bittide-hardware:2023-11-30
+      image: ghcr.io/clash-lang/nixos-bittide-hardware:2024-03-08
       options: --memory=11g
 
     steps:
@@ -538,7 +538,7 @@ jobs:
     needs: [build, lint]
 
     container:
-      image: ghcr.io/clash-lang/nixos-bittide-hardware:2023-11-30
+      image: ghcr.io/clash-lang/nixos-bittide-hardware:2024-03-08
       options: --memory=11g
 
     steps:
@@ -564,7 +564,7 @@ jobs:
         shell: git-nix-shell {0} --option connect-timeout 360 --pure --keep "GITHUB_OUTPUT"
 
     container:
-      image: ghcr.io/clash-lang/nixos-bittide-hardware:2023-11-30
+      image: ghcr.io/clash-lang/nixos-bittide-hardware:2024-03-08
       options: --memory=11g
 
     steps:
@@ -597,7 +597,7 @@ jobs:
         shell: git-nix-shell {0} --option connect-timeout 360 --pure --keep "GITHUB_OUTPUT"
 
     container:
-      image: ghcr.io/clash-lang/nixos-bittide-hardware:2023-11-30
+      image: ghcr.io/clash-lang/nixos-bittide-hardware:2024-03-08
       options: --memory=11g
 
     steps:
@@ -640,7 +640,7 @@ jobs:
       fail-fast: false
 
     container:
-      image: ghcr.io/clash-lang/nixos-bittide-hardware:2023-11-30
+      image: ghcr.io/clash-lang/nixos-bittide-hardware:2024-03-08
       volumes:
         - /opt/tools:/opt/tools
       options: --init --mac-address="6c:5a:b0:6c:13:0b" --memory=11g
@@ -713,7 +713,7 @@ jobs:
       fail-fast: false
 
     container:
-      image: ghcr.io/clash-lang/nixos-bittide-hardware:2023-11-30
+      image: ghcr.io/clash-lang/nixos-bittide-hardware:2024-03-08
       volumes:
         - /opt/tools:/opt/tools
       options: --memory=11g

--- a/cabal.project
+++ b/cabal.project
@@ -1,4 +1,4 @@
--- SPDX-FileCopyrightText: 2022-2023 Google LLC
+-- SPDX-FileCopyrightText: 2022-2024 Google LLC
 --
 -- SPDX-License-Identifier: CC0-1.0
 
@@ -62,39 +62,39 @@ index-state: 2023-12-05T05:33:28Z
 source-repository-package
   type: git
   location: https://github.com/clash-lang/clash-compiler.git
-  tag: 72edd7aabb50537910c306c7efe57cf5f82bf759
+  tag: aff963fcecf677d6d5fa22fec9c0c7edfccd9579
   subdir: clash-prelude
 
 source-repository-package
   type: git
   location: https://github.com/clash-lang/clash-compiler.git
-  tag: 72edd7aabb50537910c306c7efe57cf5f82bf759
+  tag: aff963fcecf677d6d5fa22fec9c0c7edfccd9579
   subdir: clash-ghc
 
 source-repository-package
   type: git
   location: https://github.com/clash-lang/clash-compiler.git
-  tag: 72edd7aabb50537910c306c7efe57cf5f82bf759
+  tag: aff963fcecf677d6d5fa22fec9c0c7edfccd9579
   subdir: clash-lib
 
 source-repository-package
   type: git
   location: https://github.com/clash-lang/clash-compiler.git
-  tag: 72edd7aabb50537910c306c7efe57cf5f82bf759
+  tag: aff963fcecf677d6d5fa22fec9c0c7edfccd9579
   subdir: clash-prelude-hedgehog
 
 source-repository-package
   type: git
   location: https://github.com/clash-lang/clash-compiler.git
-  tag: 72edd7aabb50537910c306c7efe57cf5f82bf759
+  tag: aff963fcecf677d6d5fa22fec9c0c7edfccd9579
   subdir: clash-cores
 
 source-repository-package
   type: git
   location: https://github.com/clash-lang/clash-protocols.git
-  tag: fcd72e95d06224e7d749451a6646ae1e1b892607
+  tag: eb76cd1be746ae91beff60c0f16d8c1dd888662c
 
 source-repository-package
   type: git
   location: https://github.com/cchalmers/circuit-notation.git
-  tag: 618e37578e699df235f2e7150108b6401731919b
+  tag: 19b386c4aa3ff690758ae089c7754303f3500cc9

--- a/clash-vexriscv/.github/workflows/ci.yml
+++ b/clash-vexriscv/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2022 Google LLC
-# 
+#
 # SPDX-License-Identifier: Apache-2.0
 
 name: CI
@@ -54,7 +54,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --target riscv32imc-unknown-none-elf --all-features
-  
+
   rust-build-programs:
     name: Build Programs
     runs-on: ubuntu-22.04
@@ -69,6 +69,7 @@ jobs:
         run: |
           apt-get update
           apt-get install -y curl build-essential
+
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: 1.67.1 # See Note [Updating Rust versions]
@@ -76,21 +77,24 @@ jobs:
           target: riscv32imc-unknown-none-elf
           components: clippy, rustfmt
 
+      - name: Caching
+        uses: Swatinem/rust-cache@v2
+
       - name: Build release binaries
         uses: actions-rs/cargo@v1
         with:
           command: build
           args: --release
-      
+
       - name: Build debug binaries
         uses: actions-rs/cargo@v1
         with:
           command: build
-      
+
       - name: Archive Integration Test Binaries
         run: |
           cd clash-vexriscv-sim; sh bundle_test_binaries.sh
-      
+
       - name: Upload Integration Test Binaries
         uses: actions/upload-artifact@v3
         with:
@@ -103,8 +107,16 @@ jobs:
     runs-on: ubuntu-22.04
     needs: [rust-build-programs]
 
+    strategy:
+      fail-fast: false
+      matrix:
+        ghc:
+          - "9.0.2"
+          - "9.2.8"
+          - "9.4.8"
+
     container:
-      image: ghcr.io/clash-lang/clash-ci-9.0.2:2022-12-13
+      image: ghcr.io/clash-lang/clash-ci:${{ matrix.ghc }}-20240221
 
     steps:
       - name: Checkout
@@ -120,8 +132,8 @@ jobs:
         with:
           path: |
             ~/.cabal/store
-          key: packages-cachebust-1-${{ hashFiles('cabal.project.freeze', 'cabal.project') }}
-          restore-keys: packages-cachebust-1-
+          key: packages-cachebust-2-${{ matrix.ghc }}-${{ hashFiles('cabal.project.freeze', 'cabal.project') }}
+          restore-keys: packages-cachebust-2-${{ matrix.ghc }}
 
       - name: Install build deps
         run: |
@@ -163,6 +175,11 @@ jobs:
       - name: Extract VexRiscv Integration Tests
         run: |
           tar -x -f vexriscv-test-binaries.tar
-      - name: Run unittests
+
+      - name: Run `clash-vexriscv` unittests
+        run: |
+          cabal run clash-vexriscv:unittests
+
+      - name: Run `clash-vexriscv-sim` unittests
         run: |
           cabal run clash-vexriscv-sim:unittests

--- a/clash-vexriscv/.vscode/settings.json
+++ b/clash-vexriscv/.vscode/settings.json
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2023 Google LLC
+
+// SPDX-License-Identifier: CC0-1.0
+{
+  "files.exclude": {
+    "**/*.dyn_hi": true,
+    "**/*.dyn_o": true,
+    "**/*.hi": true,
+    "**/*.o": true,
+    "**/*.o-boot": true,
+    "**/*.hi-boot": true,
+    "**/dist-newstyle": true,
+    "**/.stack-work": true,
+    "**/.ghc.environment.*": true,
+  },
+  "files.insertFinalNewline": true,
+  "files.trimFinalNewlines": true,
+  "files.trimTrailingWhitespace": true,
+  "editor.tabSize": 2,
+  "[rust]": {
+    "editor.tabSize": 4
+  },
+  "[haskell]": {
+    "editor.formatOnSave": false
+  },
+}

--- a/clash-vexriscv/cabal.project
+++ b/clash-vexriscv/cabal.project
@@ -8,8 +8,6 @@ packages:
 
 write-ghc-environment-files: always
 
-with-compiler: ghc-9.0.2
-
 tests: True
 
 
@@ -49,9 +47,9 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/clash-lang/clash-protocols.git
-  tag: f7ea04834d396669fe4ef404b03541601a68b136
+  tag: eb76cd1be746ae91beff60c0f16d8c1dd888662c
 
 source-repository-package
   type: git
   location: https://github.com/cchalmers/circuit-notation.git
-  tag: 618e37578e699df235f2e7150108b6401731919b
+  tag: 19b386c4aa3ff690758ae089c7754303f3500cc9

--- a/clash-vexriscv/clash-vexriscv-sim/clash-vexriscv-sim.cabal
+++ b/clash-vexriscv/clash-vexriscv-sim/clash-vexriscv-sim.cabal
@@ -60,9 +60,9 @@ common common-options
     -fno-worker-wrapper
       -- clash-prelude will set suitable version bounds for the plugins
   build-depends:
-    base >= 4.14 && < 4.16,
+    base >= 4.14 && < 4.19,
     clash-prelude >= 1.6 && < 1.10,
-    containers >= 0.6 && < 0.7,
+    containers >= 0.6 && < 0.8,
     ghc-typelits-natnormalise,
     ghc-typelits-extra,
     ghc-typelits-knownnat,
@@ -79,11 +79,11 @@ library
     Utils.Storage
   build-depends:
     base,
+    bytestring >= 0.10 && < 0.13,
     clash-prelude,
     clash-protocols,
     clash-vexriscv,
     elf >= 0.31 && < 0.32,
-    bytestring >= 0.10 && < 0.11,
 
 executable clash
   import: common-options
@@ -120,6 +120,8 @@ test-suite unittests
   default-language: Haskell2010
   hs-source-dirs: tests
   type: exitcode-stdio-1.0
+  -- TODO: enable parallel tests:
+  -- ghc-options: -threaded -rtsopts -with-rtsopts=-N
   ghc-options: -threaded
   main-is: tests.hs
   build-depends:
@@ -132,6 +134,6 @@ test-suite unittests
     containers,
     directory,
     temporary >=1.1 && <1.4,
-    tasty >= 1.2 && < 1.5,
+    tasty >= 1.2 && < 1.6,
     tasty-hunit >= 0.10 && < 0.11,
     filepath

--- a/clash-vexriscv/clash-vexriscv-sim/src/Utils/Cpu.hs
+++ b/clash-vexriscv/clash-vexriscv-sim/src/Utils/Cpu.hs
@@ -11,22 +11,12 @@ import Clash.Prelude
 
 import Protocols.Wishbone
 import VexRiscv
+import VexRiscv.VecToTuple (vecToTuple)
 
 import GHC.Stack (HasCallStack)
 
 import Utils.ProgramLoad (Memory)
 import Utils.Interconnect (interconnectTwo)
-
-emptyInput :: Input
-emptyInput =
-  Input
-    { timerInterrupt = low,
-      externalInterrupt = low,
-      softwareInterrupt = low,
-      iBusWbS2M = (emptyWishboneS2M @(BitVector 32)) {readData = 0},
-      dBusWbS2M = (emptyWishboneS2M @(BitVector 32)) {readData = 0}
-    }
-
 
 {-
 Address space
@@ -61,7 +51,7 @@ cpu bootIMem bootDMem = (output, writes, iS2M, dS2M)
     dummyS2M = dummy dummyM2S
     bootDS2M = bootDMem bootDM2S
 
-    (dS2M, unbundle -> (dummyM2S :> bootDM2S :> Nil)) = interconnectTwo
+    (dS2M, vecToTuple . unbundle -> (dummyM2S, bootDM2S)) = interconnectTwo
       (unBusAddr <$> dM2S)
       ((0x0000_0000, dummyS2M) :> (0x4000_0000, bootDS2M) :> Nil)
 

--- a/clash-vexriscv/clash-vexriscv-sim/src/Utils/ProgramLoad.hs
+++ b/clash-vexriscv/clash-vexriscv-sim/src/Utils/ProgramLoad.hs
@@ -33,8 +33,8 @@ loadProgram path = do
 
   let
       endianSwap dat =
-        L.concatMap (\[a, b, c, d] -> [d, c, b, a]) $
-        chunkFill 4 0 dat
+        L.concatMap (\(a, b, c, d) -> [d, c, b, a]) $
+        chunkFill4 0 dat
 
       -- endian swap instructions
       iMemContents = endianSwap $
@@ -51,9 +51,10 @@ loadProgram path = do
     content :: BinaryData -> [BitVector 8]
     content bin = L.map snd $ I.toAscList bin
 
-    chunkFill :: Int -> a -> [a] -> [[a]]
-    chunkFill _ _ [] = []
-    chunkFill n fill xs =
-      let (first0, rest) = L.splitAt n xs
-          first1 = first0 <> L.replicate (n - L.length first0) fill
-       in first1 : chunkFill n fill rest
+    chunkFill4 :: a -> [a] -> [(a, a, a, a)]
+    chunkFill4 fill = \case
+      [] -> []
+      [a] -> [(a, fill, fill, fill)]
+      [a, b] -> [(a, b, fill, fill)]
+      [a, b, c] -> [(a, b, c, fill)]
+      (a:b:c:d:rest) -> (a, b, c, d) : chunkFill4 fill rest

--- a/clash-vexriscv/clash-vexriscv-sim/src/Utils/Storage.hs
+++ b/clash-vexriscv/clash-vexriscv-sim/src/Utils/Storage.hs
@@ -2,17 +2,43 @@
 --
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ApplicativeDo #-}
-module Utils.Storage where
+{-# LANGUAGE RecordWildCards #-}
+
+module Utils.Storage
+  ( storage
+  ) where
 
 import Clash.Prelude
+
+import Data.Either (isLeft)
+import Protocols.Wishbone
+import GHC.Stack (HasCallStack)
 
 import qualified Data.List as L
 import qualified Data.IntMap.Strict as I
 
-import Clash.Signal.Internal (Signal((:-)))
-import Protocols.Wishbone
+newtype MappedMemory = MappedMemory (I.IntMap (BitVector 8))
+
+unMappedMemory :: MappedMemory -> I.IntMap (BitVector 8)
+unMappedMemory (MappedMemory x) = x
+
+instance NFDataX MappedMemory where
+  -- Not a product type, so no spine
+  deepErrorX = errorX
+
+  -- Keys are 'Int's and evaluated to WHNF because this is a strict map. For 'Int's,
+  -- WHNF ~ NF, so we only need to check the values.
+  hasUndefined m =
+       isLeft (isX (unMappedMemory m))
+    || (any hasUndefined $ I.elems $ unMappedMemory m)
+
+  -- Not a product type, so no spine
+  ensureSpine = id
+
+  -- This is a strict map, so we dont need to do anything. Note that WHNF ~ NF for
+  -- 'BitVector'.
+  rnfX x = seq x ()
 
 storage ::
   forall dom.
@@ -23,26 +49,34 @@ storage ::
   -- ^ contents
   Signal dom (WishboneM2S 32 4 (BitVector 32)) ->
   Signal dom (WishboneS2M (BitVector 32))
-storage contents = mealy' go (I.fromAscList $ L.zip [0..] contents)
+storage contents = mealy go (MappedMemory $ I.fromAscList $ L.zip [0..] contents)
  where
   size = L.length contents
 
-  -- Version of mealy that doesn't require NFDataX for the state.
-  -- This is needed because IntMap (Word8) does not implement NFDataX
-  mealy' fn st0 (i :- is) = o :- mealy' fn st1 is 
-    where (st1, o) = fn st0 i
-
-  go mem WishboneM2S{..}
-    | not (busCycle && strobe)        = (mem, emptyWishboneS2M)
-    | addr >= fromIntegral size       = (mem, emptyWishboneS2M { err = True })
+  go (MappedMemory mem) WishboneM2S{..}
+    | not (busCycle && strobe)        = (MappedMemory mem, emptyWishboneS2M)
+    | addr >= fromIntegral size       =
+        (MappedMemory mem, emptyWishboneS2M { err = True })
     | not writeEnable      {- read -} =
         case readDataSel mem addr busSelect of
-          Nothing -> (mem, emptyWishboneS2M { err = True })
-          Just x -> (mem, (emptyWishboneS2M @(BitVector 32)) { acknowledge = True, readData = x })
+          Nothing -> (MappedMemory mem, emptyWishboneS2M { err = True })
+          Just x -> (MappedMemory mem, (emptyWishboneS2M @(BitVector 32)) { acknowledge = True, readData = x })
     | otherwise           {- write -} =
-        (writeDataSel mem addr busSelect writeData, emptyWishboneS2M { acknowledge = True })
+        ( MappedMemory (writeDataSel mem addr busSelect writeData)
+        , emptyWishboneS2M { acknowledge = True }
+        )
 
-readDataSel :: I.IntMap (BitVector 8) -> BitVector 32 -> BitVector 4 -> Maybe (BitVector 32)
+readDataSel ::
+  HasCallStack =>
+  -- | Memory
+  I.IntMap (BitVector 8) ->
+  -- | Address
+  BitVector 32 ->
+  -- | Byte enables (@SEL@)
+  BitVector 4 ->
+  -- | Read value, or 'Nothing' if the read is invalid due to an unsupported
+  -- value of @SEL@.
+  Maybe (BitVector 32)
 readDataSel mem addr sel =
   case sel of
     0b0001 -> readByte (addr + 0)
@@ -52,8 +86,8 @@ readDataSel mem addr sel =
     0b0011 -> readWord (addr + 0)
     0b1100 -> readWord (addr + 2)
     0b1111 -> readDWord addr
-    _                    -> Nothing
-  
+    _      -> Nothing
+
   where
     readByte addr' = resize @_ @8 @32 <$> I.lookup (fromIntegral addr') mem
     readWord addr' = do
@@ -65,7 +99,18 @@ readDataSel mem addr sel =
       h <- readWord (addr' + 0)
       pure $ h `shiftL` 16 .|. l
 
-writeDataSel :: I.IntMap (BitVector 8) -> BitVector 32 -> BitVector 4 -> BitVector 32 -> I.IntMap (BitVector 8)
+writeDataSel ::
+  HasCallStack =>
+  -- | Memory
+  I.IntMap (BitVector 8) ->
+  -- | Address
+  BitVector 32 ->
+  -- | Byte enables (SEL)
+  BitVector 4 ->
+  -- | Value to write
+  BitVector 32 ->
+  -- | Updated memory
+  I.IntMap (BitVector 8)
 writeDataSel mem addr sel val =
   case sel of
     0b0001 ->
@@ -87,7 +132,7 @@ writeDataSel mem addr sel val =
       I.insert (fromIntegral $ addr + 2) lh $
       I.insert (fromIntegral $ addr + 1) hl $
       I.insert (fromIntegral $ addr + 0) hh mem
-    _ -> mem
-  
+    _ -> error $ "Got SEL = " <> show sel <> " which is unsupported"
+
   where
     (hh :: BitVector 8, hl :: BitVector 8, lh :: BitVector 8, ll :: BitVector 8) = unpack val

--- a/clash-vexriscv/clash-vexriscv/Makefile
+++ b/clash-vexriscv/clash-vexriscv/Makefile
@@ -40,13 +40,17 @@ $(OUT_DIR)/impl.o: $(FFI_DIR)/impl.cpp $(FFI_DIR)/interface.h
 $(OUT_DIR)/verilated.o: $(shell pkg-config --variable=includedir verilator)/verilated.cpp
 	$(CXX) $(FFI_CPPFLAGS) -c $(shell pkg-config --variable=includedir verilator)/verilated.cpp -o $(OUT_DIR)/verilated.o
 
+$(OUT_DIR)/verilated_threads.o: $(shell pkg-config --variable=includedir verilator)/verilated_threads.cpp
+	$(CXX) $(FFI_CPPFLAGS) -c $(shell pkg-config --variable=includedir verilator)/verilated_threads.cpp -o $(OUT_DIR)/verilated_threads.o
+
 $(OUT_DIR)/VVexRiscv__ALL.a: $(VERILATOR_DIR)/VVexRiscv__ALL.a
 	cp $(VERILATOR_DIR)/VVexRiscv__ALL.a $(OUT_DIR)/VVexRiscv__ALL.a
 
-$(OUT_DIR)/libVexRiscvFFI.a: $(OUT_DIR)/VVexRiscv__ALL.a $(OUT_DIR)/impl.o $(OUT_DIR)/verilated.o
+$(OUT_DIR)/libVexRiscvFFI.a: $(OUT_DIR)/VVexRiscv__ALL.a $(OUT_DIR)/impl.o $(OUT_DIR)/verilated.o $(OUT_DIR)/verilated_threads.o
 	rm -f $(OUT_DIR)/libVexRiscvFFI.a
 	cp $(OUT_DIR)/VVexRiscv__ALL.a $(OUT_DIR)/libVexRiscvFFI.a
 	ar r \
 		$(OUT_DIR)/libVexRiscvFFI.a \
 		$(OUT_DIR)/impl.o \
-		$(OUT_DIR)/verilated.o
+		$(OUT_DIR)/verilated.o \
+		$(OUT_DIR)/verilated_threads.o

--- a/clash-vexriscv/clash-vexriscv/clash-vexriscv.cabal
+++ b/clash-vexriscv/clash-vexriscv/clash-vexriscv.cabal
@@ -87,9 +87,9 @@ common common-options
     -fno-worker-wrapper
       -- clash-prelude will set suitable version bounds for the plugins
   build-depends:
-    base >= 4.14 && < 4.16,
+    base >= 4.14 && < 4.18,
     clash-prelude >= 1.6 && < 1.10,
-    containers >= 0.6 && < 0.7,
+    containers >= 0.6 && < 0.8,
     ghc-typelits-natnormalise,
     ghc-typelits-extra,
     ghc-typelits-knownnat,
@@ -102,19 +102,44 @@ library
   default-language: Haskell2010
   exposed-modules:
     VexRiscv
+    VexRiscv.ClockTicks
     VexRiscv.FFI
     VexRiscv.TH
+    VexRiscv.VecToTuple
+
   build-depends:
     base,
+    bytestring >= 0.10 && < 0.13,
     clash-prelude,
     clash-protocols,
-    bytestring >= 0.10 && < 0.11,
-    process >= 1.6 && < 1.8,
+    containers,
     directory >= 1.3 && < 1.4,
     filepath,
-    containers,
-    string-interpolate,
-    template-haskell,
     Glob,
+    process >= 1.6 && < 1.8,
+    string-interpolate,
+    tagged,
+    template-haskell,
   extra-libraries: VexRiscvFFI, stdc++
   include-dirs: src/
+
+test-suite unittests
+  import: common-options
+  hs-source-dirs: tests/unittests
+  type: exitcode-stdio-1.0
+  main-is: main.hs
+  ghc-options: -Wall -Wcompat -threaded -rtsopts
+  other-modules:
+    Tests.Extra
+    Tests.VexRiscv.ClockTicks
+  build-depends:
+    HUnit,
+    base,
+    clash-vexriscv,
+    bytestring,
+    hedgehog >= 1.0 && < 1.5,
+    tasty >= 1.4 && < 1.6,
+    tasty-hedgehog >= 1.2 && < 1.5,
+    tasty-hunit,
+    tasty-th,
+    template-haskell,

--- a/clash-vexriscv/clash-vexriscv/src/VexRiscv/ClockTicks.hs
+++ b/clash-vexriscv/clash-vexriscv/src/VexRiscv/ClockTicks.hs
@@ -1,0 +1,385 @@
+-- SPDX-FileCopyrightText: 2024 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+
+{-# LANGUAGE NamedFieldPuns #-}
+
+-- | Utilities dealing with clock ticks and edges (and absolute+relative
+--   event timings) in Clash.
+--
+-- This file was added when we were working on adding JTAG support on a
+-- separate domain. For that, handling two different clocks and their edges
+-- (and timing for simulation) was important.
+--
+-- We decided to keep JTAG on the CPU domain, so all functions except
+-- 'singleClockEdgesRelative' and 'singleClockEdgesAbsolute' are unused.
+--
+--
+-- TODO: Figure out whether we want to upstream as is, or whether we want to
+--       generalize to /N/ clocks first.
+module VexRiscv.ClockTicks
+  ( ClockEdgeAB(..)
+  , clockTicksAbsolute
+  , clockTicksRelative
+  , clockEdgesAbsolute
+  , clockEdgesRelative
+  , singleClockEdgesAbsolute
+  , singleClockEdgesRelative
+  ) where
+
+import Prelude
+
+import Data.Coerce (coerce)
+import Data.Int (Int64)
+import Data.List (mapAccumL)
+import Data.Ord ()
+
+import Clash.Promoted.Nat (snatToNum)
+import Clash.Signal
+  ( ActiveEdge(..), KnownDomain, Clock, SDomainConfiguration(..), knownDomain
+  , SActiveEdge(..), activeEdge
+  )
+import Clash.Signal.Internal (Signal((:-)), ClockAB(..), Femtoseconds(..), Clock(..))
+
+-- | Given two clocks, produce a list of clock ticks indicating which clock
+-- (or both) ticked. Can be used in components handling multiple clocks, such
+-- as @unsafeSynchronizer@ or dual clock FIFOs. In contrast to 'clockTicks',
+-- this version also produces the absolute time at which the tick happened.
+--
+-- If your primitive does not care about coincided clock edges, it should - by
+-- convention - replace it by @ClockB:ClockA:@.
+--
+-- Returned time is in /femtoseconds/.
+clockTicksAbsolute ::
+  (KnownDomain domA, KnownDomain domB) =>
+  Clock domA ->
+  Clock domB ->
+  [(Int64, ClockAB)]
+clockTicksAbsolute clkA clkB =
+  clockTicksEitherAbsolute (toEither clkA) (toEither clkB)
+
+-- | Given two clocks, produce a list of clock ticks indicating which clock
+-- (or both) ticked. Can be used in components handling multiple clocks, such
+-- as @unsafeSynchronizer@ or dual clock FIFOs. In contrast to 'clockTicks',
+-- this version also produces the time since the last tick. Note that the first
+-- "time since last tick" is always zero.
+--
+-- If your primitive does not care about coincided clock edges, it should - by
+-- convention - replace it by @ClockB:ClockA:@.
+--
+-- Returned time is in /femtoseconds/.
+clockTicksRelative ::
+  (KnownDomain domA, KnownDomain domB) =>
+  Clock domA ->
+  Clock domB ->
+  [(Int64, ClockAB)]
+clockTicksRelative clkA clkB =
+  clockTicksEitherRelative (toEither clkA) (toEither clkB)
+
+-- | Given two clocks, produce a list of clock ticks indicating which clock
+-- (or both) ticked. Can be used in components handling multiple clocks, such
+-- as @unsafeSynchronizer@ or dual clock FIFOs.
+--
+-- If your primitive does not care about coincided clock edges, it should - by
+-- convention - replace it by @ClockEdgeB edgeB : ClockEdgeA edgeA:@.
+--
+-- Returned time is in /femtoseconds/.
+clockEdgesAbsolute ::
+  forall domA domB .
+  (KnownDomain domA, KnownDomain domB) =>
+  Clock domA ->
+  Clock domB ->
+  [(Int64, ClockEdgeAB)]
+clockEdgesAbsolute clkA clkB =
+  clockEdgesEitherAbsolute
+    (toActiveEdge (activeEdge @domA)) (toActiveEdge (activeEdge @domB))
+    (toEither clkA) (toEither clkB)
+
+-- | Given two clocks, produce a list of clock ticks indicating which clock
+-- (or both) ticked. Can be used in components handling multiple clocks, such
+-- as @unsafeSynchronizer@ or dual clock FIFOs.
+--
+-- If your primitive does not care about coincided clock edges, it should - by
+-- convention - replace it by @ClockEdgeB edgeB : ClockEdgeA edgeA:@.
+--
+-- Returned time is in /femtoseconds/.
+clockEdgesRelative ::
+  forall domA domB .
+  (KnownDomain domA, KnownDomain domB) =>
+  Clock domA ->
+  Clock domB ->
+  [(Int64, ClockEdgeAB)]
+clockEdgesRelative clkA clkB =
+  clockEdgesEitherRelative
+    (toActiveEdge (activeEdge @domA)) (toActiveEdge (activeEdge @domB))
+    (toEither clkA) (toEither clkB)
+
+-- | Given a clock, produce a list of clock edges and the time at which the
+-- edge occurs.
+--
+-- This can be used for simulating designs that need to advance time to get
+-- accurate traces.
+--
+-- Returned time is in /femotseconds/.
+singleClockEdgesAbsolute
+  :: forall dom .
+  (KnownDomain dom) =>
+  Clock dom ->
+  [(Int64, ActiveEdge)]
+singleClockEdgesAbsolute clk =
+  singleClockEdgesEitherAbsolute
+    (toActiveEdge (activeEdge @dom))
+    (toEither clk)
+
+-- | Given a clock, produce a list of clock edges and the time since the last
+-- edge.
+--
+-- This can be used for simulating designs that need to advance time to get
+-- accurate traces.
+--
+-- Returned time is in /femotseconds/.
+singleClockEdgesRelative
+  :: forall dom .
+  (KnownDomain dom) =>
+  Clock dom ->
+  [(Int64, ActiveEdge)]
+singleClockEdgesRelative clk =
+  singleClockEdgesEitherRelative
+    (toActiveEdge (activeEdge @dom))
+    (toEither clk)
+
+
+-- | GADT version of 'ActiveEdge' to 'ActiveEdge' conversion
+toActiveEdge :: SActiveEdge edge -> ActiveEdge
+toActiveEdge SRising = Rising
+toActiveEdge SFalling = Falling
+
+toEither ::
+  forall dom.
+  KnownDomain dom =>
+  Clock dom ->
+  Either Int64 (Signal dom Int64)
+toEither (Clock _ maybePeriods)
+  | Just periods <- maybePeriods =
+      Right (unFemtosecondsSignal periods)
+  | SDomainConfiguration{sPeriod} <- knownDomain @dom =
+      -- Convert to femtoseconds - dynamic clocks use them
+      Left (1000 * snatToNum sPeriod)
+ where
+  -- Coerce whole signal instead of `fmap coerce` to prevent useless constructor
+  -- packing and unpacking.
+  unFemtosecondsSignal :: Signal dom Femtoseconds -> Signal dom Int64
+  unFemtosecondsSignal = coerce
+
+-- | Given two clock periods, produce a list of clock ticks indicating which clock
+-- (or both) ticked. Can be used in components handling multiple clocks, such
+-- as @unsafeSynchronizer@ or dual clock FIFOs. In contrast to 'clockTicksEither',
+-- this version also produces the absolute time at which the event happened.
+--
+-- If your primitive does not care about coincided clock edges, it should - by
+-- convention - replace it by @ClockB:ClockA:@.
+clockTicksEitherAbsolute ::
+  Either Int64 (Signal domA Int64) ->
+  Either Int64 (Signal domB Int64) ->
+  [(Int64, ClockAB)]
+clockTicksEitherAbsolute clkA clkB =
+  case (clkA, clkB) of
+    (Left  tA, Left  tB) | tA == tB -> zip (iterate (+tA) 0) (repeat ClockAB)
+    (Left  tA, Left  tB) -> goStatic 0 0 tA tB
+    (Right tA, Right tB) -> goDynamic 0 0 tA tB
+    (Left  tA, Right tB) -> clockTicksEitherAbsolute (Right (pure tA)) (Right tB)
+    (Right tA, Left  tB) -> clockTicksEitherAbsolute (Right tA) (Right (pure tB))
+ where
+  goStatic :: Int64 -> Int64 -> Int64 -> Int64 -> [(Int64, ClockAB)]
+  goStatic absTimeA absTimeB tA tB =
+    case compare absTimeA absTimeB of
+      LT -> (absTimeA, ClockA)  : goStatic (absTimeA + tA) absTimeB        tA tB
+      EQ -> (absTimeA, ClockAB) : goStatic (absTimeA + tA) (absTimeB + tB) tA tB
+      GT -> (absTimeB, ClockB)  : goStatic absTimeA        (absTimeB + tB) tA tB
+
+  goDynamic :: Int64 -> Int64 -> Signal domA Int64 -> Signal domB Int64 -> [(Int64, ClockAB)]
+  goDynamic absTimeA absTimeB tsA@(~(tA :- tsA0)) tsB@(~(tB :- tsB0)) =
+    -- Even though we lazily match on the signal's constructor, this shouldn't
+    -- build up a significant chain of chunks as 'absTimeX' gets evaluated
+    -- every iteration.
+    case compare absTimeA absTimeB of
+      LT -> (absTimeA, ClockA)  : goDynamic (absTimeA + tA) absTimeB        tsA0 tsB
+      EQ -> (absTimeA, ClockAB) : goDynamic (absTimeA + tA) (absTimeB + tB) tsA0 tsB0
+      GT -> (absTimeB, ClockB)  : goDynamic absTimeA        (absTimeB + tB) tsA  tsB0
+
+-- | Given two clock periods, produce a list of clock ticks indicating which clock
+-- (or both) ticked. Can be used in components handling multiple clocks, such
+-- as @unsafeSynchronizer@ or dual clock FIFOs. In contrast to 'clockTicksEither',
+-- this version also produces the time since the last event.
+--
+-- If your primitive does not care about coincided clock edges, it should - by
+-- convention - replace it by @ClockB:ClockA:@.
+clockTicksEitherRelative ::
+  Either Int64 (Signal domA Int64) ->
+  Either Int64 (Signal domB Int64) ->
+  [(Int64, ClockAB)]
+clockTicksEitherRelative clkA clkB = zip relativeTimestamps ticks
+ where
+  relativeTimestamps = 0 : zipWith (-) (tail timestamps) timestamps
+  (timestamps, ticks) = unzip (clockTicksEitherAbsolute clkA clkB)
+
+-- | Flip edge from rising to falling, and vice versa
+oppositeEdge :: ActiveEdge -> ActiveEdge
+oppositeEdge Rising = Falling
+oppositeEdge Falling = Rising
+
+data ClockEdgeAB
+  = ClockEdgeA !ActiveEdge
+  | ClockEdgeB !ActiveEdge
+  | ClockEdgeAB !ActiveEdge !ActiveEdge
+  deriving (Show, Eq)
+
+-- | Given two clock periods, produce a list of clock ticks indicating which clock
+-- (or both) ticked. Can be used in components handling multiple clocks, such
+-- as @unsafeSynchronizer@ or dual clock FIFOs. In contrast to 'clockTicksEither',
+-- this version also produces the absolute time at which the event happened.
+--
+-- If your primitive does not care about coincided clock edges, it should - by
+-- convention - replace it by @ClockEdgeB edgeB : ClockEdgeA edgeA:@.
+clockEdgesEitherAbsolute ::
+  ActiveEdge ->
+  -- ^ First active edge for clock A
+  ActiveEdge ->
+  -- ^ First active edge for clock B
+  Either Int64 (Signal domA Int64) ->
+  -- ^ Clock periods for clock A
+  Either Int64 (Signal domB Int64) ->
+  -- ^ Clock periods for clock B
+  [(Int64, ClockEdgeAB)]
+clockEdgesEitherAbsolute firstEdgeA firstEdgeB clkA clkB =
+  case (clkA, clkB) of
+    (Left  tA, Left  tB) | tA == tB -> goSame (halve tA)
+    (Left  tA, Left  tB) -> goStatic  0 0 firstEdgeA firstEdgeB (halve tA) (halve tB)
+    (Right tA, Right tB) -> goDynamic 0 0 firstEdgeA firstEdgeB (halves tA) (halves tB)
+    (Left  tA, Right tB) ->
+      clockEdgesEitherAbsolute firstEdgeA firstEdgeB (Right (pure tA)) (Right tB)
+    (Right tA, Left  tB) ->
+      clockEdgesEitherAbsolute firstEdgeA firstEdgeB (Right tA) (Right (pure tB))
+ where
+  halves = go . fmap halve
+   where
+    go ((t0, t1) :- ts) = t0 :- t1 :- go ts
+
+  halve t =
+    ( t `div` 2
+    , t - (t `div` 2)
+    )
+
+  goSame :: (Int64, Int64) -> [(Int64, ClockEdgeAB)]
+  goSame (t0, t1) =
+    zip
+      (snd $ mapAccumL (\acc t -> (acc + t, acc)) 0 (cycle [t0, t1]))
+      (cycle [ ClockEdgeAB firstEdgeA firstEdgeB
+             , ClockEdgeAB (oppositeEdge firstEdgeA) (oppositeEdge firstEdgeB)
+             ])
+
+  goStatic ::
+    Int64 -> Int64 ->
+    ActiveEdge -> ActiveEdge ->
+    (Int64, Int64) -> (Int64, Int64) ->
+    [(Int64, ClockEdgeAB)]
+  goStatic absTimeA absTimeB !edgeA !edgeB (tA0, tA1) (tB0, tB1) =
+    case compare absTimeA absTimeB of
+      -- XXX: Sorry for breaking the 80/90 limit. I have no idea how to break this
+      --      over multiple lines without sacrificing readability.
+      LT -> (absTimeA, ClockEdgeA edgeA)        : goStatic (absTimeA + tA0) absTimeB         (oppositeEdge edgeA) edgeB                (tA1, tA0) (tB0, tB1)
+      EQ -> (absTimeA, ClockEdgeAB edgeA edgeB) : goStatic (absTimeA + tA0) (absTimeB + tB0) (oppositeEdge edgeA) (oppositeEdge edgeB) (tA1, tA0) (tB1, tB0)
+      GT -> (absTimeB, ClockEdgeB edgeB)        : goStatic absTimeA         (absTimeB + tB0) edgeA                (oppositeEdge edgeB) (tA0, tA1) (tB1, tB0)
+
+  goDynamic ::
+    Int64 -> Int64 ->
+    ActiveEdge -> ActiveEdge ->
+    Signal domA Int64 -> Signal domB Int64 ->
+    [(Int64, ClockEdgeAB)]
+  goDynamic absTimeA absTimeB edgeA edgeB tsA@(~(tA :- tsA0)) tsB@(~(tB :- tsB0)) =
+    -- Even though we lazily match on the signal's constructor, this shouldn't
+    -- build up a significant chain of chunks as 'absTimeX' gets evaluated
+    -- every iteration.
+    case compare absTimeA absTimeB of
+      -- XXX: Sorry for breaking the 80/90 limit. I have no idea how to break this
+      --      over multiple lines without sacrificing readability.
+      LT -> (absTimeA, ClockEdgeA edgeA)        : goDynamic (absTimeA + tA) absTimeB        (oppositeEdge edgeA) edgeB                tsA0 tsB
+      EQ -> (absTimeA, ClockEdgeAB edgeA edgeB) : goDynamic (absTimeA + tA) (absTimeB + tB) (oppositeEdge edgeA) (oppositeEdge edgeB) tsA0 tsB0
+      GT -> (absTimeB, ClockEdgeB edgeB)        : goDynamic absTimeA        (absTimeB + tB) edgeA                (oppositeEdge edgeB) tsA  tsB0
+
+-- | Given two clock periods, produce a list of clock ticks indicating which clock
+-- (or both) ticked. Can be used in components handling multiple clocks, such
+-- as @unsafeSynchronizer@ or dual clock FIFOs. In contrast to 'clockTicksEither',
+-- this version also produces the time since the last event. For the first edge
+-- the time since the last event is set to zero.
+--
+-- If your primitive does not care about coincided clock edges, it should - by
+-- convention - replace it by @ClockEdgeB edgeB : ClockEdgeA edgeA:@.
+clockEdgesEitherRelative ::
+  ActiveEdge ->
+  -- ^ First active edge for clock A
+  ActiveEdge ->
+  -- ^ First active edge for clock B
+  Either Int64 (Signal domA Int64) ->
+  Either Int64 (Signal domB Int64) ->
+  [(Int64, ClockEdgeAB)]
+clockEdgesEitherRelative firstEdgeA firstEdgeB clkA clkB = zip relativeTimestamps ticks
+ where
+  relativeTimestamps = 0 : zipWith (-) (tail timestamps) timestamps
+  (timestamps, ticks) = unzip (clockEdgesEitherAbsolute firstEdgeA firstEdgeB clkA clkB)
+
+
+
+-- | Given the clock periods of a single clock, produce a list of clock edges
+-- and the (absolute) times when these edges are occuring.
+--
+-- Same as 'singleClockEdgesEitherRelative', but produces absolute times
+-- (in /femotseconds/).
+singleClockEdgesEitherAbsolute ::
+  ActiveEdge ->
+  Either Int64 (Signal dom Int64) ->
+  [(Int64, ActiveEdge)]
+singleClockEdgesEitherAbsolute firstEdge clk =
+  case clk of
+    Left t -> goStatic 0 firstEdge (halve t)
+    Right t -> goDynamic 0 firstEdge (halves t)
+
+  where
+    halves = go . fmap halve
+      where
+        go ((t0, t1) :- ts) = t0 :- t1 :- go ts
+
+    halve t =
+      ( t `div` 2
+      , t - (t `div` 2)
+      )
+
+    goStatic ::
+      Int64 ->
+      ActiveEdge ->
+      (Int64, Int64) ->
+      [(Int64, ActiveEdge)]
+    goStatic absTime !currentEdge (t0, t1) =
+      (absTime, currentEdge) : goStatic (absTime + t0) (oppositeEdge currentEdge) (t1, t0)
+
+    goDynamic ::
+      Int64 ->
+      ActiveEdge ->
+      Signal domA Int64 ->
+      [(Int64, ActiveEdge)]
+    goDynamic absTime !currentEdge ~(t :- ts1) =
+      (absTime, currentEdge) : goDynamic (absTime + t) (oppositeEdge currentEdge) ts1
+
+-- | Given the clock periods of a single clock, produce a list of clock edges
+-- and the (relative) times since the last edge occured.
+--
+-- Same as 'singleClockEdgesEitherAbsolute', but produces relative times
+-- (in /femotseconds/).
+singleClockEdgesEitherRelative ::
+  ActiveEdge ->
+  Either Int64 (Signal dom Int64) ->
+  [(Int64, ActiveEdge)]
+singleClockEdgesEitherRelative firstEdge clk = zip relativeTimestamps edges
+  where
+    relativeTimestamps = 0 : zipWith (-) (tail timestamps) timestamps
+    (timestamps, edges) = unzip (singleClockEdgesEitherAbsolute firstEdge clk)

--- a/clash-vexriscv/clash-vexriscv/src/VexRiscv/VecToTuple.hs
+++ b/clash-vexriscv/clash-vexriscv/src/VexRiscv/VecToTuple.hs
@@ -1,0 +1,279 @@
+-- SPDX-FileCopyrightText: 2022-2023 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE TypeFamilyDependencies #-}
+
+-- Purpose of this module
+{-# OPTIONS_GHC -Wno-incomplete-patterns #-}
+
+module VexRiscv.VecToTuple (VecToTuple(..)) where
+
+import Clash.Prelude
+
+import Data.Tagged (Tagged(..))
+
+#if MIN_VERSION_base(4,16,0)
+import Data.Tuple (Solo(Solo))
+#endif
+
+class VecToTuple a where
+  type TupType a = r | r -> a
+  vecToTuple ::  a -> TupType a
+
+-- | Silly instance
+instance VecToTuple (Vec 0 a) where
+  type TupType (Vec 0 a) = Tagged a ()
+  vecToTuple Nil = Tagged ()
+
+#if MIN_VERSION_base(4,16,0)
+instance VecToTuple (Vec 1 a) where
+  type TupType (Vec 1 a) = Solo a
+  vecToTuple (a0 :> Nil) = Solo a0
+#endif
+
+instance VecToTuple (Vec 2 a) where
+  type TupType (Vec 2 a) = (a, a)
+  vecToTuple (a0 :> a1 :> Nil) = (a0, a1)
+
+instance VecToTuple (Vec 3 a) where
+  type TupType (Vec 3 a) = (a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> Nil) = (a0, a1, a2)
+
+instance VecToTuple (Vec 4 a) where
+  type TupType (Vec 4 a) = (a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> Nil) = (a0, a1, a2, a3)
+
+instance VecToTuple (Vec 5 a) where
+  type TupType (Vec 5 a) = (a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> Nil) = (a0, a1, a2, a3, a4)
+
+instance VecToTuple (Vec 6 a) where
+  type TupType (Vec 6 a) = (a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> Nil) = (a0, a1, a2, a3, a4, a5)
+
+instance VecToTuple (Vec 7 a) where
+  type TupType (Vec 7 a) = (a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> Nil) = (a0, a1, a2, a3, a4, a5, a6)
+
+instance VecToTuple (Vec 8 a) where
+  type TupType (Vec 8 a) = (a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7)
+
+instance VecToTuple (Vec 9 a) where
+  type TupType (Vec 9 a) = (a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8)
+
+instance VecToTuple (Vec 10 a) where
+  type TupType (Vec 10 a) = (a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9)
+
+instance VecToTuple (Vec 11 a) where
+  type TupType (Vec 11 a) = (a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)
+
+instance VecToTuple (Vec 12 a) where
+  type TupType (Vec 12 a) = (a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11)
+
+instance VecToTuple (Vec 13 a) where
+  type TupType (Vec 13 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12)
+
+instance VecToTuple (Vec 14 a) where
+  type TupType (Vec 14 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13)
+
+instance VecToTuple (Vec 15 a) where
+  type TupType (Vec 15 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14)
+
+instance VecToTuple (Vec 16 a) where
+  type TupType (Vec 16 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15)
+
+instance VecToTuple (Vec 17 a) where
+  type TupType (Vec 17 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16)
+
+instance VecToTuple (Vec 18 a) where
+  type TupType (Vec 18 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17)
+
+instance VecToTuple (Vec 19 a) where
+  type TupType (Vec 19 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18)
+
+instance VecToTuple (Vec 20 a) where
+  type TupType (Vec 20 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> a19 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19)
+
+instance VecToTuple (Vec 21 a) where
+  type TupType (Vec 21 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> a19 :> a20 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20)
+
+instance VecToTuple (Vec 22 a) where
+  type TupType (Vec 22 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> a19 :> a20 :> a21 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21)
+
+instance VecToTuple (Vec 23 a) where
+  type TupType (Vec 23 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> a19 :> a20 :> a21 :> a22 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22)
+
+instance VecToTuple (Vec 24 a) where
+  type TupType (Vec 24 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> a19 :> a20 :> a21 :> a22 :> a23 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23)
+
+instance VecToTuple (Vec 25 a) where
+  type TupType (Vec 25 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> a19 :> a20 :> a21 :> a22 :> a23 :> a24 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24)
+
+instance VecToTuple (Vec 26 a) where
+  type TupType (Vec 26 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> a19 :> a20 :> a21 :> a22 :> a23 :> a24 :> a25 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25)
+
+instance VecToTuple (Vec 27 a) where
+  type TupType (Vec 27 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> a19 :> a20 :> a21 :> a22 :> a23 :> a24 :> a25 :> a26 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26)
+
+instance VecToTuple (Vec 28 a) where
+  type TupType (Vec 28 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> a19 :> a20 :> a21 :> a22 :> a23 :> a24 :> a25 :> a26 :> a27 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27)
+
+instance VecToTuple (Vec 29 a) where
+  type TupType (Vec 29 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> a19 :> a20 :> a21 :> a22 :> a23 :> a24 :> a25 :> a26 :> a27 :> a28 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28)
+
+instance VecToTuple (Vec 30 a) where
+  type TupType (Vec 30 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> a19 :> a20 :> a21 :> a22 :> a23 :> a24 :> a25 :> a26 :> a27 :> a28 :> a29 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29)
+
+instance VecToTuple (Vec 31 a) where
+  type TupType (Vec 31 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> a19 :> a20 :> a21 :> a22 :> a23 :> a24 :> a25 :> a26 :> a27 :> a28 :> a29 :> a30 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30)
+
+instance VecToTuple (Vec 32 a) where
+  type TupType (Vec 32 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> a19 :> a20 :> a21 :> a22 :> a23 :> a24 :> a25 :> a26 :> a27 :> a28 :> a29 :> a30 :> a31 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31)
+
+instance VecToTuple (Vec 33 a) where
+  type TupType (Vec 33 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> a19 :> a20 :> a21 :> a22 :> a23 :> a24 :> a25 :> a26 :> a27 :> a28 :> a29 :> a30 :> a31 :> a32 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a32)
+
+instance VecToTuple (Vec 34 a) where
+  type TupType (Vec 34 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> a19 :> a20 :> a21 :> a22 :> a23 :> a24 :> a25 :> a26 :> a27 :> a28 :> a29 :> a30 :> a31 :> a32 :> a33 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a32, a33)
+
+instance VecToTuple (Vec 35 a) where
+  type TupType (Vec 35 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> a19 :> a20 :> a21 :> a22 :> a23 :> a24 :> a25 :> a26 :> a27 :> a28 :> a29 :> a30 :> a31 :> a32 :> a33 :> a34 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a32, a33, a34)
+
+instance VecToTuple (Vec 36 a) where
+  type TupType (Vec 36 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> a19 :> a20 :> a21 :> a22 :> a23 :> a24 :> a25 :> a26 :> a27 :> a28 :> a29 :> a30 :> a31 :> a32 :> a33 :> a34 :> a35 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a32, a33, a34, a35)
+
+instance VecToTuple (Vec 37 a) where
+  type TupType (Vec 37 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> a19 :> a20 :> a21 :> a22 :> a23 :> a24 :> a25 :> a26 :> a27 :> a28 :> a29 :> a30 :> a31 :> a32 :> a33 :> a34 :> a35 :> a36 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36)
+
+instance VecToTuple (Vec 38 a) where
+  type TupType (Vec 38 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> a19 :> a20 :> a21 :> a22 :> a23 :> a24 :> a25 :> a26 :> a27 :> a28 :> a29 :> a30 :> a31 :> a32 :> a33 :> a34 :> a35 :> a36 :> a37 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37)
+
+instance VecToTuple (Vec 39 a) where
+  type TupType (Vec 39 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> a19 :> a20 :> a21 :> a22 :> a23 :> a24 :> a25 :> a26 :> a27 :> a28 :> a29 :> a30 :> a31 :> a32 :> a33 :> a34 :> a35 :> a36 :> a37 :> a38 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38)
+
+instance VecToTuple (Vec 40 a) where
+  type TupType (Vec 40 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> a19 :> a20 :> a21 :> a22 :> a23 :> a24 :> a25 :> a26 :> a27 :> a28 :> a29 :> a30 :> a31 :> a32 :> a33 :> a34 :> a35 :> a36 :> a37 :> a38 :> a39 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39)
+
+instance VecToTuple (Vec 41 a) where
+  type TupType (Vec 41 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> a19 :> a20 :> a21 :> a22 :> a23 :> a24 :> a25 :> a26 :> a27 :> a28 :> a29 :> a30 :> a31 :> a32 :> a33 :> a34 :> a35 :> a36 :> a37 :> a38 :> a39 :> a40 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40)
+
+instance VecToTuple (Vec 42 a) where
+  type TupType (Vec 42 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> a19 :> a20 :> a21 :> a22 :> a23 :> a24 :> a25 :> a26 :> a27 :> a28 :> a29 :> a30 :> a31 :> a32 :> a33 :> a34 :> a35 :> a36 :> a37 :> a38 :> a39 :> a40 :> a41 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41)
+
+instance VecToTuple (Vec 43 a) where
+  type TupType (Vec 43 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> a19 :> a20 :> a21 :> a22 :> a23 :> a24 :> a25 :> a26 :> a27 :> a28 :> a29 :> a30 :> a31 :> a32 :> a33 :> a34 :> a35 :> a36 :> a37 :> a38 :> a39 :> a40 :> a41 :> a42 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41, a42)
+
+instance VecToTuple (Vec 44 a) where
+  type TupType (Vec 44 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> a19 :> a20 :> a21 :> a22 :> a23 :> a24 :> a25 :> a26 :> a27 :> a28 :> a29 :> a30 :> a31 :> a32 :> a33 :> a34 :> a35 :> a36 :> a37 :> a38 :> a39 :> a40 :> a41 :> a42 :> a43 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41, a42, a43)
+
+instance VecToTuple (Vec 45 a) where
+  type TupType (Vec 45 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> a19 :> a20 :> a21 :> a22 :> a23 :> a24 :> a25 :> a26 :> a27 :> a28 :> a29 :> a30 :> a31 :> a32 :> a33 :> a34 :> a35 :> a36 :> a37 :> a38 :> a39 :> a40 :> a41 :> a42 :> a43 :> a44 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41, a42, a43, a44)
+
+instance VecToTuple (Vec 46 a) where
+  type TupType (Vec 46 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> a19 :> a20 :> a21 :> a22 :> a23 :> a24 :> a25 :> a26 :> a27 :> a28 :> a29 :> a30 :> a31 :> a32 :> a33 :> a34 :> a35 :> a36 :> a37 :> a38 :> a39 :> a40 :> a41 :> a42 :> a43 :> a44 :> a45 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41, a42, a43, a44, a45)
+
+instance VecToTuple (Vec 47 a) where
+  type TupType (Vec 47 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> a19 :> a20 :> a21 :> a22 :> a23 :> a24 :> a25 :> a26 :> a27 :> a28 :> a29 :> a30 :> a31 :> a32 :> a33 :> a34 :> a35 :> a36 :> a37 :> a38 :> a39 :> a40 :> a41 :> a42 :> a43 :> a44 :> a45 :> a46 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41, a42, a43, a44, a45, a46)
+
+instance VecToTuple (Vec 48 a) where
+  type TupType (Vec 48 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> a19 :> a20 :> a21 :> a22 :> a23 :> a24 :> a25 :> a26 :> a27 :> a28 :> a29 :> a30 :> a31 :> a32 :> a33 :> a34 :> a35 :> a36 :> a37 :> a38 :> a39 :> a40 :> a41 :> a42 :> a43 :> a44 :> a45 :> a46 :> a47 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41, a42, a43, a44, a45, a46, a47)
+
+instance VecToTuple (Vec 49 a) where
+  type TupType (Vec 49 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> a19 :> a20 :> a21 :> a22 :> a23 :> a24 :> a25 :> a26 :> a27 :> a28 :> a29 :> a30 :> a31 :> a32 :> a33 :> a34 :> a35 :> a36 :> a37 :> a38 :> a39 :> a40 :> a41 :> a42 :> a43 :> a44 :> a45 :> a46 :> a47 :> a48 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41, a42, a43, a44, a45, a46, a47, a48)
+
+instance VecToTuple (Vec 50 a) where
+  type TupType (Vec 50 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> a19 :> a20 :> a21 :> a22 :> a23 :> a24 :> a25 :> a26 :> a27 :> a28 :> a29 :> a30 :> a31 :> a32 :> a33 :> a34 :> a35 :> a36 :> a37 :> a38 :> a39 :> a40 :> a41 :> a42 :> a43 :> a44 :> a45 :> a46 :> a47 :> a48 :> a49 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41, a42, a43, a44, a45, a46, a47, a48, a49)
+
+instance VecToTuple (Vec 51 a) where
+  type TupType (Vec 51 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> a19 :> a20 :> a21 :> a22 :> a23 :> a24 :> a25 :> a26 :> a27 :> a28 :> a29 :> a30 :> a31 :> a32 :> a33 :> a34 :> a35 :> a36 :> a37 :> a38 :> a39 :> a40 :> a41 :> a42 :> a43 :> a44 :> a45 :> a46 :> a47 :> a48 :> a49 :> a50 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41, a42, a43, a44, a45, a46, a47, a48, a49, a50)
+
+instance VecToTuple (Vec 52 a) where
+  type TupType (Vec 52 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> a19 :> a20 :> a21 :> a22 :> a23 :> a24 :> a25 :> a26 :> a27 :> a28 :> a29 :> a30 :> a31 :> a32 :> a33 :> a34 :> a35 :> a36 :> a37 :> a38 :> a39 :> a40 :> a41 :> a42 :> a43 :> a44 :> a45 :> a46 :> a47 :> a48 :> a49 :> a50 :> a51 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41, a42, a43, a44, a45, a46, a47, a48, a49, a50, a51)
+
+instance VecToTuple (Vec 53 a) where
+  type TupType (Vec 53 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> a19 :> a20 :> a21 :> a22 :> a23 :> a24 :> a25 :> a26 :> a27 :> a28 :> a29 :> a30 :> a31 :> a32 :> a33 :> a34 :> a35 :> a36 :> a37 :> a38 :> a39 :> a40 :> a41 :> a42 :> a43 :> a44 :> a45 :> a46 :> a47 :> a48 :> a49 :> a50 :> a51 :> a52 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41, a42, a43, a44, a45, a46, a47, a48, a49, a50, a51, a52)
+
+instance VecToTuple (Vec 54 a) where
+  type TupType (Vec 54 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> a19 :> a20 :> a21 :> a22 :> a23 :> a24 :> a25 :> a26 :> a27 :> a28 :> a29 :> a30 :> a31 :> a32 :> a33 :> a34 :> a35 :> a36 :> a37 :> a38 :> a39 :> a40 :> a41 :> a42 :> a43 :> a44 :> a45 :> a46 :> a47 :> a48 :> a49 :> a50 :> a51 :> a52 :> a53 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41, a42, a43, a44, a45, a46, a47, a48, a49, a50, a51, a52, a53)
+
+instance VecToTuple (Vec 55 a) where
+  type TupType (Vec 55 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> a19 :> a20 :> a21 :> a22 :> a23 :> a24 :> a25 :> a26 :> a27 :> a28 :> a29 :> a30 :> a31 :> a32 :> a33 :> a34 :> a35 :> a36 :> a37 :> a38 :> a39 :> a40 :> a41 :> a42 :> a43 :> a44 :> a45 :> a46 :> a47 :> a48 :> a49 :> a50 :> a51 :> a52 :> a53 :> a54 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41, a42, a43, a44, a45, a46, a47, a48, a49, a50, a51, a52, a53, a54)
+
+instance VecToTuple (Vec 56 a) where
+  type TupType (Vec 56 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> a19 :> a20 :> a21 :> a22 :> a23 :> a24 :> a25 :> a26 :> a27 :> a28 :> a29 :> a30 :> a31 :> a32 :> a33 :> a34 :> a35 :> a36 :> a37 :> a38 :> a39 :> a40 :> a41 :> a42 :> a43 :> a44 :> a45 :> a46 :> a47 :> a48 :> a49 :> a50 :> a51 :> a52 :> a53 :> a54 :> a55 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41, a42, a43, a44, a45, a46, a47, a48, a49, a50, a51, a52, a53, a54, a55)
+
+instance VecToTuple (Vec 57 a) where
+  type TupType (Vec 57 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> a19 :> a20 :> a21 :> a22 :> a23 :> a24 :> a25 :> a26 :> a27 :> a28 :> a29 :> a30 :> a31 :> a32 :> a33 :> a34 :> a35 :> a36 :> a37 :> a38 :> a39 :> a40 :> a41 :> a42 :> a43 :> a44 :> a45 :> a46 :> a47 :> a48 :> a49 :> a50 :> a51 :> a52 :> a53 :> a54 :> a55 :> a56 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41, a42, a43, a44, a45, a46, a47, a48, a49, a50, a51, a52, a53, a54, a55, a56)
+
+instance VecToTuple (Vec 58 a) where
+  type TupType (Vec 58 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> a19 :> a20 :> a21 :> a22 :> a23 :> a24 :> a25 :> a26 :> a27 :> a28 :> a29 :> a30 :> a31 :> a32 :> a33 :> a34 :> a35 :> a36 :> a37 :> a38 :> a39 :> a40 :> a41 :> a42 :> a43 :> a44 :> a45 :> a46 :> a47 :> a48 :> a49 :> a50 :> a51 :> a52 :> a53 :> a54 :> a55 :> a56 :> a57 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41, a42, a43, a44, a45, a46, a47, a48, a49, a50, a51, a52, a53, a54, a55, a56, a57)
+
+instance VecToTuple (Vec 59 a) where
+  type TupType (Vec 59 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> a19 :> a20 :> a21 :> a22 :> a23 :> a24 :> a25 :> a26 :> a27 :> a28 :> a29 :> a30 :> a31 :> a32 :> a33 :> a34 :> a35 :> a36 :> a37 :> a38 :> a39 :> a40 :> a41 :> a42 :> a43 :> a44 :> a45 :> a46 :> a47 :> a48 :> a49 :> a50 :> a51 :> a52 :> a53 :> a54 :> a55 :> a56 :> a57 :> a58 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41, a42, a43, a44, a45, a46, a47, a48, a49, a50, a51, a52, a53, a54, a55, a56, a57, a58)
+
+instance VecToTuple (Vec 60 a) where
+  type TupType (Vec 60 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> a19 :> a20 :> a21 :> a22 :> a23 :> a24 :> a25 :> a26 :> a27 :> a28 :> a29 :> a30 :> a31 :> a32 :> a33 :> a34 :> a35 :> a36 :> a37 :> a38 :> a39 :> a40 :> a41 :> a42 :> a43 :> a44 :> a45 :> a46 :> a47 :> a48 :> a49 :> a50 :> a51 :> a52 :> a53 :> a54 :> a55 :> a56 :> a57 :> a58 :> a59 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41, a42, a43, a44, a45, a46, a47, a48, a49, a50, a51, a52, a53, a54, a55, a56, a57, a58, a59)
+
+instance VecToTuple (Vec 61 a) where
+  type TupType (Vec 61 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> a19 :> a20 :> a21 :> a22 :> a23 :> a24 :> a25 :> a26 :> a27 :> a28 :> a29 :> a30 :> a31 :> a32 :> a33 :> a34 :> a35 :> a36 :> a37 :> a38 :> a39 :> a40 :> a41 :> a42 :> a43 :> a44 :> a45 :> a46 :> a47 :> a48 :> a49 :> a50 :> a51 :> a52 :> a53 :> a54 :> a55 :> a56 :> a57 :> a58 :> a59 :> a60 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41, a42, a43, a44, a45, a46, a47, a48, a49, a50, a51, a52, a53, a54, a55, a56, a57, a58, a59, a60)
+
+instance VecToTuple (Vec 62 a) where
+  type TupType (Vec 62 a) = (a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a, a)
+  vecToTuple (a0 :> a1 :> a2 :> a3 :> a4 :> a5 :> a6 :> a7 :> a8 :> a9 :> a10 :> a11 :> a12 :> a13 :> a14 :> a15 :> a16 :> a17 :> a18 :> a19 :> a20 :> a21 :> a22 :> a23 :> a24 :> a25 :> a26 :> a27 :> a28 :> a29 :> a30 :> a31 :> a32 :> a33 :> a34 :> a35 :> a36 :> a37 :> a38 :> a39 :> a40 :> a41 :> a42 :> a43 :> a44 :> a45 :> a46 :> a47 :> a48 :> a49 :> a50 :> a51 :> a52 :> a53 :> a54 :> a55 :> a56 :> a57 :> a58 :> a59 :> a60 :> a61 :> Nil) = (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a32, a33, a34, a35, a36, a37, a38, a39, a40, a41, a42, a43, a44, a45, a46, a47, a48, a49, a50, a51, a52, a53, a54, a55, a56, a57, a58, a59, a60, a61)

--- a/clash-vexriscv/clash-vexriscv/src/ffi/impl.cpp
+++ b/clash-vexriscv/clash-vexriscv/src/ffi/impl.cpp
@@ -7,57 +7,123 @@
 #include "interface.h"
 
 extern "C" {
-  VVexRiscv* vexr_init();
-  void vexr_shutdown(VVexRiscv *top);
-  void vexr_step(VVexRiscv *top, const INPUT *input, OUTPUT *output);
+	VVexRiscv* vexr_init();
+	void vexr_shutdown(VVexRiscv *top);
+
+	void vexr_init_stage1(VVexRiscv *top, const NON_COMB_INPUT *input, OUTPUT *output);
+	void vexr_init_stage2(VVexRiscv *top, const COMB_INPUT *input);
+	void vexr_step_rising_edge(VVexRiscv *top, uint64_t time_add, const NON_COMB_INPUT *input, OUTPUT *output);
+	void vexr_step_falling_edge(VVexRiscv *top, uint64_t time_add, const COMB_INPUT *input);
 }
 
+static VerilatedContext* contextp = 0;
 
 VVexRiscv* vexr_init()
 {
-  return new VVexRiscv();
+	contextp = new VerilatedContext;
+	VVexRiscv *v = new VVexRiscv(contextp);
+	Verilated::traceEverOn(true);
+	v->clk = false;
+	return v;
+}
+
+// Set all inputs that cannot combinationaly depend on outputs. I.e., all inputs
+// except the Wishbone buses.
+void set_non_comb_inputs(VVexRiscv *top, const NON_COMB_INPUT *input)
+{
+	top->reset = input->reset;
+	top->timerInterrupt = input->timerInterrupt;
+	top->externalInterrupt = input->externalInterrupt;
+	top->softwareInterrupt = input->softwareInterrupt;
+}
+
+// Set all inputs that can combinationaly depend on outputs. I.e., the Wishbone
+// buses.
+void set_comb_inputs(VVexRiscv *top, const COMB_INPUT *input)
+{
+	top->iBusWishbone_ACK = input->iBusWishbone_ACK;
+	top->iBusWishbone_DAT_MISO = input->iBusWishbone_DAT_MISO;
+	top->iBusWishbone_ERR = input->iBusWishbone_ERR;
+	top->dBusWishbone_ACK = input->dBusWishbone_ACK;
+	top->dBusWishbone_DAT_MISO = input->dBusWishbone_DAT_MISO;
+	top->dBusWishbone_ERR = input->dBusWishbone_ERR;
+}
+
+// Set all outputs
+void set_ouputs(VVexRiscv *top, OUTPUT *output)
+{
+	output->iBusWishbone_CYC = top->iBusWishbone_CYC;
+	output->iBusWishbone_STB = top->iBusWishbone_STB;
+	output->iBusWishbone_WE = top->iBusWishbone_WE;
+	output->iBusWishbone_ADR = top->iBusWishbone_ADR;
+	output->iBusWishbone_DAT_MOSI = top->iBusWishbone_DAT_MOSI;
+	output->iBusWishbone_SEL = top->iBusWishbone_SEL;
+	output->iBusWishbone_CTI = top->iBusWishbone_CTI;
+	output->iBusWishbone_BTE = top->iBusWishbone_BTE;
+	output->dBusWishbone_CYC = top->dBusWishbone_CYC;
+	output->dBusWishbone_STB = top->dBusWishbone_STB;
+	output->dBusWishbone_WE = top->dBusWishbone_WE;
+	output->dBusWishbone_ADR = top->dBusWishbone_ADR;
+	output->dBusWishbone_DAT_MOSI = top->dBusWishbone_DAT_MOSI;
+	output->dBusWishbone_SEL = top->dBusWishbone_SEL;
+	output->dBusWishbone_CTI = top->dBusWishbone_CTI;
+	output->dBusWishbone_BTE = top->dBusWishbone_BTE;
+}
+
+void vexr_init_stage1(VVexRiscv *top, const NON_COMB_INPUT *input, OUTPUT *output)
+{
+	// Set all inputs that cannot combinationaly depend on outputs. I.e., all inputs
+	// except the Wishbone buses.
+	set_non_comb_inputs(top, input);
+
+	// Combinatorially respond to the inputs
+	top->eval();
+	set_ouputs(top, output);
+
+	// Advance time by 50 nanoseconds. This is an arbitrary value. Ideally, we would
+	// do something similar to Clash's template tag "~LONGESTPERIOD".
+	contextp->timeInc(50000);
+}
+
+void vexr_init_stage2(VVexRiscv *top, const COMB_INPUT *input)
+{
+	set_comb_inputs(top, input);
 }
 
 void vexr_shutdown(VVexRiscv *top)
 {
-  delete top;
+	delete top;
+	delete contextp;
+	contextp = 0;
 }
 
-void vexr_step(VVexRiscv *top, const INPUT *input, OUTPUT *output)
+
+void vexr_step_rising_edge(VVexRiscv *top, uint64_t time_add, const NON_COMB_INPUT *input, OUTPUT *output)
 {
-  // set inputs
-  top->reset = input->reset;
-  top->timerInterrupt = input->timerInterrupt;
-  top->externalInterrupt = input->externalInterrupt;
-  top->softwareInterrupt = input->softwareInterrupt;
-  top->iBusWishbone_ACK = input->iBusWishbone_ACK;
-  top->iBusWishbone_DAT_MISO = input->iBusWishbone_DAT_MISO;
-  top->iBusWishbone_ERR = input->iBusWishbone_ERR;
-  top->dBusWishbone_ACK = input->dBusWishbone_ACK;
-  top->dBusWishbone_DAT_MISO = input->dBusWishbone_DAT_MISO;
-  top->dBusWishbone_ERR = input->dBusWishbone_ERR;
+	// Advance time since last event. Note that this is 0 for the first call to
+	// this function. To get a sensisble waveform, vexr_init has already advanced
+	// time.
+	contextp->timeInc(time_add); // XXX: time_add is in femtoseconds, timeinc expects picoseconds
 
-  // run one cycle of the simulation
-  top->clk = true;
-  top->eval();
-  top->clk = false;
-  top->eval();
+	// docssss
+	set_non_comb_inputs(top, input);
 
-  // update outputs
-  output->iBusWishbone_CYC = top->iBusWishbone_CYC;
-  output->iBusWishbone_STB = top->iBusWishbone_STB;
-  output->iBusWishbone_WE = top->iBusWishbone_WE;
-  output->iBusWishbone_ADR = top->iBusWishbone_ADR;
-  output->iBusWishbone_DAT_MOSI = top->iBusWishbone_DAT_MOSI;
-  output->iBusWishbone_SEL = top->iBusWishbone_SEL;
-  output->iBusWishbone_CTI = top->iBusWishbone_CTI;
-  output->iBusWishbone_BTE = top->iBusWishbone_BTE;
-  output->dBusWishbone_CYC = top->dBusWishbone_CYC;
-  output->dBusWishbone_STB = top->dBusWishbone_STB;
-  output->dBusWishbone_WE = top->dBusWishbone_WE;
-  output->dBusWishbone_ADR = top->dBusWishbone_ADR;
-  output->dBusWishbone_DAT_MOSI = top->dBusWishbone_DAT_MOSI;
-  output->dBusWishbone_SEL = top->dBusWishbone_SEL;
-  output->dBusWishbone_CTI = top->dBusWishbone_CTI;
-  output->dBusWishbone_BTE = top->dBusWishbone_BTE;
+	top->clk = true;
+	top->eval();
+
+	// Set all outputs
+	set_ouputs(top, output);
+}
+
+void vexr_step_falling_edge(VVexRiscv *top, uint64_t time_add, const COMB_INPUT *input)
+{
+	// advance time since last event
+	contextp->timeInc(time_add); // time_add is in femtoseconds, timeinc expects picoseconds
+
+	// Update inputs
+	top->clk = false;
+	set_comb_inputs(top, input);
+
+	// Evaluate the simulation
+	top->eval();
 }

--- a/clash-vexriscv/clash-vexriscv/src/ffi/interface.h
+++ b/clash-vexriscv/clash-vexriscv/src/ffi/interface.h
@@ -14,7 +14,9 @@ typedef struct {
   bit      timerInterrupt;
   bit      externalInterrupt;
   bit      softwareInterrupt;
+} NON_COMB_INPUT;
 
+typedef struct {
   bit      iBusWishbone_ACK;
   uint32_t iBusWishbone_DAT_MISO;
   bit      iBusWishbone_ERR;
@@ -22,7 +24,7 @@ typedef struct {
   bit      dBusWishbone_ACK;
   uint32_t dBusWishbone_DAT_MISO;
   bit      dBusWishbone_ERR;
-} INPUT;
+} COMB_INPUT;
 
 typedef struct {
   bit      iBusWishbone_CYC;
@@ -44,39 +46,4 @@ typedef struct {
   uint8_t  dBusWishbone_BTE;
 } OUTPUT;
 
-
 #endif
-
-/*
-  input               reset
-  input               timerInterrupt,
-  input               externalInterrupt,
-  input               softwareInterrupt,
-
-  input               iBusWishbone_ACK,
-  input      [31:0]   iBusWishbone_DAT_MISO,
-  input               iBusWishbone_ERR,
-
-  input               dBusWishbone_ACK,
-  input      [31:0]   dBusWishbone_DAT_MISO,
-  input               dBusWishbone_ERR,
-
-
-  output              iBusWishbone_CYC,
-  output              iBusWishbone_STB,
-  output              iBusWishbone_WE,
-  output     [29:0]   iBusWishbone_ADR,
-  output     [31:0]   iBusWishbone_DAT_MOSI,
-  output     [3:0]    iBusWishbone_SEL,
-  output     [2:0]    iBusWishbone_CTI,
-  output     [1:0]    iBusWishbone_BTE,
-
-  output              dBusWishbone_CYC,
-  output              dBusWishbone_STB,
-  output              dBusWishbone_WE,
-  output     [29:0]   dBusWishbone_ADR,
-  output     [31:0]   dBusWishbone_DAT_MOSI,
-  output reg [3:0]    dBusWishbone_SEL,
-  output     [2:0]    dBusWishbone_CTI,
-  output     [1:0]    dBusWishbone_BTE,
-*/

--- a/clash-vexriscv/clash-vexriscv/tests/unittests/Tests/Extra.hs
+++ b/clash-vexriscv/clash-vexriscv/tests/unittests/Tests/Extra.hs
@@ -1,0 +1,35 @@
+-- SPDX-FileCopyrightText: 2024 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+
+module Tests.Extra where
+
+import Prelude
+
+import Data.Functor ((<&>))
+import Language.Haskell.TH (mkName)
+import Language.Haskell.TH.Lib
+
+-- | Generate a do-expression where each statement is a call to @test@ and the
+-- arguments are determined by the carthesian product of given argument names.
+--
+-- For example:
+--
+-- >   carthesianProductTests ["x", "y"]
+-- > ======>
+-- >   do
+-- >     test x x
+-- >     test x y
+-- >     test y x
+-- >     test y y
+--
+carthesianProductTests :: [String] -> ExpQ
+carthesianProductTests names = doE $
+  cartProd names <&> \(aName, bName) -> noBindS $
+    let
+      aExp = varE (mkName aName)
+      bExp = varE (mkName bName)
+    in
+      [| test $aExp $bExp |]
+ where
+  cartProd xs = [(a, b) | a <- xs, b <- xs]

--- a/clash-vexriscv/clash-vexriscv/tests/unittests/Tests/VexRiscv/ClockTicks.hs
+++ b/clash-vexriscv/clash-vexriscv/tests/unittests/Tests/VexRiscv/ClockTicks.hs
@@ -1,0 +1,325 @@
+-- SPDX-FileCopyrightText: 2024 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+-- Suppress Clash domain warnings
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+-- Clock definitions aren't much more readable with top level signatures..
+{-# OPTIONS_GHC -Wno-missing-signatures #-}
+
+module Tests.VexRiscv.ClockTicks where
+
+import qualified Prelude as P
+import Clash.Explicit.Prelude hiding (d122, d107, d61)
+
+import VexRiscv.ClockTicks
+  ( ClockEdgeAB(..), clockTicksAbsolute, clockTicksRelative
+  , clockEdgesAbsolute, clockEdgesRelative
+  )
+import Clash.Signal.Internal (ClockAB(..), Femtoseconds(..), clockTicks, dynamicClockGen)
+
+import Data.Bifunctor (second)
+import qualified Data.List as L
+import Data.Maybe (catMaybes)
+import Data.Int (Int64)
+
+import Test.Tasty
+import Test.Tasty.TH
+import Test.Tasty.HUnit
+
+import Tests.Extra (carthesianProductTests)
+
+createDomain vSystem{vName="R61", vPeriod=61}
+createDomain vSystem{vName="R107", vPeriod=107}
+createDomain vSystem{vName="R122", vPeriod=122}
+
+createDomain vSystem{vName="F61", vPeriod=61, vActiveEdge=Falling}
+createDomain vSystem{vName="F107", vPeriod=107, vActiveEdge=Falling}
+createDomain vSystem{vName="F122", vPeriod=122, vActiveEdge=Falling}
+
+createDomain vSystem{vName="D61", vPeriod=61}
+createDomain vSystem{vName="D107", vPeriod=107}
+createDomain vSystem{vName="D122", vPeriod=122}
+
+r61  = clockGen @R61
+r107 = clockGen @R107
+r122 = clockGen @R122
+
+f61  = clockGen @F61
+f107 = clockGen @F107
+f122 = clockGen @F122
+
+-- | Used in production code. We're seeing strange things there, so we add some
+-- tests here making sure that it's not this module messing up.
+createDomain vXilinxSystem{vName="CPU"}
+createDomain vXilinxSystem{vName="JTAG", vPeriod=hzToPeriod 50_000}
+
+-- | Clock whose clock period differs slightly from 61 ps every tick
+d61 :: Clock D61
+d61 = dynamicClockGen (fromList periods)
+ where
+  -- Note that the random values are subtracted as femtoseconds. This makes sure
+  -- we end up with periods that are not divisable by 2, triggering an interesting
+  -- test case.
+  periods = P.cycle $ (\r -> Femtoseconds (1000*61 + r)) <$> rands
+  rands  = [2, 3, 5, 8,-1, 7, -8, -2, -5, -7, -10, -9, 1, -3, 10, 0, 6,-6, 9, -4, 4]
+
+-- | Clock whose clock period differs slightly from 107 ps every tick
+d107 :: Clock D107
+d107 = dynamicClockGen (fromList periods)
+ where
+  periods = P.cycle $ (\r -> Femtoseconds (1000*107 + r)) <$> rands
+  rands = [-1, -5, -3, 2, -8, -4, 8, -9, 9, 5, -6, 1, 6, 4, 0, 3, 7, -2, -7, 10, -10]
+
+-- | Clock whose clock period differs slightly from 122 ps every tick
+d122 :: Clock D122
+d122 = dynamicClockGen (fromList periods)
+ where
+  periods = P.cycle $ (\r -> Femtoseconds (1000*122 + r)) <$> rands
+  rands = [0, 3, -8, -6, 10, -9, -4, -3, 5, 1, -10, 8, -1, 4, 6, -5, 2, -7, -2, 9, 7]
+
+-- | Compare to "infinite" lists, by comparing the first /N/ samples. See
+-- implemenation for the value of /N/.
+infEq :: (Eq a, Show a) => [a] -> [a] -> Assertion
+infEq as bs = let n = 10000 in P.take n as @=? P.take n bs
+
+-- | Convert specific edges of 'ClockEdgeAB' to 'ClockAB'.
+toClockAB :: ActiveEdge -> ActiveEdge -> ClockEdgeAB -> Maybe ClockAB
+toClockAB filterA filterB = go
+ where
+  go (ClockEdgeA edge) | edge == filterA = Just ClockA
+  go (ClockEdgeB edge) | edge == filterB = Just ClockB
+  go (ClockEdgeAB edgeA edgeB)
+    | edgeA == filterA && edgeB == filterB = Just ClockAB
+    | edgeA == filterA = Just ClockA
+    | edgeB == filterB = Just ClockB
+  go _ = Nothing
+
+clockToActiveEdge :: forall dom. KnownDomain dom => Clock dom -> ActiveEdge
+clockToActiveEdge _clk = case activeEdge @dom of
+  SRising -> Rising
+  SFalling -> Falling
+
+clockToPeriod :: forall dom a. (Integral a, KnownDomain dom) => Clock dom -> a
+clockToPeriod _clk = snatToNum (clockPeriod @dom)
+
+-- | Convert specific edges of 'ClockEdgeAB' to 'ClockAB'.
+toClockABs :: ActiveEdge -> ActiveEdge -> [ClockEdgeAB] -> [ClockAB]
+toClockABs filterA filterB = catMaybes . P.map (toClockAB filterA filterB)
+
+-- | Convert a list of relative event timestamps to a list of absolute timestamps
+relativeToAbsolute :: [Int64] -> [Int64]
+relativeToAbsolute = snd . L.mapAccumL (\acc t -> let new = acc + t in (new, new)) 0
+
+-- | Convert a list of absolute event timestamps to a list of relative timestamps
+absoluteToRelative :: [Int64] -> [Int64]
+absoluteToRelative absoluteTimestamps =
+  0 : P.zipWith (-) (P.tail absoluteTimestamps) absoluteTimestamps
+
+unzipFirst :: ([a] -> [b]) -> [(a, c)] -> [(b, c)]
+unzipFirst f (P.unzip -> (as, cs)) = P.zip (f as) cs
+
+unzipSecond :: ([a] -> [b]) -> [(c, a)] -> [(c, b)]
+unzipSecond f (P.unzip -> (cs, as)) = P.zip cs (f as)
+
+-- | Check that 'clockTicksAbsolute' produces the same ratio of clock ticks as
+-- @clash-prelude@'s 'clockTicks'
+case_eqClockTicksAbsolute :: Assertion
+case_eqClockTicksAbsolute =
+  $(carthesianProductTests ["r61", "r107", "r122", "d61", "d107", "d122", "f61", "f107", "f122"])
+ where
+  test a b = fmap snd (clockTicksAbsolute a b) `infEq` clockTicks a b
+
+-- | Check that 'clockTicksRelative' produces the same ratio of clock ticks as
+-- @clash-prelude@'s 'clockTicks'
+case_eqClockTicksRelative :: Assertion
+case_eqClockTicksRelative =
+  $(carthesianProductTests ["r61", "r107", "r122", "d61", "d107", "d122", "f61", "f107", "f122"])
+ where
+  test a b = fmap snd (clockTicksRelative a b) `infEq` clockTicks a b
+
+-- | Check that 'clockEdgesAbsolute' produces the same ratio of clock ticks as
+-- @clash-prelude@'s 'clockTicks'
+case_eqClockEdgesAbsolute :: Assertion
+case_eqClockEdgesAbsolute =
+  $(carthesianProductTests ["r61", "r107", "r122", "d61", "d107", "d122", "f61", "f107", "f122"])
+ where
+  test a b = go a b (clockEdgesAbsolute a b) `infEq` clockTicks a b
+  go a b = toClockABs (clockToActiveEdge a) (clockToActiveEdge b) . fmap snd
+
+-- | Check that 'clockEdgesRelative' produces the same ratio of clock ticks as
+-- @clash-prelude@'s 'clockTicks'
+case_eqClockEdgesRelative :: Assertion
+case_eqClockEdgesRelative =
+  $(carthesianProductTests ["r61", "r107", "r122", "d61", "d107", "d122", "f61", "f107", "f122"])
+ where
+  test a b = go a b (clockEdgesRelative a b) `infEq` clockTicks a b
+  go a b = toClockABs (clockToActiveEdge a) (clockToActiveEdge b) . fmap snd
+
+-- | Check that 'clockEdgesAbsolute' produces the same ratio of clock ticks and
+-- same timestamps as 'clockTicksAbsolute'.
+case_eqClockEdgesTicksAbsolute :: Assertion
+case_eqClockEdgesTicksAbsolute =
+  $(carthesianProductTests ["r61", "r107", "r122", "d61", "d107", "d122", "f61", "f107", "f122"])
+ where
+  test a b = go a b (clockEdgesAbsolute a b) `infEq` clockTicksAbsolute a b
+
+  go a b (P.unzip -> (times, edges)) =
+    catMaybes (P.zipWith (liftA2 (,)) maybeTimes maybeEdges)
+   where
+    maybeTimes = Just <$> times
+    maybeEdges = toClockAB (clockToActiveEdge a) (clockToActiveEdge b) <$> edges
+
+-- | Check that 'clockEdgesRelative' produces the same ratio of clock ticks and
+-- same timestamps as 'clockTicksRelative'.
+case_eqClockEdgesTicksRelative :: Assertion
+case_eqClockEdgesTicksRelative =
+  $(carthesianProductTests ["r61", "r107", "r122", "d61", "d107", "d122", "f61", "f107", "f122"])
+ where
+  test a b = go a b (clockEdgesRelative a b) `infEq` clockTicksRelative a b
+
+  go a b (P.unzip -> (relativeTimes, edges)) =
+    unzipFirst
+      absoluteToRelative
+      (catMaybes (P.zipWith (liftA2 (,)) maybeAbsoluteTimes maybeEdges))
+   where
+    maybeAbsoluteTimes :: [Maybe Int64]
+    maybeAbsoluteTimes = Just <$> absoluteTimes
+
+    absoluteTimes :: [Int64]
+    absoluteTimes = relativeToAbsolute relativeTimes
+
+    maybeEdges :: [Maybe ClockAB]
+    maybeEdges = toClockAB (clockToActiveEdge a) (clockToActiveEdge b) <$> edges
+
+-- | Check that `clockTicksRelative` has a sane time in between events when it
+-- gets passed two of the same clocks.
+case_sanityClockTicksRelativeSame :: Assertion
+case_sanityClockTicksRelativeSame = do
+  test r61
+  test r107
+  test r122
+  test f122
+  test f107
+  test f122
+ where
+  test c = clockTicksRelative c c `infEq` expected c
+  expected c = P.zip (0 : P.repeat (1000 * clockToPeriod c)) (P.repeat ClockAB)
+
+-- | Check that `clockTicksRelative` has a sane time in between events when it
+-- gets passed one fast clock and one slow clock, where the fast clock is exactly
+-- twice as fast as the slow clock.
+case_sanityClockTicksRelativeDouble :: Assertion
+case_sanityClockTicksRelativeDouble = do
+  test r61 r122
+ where
+  test c0 c1 = clockTicksRelative c0 c1 `infEq` expected c0 c1
+  expected c0 _c1 = P.zip (0 : P.repeat (1000 * clockToPeriod c0)) (P.cycle [ClockAB, ClockA])
+
+-- | Check that `clockTicksRelative` has a sane time in between events when it
+-- gets passed two of the same clocks.
+case_sanityClockEdgesRelativeSame :: Assertion
+case_sanityClockEdgesRelativeSame = do
+  test r61
+  test r107
+  test r122
+  test f122
+  test f107
+  test f122
+ where
+  test c = clockTicksRelative c c `infEq` expected c
+  expected c = P.zip (0 : P.repeat (1000 * clockToPeriod c)) (P.repeat ClockAB)
+
+-- | Check that `clockTicksRelative` has a sane time in between events when it
+-- gets passed one fast clock and one slow clock, where the fast clock is exactly
+-- twice as fast as the slow clock.
+case_sanityClockEdgesRelativeDouble :: Assertion
+case_sanityClockEdgesRelativeDouble = do
+  test r61 r122
+ where
+  test c0 c1 = clockEdgesRelative c0 c1 `infEq` expected c0 c1
+  expected c0 _c1 =
+    P.zip
+      (0 : P.repeat ((1000 * clockToPeriod c0) `div` 2))
+      (P.cycle [ ClockEdgeAB Rising Rising
+               , ClockEdgeA  Falling
+               , ClockEdgeAB Rising Falling
+               , ClockEdgeA  Falling
+               ])
+
+-- | Make sure that swapping the arguments makes no difference for timing calculations
+case_flipped :: Assertion
+case_flipped =
+  $(carthesianProductTests ["r61", "r107", "r122", "d61", "d107", "d122", "f61", "f107", "f122"])
+ where
+  test a b = do
+    clockEdgesAbsolute a b `infEq` P.map (second flipClockEdge) (clockEdgesAbsolute b a)
+    clockEdgesRelative a b `infEq` P.map (second flipClockEdge) (clockEdgesRelative b a)
+    clockTicksAbsolute a b `infEq` P.map (second flipClock)     (clockTicksAbsolute b a)
+    clockTicksRelative a b `infEq` P.map (second flipClock)     (clockTicksRelative b a)
+
+  flipClockEdge :: ClockEdgeAB -> ClockEdgeAB
+  flipClockEdge (ClockEdgeA edge) = ClockEdgeB edge
+  flipClockEdge (ClockEdgeB edge) = ClockEdgeA edge
+  flipClockEdge (ClockEdgeAB edgeA edgeB) = ClockEdgeAB edgeB edgeA
+
+  flipClock :: ClockAB -> ClockAB
+  flipClock ClockA = ClockB
+  flipClock ClockB = ClockA
+  flipClock ClockAB = ClockAB
+
+-- | Check results produced by 'clockTicksAbsolute' and 'clockEdgesAbsolute' manually
+-- to rule out functions in "ClockTicks" causing the strange behavior we're seeing
+-- in production.
+case_sanityJtagCpu :: Assertion
+case_sanityJtagCpu = do
+  expectedAbsJtagEdges `infEq` P.map fst absJtagEdges
+  expectedAbsJtagTicks `infEq` P.map fst absJtagTicks
+  expectedAbsCpuEdges `infEq` P.map fst absCpuEdges
+  expectedAbsCpuTicks `infEq` P.map fst absCpuTicks
+ where
+  -- JTAG
+  expectedAbsJtagEdges = [0, halfJtagPeriodFs ..]
+  expectedAbsJtagTicks = [0, jtagPeriodFs ..]
+
+  halfJtagPeriodFs = jtagPeriodFs `div` 2
+  jtagPeriodFs = 1000 * clockToPeriod jtagClk :: Int64
+
+  isJtagEdge (ClockEdgeA _) = False
+  isJtagEdge _ = True
+
+  isJtagTick ClockA = False
+  isJtagTick _ = True
+
+  absJtagEdges = filter (isJtagEdge . snd) absEdges
+  absJtagTicks = filter (isJtagTick . snd) absTicks
+
+  -- CPU
+  expectedAbsCpuEdges = [0, halfCpuPeriodFs ..]
+  expectedAbsCpuTicks = [0, cpuPeriodFs ..]
+
+  halfCpuPeriodFs = cpuPeriodFs `div` 2
+  cpuPeriodFs = 1000 * clockToPeriod cpuClk :: Int64
+
+  isCpuEdge (ClockEdgeB _) = False
+  isCpuEdge _ = True
+
+  isCpuTick ClockB = False
+  isCpuTick _ = True
+
+  absCpuEdges = filter (isCpuEdge . snd) absEdges
+  absCpuTicks = filter (isCpuTick . snd) absTicks
+
+  -- BOTH
+  absTicks = clockTicksAbsolute cpuClk jtagClk
+  absEdges = clockEdgesAbsolute cpuClk jtagClk
+
+  cpuClk = clockGen @CPU
+  jtagClk = clockGen @JTAG
+
+tests :: TestTree
+tests = $(testGroupGenerator)

--- a/clash-vexriscv/clash-vexriscv/tests/unittests/main.hs
+++ b/clash-vexriscv/clash-vexriscv/tests/unittests/main.hs
@@ -1,0 +1,26 @@
+-- SPDX-FileCopyrightText: 2024 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+
+module Main where
+
+import Prelude
+
+import Test.Tasty
+import Test.Tasty.Hedgehog
+
+import qualified Tests.VexRiscv.ClockTicks
+
+tests :: TestTree
+tests = testGroup "Tests"
+  [ Tests.VexRiscv.ClockTicks.tests
+  ]
+
+setDefaultHedgehogTestLimit :: HedgehogTestLimit -> HedgehogTestLimit
+setDefaultHedgehogTestLimit (HedgehogTestLimit Nothing) = HedgehogTestLimit (Just 1000)
+setDefaultHedgehogTestLimit opt = opt
+
+main :: IO ()
+main = defaultMain $
+  adjustOption setDefaultHedgehogTestLimit
+  tests

--- a/clash-vexriscv/nix/nixpkgs.nix
+++ b/clash-vexriscv/nix/nixpkgs.nix
@@ -7,8 +7,8 @@ let
   rust_overlay = import (builtins.fetchTarball "https://github.com/oxalica/rust-overlay/archive/master.tar.gz");
   overlay = _: nixpkgs: {
     # Nix tooling
-    niv = (import sources.niv {}).niv;
     gitignore = import sources.gitignore { inherit (nixpkgs) lib; };
+    openocd-vexriscv = import ./openocd-vexriscv.nix { inherit (nixpkgs) pkgs; };
 
     # Haskell overrides
     haskellPackages = nixpkgs.haskellPackages.override {

--- a/clash-vexriscv/nix/openocd-vexriscv.nix
+++ b/clash-vexriscv/nix/openocd-vexriscv.nix
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: 2023 Google LLC
+
+# SPDX-License-Identifier: CC0-1.0
+{ pkgs ? import ./nixpkgs.nix {} }:
+
+pkgs.stdenv.mkDerivation rec {
+  name = "openocd-vexriscv";
+
+  buildInputs = [
+    pkgs.autoconf
+    pkgs.automake
+    pkgs.coreutils
+    pkgs.git
+    pkgs.libtool
+    pkgs.libusb1
+    pkgs.libyaml
+    pkgs.pkg-config
+    pkgs.texinfo
+    pkgs.which
+  ];
+
+  src = pkgs.fetchgit {
+    url = "https://github.com/SpinalHDL/openocd_riscv.git";
+    rev = "058dfa50d625893bee9fecf8d604141911fac125";
+    sha256 = "sha256-5BvR45A3/7NqivQpYwaFnu7ra/Rf8giRig8R3zSYVd8=";
+  };
+
+  installPhase = ''
+    SKIP_SUBMODULE=1 ./bootstrap
+    ./configure --enable-ftdi --enable-dummy --prefix=$out
+    make -j $(nproc)
+    make install
+    mv $out/bin/openocd $out/bin/openocd-vexriscv
+  '';
+}

--- a/clash-vexriscv/nix/sources.json
+++ b/clash-vexriscv/nix/sources.json
@@ -5,22 +5,22 @@
         "homepage": "",
         "owner": "hercules-ci",
         "repo": "gitignore.nix",
-        "rev": "a20de23b925fd8264fd7fad6454652e142fd7f73",
-        "sha256": "07vg2i9va38zbld9abs9lzqblz193vc5wvqd6h7amkmwf66ljcgh",
+        "rev": "43e1aa1308018f37118e34d3a9cb4f5e75dc11d5",
+        "sha256": "1rlja3ba9s1n0icy3aarwhx9hk1jyfgngzizbn1afwwdlpvdlqw0",
         "type": "tarball",
-        "url": "https://github.com/hercules-ci/gitignore.nix/archive/a20de23b925fd8264fd7fad6454652e142fd7f73.tar.gz",
+        "url": "https://github.com/hercules-ci/gitignore.nix/archive/43e1aa1308018f37118e34d3a9cb4f5e75dc11d5.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {
-        "branch": "nixos-22.11",
+        "branch": "nixos-23.11",
         "description": "Nix Packages collection",
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8c54d842d9544361aac5f5b212ba04e4089e8efe",
-        "sha256": "14hk2lyxy8ajczn77363vw05w24fyx9889q3b89riqgs28acyz87",
+        "rev": "5bf1cadb72ab4e77cb0b700dab76bcdaf88f706b",
+        "sha256": "0zjwk71lsri9zmlmhwgz1ny9dv91kaznii2wjff4g2d3w47gy8nj",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/8c54d842d9544361aac5f5b212ba04e4089e8efe.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/5bf1cadb72ab4e77cb0b700dab76bcdaf88f706b.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/clash-vexriscv/shell.nix
+++ b/clash-vexriscv/shell.nix
@@ -7,18 +7,37 @@ pkgs.mkShell {
   name = "shell";
   buildInputs =
     [
-      pkgs.buildPackages.cabal-install
-      pkgs.buildPackages.gcc
-      pkgs.buildPackages.ghc
-      pkgs.buildPackages.pkg-config
-      pkgs.buildPackages.sbt
-      pkgs.buildPackages.scala
-      pkgs.buildPackages.verilator
+      pkgs.gcc
+      pkgs.pkg-config
+      pkgs.sbt
+      pkgs.scala
+      pkgs.verilator
+
+      # Haskell toolchain
+      pkgs.cabal-install
+      # pkgs.haskell.compiler.ghc90
+      # pkgs.haskell.compiler.ghc92
+      pkgs.haskell.compiler.ghc94
+      # pkgs.haskell.compiler.ghc96
 
       (pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml)
 
+      # VexRiscV needs a special openocd
+      pkgs.openocd-vexriscv
+
       # For Cabal to clone git repos
-      pkgs.buildPackages.git
+      pkgs.git
+
+      # For upgrading Nix env. To update dependencies (within bounds of the currently
+      # tracking NixOS version) use:
+      #
+      #   niv update
+      #
+      # If you want to upgrade nixpkgs to another NixOS version, use:
+      #
+      #   niv update nixpkgs -b nixos-23.11
+      #
+      pkgs.niv
     ]
     ;
 

--- a/nix/nixpkgs.nix
+++ b/nix/nixpkgs.nix
@@ -4,7 +4,6 @@ let
   rust_overlay = import (builtins.fetchTarball "https://github.com/oxalica/rust-overlay/archive/master.tar.gz");
   overlay = _: nixpkgs: {
     # Nix tooling
-    niv = (import sources.niv {}).niv;
     gitignore = import sources.gitignore { inherit (nixpkgs) lib; };
 
     verilog-ethernet = import ./verilog-ethernet.nix { inherit (nixpkgs) pkgs; };

--- a/nix/openocd-vexriscv.nix
+++ b/nix/openocd-vexriscv.nix
@@ -19,7 +19,9 @@ pkgs.stdenv.mkDerivation rec {
   src = pkgs.fetchgit {
     url = "https://github.com/SpinalHDL/openocd_riscv.git";
     rev = "058dfa50d625893bee9fecf8d604141911fac125";
-    sha256 = "sha256-5BvR45A3/7NqivQpYwaFnu7ra/Rf8giRig8R3zSYVd8=";
+    sha256 = "sha256-LbT0L+VDFLlSrLkHa0P5pfmZHJI5uaMazrLXj8WFpck=";
+    fetchSubmodules = true;
+    deepClone = true;
   };
 
   installPhase = ''

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,22 +5,22 @@
         "homepage": "",
         "owner": "hercules-ci",
         "repo": "gitignore.nix",
-        "rev": "a20de23b925fd8264fd7fad6454652e142fd7f73",
-        "sha256": "07vg2i9va38zbld9abs9lzqblz193vc5wvqd6h7amkmwf66ljcgh",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "sha256": "02wxkdpbhlm3yk5mhkhsp3kwakc16xpmsf2baw57nz1dg459qv8w",
         "type": "tarball",
-        "url": "https://github.com/hercules-ci/gitignore.nix/archive/a20de23b925fd8264fd7fad6454652e142fd7f73.tar.gz",
+        "url": "https://github.com/hercules-ci/gitignore.nix/archive/637db329424fd7e46cf4185293b9cc8c88c95394.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {
-        "branch": "nixos-22.11",
+        "branch": "nixos-23.11",
         "description": "Nix Packages collection",
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8c54d842d9544361aac5f5b212ba04e4089e8efe",
-        "sha256": "14hk2lyxy8ajczn77363vw05w24fyx9889q3b89riqgs28acyz87",
+        "rev": "880992dcc006a5e00dd0591446fdf723e6a51a64",
+        "sha256": "1rsbjwbjgnrh0gm54w7nlshkkgp5718d5rk4x8kvklpfivlpfb5n",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/8c54d842d9544361aac5f5b212ba04e4089e8efe.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/880992dcc006a5e00dd0591446fdf723e6a51a64.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/shell.nix
+++ b/shell.nix
@@ -13,37 +13,37 @@ pkgs.mkShell {
     # pkgs.haskellPackages.bittide-extra.env.nativeBuildInputs ++
     #
     [
-      pkgs.buildPackages.cabal-install
-      pkgs.buildPackages.dtc
-      pkgs.buildPackages.gcc
-      pkgs.buildPackages.ghc
-      pkgs.buildPackages.pkg-config
-      pkgs.buildPackages.python310Full
-      pkgs.buildPackages.python310Packages.matplotlib
-      pkgs.buildPackages.python310Packages.scipy
-      pkgs.buildPackages.python310Packages.GitPython
-      pkgs.buildPackages.sbt
-      pkgs.buildPackages.scala
-      pkgs.buildPackages.verilator
-      pkgs.buildPackages.which
-      pkgs.buildPackages.jq
+      pkgs.cabal-install
+      pkgs.dtc
+      pkgs.gcc
+      pkgs.ghc
+      pkgs.pkg-config
+      pkgs.python310Full
+      pkgs.python310Packages.matplotlib
+      pkgs.python310Packages.scipy
+      pkgs.python310Packages.GitPython
+      pkgs.sbt
+      pkgs.scala
+      pkgs.verilator
+      pkgs.which
+      pkgs.jq
 
       # Simulation report generation
-      pkgs.buildPackages.dot2tex
-      pkgs.buildPackages.texlive.combined.scheme-medium
-      pkgs.buildPackages.poppler_utils
+      pkgs.dot2tex
+      pkgs.texlive.combined.scheme-medium
+      pkgs.poppler_utils
 
       (pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml)
 
       # For Cabal to clone git repos
-      pkgs.buildPackages.git
+      pkgs.git
 
       # HDL dependencies
       pkgs.verilog-ethernet
 
       # CI cache scripts
-      pkgs.buildPackages.python310Packages.docopt
-      pkgs.buildPackages.python310Packages.dateutil
+      pkgs.python310Packages.docopt
+      pkgs.python310Packages.dateutil
       pkgs.mc
 
       # VexRiscv OpenOCD

--- a/shell.nix
+++ b/shell.nix
@@ -16,12 +16,12 @@ pkgs.mkShell {
       pkgs.cabal-install
       pkgs.dtc
       pkgs.gcc
-      pkgs.ghc
+      pkgs.haskell.compiler.ghc90
       pkgs.pkg-config
-      pkgs.python310Full
-      pkgs.python310Packages.matplotlib
-      pkgs.python310Packages.scipy
-      pkgs.python310Packages.GitPython
+      pkgs.python311Full
+      pkgs.python311Packages.matplotlib
+      pkgs.python311Packages.scipy
+      pkgs.python311Packages.GitPython
       pkgs.sbt
       pkgs.scala
       pkgs.verilator
@@ -37,17 +37,29 @@ pkgs.mkShell {
 
       # For Cabal to clone git repos
       pkgs.git
+      pkgs.cacert
 
       # HDL dependencies
       pkgs.verilog-ethernet
 
       # CI cache scripts
-      pkgs.python310Packages.docopt
-      pkgs.python310Packages.dateutil
+      pkgs.python311Packages.docopt
+      pkgs.python311Packages.dateutil
       pkgs.mc
 
       # VexRiscv OpenOCD
       pkgs.openocd-vexriscv
+
+      # For upgrading Nix env. To update dependencies (within bounds of the currently
+      # tracking NixOS version) use:
+      #
+      #   niv update
+      #
+      # If you want to upgrade nixpkgs to another NixOS version, use:
+      #
+      #   niv update nixpkgs -b nixos-23.11
+      #
+      pkgs.niv
     ]
     ;
 

--- a/update-clash-vexriscv-subtree.sh
+++ b/update-clash-vexriscv-subtree.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage:
+#
+#   ./update-clash-vexriscv-subtree.sh <hash>
+#
+# Example:
+#
+#   ./update-clash-vexriscv-subtree.sh 6a0805f237ec511d2db9cbabbb8f28e6bbe93db4
+#
+
+# SPDX-FileCopyrightText: 2022-2024 Google LLC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+git subtree pull --prefix clash-vexriscv/ https://github.com/clash-lang/clash-vexriscv.git "$1" --squash


### PR DESCRIPTION
Mostly to get a newer Verilator, which is needed for the version of `clash-vexriscv` with the simulation hack removed.