### PR TITLE
Reduce simulated topologies to the safe ones

### DIFF
--- a/.github/simulation/safe.json
+++ b/.github/simulation/safe.json
@@ -1,0 +1,8 @@
+[
+  {"topology": "diamond",   "hmem": 16,  "steps": 100000000, "args": "--frame-size 15000000" },
+  {"topology": "complete",  "hmem": 16,  "steps": 100000000, "args": "--nodes 3 --frame-size 15000000"},
+  {"topology": "cycle",     "hmem": 16,  "steps": 120000000, "args": "--nodes 5 --frame-size 15000000 "},
+  {"topology": "torus2d",   "hmem": 32,  "steps": 120000000, "args": "--rows 2 --cols 3 --frame-size 15000000 "},
+  {"topology": "star",      "hmem": 64,  "steps": 120000000, "args": "--nodes 7 --frame-size 15000000 "},
+  {"topology": "line",      "hmem": 64,  "steps": 120000000, "args": "--nodes 4 --frame-size 15000000 "}
+]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,7 +165,7 @@ jobs:
       - name: Generate matrix
         run: |
           if [[ "${{ github.event_name }}" == "schedule" || $(.github/scripts/force_expensive_checks.sh) == "true" ]]; then
-            cp .github/simulation/all.json sim.json
+            cp .github/simulation/safe.json sim.json
           else
             cp .github/simulation/staging.json sim.json
           fi

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -37,7 +37,7 @@ Copyright: 2022 Google LLC
 License: Apache-2.0
 
 Files: .github/simulation/*
-Copyright: 2022 Google LLC
+Copyright: 2022-2024 Google LLC
 License: Apache-2.0
 
 Files: .github/hitl/*


### PR DESCRIPTION
Some of the simulated topologies sometimes fail on nightly CI. The problem is known (cf. #450) and can be fixed by further increasing the waiting time, but this would also increase the duration of the nightly CI jobs substantially. 

Thus, as there is no benefit of running even longer jobs at night for detecting implementation faults, this PR instead reduces the number of simulation jobs to a safe subset, which is sufficient for identification of potential uprising implementation errors that are directly detected by the simulation runs.