### PR TITLE
Fix shake dependencies

### DIFF
--- a/bittide-instances/bittide-instances.cabal
+++ b/bittide-instances/bittide-instances.cabal
@@ -12,6 +12,7 @@ Copyright:           Copyright © 2022-2024 Google LLC
 
 data-files:
   data/constraints/*.xdc
+  data/test_configs/*.yml
 
 common common-options
   default-extensions:

--- a/bittide-shake/bittide-shake.cabal
+++ b/bittide-shake/bittide-shake.cabal
@@ -60,7 +60,6 @@ executable shake
   main-is: exe/Main.hs
   Build-Depends:
     , ansi-terminal
-    , bittide-instances
     , bittide-shake
     , directory
     , Glob


### PR DESCRIPTION
The PR removes the dependency of `bittide-shake` on `bittide-instances`. The required `data` files are shared using `cabal sdist` instead of using relative paths offering a more robust solution in general.