### PR TITLE
Store post processed plot data as CSV

### DIFF
--- a/bittide-tools/bittide-tools.cabal
+++ b/bittide-tools/bittide-tools.cabal
@@ -114,6 +114,7 @@ executable cc-plot
     filepath,
     text,
     typelits-witnesses,
+    unordered-containers,
     vector,
   default-extensions: ImplicitPrelude
   -- enable rtsopts so we can setup memory limits


### PR DESCRIPTION
This PR adds an additional CSV writer to the post-process plotting tool, which stores the recovered data used for generating the plots in some additional CSV files.

The generated files are structured as follows:

* **Index:** The row index
* **Synchronized Time (fs):** The reference time shared along all nodes in fs (absolute since the test start).
* **Local Clock time (fs):** The local time measured by the particular node in fs (absolute since the test start).
* **Integrated FINC/FDECs:** The running sum of the FINCs and FDECs according to the sign function, i.e.,
  *  `FINC` → 1 
  *  `FDEC` → -1
* **Reframing State:** The state of the reframing state machine _(note that reframing is currently disabled for the HITL tests)_
  * `Detect`: Waiting for the elastic buffers to become stable
  * `Wait`: Waiting for the waiting time to elapse (red marking within the plots)
  * `Done`: Waiting time has elapsed
* **EB ℓ**: The occupancies of the elastic buffer corresponding to link ℓ
* **ℓ is stable**: boolean flag of the stability detector indicating whether it determines the occupancies of the elastic buffer corresponding to link ℓ to be stable
* **ℓ is settled**: boolean flag of the stability detector indicating whether it determines the occupancies of the elastic buffer corresponding to link ℓ to be stable and centered