### PR TITLE
Support postproc data in HITLT configs

### DIFF
--- a/bittide-tools/bittide-tools.cabal
+++ b/bittide-tools/bittide-tools.cabal
@@ -125,6 +125,7 @@ executable hitl-config-gen
   import: common-options
   main-is: hitl/config-gen/Main.hs
   build-depends:
+    aeson,
     bittide-instances,
     bittide-experiments,
     bytestring,


### PR DESCRIPTION
This PR adds support for placing additional data to the HITLT configs, which is not required by the HITL test itself, but can be utilized by later post processing steps.