### PR TITLE
Enable multiple threads when compiling sources

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -31,30 +31,37 @@ package bittide
 
 package clash-prelude
   flags: -multiple-hidden
+  ghc-options: +RTS -qn8 -A64M -RTS -j8
+
+package clash-lib
+  ghc-options: +RTS -qn8 -A64M -RTS -j8
+
+package clash-ghc
+  ghc-options: +RTS -qn8 -A64M -RTS -j8
 
 package bittide
-  ghc-options: +RTS -xp -RTS
+  ghc-options: +RTS -xp -qn8 -A64M -RTS -j8
 
 package bittide-experiments
-  ghc-options: +RTS -xp -RTS
+  ghc-options: +RTS -xp -qn8 -A64M -RTS -j8
 
 package bittide-extra
-  ghc-options: +RTS -xp -RTS
+  ghc-options: +RTS -xp -qn8 -A64M -RTS -j8
 
 package bittide-instances
-  ghc-options: +RTS -xp -RTS
+  ghc-options: +RTS -xp -qn8 -A64M -RTS -j8
 
 package bittide-shake
-  ghc-options: +RTS -xp -RTS
+  ghc-options: +RTS -xp -qn8 -A64M -RTS -j8
 
 package bittide-tools
-  ghc-options: +RTS -xp -RTS
+  ghc-options: +RTS -xp -qn8 -A64M -RTS -j8
 
 package clash-vexriscv
-  ghc-options: +RTS -xp -RTS
+  ghc-options: +RTS -xp -qn8 -A64M -RTS -j8
 
 package clash-vexriscv-sim
-  ghc-options: +RTS -xp -RTS
+  ghc-options: +RTS -xp -qn8 -A64M -RTS -j8
 
 -- index state, to go along with the cabal.project.freeze file. update the index
 -- state by running `cabal update` twice and looking at the index state it


### PR DESCRIPTION
Speeds up compilation 30-50%. I have no idea why this isn't enabled by default. Similar to what we concluded for `clash-{prelude,lib,ghc}` GHC doesn't scale well beyond 8 cores, which is why we limit it to what it is now. This should probably be reevaluated every time we upgrade GHC.

# Benchmark script
```python
#!/usr/bin/env python3
import subprocess
import time


SED_REPLACE_CMD = r"s/-qn[0-9]+ -A[0-9]+M -RTS -j[0-9]+/-qn{qn} -A{mem}M -RTS -j{j}/g"

QNS = [1, 2, 4, 8]
MEMS = [64, 128, 256]
JS = [1, 2, 4, 8, 16]


def sed(qn, mem, j):
    sed_cmd = SED_REPLACE_CMD.format(qn=qn, mem=mem, j=j)
    subprocess.check_call(["sed", "-E", "-i", sed_cmd, "cabal.project"])

with open("bench.csv", "w") as csv:
    csv.write("qn,mem,j,error,time\n")
    csv.flush()
    for qn in QNS:
        for mem in MEMS:
            for j in JS:
                sed(qn, mem, j)
                subprocess.check_call(["cabal", "clean"])
                subprocess.check_call(["cabal", "update"])

                before_time = time.time()
                error = 0
                try:
                    subprocess.check_call(["cabal", "build", "all"])
                except:
                    error = 1
                after_time = time.time()

                elapsed_time = after_time - before_time
                csv.write(f"{qn},{mem},{j},{error},{elapsed_time}\n")
                csv.flush()
```

# Results for AMD Ryzen 9 5900X / 64 GiB 3200 MHz
| qn | mem | j  | error | time   |
|----|-----|----|-------|--------|
| 8  | 64  | 8  | 0     | 76.62  |
| 8  | 128 | 8  | 0     | 77.52  |
| 8  | 64  | 16 | 0     | 77.61  |
| 4  | 64  | 8  | 0     | 78.16  |
| 4  | 64  | 16 | 0     | 78.46  |
| 8  | 128 | 16 | 0     | 78.61  |
| 8  | 256 | 4  | 0     | 78.88  |
| 4  | 128 | 8  | 0     | 79.09  |
| 8  | 64  | 4  | 0     | 79.41  |
| 8  | 256 | 8  | 0     | 79.49  |
| 8  | 128 | 4  | 0     | 79.57  |
| 4  | 256 | 4  | 0     | 79.65  |
| 4  | 64  | 4  | 0     | 80.28  |
| 4  | 256 | 8  | 0     | 80.44  |
| 4  | 128 | 16 | 0     | 80.46  |
| 4  | 128 | 4  | 0     | 80.52  |
| 2  | 64  | 16 | 0     | 81.14  |
| 2  | 256 | 8  | 0     | 81.32  |
| 2  | 128 | 8  | 0     | 81.32  |
| 2  | 64  | 8  | 0     | 81.49  |
| 2  | 256 | 4  | 0     | 82.63  |
| 8  | 256 | 16 | 0     | 83.13  |
| 2  | 128 | 4  | 0     | 83.21  |
| 2  | 128 | 16 | 0     | 84.36  |
| 2  | 64  | 4  | 0     | 84.41  |
| 1  | 64  | 16 | 0     | 84.64  |
| 1  | 128 | 8  | 0     | 84.66  |
| 1  | 256 | 8  | 0     | 84.86  |
| 4  | 256 | 16 | 0     | 85.08  |
| 1  | 256 | 4  | 0     | 85.20  |
| 1  | 128 | 16 | 0     | 85.37  |
| 2  | 256 | 16 | 0     | 86.48  |
| 1  | 128 | 4  | 0     | 86.82  |
| 1  | 64  | 8  | 0     | 86.98  |
| 8  | 256 | 2  | 0     | 87.76  |
| 1  | 256 | 16 | 0     | 88.71  |
| 8  | 128 | 2  | 0     | 88.81  |
| 4  | 64  | 2  | 0     | 89.75  |
| 4  | 128 | 2  | 0     | 90.06  |
| 2  | 256 | 2  | 0     | 90.53  |
| 1  | 64  | 4  | 0     | 90.61  |
| 2  | 64  | 2  | 0     | 91.13  |
| 2  | 128 | 2  | 0     | 91.40  |
| 8  | 64  | 2  | 0     | 91.52  |
| 1  | 256 | 2  | 0     | 91.99  |
| 4  | 256 | 2  | 0     | 92.28  |
| 1  | 128 | 2  | 0     | 94.85  |
| 1  | 64  | 2  | 0     | 98.32  |
| 8  | 256 | 1  | 0     | 108.38 |
| 1  | 256 | 1  | 0     | 108.85 |
| 4  | 128 | 1  | 0     | 110.04 |
| 4  | 256 | 1  | 0     | 110.80 |
| 8  | 128 | 1  | 0     | 110.86 |
| 2  | 256 | 1  | 0     | 111.06 |
| 2  | 128 | 1  | 0     | 111.46 |
| 2  | 64  | 1  | 0     | 111.98 |
| 8  | 64  | 1  | 0     | 112.16 |
| 4  | 64  | 1  | 0     | 112.25 |
| 1  | 128 | 1  | 0     | 112.84 |
| 1  | 64  | 1  | 0     | 127.23 |