### PR TITLE
Run Docker in priviliged mode with host mappings on HITL runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -733,7 +733,12 @@ jobs:
       image: ghcr.io/clash-lang/nixos-bittide-hardware:2024-03-13
       volumes:
         - /opt/tools:/opt/tools
-      options: --memory=11g
+
+      # XXX: User '1001' corresponds to 'bittide' on Linux installation that has
+      #      access to the hardware. We need to set this, lest Docker will write
+      #      files as 'root' and the runner software will be unable to run
+      #      cleaning jobs.
+      options: --memory=11g --userns host --privileged --user 1001:1001
 
     steps:
       - name: Checkout


### PR DESCRIPTION
`--privileged` is needed to access USB devices (i.e., JTAG), while `--usersns host` is needed to get the former to work. This is done as part of a separate PR to give everyone the chance to rebase on top of it, as running CI jobs with and without the flags causes permission errors as the different docker instances will write files under different users. Also see https://stackoverflow.com/a/65964376.