### PR TITLE
Add rust logging

### DIFF
--- a/firmware-binaries/Cargo.lock
+++ b/firmware-binaries/Cargo.lock
@@ -37,6 +37,7 @@ name = "bittide-sys"
 version = "0.1.0"
 dependencies = [
  "fdt",
+ "log",
  "ufmt",
 ]
 
@@ -141,6 +142,12 @@ dependencies = [
  "autocfg",
  "scopeguard",
 ]
+
+[[package]]
+name = "log"
+version = "0.4.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "memchr"

--- a/firmware-support/Cargo.lock
+++ b/firmware-support/Cargo.lock
@@ -53,6 +53,7 @@ dependencies = [
  "fdt",
  "lazy_static",
  "libc",
+ "log",
  "object",
  "proptest",
  "rand",
@@ -225,6 +226,12 @@ name = "linux-raw-sys"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
+
+[[package]]
+name = "log"
+version = "0.4.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "memchr"

--- a/firmware-support/bittide-sys/Cargo.toml
+++ b/firmware-support/bittide-sys/Cargo.toml
@@ -18,6 +18,7 @@ default = []
 [dependencies]
 fdt = "0.1.0"
 ufmt = "0.2.0"
+log = "0.4.21"
 
 [dev-dependencies]
 proptest = "1.0"

--- a/firmware-support/bittide-sys/src/uart.rs
+++ b/firmware-support/bittide-sys/src/uart.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 Google LLC
+// SPDX-FileCopyrightText: 2022-2024 Google LLC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -10,6 +10,7 @@ pub struct UartStatus {
 pub struct TransmitBufferFull;
 pub struct ReceiveBufferEmpty;
 
+#[derive(Clone)]
 /// `Uart` is a structure representing a universal asynchronous receiver-transmitter.
 pub struct Uart {
     /// `payload_addr` is a mutable pointer to the address of the data payload.
@@ -34,7 +35,7 @@ impl Uart {
     }
 
     /// UART status register output
-    pub fn read_status(&mut self) -> UartStatus {
+    pub fn read_status(&self) -> UartStatus {
         let flags: u8 = unsafe { self.flags_addr.read_volatile() };
 
         let rx_mask = 0b10;
@@ -51,7 +52,7 @@ impl Uart {
 
     /// The `receive` function attempts to receive data from the UART. If no
     /// data is available, it keeps looping until data is available.
-    pub fn receive(&mut self) -> u8 {
+    pub fn receive(&self) -> u8 {
         loop {
             if let Ok(val) = self.try_receive() {
                 return val;
@@ -61,7 +62,7 @@ impl Uart {
 
     /// The `try_receive` function attempts to receive data from the UART. If no
     /// data is available, it returns None.
-    pub fn try_receive(&mut self) -> Result<u8, ReceiveBufferEmpty> {
+    pub fn try_receive(&self) -> Result<u8, ReceiveBufferEmpty> {
         if self.read_status().receive_buffer_empty {
             Err(ReceiveBufferEmpty)
         } else {
@@ -74,7 +75,7 @@ impl Uart {
 
     /// The `send` function sends the given data to the UART. If the UART is
     /// unable to accept the data, it keeps looping until it can send the data.
-    pub fn send(&mut self, data: u8) {
+    pub fn send(&self, data: u8) {
         loop {
             if let Ok(()) = self.try_send(data) {
                 return;
@@ -84,7 +85,7 @@ impl Uart {
 
     /// The `try_send` function attempts to send the given data to the UART. If
     /// the UART is unable to accept the data, it returns an error.
-    pub fn try_send(&mut self, data: u8) -> Result<(), TransmitBufferFull> {
+    pub fn try_send(&self, data: u8) -> Result<(), TransmitBufferFull> {
         if self.read_status().transmit_buffer_full {
             Err(TransmitBufferFull)
         } else {

--- a/firmware-support/bittide-sys/src/uart.rs
+++ b/firmware-support/bittide-sys/src/uart.rs
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod log;
 pub struct UartStatus {
     pub receive_buffer_empty: bool,
     pub transmit_buffer_full: bool,
@@ -106,4 +107,13 @@ impl ufmt::uWrite for Uart {
     }
 
     type Error = ();
+}
+
+impl core::fmt::Write for Uart {
+    fn write_str(&mut self, s: &str) -> core::fmt::Result {
+        for b in s.bytes() {
+            self.send(b);
+        }
+        Ok(())
+    }
 }

--- a/firmware-support/bittide-sys/src/uart/log.rs
+++ b/firmware-support/bittide-sys/src/uart/log.rs
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: 2024 Google LLC
+//
+// SPDX-License-Identifier: Apache-2.0
+use crate::uart;
+
+// The logger utilizes core::fmt to format the log messages because ufmt formatting is not
+// compatible with (dependencies of) the log crate.
+use core::fmt::Write;
+
+/// A global logger instance to be used with the `log` crate.
+///
+/// Use `set_logger` to set the `Uart` instance to be used for logging.
+/// # Safety
+/// Using this logger is only safe if there is only one thread of execution.
+/// Even though `UartLogger` is `Send` and `Sync`, The underlying `Uart` is not `Send` or `Sync`.
+pub static mut LOGGER: UartLogger = UartLogger { uart: None };
+
+/// Wrapper for `Uart` to be used as a logger with the `log` crate
+/// Instead of making a new logger, use the `set_logger` method of the `LOGGER` instance.
+/// # Safety
+/// Using this logger is only safe if there is only one thread of execution.
+/// Even though `UartLogger` is `Send` and `Sync`, The underlying `Uart` is not `Send` or `Sync`.
+pub struct UartLogger {
+    uart: Option<uart::Uart>,
+}
+
+impl UartLogger {
+    /// Set the logger to use the given UART.
+    /// # Safety
+    /// Using this function and logger is only safe if there is only one thread of execution.
+    /// This function is used to assign the `Uart` instance to a global (`static mut`), but `Uart` is not `Send` or `Sync`.
+    pub unsafe fn set_logger(&mut self, uart: uart::Uart) {
+        self.uart = Some(uart);
+    }
+}
+
+impl log::Log for UartLogger {
+    fn enabled(&self, metadata: &log::Metadata) -> bool {
+        log::Level::Info <= metadata.level()
+    }
+
+    fn log(&self, record: &log::Record) {
+        if self.enabled(record.metadata()) {
+            unsafe {
+                match &mut LOGGER.uart {
+                    Some(l) => {
+                        writeln!(
+                            l,
+                            "{} | {}:{} - {}",
+                            record.level(),
+                            record.file().unwrap(),
+                            record.line().unwrap(),
+                            record.args()
+                        )
+                        .ok();
+                    }
+                    None => panic!("Logger not set"),
+                }
+            }
+        }
+    }
+
+    fn flush(&self) {}
+}
+
+unsafe impl core::marker::Send for UartLogger {}
+unsafe impl core::marker::Sync for UartLogger {}

--- a/host-tools/Cargo.lock
+++ b/host-tools/Cargo.lock
@@ -7,6 +7,7 @@ name = "bittide-sys"
 version = "0.1.0"
 dependencies = [
  "fdt",
+ "log",
  "ufmt",
 ]
 
@@ -26,6 +27,12 @@ name = "fdt"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784a4df722dc6267a04af36895398f59d21d07dce47232adf31ec0ff2fa45e67"
+
+[[package]]
+name = "log"
+version = "0.4.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "proc-macro2"


### PR DESCRIPTION
Implement a logger to be used with the [log](https://docs.rs/log/latest/log/) package: 

The [smoltcp](https://docs.rs/smoltcp/latest/smoltcp/) package we aim to use utilizes this package to enable debugging.
Unfortunately we can not use `ufmt` in combination with this package because the required `uDisplay` trait is not implemented for the [Arguments](https://doc.rust-lang.org/nightly/core/fmt/struct.Arguments.html) datatype.

We also can not create a wrapper for `Arguments` because we can not access the relevant fields.

Regarding the binary size implications, I did some tests using [cargo-bloat](https://crates.io/crates/cargo-bloat):
Without the `log` package and without using a debug logger, `cargo bloat --release -n 15` returned:
```
 File  .text    Size             Crate Name
14.4%  28.0%  5.4KiB           smoltcp smoltcp::iface::interface::ethernet::<impl smoltcp::iface::interface::InterfaceInner>::process_ethernet
10.6%  20.6%  4.0KiB         [Unknown] main
 5.9%  11.5%  2.2KiB           smoltcp smoltcp::iface::interface::InterfaceInner::dispatch_ip
 1.4%   2.7%    532B           smoltcp smoltcp::iface::interface::Interface::poll_at::{{closure}}
 1.3%   2.5%    502B compiler_builtins compiler_builtins::int::specialized_div_rem::u64_div_rem
 1.1%   2.2%    432B           smoltcp smoltcp::wire::tcp::TcpOption::emit
 1.0%   1.9%    368B compiler_builtins compiler_builtins::mem::memmove
 0.8%   1.5%    304B           smoltcp smoltcp::wire::ipv4::Repr::emit
 0.8%   1.5%    302B           smoltcp smoltcp::socket::tcp::Socket::reset
 0.8%   1.5%    292B           smoltcp smoltcp::socket::tcp::Socket::ack_reply
 0.7%   1.4%    282B           smoltcp smoltcp::wire::arp::Repr::emit
 0.7%   1.4%    276B           smoltcp heapless::linear_map::LinearMap<K,V,_>::insert
 0.7%   1.4%    274B           smoltcp smoltcp::iface::interface::InterfaceInner::is_broadcast_v4
 0.6%   1.2%    244B           smoltcp smoltcp::iface::route::Routes::lookup
 0.6%   1.1%    224B           smoltcp smoltcp::socket::tcp::Socket::rst_reply
 9.5%  18.5%  3.6KiB                   And 68 smaller methods. Use -n N to show more.
51.4% 100.0% 19.4KiB                   .text section size, the file size is 37.8KiB
```
I extended the `main` function with:
```rs
unsafe {LOGGER.set_logger(uart)};

uwriteln!(uart, "Starting smoltcp-echo").unwrap();
info!("Static info string");
debug!("Formatted {} string", "debug");
warn!("Warning message, look at {:?}", uart);
```
and added `log` as dependency to `Cargo.toml`.
```
log = {version = "0.4.21", features = ["release_max_level_off"]}
```
```
 File  .text    Size             Crate Name
25.0%  51.2% 10.3KiB         [Unknown] main
 5.4%  11.1%  2.2KiB           smoltcp smoltcp::iface::interface::InterfaceInner::dispatch_ip
 1.3%   2.6%    536B           smoltcp smoltcp::iface::interface::Interface::poll_at::{{closure}}
 1.2%   2.4%    502B compiler_builtins compiler_builtins::int::specialized_div_rem::u64_div_rem
 1.0%   2.1%    432B           smoltcp smoltcp::wire::tcp::TcpOption::emit
 0.9%   1.8%    368B compiler_builtins compiler_builtins::mem::memmove
 0.7%   1.5%    304B           smoltcp smoltcp::wire::ipv4::Repr::emit
 0.7%   1.5%    302B           smoltcp smoltcp::socket::tcp::Socket::reset
 0.7%   1.4%    292B           smoltcp smoltcp::socket::tcp::Socket::ack_reply
 0.7%   1.4%    282B           smoltcp smoltcp::wire::arp::Repr::emit
 0.7%   1.3%    276B           smoltcp heapless::linear_map::LinearMap<K,V,_>::insert
 0.6%   1.3%    274B           smoltcp smoltcp::iface::interface::InterfaceInner::is_broadcast_v4
 0.6%   1.2%    244B           smoltcp smoltcp::iface::route::Routes::lookup
 0.5%   1.1%    224B           smoltcp smoltcp::socket::tcp::Socket::rst_reply
 0.5%   1.1%    222B           smoltcp smoltcp::iface::neighbor::Cache::lookup
 7.8%  16.1%  3.2KiB                   And 62 smaller methods. Use -n N to show more.
48.8% 100.0% 20.2KiB                   .text section size, the file size is 41.3KiB
```
Removing the feature, or changing it to `"release_max_level_trace"` resulted in the same lower binary size as without the logging infra. Other levels made no measurable difference.

I think we should not should try to not use `core::fmt` in our code, but `smoltcp` already has it and this allows us to make use of it.

I also looked into adding adding a single `writeln` invocation, this increased the binary size to 42.9KiB.
When comparing the function sizes of a version with and without this invocation, I noticed the size stems from:
```
284B              core core::fmt::write
184B       bittide_sys <&mut W as core::fmt::Write>::write_char
58B       bittide_sys <bittide_sys::uart::Uart as core::fmt::Write>::write_str
52B       bittide_sys ufmt::Formatter<W>::write_str
46B              core core::fmt::getcount
44B       bittide_sys core::fmt::Write::write_fmt
28B              core <core::str::iter::Bytes as core::iter::traits::iterator::Iterator>::next
14B       bittide_sys bittide_sys::uart::Uart::send
4B              core core::ops::function::FnOnce::call_once
2B              core core::ptr::drop_in_place<&mut bittide_sys::uart::Uart>
```
and
~19.4KiB                   .text section size~ => 20.2KiB                   .text section size
Which does not add up to the added KiBs interestingly...