### PR TITLE
Fix tcl typo

### DIFF
--- a/bittide-shake/data/tcl/HardwareTest.tcl
+++ b/bittide-shake/data/tcl/HardwareTest.tcl
@@ -466,7 +466,7 @@ proc has_expected_targets {url expected_target_dict} {
                 append err_msg \n
             }
             set unexpected_targets [difference $hw_targets $expected_names]
-            if {[llength $unexpected_targets] > 0]} {
+            if {[llength $unexpected_targets] > 0} {
                 append err_msg "Hardware targets which are not expected:\n"
                 foreach tgt $unexpected_targets {
                     append err_msg $tgt \n


### PR DESCRIPTION
Nightly failed and crashed on a tcl typo:
https://github.com/bittide/bittide-hardware/actions/runs/8743400653/job/23994929621

Now we get:
```
Expected hardware targets:
192.168.102.130:3121/xilinx_tcf/Digilent/210308B3B272 - FPGA 0 <- not found
192.168.102.130:3121/xilinx_tcf/Digilent/210308B0992E - FPGA 1
192.168.102.130:3121/xilinx_tcf/Digilent/210308B0AE73 - FPGA 2
192.168.102.130:3121/xilinx_tcf/Digilent/210308B0AE6D - FPGA 3
192.168.102.130:3121/xilinx_tcf/Digilent/210308B0AFD4 - FPGA 4
192.168.102.130:3121/xilinx_tcf/Digilent/210308B0AE65 - FPGA 5
192.168.102.130:3121/xilinx_tcf/Digilent/210308B3A22D - FPGA 6
192.168.102.130:3121/xilinx_tcf/Digilent/210308B0B0C2 - FPGA 7
```
When I manually turn off FPGA 0