### PR TITLE
Improve the clock reports

### DIFF
--- a/bittide-instances/src/Bittide/Instances/Hitl/HwCcTopologies.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/HwCcTopologies.hs
@@ -82,6 +82,8 @@ import VexRiscv
 
 import qualified Data.Map.Strict as Map (fromList)
 
+type AllStablePeriod = Seconds 5
+
 data TestConfig =
   TestConfig
     { fpgaEnabled :: Bool
@@ -369,7 +371,7 @@ hwCcTopologyWithRiscvTest refClkDiff sysClkDiff syncIn rxns rxps miso =
     (startTest .&&. syncStart .&&. ((not <$> allUp) .||. transceiversFailedAfterUp))
 
   endSuccess :: Signal Basic125 Bool
-  endSuccess = trueFor (SNat @(Seconds 5)) sysClk syncRst allStable
+  endSuccess = trueFor (SNat @AllStablePeriod) sysClk syncRst allStable
 
   done = endSuccess .||. transceiversFailedAfterUp .||. startBeforeAllUp
   success = not <$> (transceiversFailedAfterUp .||. startBeforeAllUp)
@@ -517,6 +519,8 @@ tests = Map.fromList
             , waitTime = fromEnum cccReframingWaitTime
             , clockOffsets = toList $ repeat @n 0
             , startupOffsets = toList $ repeat @n 0
+            , stopAfterStable =
+                Just $ natToNum @(PeriodToCycles Basic125 AllStablePeriod)
             }
       )
     )

--- a/bittide-tools/bittide-tools.cabal
+++ b/bittide-tools/bittide-tools.cabal
@@ -111,6 +111,7 @@ executable cc-plot
     containers,
     data-default,
     directory,
+    extra,
     filepath,
     text,
     typelits-witnesses,

--- a/bittide-tools/clockcontrol/sim/src/Main.hs
+++ b/bittide-tools/clockcontrol/sim/src/Main.hs
@@ -72,7 +72,7 @@ main = do
             saveSimConfig t cfg
             when (isJust isStable && createReport) $
               checkIntermediateResults outDir
-                 >>= maybe (generateReport "Simulation Report" outDir cfg) die
+                 >>= maybe (generateReport "Simulation Report" outDir [] cfg) die
         , ..
         }
 


### PR DESCRIPTION
The PR fixes several issues with the data that is presented by the clock control reports and adds some new features:

* Disabled nodes and links have been removed from the plots.
* The descriptions in the configuration table have been adapted to suite both: 
   the HITLT and the simulation report.
* A mapping to the corresponding FPGA IDs has been added to the HITLT report.
* A legend for the different markings in the elastic buffers plots has been added.
* Several minor layout issues have been fixed.