### PR TITLE
Add more parameters to the HITL topology test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,7 +220,7 @@ jobs:
             --get-rusty \
             --steps ${{ matrix.target.steps }} \
             --samples 1000 \
-            --max-startup-offset 2000 \
+            --max-startup-delay 2000 \
             --stop-after-stable ${{ matrix.target.steps }} \
             --create-report \
             ${{ matrix.target.topology }} ${{ matrix.target.args }}

--- a/bittide-experiments/src/Bittide/Hitl.hs
+++ b/bittide-experiments/src/Bittide/Hitl.hs
@@ -73,8 +73,10 @@ import Clash.Prelude
 
 import Clash.Cores.Xilinx.VIO (vioProbe)
 
-import Data.Aeson (ToJSON(toJSON), object, (.=))
-import Data.Aeson.Encode.Pretty (encodePretty)
+import Data.Aeson (ToJSON(toJSON), Value(Number), object, (.=))
+import Data.Aeson.Encode.Pretty
+  ( Config(..), NumberFormat(..), encodePretty', defConfig )
+import Data.Aeson.Text (encodeToTextBuilder)
 import Data.Map (Map)
 import Data.Maybe (isJust)
 import Data.Text (Text)
@@ -352,7 +354,11 @@ packAndEncode ::
   (BitPack a, ToJSON b) =>
   HitlTestsWithPostProcData a b ->
   LazyByteString.ByteString
-packAndEncode = encodePretty . toPacked
+packAndEncode = encodePretty'
+  defConfig
+    { confNumFormat = Custom (encodeToTextBuilder . Number)
+    }
+  . toPacked
 
 -- | Whether a test has been completed, see 'hitlVio'.
 type Done = Bool

--- a/bittide-experiments/src/Bittide/Report/ClockControl.hs
+++ b/bittide-experiments/src/Bittide/Report/ClockControl.hs
@@ -196,7 +196,7 @@ toLatex datetime runref header clocksPdf ebsPdf topTikz ids SimConf{..} = unline
   , "\\begin{large}"
   , "  \\begin{tabular}{rl}"
   , "    duration \\textit{(clock cycles)}:"
-  , "      & " <> show simulationSteps <> " \\\\"
+  , "      & " <> show duration <> " \\\\"
   , "    stability detector - framesize:"
   , "      & " <> show stabilityFrameSize <> " \\\\"
   , "    stability detector - margin:"
@@ -205,14 +205,14 @@ toLatex datetime runref header clocksPdf ebsPdf topTikz ids SimConf{..} = unline
   , "      & " <> maybe "not used" show stopAfterStable <> " \\\\"
   , "    clock offsets \\textit{(fs)}:"
   , "      & " <> intercalate ", " (show <$> clockOffsets) <> " \\\\"
-  , "    startup offsets \\textit{(clock cycles)}:"
-  , "      & " <> intercalate ", " (show <$> startupOffsets) <> " \\\\"
+  , "    startup delays \\textit{(clock cycles)}:"
+  , "      & " <> intercalate ", " (show <$> startupDelays) <> " \\\\"
   , "    reframing:"
   , "      & " <> "\\textit{"
-               <> bool "enabled" "disabled" disableReframing
+               <> bool "disabled" "enabled" reframe
                <> "} \\\\"
-  , if disableReframing then "" else
-      "    wait time: & " <> show waitTime <> " \\\\"
+  , if reframe then "    wait time: & " <> show waitTime <> " \\\\" else ""
+
   , "    all buffers stable at the end of simulation:"
   , "      & " <> maybe ""
                    ( bool "\\textcolor{red!50!black}{\\ding{55}}"
@@ -250,7 +250,7 @@ toLatex datetime runref header clocksPdf ebsPdf topTikz ids SimConf{..} = unline
   , "    (D) at ($ (C.north east) + (0.2,0) $) {"
   , "      \\small\\textit{buffer is stable and centered}"
   , "    };"
-  , if disableReframing then "" else unlines
+  , if not reframe then "" else unlines
       [ "    \\node[overlay,anchor=north west,fill=red]"
       , "    (E) at ($ (A.south west) + (0,-0.2) $) {};"
       , "    \\node[overlay,anchor=north west,inner sep=0pt]"

--- a/bittide-instances/src/Bittide/Instances/Domains.hs
+++ b/bittide-instances/src/Bittide/Instances/Domains.hs
@@ -31,7 +31,7 @@ createDomain vXilinxSystem{vName="GthTx", vPeriod= hzToPeriod 125e6}
 createDomain vXilinxSystem{vName="Internal", vPeriod=hzToPeriod 200e6}
 
 type CccBufferSize = 25 :: Nat
-type CccStabilityCheckerMargin = 16 :: Nat
+type CccStabilityCheckerMargin = 25 :: Nat
 type CccStabilityCheckerFramesize dom = PeriodToCycles dom (Seconds 2)
 type CccReframingWaitTime dom = PeriodToCycles dom (Seconds 5)
 

--- a/bittide-instances/src/Bittide/Instances/Hitl/FullMeshHwCc.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/FullMeshHwCc.hs
@@ -469,16 +469,16 @@ fullMeshHwCcTest refClkDiff sysClkDiff syncIn rxns rxps miso =
 tests :: HitlTestsWithPostProcData () SimConf
 tests = Map.singleton "CC" $
   ( allFpgas ()
-  , def { mTopologyType = Just $ Complete (natToInteger @FpgaCount)
-        , simulationSamples = 1000
-        , simulationSteps = natToNum @(PeriodToCycles Basic125 (Seconds 60))
-        , stabilityMargin = snatToNum cccStabilityCheckerMargin
+  , def { mTopologyType      = Just $ Complete (natToInteger @FpgaCount)
+        , samples            = 1000
+        , duration           = natToNum @(PeriodToCycles Basic125 (Seconds 60))
+        , stabilityMargin    = snatToNum cccStabilityCheckerMargin
         , stabilityFrameSize = snatToNum cccStabilityCheckerFramesize
-        , disableReframing = not $ cccEnableReframing
-        , rusty = cccEnableRustySimulation
-        , waitTime = fromEnum cccReframingWaitTime
-        , clockOffsets = toList $ repeat @FpgaCount 0
-        , startupOffsets = toList $ repeat @FpgaCount 0
+        , reframe            = cccEnableReframing
+        , rusty              = cccEnableRustySimulation
+        , waitTime           = fromEnum cccReframingWaitTime
+        , clockOffsets       = toList $ repeat @FpgaCount 0
+        , startupDelays      = toList $ repeat @FpgaCount 0
         }
   )
  where

--- a/bittide-instances/src/Bittide/Instances/Hitl/FullMeshSwCc.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/FullMeshSwCc.hs
@@ -354,16 +354,16 @@ fullMeshSwCcTest refClkDiff sysClkDiff syncIn rxns rxps miso =
 tests :: HitlTestsWithPostProcData () SimConf
 tests = Map.singleton "CC" $
   ( allFpgas ()
-  , def { mTopologyType = Just $ Complete (natToInteger @FpgaCount)
-        , simulationSamples = 1000
-        , simulationSteps = natToNum @(PeriodToCycles Basic125 (Seconds 60))
-        , stabilityMargin = snatToNum cccStabilityCheckerMargin
+  , def { mTopologyType      = Just $ Complete (natToInteger @FpgaCount)
+        , samples            = 1000
+        , duration           = natToNum @(PeriodToCycles Basic125 (Seconds 60))
+        , stabilityMargin    = snatToNum cccStabilityCheckerMargin
         , stabilityFrameSize = snatToNum cccStabilityCheckerFramesize
-        , disableReframing = not $ cccEnableReframing
-        , rusty = cccEnableRustySimulation
-        , waitTime = fromEnum cccReframingWaitTime
-        , clockOffsets = toList $ repeat @FpgaCount 0
-        , startupOffsets = toList $ repeat @FpgaCount 0
+        , reframe            = cccEnableReframing
+        , rusty              = cccEnableRustySimulation
+        , waitTime           = fromEnum cccReframingWaitTime
+        , clockOffsets       = toList $ repeat @FpgaCount 0
+        , startupDelays      = toList $ repeat @FpgaCount 0
         }
   )
  where

--- a/bittide-instances/src/Bittide/Instances/Hitl/IlaPlot.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/IlaPlot.hs
@@ -435,9 +435,9 @@ callistoClockControlWithIla dynClk clk rst ccc IlaControl{..} mask ebs =
   -- local timestamp on the stable clock
   localTs :: Signal sys (DiffResult (LocalTimestamp dyn))
   localTs = case maxGeqPlusApp of
-    Dict -> overflowResistantDiff clk rst
+    Dict -> overflowResistantDiff clk syncRst
               (delay clk enableGen False (isJust <$> captureCond))
-          $ let ccRst = xpmResetSynchronizer Asserted clk dynClk rst
+          $ let ccRst = xpmResetSynchronizer Asserted clk dynClk syncRst
                 lts :: Signal dyn (Unsigned 8)
                 lts = register dynClk ccRst enableGen minBound
                     $ satSucc SatWrap <$> lts
@@ -493,8 +493,8 @@ callistoClockControlWithIla dynClk clk rst ccc IlaControl{..} mask ebs =
           )
 
   -- produce at least two calibration captures
-  calibrating = unsafeToActiveLow rst .&&.
-    moore clk rst enableGen
+  calibrating = unsafeToActiveLow syncRst .&&.
+    moore clk syncRst enableGen
       (\s -> bool s $ satSucc SatBound s)
       (/= maxBound)
       (minBound :: Index 3)

--- a/bittide-tools/clockcontrol/sim/src/Main.hs
+++ b/bittide-tools/clockcontrol/sim/src/Main.hs
@@ -42,9 +42,8 @@ main = do
     checkDependencies
       >>= maybe (return ()) die
 
-  sccc <- someCCC (Proxy @Bittide)
-    (not disableReframing) rusty waitTime
-      (toInteger stabilityMargin) (toInteger stabilityFrameSize)
+  sccc <- someCCC (Proxy @Bittide) reframe rusty waitTime
+    (toInteger stabilityMargin) (toInteger stabilityFrameSize)
 
   isStable <- case mTopologyType of
     Nothing ->
@@ -53,21 +52,21 @@ main = do
     Just tt -> fromTopologyType tt >>= \case
       Left err -> die $ "Error : " <> err
       Right t -> simPlot t SimPlotSettings
-        { samples      = simulationSamples
-        , periodsize   = simulationSteps `quot` simulationSamples
-        , mode         = outMode
-        , dir          = outDir
-        , stopStable   =
+        { plotSamples = samples
+        , periodsize = duration `quot` samples
+        , mode = outMode
+        , dir = outDir
+        , stopStable =
             if stopWhenStable
             then Just 0
-            else (`quot` simulationSamples) <$> stopAfterStable
+            else (`quot` samples) <$> stopAfterStable
         , fixClockOffs = clockOffsets
-        , fixStartOffs = startupOffsets
-        , maxStartOff  = maxStartupOffset
-        , save         = \clockOffs startOffs isStable -> do
-            let cfg = simCfg { stable         = isStable
-                             , clockOffsets   = clockOffs
-                             , startupOffsets = startOffs
+        , fixStartDelays = startupDelays
+        , maxStartDelay = maxStartupDelay
+        , save = \clockOffs startDelays isStable -> do
+            let cfg = simCfg { stable        = isStable
+                             , clockOffsets  = clockOffs
+                             , startupDelays = startDelays
                              }
             saveSimConfig t cfg
             when (isJust isStable && createReport) $


### PR DESCRIPTION
The PR adds the following new HITLT configuration parameters to the `hwCCTopologies` test:

* Step size selection
* Initial clock shift (per FPGA)
* Startup delay (per FPGA)

Furthermore, a calibration routine has been added, which identifies the natural clock shift of the clock sources to be elided prior to the test start.

---

### Depends on

* #509 

