### PR TITLE
Re-enable reframing for simulation

### DIFF
--- a/bittide-experiments/src/Bittide/Simulate/Config.hs
+++ b/bittide-experiments/src/Bittide/Simulate/Config.hs
@@ -165,7 +165,7 @@ simConfigCLIParser =
                <> "must remain within to be considered stable"
                )
           )
-    <*> flag False True
+    <*> flag (reframe def) False
           (  long "disable-reframing"
           <> short 'e'
           <> help "Disables clock control reframing"


### PR DESCRIPTION
We accidentally disabled reframing for simulation due to complementing the flag's semantics. Nightly CI fails as consequence. The PR fixes it again.