### PR TITLE
Add tooling for transceiver word alignment

### DIFF
--- a/bittide/bittide.cabal
+++ b/bittide/bittide.cabal
@@ -143,6 +143,7 @@ library
     Bittide.SharedTypes
     Bittide.Switch
     Bittide.Transceiver
+    Bittide.Transceiver.WordAlign
     Bittide.Wishbone
     Clash.Cores.Extra
     Clash.Cores.UART.Extra
@@ -192,6 +193,7 @@ test-suite unittests
     Tests.Shared
     Tests.StabilityChecker
     Tests.Switch
+    Tests.Transceiver.WordAlign
     Tests.Wishbone
   build-depends:
     HUnit,

--- a/bittide/src/Bittide/Transceiver/WordAlign.hs
+++ b/bittide/src/Bittide/Transceiver/WordAlign.hs
@@ -1,0 +1,168 @@
+-- SPDX-FileCopyrightText: 2024 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+
+{-# LANGUAGE NamedFieldPuns #-}
+
+-- | Fundamentally, our transceivers are sending over single bits. Through transceiver
+-- IP we can send words (e.g., 32 bits) on one end and receive words on the other
+-- end. The IP makes sure that any received are byte aligned. That means that a
+-- stream:
+--
+-- > -----------------------------------------------
+-- > | B3 B2 B1 B0 | B3 B2 B1 B0 | B3 B2 B1 B0 | ...
+-- > -----------------------------------------------
+--
+-- ..might be received on the other end as:
+--
+-- > -----------------------------------------------
+-- > | .. .. B3 B2 | B1 B0 B3 B2 | B1 B0 B3 B2 | ...
+-- > -----------------------------------------------
+--
+-- or by any other shift (or none at all!). This module provides utilities to end
+-- up with a word aligned stream. The basic idea is that, while \"booting\" the
+-- connection the MSB of each byte is reserved, where an asserted MSB indicates
+-- the start of a word. The other bits can be used to detect a valid connection
+-- through PRBS streams.
+--
+-- TODO: Remove this module in favor of retry logic. That is, we can keep
+--       resetting the transceivers until they're aligned. Its unclear how exactly
+--       this should work though.
+module Bittide.Transceiver.WordAlign
+  ( alignBytesFromMsbs
+  , alignBytes
+  , align
+
+  -- * Convenience functions
+  , alignSymbol
+  , splitMsbs
+  , joinMsbs
+  , dealignBytes
+  ) where
+
+import Clash.Prelude
+import Data.Bifunctor (Bifunctor (bimap))
+import Bittide.SharedTypes (Bytes, Byte)
+
+data AlignState n a
+  = Waiting
+  | Aligning { prev :: Vec n a, offset :: Index n }
+  deriving (Show, Generic, ShowX, NFDataX)
+
+alignSymbol :: forall n . (KnownNat n, 1 <= n) => BitVector n
+alignSymbol = bit (natToNum @(n - 1))
+
+-- | Split the MSBs of a 'BitVector's \"bytes\" into a 'BitVector' of MSBs and a
+-- 'BitVector' of the remaining bits.
+splitMsbs ::
+  forall nBytes byteWidth .
+  ( KnownNat nBytes
+  , KnownNat byteWidth
+  , 1 <= byteWidth
+  ) =>
+  BitVector (nBytes * byteWidth) ->
+  ( BitVector nBytes
+  , BitVector (nBytes * (byteWidth - 1))
+  )
+splitMsbs =
+    bimap pack pack
+  . unzip
+  . unpack @(Vec nBytes (Bit, BitVector (byteWidth - 1)))
+
+-- | Opposite of 'splitMsbs'.
+joinMsbs ::
+  forall nBytes byteWidth .
+  ( KnownNat nBytes
+  , KnownNat byteWidth
+  , 1 <= byteWidth
+  ) =>
+  BitVector nBytes ->
+  BitVector (nBytes * (byteWidth - 1)) ->
+  BitVector (nBytes * byteWidth)
+joinMsbs msbs bvs = pack $
+  zip
+    (unpack @(Vec nBytes Bool) msbs)
+    (unpack @(Vec nBytes (BitVector(byteWidth - 1))) bvs)
+
+-- | Specialized version of 'align' that works on 'BitVector' and assumes that
+-- the alignment bits are stored in the MSBs of the bytes.
+alignBytesFromMsbs ::
+  forall n dom .
+  ( HiddenClockResetEnable dom
+  , KnownNat n
+  , 1 <= n
+  ) =>
+  -- | Data with alignment bits in the byte's MSBs
+  Signal dom (Bytes n) ->
+  -- | 'Nothing' until an alignment symbol has been observed. 'Just' if an alignment
+  -- symbol has been observed.
+  Signal dom (Maybe (Bytes n))
+alignBytesFromMsbs dat = alignBytes (fst . splitMsbs <$> dat) dat
+
+-- | Specialized version of 'align' that works on 'BitVector'
+alignBytes ::
+  forall n dom .
+  ( HiddenClockResetEnable dom
+  , KnownNat n
+  , 1 <= n
+  ) =>
+  -- | One hot encoded alignment signal. Data is assumed to be invalid as long as
+  -- all booleans are 'False'.
+  Signal dom (BitVector n) ->
+  -- | Data
+  Signal dom (Bytes n) ->
+  -- | 'Nothing' until an alignment symbol has been observed. 'Just' if an alignment
+  -- symbol has been observed.
+  Signal dom (Maybe (Bytes n))
+alignBytes aligns =
+    fmap (fmap pack)
+  . align @Byte (unpack <$> aligns)
+  . fmap unpack
+
+-- |
+align ::
+  forall a n dom .
+  ( HiddenClockResetEnable dom
+  , KnownNat n
+  , NFDataX a
+  , 1 <= n
+  ) =>
+  -- | One hot encoded alignment signal. Data is assumed to be invalid as long as
+  -- all booleans are 'False'.
+  Signal dom (Vec n Bool) ->
+  -- | Data
+  Signal dom (Vec n a) ->
+  -- | 'Nothing' until an alignment symbol has been observed. 'Just' if an
+  -- alignment symbol has been observed.
+  Signal dom (Maybe (Vec n a))
+align = curry (delay Nothing . mealyB go (Waiting @n @a))
+ where
+  go :: AlignState n a -> (Vec n Bool, Vec n a) -> (AlignState n a, Maybe (Vec n a))
+  go Waiting (alignment, as) = (, Nothing) $
+    case elemIndex True alignment of
+      Just offset -> Aligning{prev=as, offset}
+      Nothing -> Waiting
+  go (Aligning{prev, offset}) (_, current) =
+    ( Aligning{prev=current, offset}
+    , Just (takeI (rotateLeft (prev ++ current) offset))
+    )
+
+-- | Opposite of 'align'. Useful for testing. The first and last word are padded
+-- with zeros. If the given offset is zero, the first and last word are all zeros.
+-- This function mimics the behavior of the transceiver IP, i.e., it mimics reading
+-- at a certain offset in the stream. (Also see this module's documentation.)
+dealignBytes ::
+  forall nBytes .
+  (KnownNat nBytes) =>
+  -- Offset in number of bytes
+  Index nBytes ->
+  [Bytes nBytes] ->
+  [Bytes nBytes]
+dealignBytes offset = go 0
+ where
+  go :: Bytes nBytes -> [Bytes nBytes] -> [Bytes nBytes]
+  go prev [] = [dealignWord prev 0]
+  go prev (bv : bvs) = dealignWord prev bv : go bv bvs
+
+  dealignWord :: Bytes nBytes -> Bytes nBytes -> Bytes nBytes
+  dealignWord bv1 bv2 = truncateB (shiftR (bv1 ++# bv2) (8 * fromIntegral offset))

--- a/bittide/tests/Tests/Transceiver/WordAlign.hs
+++ b/bittide/tests/Tests/Transceiver/WordAlign.hs
@@ -1,0 +1,113 @@
+-- SPDX-FileCopyrightText: 2024 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+
+{-# LANGUAGE OverloadedStrings #-}
+
+module Tests.Transceiver.WordAlign where
+
+import Clash.Prelude hiding (someNatVal)
+
+import Clash.Explicit.Reset (noReset)
+import Clash.Hedgehog.Sized.BitVector (genDefinedBitVector)
+import Clash.Hedgehog.Sized.Index (genIndex)
+import Data.Maybe (catMaybes)
+import Data.Proxy (Proxy(..))
+import GHC.TypeNats (someNatVal)
+import Hedgehog
+import Test.Tasty
+import Test.Tasty.Hedgehog
+import Test.Tasty.HUnit
+
+import qualified Bittide.Transceiver.WordAlign as WordAlign
+import qualified Clash.Explicit.Prelude as E
+import qualified Data.List as L
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
+
+withSomeSNat :: Natural -> (forall (n :: Nat). SNat n -> r) -> r
+withSomeSNat n f = case someNatVal n of
+  SomeNat (_ :: Proxy n) -> f (SNat @n)
+
+-- | Very simply sanity check for the 'dealign' function. Is non-exhaustive, but
+-- is used extensively in 'prop_wordAlignFromMsb'.
+case_dealign :: Assertion
+case_dealign = do
+  [0xCDEF, 0x0000] @=? WordAlign.dealignBytes (0 :: Index 2) [0xCDEF]
+  [0xDEFC, 0x0000] @=? WordAlign.dealignBytes (0 :: Index 2) [0xDEFC]
+  [0xEFCD, 0x0000] @=? WordAlign.dealignBytes (0 :: Index 2) [0xEFCD]
+  [0xFCDE, 0x0000] @=? WordAlign.dealignBytes (0 :: Index 2) [0xFCDE]
+
+  [0x00CD, 0xEF00] @=? WordAlign.dealignBytes (1 :: Index 2) [0xCDEF]
+  [0x00DE, 0xFC00] @=? WordAlign.dealignBytes (1 :: Index 2) [0xDEFC]
+  [0x00EF, 0xCD00] @=? WordAlign.dealignBytes (1 :: Index 2) [0xEFCD]
+  [0x00FC, 0xDE00] @=? WordAlign.dealignBytes (1 :: Index 2) [0xFCDE]
+
+prop_wordAlignFromMsb :: Property
+prop_wordAlignFromMsb = property $ do
+  -- Generate type level constructs for worker function
+  nBytesMinusOne <- forAll $ Gen.integral (Range.linear 0 15)
+  withSomeSNat nBytesMinusOne (go . succSNat)
+ where
+  -- Worker function that only deals with term level naturals
+  go :: forall nBytes . (1 <= nBytes) => SNat nBytes -> PropertyT IO ()
+  go SNat = leToPlus @1 @nBytes $ do
+    -- How much offset is "inserted" by the "transceiver"s
+    byteOffset <- forAll $ genIndex Range.constantBounded
+
+    -- Number of cycles to keep all valid bits deasserted
+    nInvalidCycles <- forAll $ Gen.integral (Range.linear 0 64)
+
+    -- Number of cycles where we expect to transfer valid data. Note that we only
+    -- set the valid bits once - once detected the align functions should ignore
+    -- the valid bits. We always generate at least one valid cycle, to simplify
+    -- the test implementation.
+    nValidCycles <- forAll $ Gen.integral (Range.linear 1 64)
+
+    -- First value of valid word. Subsequent values are incremented by one.
+    startWord <- forAll $ genDefinedBitVector @_ @(7 * nBytes)
+
+    let
+      invalidWord = WordAlign.joinMsbs @nBytes @8 0 (errorX "go: invalid")
+      validWord n =
+        -- All words after the first valid word have their valid bits set
+        -- "chaotically". That is, the word written is reduced using XOR to
+        -- determine the valid bits. These should be ignored by the align functions.
+        WordAlign.joinMsbs @nBytes (toValids (startWord + n)) (startWord + n)
+
+      invalidCycles = L.replicate nInvalidCycles invalidWord
+      firstValidCycle = WordAlign.joinMsbs @nBytes WordAlign.alignSymbol startWord
+      restOfValidCycles = [validWord n | n <- [1..satPred SatBound nValidCycles]]
+      validCycles = firstValidCycle : restOfValidCycles
+      cycles = WordAlign.dealignBytes byteOffset (invalidCycles <> validCycles)
+
+      -- How quickly the align function can respond to inputs
+      pipelineDepth = 1
+
+      actual =
+          L.map (snd . WordAlign.splitMsbs @nBytes @8)
+        $ L.take (L.length validCycles)
+        $ catMaybes
+        $ E.sampleN (L.length cycles + pipelineDepth)
+        $ withClockResetEnable @XilinxSystem clockGen noReset enableGen
+        $ WordAlign.alignBytesFromMsbs @nBytes
+        $ E.fromList $ cycles <> L.repeat 0
+
+      expected = [startWord + n | n <- [0..satPred SatBound nValidCycles]]
+
+    footnote $ "invalidCycles: " <> show invalidCycles
+    footnote $ "validCycles: " <> show validCycles
+    footnote $ "cycles: " <> show cycles
+
+    L.length expected === fromIntegral nValidCycles -- sanity check
+    expected === actual
+
+-- | \"Chaotic\" valid bits, based on the input word.
+toValids :: forall n . KnownNat n => BitVector (7 * n) -> BitVector n
+toValids = pack . map reduceXor . unpack @(Vec n (BitVector 7))
+
+tests :: TestTree
+tests = testGroup "WordAlign"
+  [ testPropertyNamed "prop_wordAlignFromMsb" "prop_wordAlignFromMsb" prop_wordAlignFromMsb
+  , testCase "case_dealign" case_dealign
+  ]

--- a/bittide/tests/UnitTests.hs
+++ b/bittide/tests/UnitTests.hs
@@ -19,6 +19,7 @@ import qualified Tests.ProcessingElement.ReadElf
 import qualified Tests.ScatterGather
 import qualified Tests.StabilityChecker
 import qualified Tests.Switch
+import qualified Tests.Transceiver.WordAlign
 import qualified Tests.Wishbone
 
 tests :: TestTree
@@ -33,6 +34,7 @@ tests = testGroup "Unittests"
   , Tests.ScatterGather.tests
   , Tests.StabilityChecker.tests
   , Tests.Switch.tests
+  , Tests.Transceiver.WordAlign.tests
   , Tests.Wishbone.tests
   ]
 


### PR DESCRIPTION
It's fairly generic code, that will be used in upcoming PRs trying to observe UGNs. We decided to publish it as a separate PR to parallelize the review process a bit more.

@lmbollen If you see any mention of "valid bits" - that's not proper terminology. They should be called "alignment bits". I tried to remove them all..