### PR TITLE
Instantiate core for temperature readouts

### DIFF
--- a/.github/synthesis/all.json
+++ b/.github/synthesis/all.json
@@ -22,6 +22,7 @@
   {"top": "hwCcTopologyTest",              "stage": "test",   "targets": "All"          },
   {"top": "linkConfigurationTest",         "stage": "test",   "targets": "All"          },
   {"top": "syncInSyncOut",                 "stage": "test",   "targets": "All"          },
+  {"top": "temperatureMonitor",            "stage": "test",   "targets": "All"          },
   {"top": "transceiversUpTest",            "stage": "test",   "targets": "All"          },
   {"top": "vexRiscvTest",                  "stage": "test",   "targets": "Specific [-1]"}
 ]

--- a/bittide-instances/bittide-instances.cabal
+++ b/bittide-instances/bittide-instances.cabal
@@ -124,6 +124,7 @@ library
     Bittide.Instances.Hitl.Setup
     Bittide.Instances.Hitl.SyncInSyncOut
     Bittide.Instances.Hitl.Tcl.ExtraProbes
+    Bittide.Instances.Hitl.TemperatureMonitor
     Bittide.Instances.Hitl.Tests
     Bittide.Instances.Hitl.Transceivers
     Bittide.Instances.Hitl.VexRiscv

--- a/bittide-instances/data/constraints/temperatureMonitor.xdc
+++ b/bittide-instances/data/constraints/temperatureMonitor.xdc
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2024 Google LLC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# CLK_125MHZ_P
+set_property PACKAGE_PIN G10 [get_ports "CLK_125MHZ_p"]
+set_property IOSTANDARD LVDS [get_ports "CLK_125MHZ_p"]
+# CLK_125MHZ_P
+set_property PACKAGE_PIN F10 [get_ports "CLK_125MHZ_n"]
+set_property IOSTANDARD LVDS [get_ports "CLK_125MHZ_n"]
+
+# GPIO_LED_0_LS
+set_property PACKAGE_PIN AP8      [get_ports "done"]
+set_property IOSTANDARD  LVCMOS18 [get_ports "done"]
+# GPIO_LED_1_LS
+set_property PACKAGE_PIN H23      [get_ports "success"]
+set_property IOSTANDARD  LVCMOS18 [get_ports "success"]

--- a/bittide-instances/src/Bittide/Instances/Hitl/TemperatureMonitor.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/TemperatureMonitor.hs
@@ -1,0 +1,98 @@
+-- SPDX-FileCopyrightText: 2024 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Check whether the temperature of the system monitor in the FPGA is within a
+given range.
+-}
+module Bittide.Instances.Hitl.TemperatureMonitor where
+
+import Clash.Prelude
+
+import Data.Maybe (isJust)
+
+import Clash.Annotations.TH (makeTopEntity)
+import Clash.Xilinx.ClockGen (clockWizardDifferential)
+
+import Bittide.Arithmetic.Time (trueFor)
+import Bittide.Hitl (HitlTests, allFpgas, hitlVioBool, noConfigTest)
+
+import Bittide.Instances.Domains
+
+import Clash.Cores.Xilinx.Ila (ila, ilaConfig)
+
+import qualified Clash.Cores.Xilinx.SystemMonitor as SysMon
+import qualified Clash.Explicit.Prelude as E
+
+temperatureMonitor ::
+  "CLK_125MHZ" ::: DiffClock Ext125 ->
+  ""
+    ::: Signal
+          Basic200
+          ( "done" ::: Bool
+          , "success" ::: Bool
+          )
+temperatureMonitor diffClk = temperatureIla `hwSeqX` bundle (testDone, testSuccess)
+ where
+  (clk, rst) = clockWizardDifferential diffClk E.noReset
+
+  (status, temperatureMaybe) =
+    unbundle
+      $ withClockResetEnable clk rst enableGen SysMon.temperatureMonitorCelcius
+  temperature = E.regMaybe clk rst enableGen 0 temperatureMaybe
+
+  testDone = trueFor (SNat @(Milliseconds 1200)) clk testRst (pure True)
+  testSuccess =
+    trueFor (SNat @(Seconds 1)) clk testRst
+      $ 20
+      .<=. temperature
+      .&&. temperature .<=. 45
+
+  testRst = unsafeFromActiveLow $ hitlVioBool clk testDone testSuccess
+
+  capture :: Signal Basic200 Bool
+  capture =
+    withClockResetEnable clk rst enableGen
+      $ onChange
+      $ bundle
+        ( temperature
+        , status
+        )
+   where
+    onChange ::
+      (HiddenClockResetEnable dom, Eq a, NFDataX a) => Signal dom a -> Signal dom Bool
+    onChange x = (Just <$> x) ./=. register Nothing (Just <$> x)
+
+  temperatureIla :: Signal Basic200 ()
+  temperatureIla =
+    setName @"temperatureIla"
+      $ ila
+        ( ilaConfig
+            $ "trigger"
+            :> "capture"
+            :> "probe_temperatureReady"
+            :> "probe_temperature"
+            :> "probe_busy"
+            :> "probe_channel"
+            :> "probe_endOfConversion"
+            :> "probe_endOfSequence"
+            :> Nil
+        )
+        clk
+        -- Trigger as soon as we come out of reset
+        (unsafeToActiveLow rst)
+        capture
+        -- Debug probes
+        (isJust <$> temperatureMaybe)
+        temperature
+        ((.busy) <$> status)
+        ((.channel) <$> status)
+        ((.endOfConversion) <$> status)
+        ((.endOfSequence) <$> status)
+
+makeTopEntity 'temperatureMonitor
+
+tests :: HitlTests ()
+tests = noConfigTest "TemperatureMonitor" allFpgas

--- a/bittide-instances/src/Bittide/Instances/Hitl/Tests.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/Tests.hs
@@ -22,6 +22,7 @@ import qualified Bittide.Instances.Hitl.HwCcTopologies as HwCcTopologies
 import qualified Bittide.Instances.Hitl.LinkConfiguration as LinkConfiguration
 import qualified Bittide.Instances.Hitl.SyncInSyncOut as SyncInSyncOut
 import qualified Bittide.Instances.Hitl.Tcl.ExtraProbes as ExtraProbes
+import qualified Bittide.Instances.Hitl.TemperatureMonitor as TemperatureMonitor
 import qualified Bittide.Instances.Hitl.Transceivers as Transceivers
 import qualified Bittide.Instances.Hitl.VexRiscv as VexRiscv
 
@@ -53,6 +54,7 @@ hitlTests =
   , knownType 'HwCcTopologies.hwCcTopologyTest HwCcTopologies.tests
   , knownType 'LinkConfiguration.linkConfigurationTest LinkConfiguration.tests
   , knownType 'SyncInSyncOut.syncInSyncOut SyncInSyncOut.tests
+  , knownType 'TemperatureMonitor.temperatureMonitor TemperatureMonitor.tests
   , knownType 'Transceivers.transceiversUpTest Transceivers.tests
   , knownType 'VexRiscv.vexRiscvTest VexRiscv.tests
   , -- tests that are loaded from config files

--- a/bittide-shake/exe/Main.hs
+++ b/bittide-shake/exe/Main.hs
@@ -219,6 +219,7 @@ targets =
     , testTarget "Bittide.Instances.Hitl.LinkConfiguration.linkConfigurationTest"
     , testTarget "Bittide.Instances.Hitl.SyncInSyncOut.syncInSyncOut"
     , testTarget "Bittide.Instances.Hitl.Tcl.ExtraProbes.extraProbesTest"
+    , testTarget "Bittide.Instances.Hitl.TemperatureMonitor.temperatureMonitor"
     , testTarget "Bittide.Instances.Hitl.Transceivers.transceiversUpTest"
     , (testTarget "Bittide.Instances.Hitl.VexRiscv.vexRiscvTest")
         { targetPostProcess = Just "post-vex-riscv-test"

--- a/bittide/bittide.cabal
+++ b/bittide/bittide.cabal
@@ -160,6 +160,7 @@ library
     Clash.Cores.Xilinx.GTH
     Clash.Cores.Xilinx.GTH.BlackBoxes
     Clash.Cores.Xilinx.GTH.Internal
+    Clash.Cores.Xilinx.SystemMonitor
     Clash.Cores.Xilinx.Xpm.Cdc.Handshake.Extra
     Clash.Explicit.Reset.Extra
     Clash.Functor.Extra

--- a/bittide/src/Clash/Cores/Xilinx/SystemMonitor.hs
+++ b/bittide/src/Clash/Cores/Xilinx/SystemMonitor.hs
@@ -1,0 +1,244 @@
+-- SPDX-FileCopyrightText: 2024 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE NoFieldSelectors #-}
+
+module Clash.Cores.Xilinx.SystemMonitor (Status (..), temperatureMonitorCelcius) where
+
+import Clash.Prelude
+
+import Clash.Cores.Xilinx.Xpm.Cdc.Internal
+
+-- | A wrapper for a SYSMONE1 instance which only monitors the FPGA temperature.
+temperatureMonitorCelcius ::
+  forall dom.
+  (HiddenClockResetEnable dom, 1 <= DomainPeriod dom) =>
+  Signal dom (Status, Maybe (Signed 11))
+temperatureMonitorCelcius = bundle (status, tOut)
+ where
+  tOut = mux dRdy (Just <$> temperature) (pure Nothing)
+  temperature = toSigned <$> dflipflop (toCelcius <$> dflipflop measurement)
+
+  toSigned ::
+    forall int frac. (KnownNat int, KnownNat frac) => SFixed int frac -> Signed int
+  toSigned = (resize . bitCoerce) . flip shiftR (natToNum @frac)
+
+  -- The 10-bit measurement is stored in the MSBs.
+  measurement = unpack . resize . flip shiftR 6 <$> dO
+  (status, dRdy, dO) = unbundle $ sysMon @dom hasClock hasReset dEn dAddr dWe dI
+
+  dEn = counter .==. pure 0
+  dWe = pure False
+  dAddr = pure 0x00
+  dI = pure 0x00
+
+  counter = register (0 :: Index 10) $ satSucc SatWrap <$> counter
+
+{- | Convert the measurement to temperature in degrees Celcius. Assumes the temperature
+sensor uses the on-chip reference. For more information see:
+
+    https://docs.amd.com/v/u/en-US/ug580-ultrascale-sysmon
+-}
+toCelcius ::
+  forall adcDepth. (KnownNat adcDepth) => Unsigned adcDepth -> SFixed (adcDepth + 1) 14
+toCelcius measurement = t
+ where
+  t = measurementSF * (a `shiftR` (natToNum @adcDepth)) + b
+  measurementSF :: SFixed (adcDepth + 1) 14
+  measurementSF = bitCoerce (resize measurement `shiftL` 14)
+  a = 501.3743
+  b = -273.6777
+
+data Status = Status
+  { busy :: Bool
+  , channel :: BitVector 6
+  , endOfConversion :: Bool
+  , endOfSequence :: Bool
+  }
+  deriving (Eq, Generic, NFDataX)
+
+{- The internal ADC clock is derived from the DRP clock. The SYSMON supports a DRP clock
+frequency up to 250 MHz, whereas the The maximum frequency of the ADC clock is 5.2 MHz.
+A clock divider with a minimal value of 2 is used to get the appropriate ADC clock
+frequency.
+-}
+type AdcClockDiv dom = Max 2 (HzToPeriod 5_200_000 `DivRU` DomainPeriod dom)
+
+{- | A System Monitor (SYSMONE1) instance with an exposed Dynamic Reconfiguration Port
+(DRP) interface. The SYSMON supports a DRP clock frequency up to 250 MHz. The clock
+division ratio between the DRP clock (dClk) and and the lower frequency ADC clock is set
+such that the ADC clock frequency is at most 5.2 MHz (the maximum ADCCCLK frequency).
+For more information see:
+
+    https://docs.amd.com/r/en-US/ug974-vivado-ultrascale-libraries/SYSMONE1
+
+TODO: Make the instance configurable through its parameters.
+-}
+sysMon ::
+  forall dom.
+  (KnownDomain dom, 1 <= DomainPeriod dom) =>
+  -- | Clock input for the dynamic reconfiguration port.
+  Clock dom ->
+  -- | Reset signal for the SYSMON control logic.
+  Reset dom ->
+  -- | Enable signal for the dynamic reconfiguration port.
+  Signal dom Bool ->
+  -- | DRP address bus
+  Signal dom (BitVector 8) ->
+  -- | DRP write enable
+  Signal dom Bool ->
+  -- | DRP input data bus
+  Signal dom (BitVector 16) ->
+  -- | (SYSMON status ports, DRP data ready, DRP data)
+  Signal dom (Status, Bool, BitVector 16)
+sysMon dClk rst dEn dAddr dWe dI
+  | natToInteger @(DomainToHz dom) > 250_000_000 =
+      clashCompileError "DRP clock frequency cannot be higher than 250 MHz"
+  | clashSimulation = sim
+  | otherwise = synth
+ where
+  -- Definition used in Clash simulation
+  sim = pure (status, False, 0)
+   where
+    status =
+      Status
+        { busy = False
+        , channel = 0
+        , endOfConversion = False
+        , endOfSequence = False
+        }
+
+  -- Definition used for HDL generation
+  clkDiv :: BitVector 8
+  clkDiv = natToNum @(AdcClockDiv dom)
+  synth = bundle (status, dRdy, dO)
+   where
+    status = Status <$> busy <*> channel <*> eoc <*> eos
+    ( _
+      , _
+      , unPort -> dO
+      , unPort -> dRdy
+      , _
+      , _
+      , unPort -> busy
+      , unPort -> channel
+      , unPort -> eoc
+      , unPort -> eos
+      , _
+      , _
+      , _
+      , _
+      ) = go
+
+    go ::
+      ( Port "ALM" dom (BitVector 16)
+      , Port "OT" dom Bool
+      , Port "DO" dom (BitVector 16)
+      , Port "DRDY" dom Bool
+      , Port "I2C_SCLK_TS" dom Bit
+      , Port "I2C_SDA_TS" dom Bit
+      , Port "BUSY" dom Bool
+      , Port "CHANNEL" dom (BitVector 6)
+      , Port "EOC" dom Bool
+      , Port "EOS" dom Bool
+      , Port "JTAGBUSY" dom Bool
+      , Port "JTAGLOCKED" dom Bool
+      , Port "JTAGMODIFIED" dom Bool
+      , Port "MUXADDR" dom (BitVector 5)
+      )
+    go =
+      inst
+        (instConfig "SYSMONE1")
+          { library = Just "UNISIM"
+          , libraryImport = Just "UNISIM.vcomponents.all"
+          }
+{- ORMOLU_DISABLE -}
+        -- Analog Bus Register
+        (Param @"INIT_45" @(BitVector 16) 0)
+        -- INIT_40 - INIT_44: SYSMON configuration registers
+        (Param @"INIT_40" @(BitVector 16) 0x9000) -- 16 sample average filter, disable averaging of calibration coefficients
+        (Param @"INIT_41" @(BitVector 16) 0x2ED0) -- Continuous seq mode, disable ALM[6:4], enable calibration
+        (Param @"INIT_42" @(BitVector 16) (clkDiv ++# 0))
+        (Param @"INIT_43" @(BitVector 16) 0x000F) -- Disable ALM[11:8]
+        (Param @"INIT_44" @(BitVector 16) 0)
+        -- INIT_46 - INIT_4F: Sequence Registers
+        (Param @"INIT_46" @(BitVector 16) 0)
+        (Param @"INIT_47" @(BitVector 16) 0)
+        (Param @"INIT_48" @(BitVector 16) 0x4701) -- Enable Temp, VCCINT, VCCAUX, VCCBRAM and calibration
+        (Param @"INIT_49" @(BitVector 16) 0)
+        (Param @"INIT_4A" @(BitVector 16) 0)
+        (Param @"INIT_4B" @(BitVector 16) 0)
+        (Param @"INIT_4C" @(BitVector 16) 0)
+        (Param @"INIT_4D" @(BitVector 16) 0)
+        (Param @"INIT_4E" @(BitVector 16) 0)
+        (Param @"INIT_4F" @(BitVector 16) 0)
+        -- INIT_50 - INIT_5F: Alarm Limit Registers
+        (Param @"INIT_50" @(BitVector 16) 0)
+        (Param @"INIT_51" @(BitVector 16) 0)
+        (Param @"INIT_52" @(BitVector 16) 0)
+        (Param @"INIT_53" @(BitVector 16) 0)
+        (Param @"INIT_54" @(BitVector 16) 0)
+        (Param @"INIT_55" @(BitVector 16) 0)
+        (Param @"INIT_56" @(BitVector 16) 0)
+        (Param @"INIT_57" @(BitVector 16) 0)
+        (Param @"INIT_58" @(BitVector 16) 0)
+        (Param @"INIT_59" @(BitVector 16) 0)
+        (Param @"INIT_5A" @(BitVector 16) 0)
+        (Param @"INIT_5B" @(BitVector 16) 0)
+        (Param @"INIT_5C" @(BitVector 16) 0)
+        (Param @"INIT_5D" @(BitVector 16) 0)
+        (Param @"INIT_5E" @(BitVector 16) 0)
+        (Param @"INIT_5F" @(BitVector 16) 0)
+        -- INIT_60 - INIT_6F: User Supply Alarms
+        (Param @"INIT_60" @(BitVector 16) 0)
+        (Param @"INIT_61" @(BitVector 16) 0)
+        (Param @"INIT_62" @(BitVector 16) 0)
+        (Param @"INIT_63" @(BitVector 16) 0)
+        (Param @"INIT_64" @(BitVector 16) 0)
+        (Param @"INIT_65" @(BitVector 16) 0)
+        (Param @"INIT_66" @(BitVector 16) 0)
+        (Param @"INIT_67" @(BitVector 16) 0)
+        (Param @"INIT_68" @(BitVector 16) 0)
+        (Param @"INIT_69" @(BitVector 16) 0)
+        (Param @"INIT_6A" @(BitVector 16) 0)
+        (Param @"INIT_6B" @(BitVector 16) 0)
+        (Param @"INIT_6C" @(BitVector 16) 0)
+        (Param @"INIT_6D" @(BitVector 16) 0)
+        (Param @"INIT_6E" @(BitVector 16) 0)
+        (Param @"INIT_6F" @(BitVector 16) 0)
+        -- Programmable Inversion Attributes: Specifies the use of the built-in
+        -- programmable inversion on specific pins.
+        (Param @"IS_CONVSTCLK_INVERTED" @Bit 0)
+        (Param @"IS_DCLK_INVERTED"      @Bit 0)
+        -- Analog simulation data file name
+        (Param @"SIM_MONITOR_FILE"      @String "design.txt")
+        -- SYSMON User voltage monitor
+        (Param @"SYSMON_VUSER0_BANK"    @Integer 0)
+        (Param @"SYSMON_VUSER0_MONITOR" @String "NONE")
+        (Param @"SYSMON_VUSER1_BANK"    @Integer 0)
+        (Param @"SYSMON_VUSER1_MONITOR" @String "NONE")
+        (Param @"SYSMON_VUSER2_BANK"    @Integer 0)
+        (Param @"SYSMON_VUSER2_MONITOR" @String "NONE")
+        (Param @"SYSMON_VUSER3_BANK"    @Integer 0)
+        (Param @"SYSMON_VUSER3_MONITOR" @String "NONE")
+        -- Auxiliary Analog-Input Pairs
+        (Port      @"VAUXN"             (pure 0 :: Signal dom (BitVector 16)))
+        (Port      @"VAUXP"             (pure 0 :: Signal dom (BitVector 16)))
+        -- SYSMON reset, conversion start and clock inputs
+        (ResetPort @"RESET" @ActiveHigh rst)
+        (Port      @"CONVSTCLK"         (pure 0 :: Signal dom Bit))
+        (Port      @"CONVST"            (pure 0 :: Signal dom Bit))
+        -- Dedicated Analog Input Pair
+        (Port      @"VN"                (pure 0 :: Signal dom Bit))
+        (Port      @"VP"                (pure 0 :: Signal dom Bit))
+        -- Dynamic Reconfiguration Port (DRP)
+        (ClockPort @"DCLK"              dClk)
+        (Port      @"DADDR"             dAddr)
+        (Port      @"DEN"               dEn)
+        (Port      @"DI"                dI)
+        (Port      @"DWE"               dWe)
+        -- I2C interface
+        (Port      @"I2C_SCLK"          (pure 0 :: Signal dom Bit))
+        (Port      @"I2C_SDA"           (pure 0 :: Signal dom Bit))
+{- ORMOLU_ENABLE -}


### PR DESCRIPTION
This PR adds a blackbox for System Monitor, specifically [`SYSMONE1`](https://docs.amd.com/r/en-US/ug974-vivado-ultrascale-libraries/SYSMONE1). We want to use this to readout the temperature sensor in the FPGA, so an additional wrapper is added to solely readout that sensor. 

The System Monitor is tested in the HITL test `temperatureMonitor`, which is only run on the nightly CI. Since this test will not run on pushing, the test successfully ran ~~[here](https://github.com/bittide/bittide-hardware/actions/runs/10367560375)~~ [here](https://github.com/bittide/bittide-hardware/actions/runs/10612593859/job/29414950456).