### PR TITLE
Improve naming of ILA data dumps

### DIFF
--- a/bittide-experiments/src/Bittide/Topology.hs
+++ b/bittide-experiments/src/Bittide/Topology.hs
@@ -553,7 +553,7 @@ dumbbell sw@SNat sl@SNat sr@SNat =
 -- nodes of each sub-graph.
 hourglass :: SNat n -> Topology (n + n)
 hourglass sn =
-  ( dumbbell sn d0 sn )
+  ( dumbbell d0 sn sn )
   { topologyName = "hourglass"
   , topologyType = Hourglass $ snatToInteger sn
   }

--- a/bittide-instances/src/Bittide/Instances/Hitl/FullMeshHwCc.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/FullMeshHwCc.hs
@@ -266,7 +266,7 @@ fullMeshHwTest refClk sysClk IlaControl{syncRst = rst, ..} rxns rxps miso =
   capture = (captureFlag .&&. allUp) .||. unsafeToActiveHigh syncRst
 
   fincFdecIla :: Signal Basic125 ()
-  fincFdecIla = ila
+  fincFdecIla = setName @"fincFdecIla" $ ila
     (ilaConfig $
          "trigger_0"
       :> "capture_0"

--- a/bittide-instances/src/Bittide/Instances/Hitl/FullMeshSwCc.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/FullMeshSwCc.hs
@@ -223,7 +223,7 @@ fullMeshHwTest refClk sysClk IlaControl{syncRst = rst, ..} rxns rxps miso =
   capture = (captureFlag .&&. allUp) .||. unsafeToActiveHigh syncRst
 
   fincFdecIla :: Signal Basic125 ()
-  fincFdecIla = ila
+  fincFdecIla = setName @"fincFdecIla" $ ila
     (ilaConfig $
          "trigger_0"
       :> "capture_0"

--- a/bittide-instances/src/Bittide/Instances/Hitl/HwCcTopologies.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/HwCcTopologies.hs
@@ -374,7 +374,7 @@ topologyTest refClk sysClk sysRst IlaControl{syncRst = rst, ..} rxns rxps miso c
   capture = (captureFlag .&&. allUp) .||. unsafeToActiveHigh syncRst
 
   fincFdecIla :: Signal Basic125 ()
-  fincFdecIla = ila
+  fincFdecIla = setName @"fincFdecIla" ila
     (ilaConfig $
          "trigger_0"
       :> "capture_0"

--- a/bittide-instances/src/Bittide/Instances/Hitl/Post/BoardTestExtended.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/Post/BoardTestExtended.hs
@@ -11,8 +11,10 @@ module Bittide.Instances.Hitl.Post.BoardTestExtended (postBoardTestExtended) whe
 import Prelude
 
 import Data.Csv
+import Data.List (isSuffixOf)
 import System.Exit (ExitCode(..))
 import Test.Tasty.HUnit
+import System.FilePath
 
 import Bittide.Instances.Hitl.Post.PostProcess
 
@@ -61,7 +63,9 @@ processCsv csvPath_ = do
 postBoardTestExtended :: ExitCode -> [FlattenedIlaCsvPath] -> Assertion
 postBoardTestExtended _exitCode ilaCsvPaths = do
   let
-    csvToProcess = filter ((== "boardTestIla") . ilaName) ilaCsvPaths
+    csvToProcess = filter ((baseNameEndsWith "boardTestIla") . ilaName) ilaCsvPaths
   assertBool "Expected at least 1 CSV file, but got 0" $ not (null csvToProcess)
   mapM_ (processCsv . csvPath) csvToProcess
   putStrLn $ "Successfully performed post processing of " <> show (length csvToProcess) <> " ILA CSV dumps"
+ where
+  baseNameEndsWith x = isSuffixOf x . takeBaseName

--- a/bittide-shake/data/tcl/HardwareTest.tcl
+++ b/bittide-shake/data/tcl/HardwareTest.tcl
@@ -220,9 +220,8 @@ proc get_ila_dicts {} {
         set ila_dict {}
 
         set cell_name [get_property CELL_NAME $hw_ila]
-        set idx_start [expr {[string first _ $cell_name] + 1}]
-        set idx_end [expr {[string first / $cell_name] - 1}]
-        set short_name [string range $cell_name $idx_start $idx_end]
+        set after_last [expr [string last "/" $cell_name] + 1]
+        set short_name [string range $cell_name $after_last end]
         dict set ila_dict name $short_name
         dict set ila_dict cell_name $cell_name
 

--- a/bittide-shake/data/tcl/HardwareTest.tcl
+++ b/bittide-shake/data/tcl/HardwareTest.tcl
@@ -219,9 +219,14 @@ proc get_ila_dicts {} {
     foreach hw_ila $hw_ilas {
         set ila_dict {}
 
+        # The short name is the name of the module the ILA is in. For example a
+        # cell named `fullMeshSwCcTest/ilaPlot/ila_inst` will give the short
+        # name `ilaPlot`.
         set cell_name [get_property CELL_NAME $hw_ila]
-        set after_last [expr [string last "/" $cell_name] + 1]
-        set short_name [string range $cell_name $after_last end]
+        set before_last [expr [string last / $cell_name] - 1]
+        set module_name [string range $cell_name 0 $before_last]
+        set after_second_to_last [expr [string last / $module_name] + 1]
+        set short_name [string range $cell_name $after_second_to_last $before_last]
         dict set ila_dict name $short_name
         dict set ila_dict cell_name $cell_name
 

--- a/bittide/src/Bittide/ProcessingElement.hs
+++ b/bittide/src/Bittide/ProcessingElement.hs
@@ -50,8 +50,8 @@ processingElement ::
     (Vec (nBusses-2) (Wishbone dom 'Standard (MappedBusAddrWidth 32 nBusses) (Bytes 4)))
 processingElement (PeConfig memMapConfig initI initD) = circuit $ \jtagIn -> do
   (iBus0, dBus0) <- rvCircuit (pure low) (pure low) (pure low) -< jtagIn
-  iBus1 <- setName @"instr_bus" (ilaWb 2 D4096) -< iBus0
-  dBus1 <- setName @"data_bus" (ilaWb 2 D4096) -< dBus0
+  iBus1 <- ilaWb (SSymbol @"instructionBus") 2 D4096 -< iBus0
+  dBus1 <- ilaWb (SSymbol @"dataBus") 2 D4096 -< dBus0
   ([iMemBus, dMemBus], extBusses) <-
     (splitAtC d2 <| singleMasterInterconnect memMapConfig) -< dBus1
   wbStorage initD -< dMemBus

--- a/bittide/src/Bittide/Wishbone.hs
+++ b/bittide/src/Bittide/Wishbone.hs
@@ -100,8 +100,12 @@ dupWb = Circuit go
 -- transaction, while capture will be active for as long as trigger and a cycle
 -- after it.
 ilaWb ::
-  forall dom addrW a .
+  forall name dom addrW a .
   HiddenClock dom =>
+  -- | Name of the module of the `ila` wrapper. Naming the internal ILA is
+  -- unreliable when more than one ILA is used with the same arguments, but the
+  -- module name can be set reliably.
+  SSymbol name ->
   -- | Number of registers to insert at each probe. Supported values: 0-6.
   -- Corresponds to @C_INPUT_PIPE_STAGES@. Default is @0@.
   Index 7 ->
@@ -111,7 +115,7 @@ ilaWb ::
   Circuit
     (Wishbone dom 'Standard addrW a)
     (Wishbone dom 'Standard addrW a)
-ilaWb stages0 depth0 = Circuit $ \(m2s, s2m) ->
+ilaWb SSymbol stages0 depth0 = Circuit $ \(m2s, s2m) ->
   let
     -- Our TCL infrastructure looks for 'trigger' and 'capture' and uses it to
     -- trigger the ILA and do selective capture. Though defaults are changable
@@ -121,7 +125,7 @@ ilaWb stages0 depth0 = Circuit $ \(m2s, s2m) ->
     capture = trigger .||. dflipflop trigger
 
     ilaInst :: Signal dom ()
-    ilaInst = ila
+    ilaInst = setName @name $ ila
       ((ilaConfig $
            "m2s_addr"
         :> "m2s_writeData"


### PR DESCRIPTION
@kleinreact proposed changing the way the Tcl inteprets an ILA name based on the cell-name in Vivado (see discussion on the closed PR #456 ). The goal is to get better file names for the ILA data dumps.

The `ilaWb` instances in `processingElement` do not have proper naming, as the `setName` in the circuit notation seems to have no effect. See issue #530 .

An example of the changes in file names for `fullMeshSwCcTest`:
Cell names and ILA dump filenames on staging:
```
Bittide_Instances_Hitl_FullMeshSwCc_fullMeshSwCcTest_callistoClockControlWithIla_callistoResult/ilaPlot/ilaPlot 
Bittide_Instances_Hitl_FullMeshSwCc_fullMeshSwCcTest_fullMeshSwCcTest78_result_227/ila_inst_0 
Bittide_Instances_Hitl_FullMeshSwCc_fullMeshSwCcTest_ilaWb58_result_22/ila_inst 
Bittide_Instances_Hitl_FullMeshSwCc_fullMeshSwCcTest_ilaWb58_result_28/ila_inst

Instances_Hitl_FullMeshSwCc_fullMeshSwCcTest_callistoClockControlWithIla_callistoResult.csv
Instances_Hitl_FullMeshSwCc_fullMeshSwCcTest_fullMeshSwCcTest78_result_227.csv
Instances_Hitl_FullMeshSwCc_fullMeshSwCcTest_ilaWb58_result_22.csv
Instances_Hitl_FullMeshSwCc_fullMeshSwCcTest_ilaWb58_result_28.csv
```
This branch:
```
Bittide_Instances_Hitl_FullMeshSwCc_fullMeshSwCcTest_callistoClockControlWithIla_callistoResult/ilaPlot/ilaPlot
fincFdecIla/fincFdecIla
Bittide_Instances_Hitl_FullMeshSwCc_fullMeshSwCcTest_ilaWb58_result_22/ila_inst
Bittide_Instances_Hitl_FullMeshSwCc_fullMeshSwCcTest_ilaWb58_result_28/ila_inst


ilaPlot.csv
fincFdecIla.csv
Instances_Hitl_FullMeshSwCc_fullMeshSwCcTest_ilaWb58_result_22.csv
Instances_Hitl_FullMeshSwCc_fullMeshSwCcTest_ilaWb58_result_28.csv
```