### PR TITLE
Fix hourglass topology

### DIFF
--- a/bittide-experiments/src/Bittide/Topology.hs
+++ b/bittide-experiments/src/Bittide/Topology.hs
@@ -553,7 +553,7 @@ dumbbell sw@SNat sl@SNat sr@SNat =
 -- nodes of each sub-graph.
 hourglass :: SNat n -> Topology (n + n)
 hourglass sn =
-  ( dumbbell sn d0 sn )
+  ( dumbbell d0 sn sn )
   { topologyName = "hourglass"
   , topologyType = Hourglass $ snatToInteger sn
   }


### PR DESCRIPTION
Fixes the hourglass topology, which is just a special case of a dumbbell with no rod and balanced weights. However, these configuration parameters were passed in the wrong order resulting in a pendulum topology with the weight equals to the thread length instead. This PR puts the arguments into the order right again.