### PR TITLE
Improve reset behaviour of transceiver with no receive clock or data

### DIFF
--- a/bittide/src/Bittide/Transceiver/ResetManager.hs
+++ b/bittide/src/Bittide/Transceiver/ResetManager.hs
@@ -143,7 +143,9 @@ resetManager config clk rst tx_init_done rx_init_done rx_data_good =
   update :: (State dom, Statistics) -> (Bool, Bool, Bool) -> (State dom, Statistics)
   update st (tx_done, rx_done, rx_good) =
     case st of
-      -- Reset everything:
+      -- The reset of the PLLs and data directions is triggerd by the fallig
+      -- edge of the active-high reset_all signal. So the actual reset is
+      -- initialized one cycle later.
       (StartTx, stats) -> (TxWait minBound, stats)
 
       -- Wait for transceiver to indicate it is done


### PR DESCRIPTION
Up until now we have only used the transceivers in cases where they receive data. We now also want to use the internal `gthCore` to only extract the tx clock from the transceiver PLL. The reset bahaviour of the transceivers was incorrect, but worked because we keep resetting the whole component when the word alignment of the received data failed. This PR improves the reset behaviour of the transceivers when no receive channel is connected.

Note that no specific test is added in this PR, for a test which uses these changes see #538 .