### PR TITLE
small changes

### DIFF
--- a/bittide/src/Bittide/Wishbone.hs
+++ b/bittide/src/Bittide/Wishbone.hs
@@ -419,9 +419,8 @@ fifoWithMeta depth@SNat = Circuit circuitFunction
 -- Read operations will read from the index corresponding to the world-aligned
 -- Wishbone address.
 wbToVec ::
-  forall dom nBytes addrW nRegisters .
-  ( HiddenClockResetEnable dom
-  , KnownNat nBytes
+  forall nBytes addrW nRegisters .
+  ( KnownNat nBytes
   , 1 <= nBytes
   , KnownNat addrW
   , 2 <= addrW

--- a/nix/verilog-ethernet.nix
+++ b/nix/verilog-ethernet.nix
@@ -5,8 +5,8 @@ pkgs.stdenv.mkDerivation rec {
 
   src = pkgs.fetchgit {
     url = "https://github.com/alexforencich/verilog-ethernet.git";
-    rev = "ab0c382123f2f0b80480d99c3d9837af028e7295";
-    sha256 = "sha256-xFhQXSRb+aaL5rHRmwgKCpJmgjpWib+PvaYp5kgP6To=";
+    rev = "baac5f8d811d43853d59d69957975ead8bbed088";
+    sha256 = "sha256-rxoUHjOxxQc/JjEp06vibCJ2OIWbsbEtnkqS1gS+A7g=";
   };
 
   installPhase = ''


### PR DESCRIPTION
The `HiddenClockResetEnable` constraint is not necessery for it is a stateless component that does not use these signals.

We need the `verilog-ethernet` bump to use the new API of the ethernet components 