### PR TITLE
Add patches `verilog-ethernet` version

### DIFF
--- a/nix/verilog-ethernet.nix
+++ b/nix/verilog-ethernet.nix
@@ -2,7 +2,7 @@
 
 pkgs.stdenv.mkDerivation rec {
   name = "verilog-ethernet";
-  src = verilog-ethernet-patches;
+  src = verilog-ethernet-patched;
 
   verilog-ethernet-src = pkgs.fetchgit {
     url = "https://github.com/alexforencich/verilog-ethernet.git";

--- a/nix/verilog-ethernet.nix
+++ b/nix/verilog-ethernet.nix
@@ -2,11 +2,23 @@
 
 pkgs.stdenv.mkDerivation rec {
   name = "verilog-ethernet";
+  src = verilog-ethernet-patches;
 
-  src = pkgs.fetchgit {
+  verilog-ethernet-src = pkgs.fetchgit {
     url = "https://github.com/alexforencich/verilog-ethernet.git";
     rev = "baac5f8d811d43853d59d69957975ead8bbed088";
     sha256 = "sha256-rxoUHjOxxQc/JjEp06vibCJ2OIWbsbEtnkqS1gS+A7g=";
+  };
+
+  verilog-ethernet-patches = pkgs.applyPatches {
+    name = "verilog-ethernet-patched";
+    src = verilog-ethernet-src;
+    patches = [
+      (pkgs.fetchpatch {
+        url = "https://github.com/lmbollen/verilog-ethernet/commit/f762edd71dfebc129dacac64ff5cd5fbf7d67801.patch";
+        hash = "sha256-hKHsNViPInDKzOP3OwMZFlQ0RjYYTFPRu6rOJF1g0hQ=";
+      })
+    ];
   };
 
   installPhase = ''

--- a/nix/verilog-ethernet.nix
+++ b/nix/verilog-ethernet.nix
@@ -10,7 +10,7 @@ pkgs.stdenv.mkDerivation rec {
     sha256 = "sha256-rxoUHjOxxQc/JjEp06vibCJ2OIWbsbEtnkqS1gS+A7g=";
   };
 
-  verilog-ethernet-patches = pkgs.applyPatches {
+  verilog-ethernet-patched = pkgs.applyPatches {
     name = "verilog-ethernet-patched";
     src = verilog-ethernet-src;
     patches = [


### PR DESCRIPTION
This removes a non-existing parameter from an ddr primitive instantiation.
See https://github.com/alexforencich/verilog-ethernet/pull/214