### PR TITLE
Measure UGNs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Google LLC
+# SPDX-FileCopyrightText: 2022-2024 Google LLC
 #
 # SPDX-License-Identifier: CC0-1.0
 
@@ -48,10 +48,9 @@ cabal.config
 *.iml
 
 # HDL directories often created during development cycle
-
-/bittide/vhdl
-/bittide/verilog
-/bittide/systemverilog
+vhdl/
+verilog/
+systemverilog/
 
 # Nix output
 result*
@@ -64,12 +63,6 @@ _build/
 
 # Rust build files
 target/
-
-# Bittide HDL directories
-bittide/verilog
-bittide/vhdl
-bittide/systemverilog
-vhdl/
 
 # Vivado
 vivado.jou

--- a/bittide-experiments/src/Bittide/Simulate/ElasticBuffer.hs
+++ b/bittide-experiments/src/Bittide/Simulate/ElasticBuffer.hs
@@ -17,6 +17,6 @@ elasticBuffer ::
   (HasCallStack, KnownDomain readDom, KnownDomain writeDom, KnownNat n) =>
   Clock readDom ->
   Clock writeDom ->
-  Signal readDom (DataCount n)
+  Signal readDom (RelDataCount n)
 elasticBuffer clkRead clkWrite = resize . fst
   <$> domainDiffCounter clkWrite resetGen clkRead resetGen

--- a/bittide-experiments/src/Bittide/Simulate/Topology.hs
+++ b/bittide-experiments/src/Bittide/Simulate/Topology.hs
@@ -81,7 +81,7 @@ simulationEntity ::
         ( Period
         , ReframingState
         , Vec nodes
-            ( DataCount dcount
+            ( RelDataCount dcount
             , StabilityIndication
             )
         )
@@ -102,7 +102,7 @@ simulationEntity topology ccc !clockOffsets !startupOffsets =
   !rsts = resetGenN' <$> startupOffsets
 
   -- elastic buffers
-  ebs :: Vec nodes (Vec nodes (Signal dom (DataCount dcount)))
+  ebs :: Vec nodes (Vec nodes (Signal dom (RelDataCount dcount)))
   !ebs = imap ebv clocks
   ebv x = flip imap clocks . eb x
   eb x xClk y yClk
@@ -167,7 +167,7 @@ simulate ::
         ( Period
         , ReframingState
         , Vec nodes
-            ( DataCount dcount
+            ( RelDataCount dcount
             , StabilityIndication
             )
         )
@@ -177,7 +177,7 @@ simulate ::
     [ ( Period
       , Period
       , ReframingState
-      , [ ( DataCount dcount
+      , [ ( RelDataCount dcount
           , StabilityIndication
           )
         ]

--- a/bittide-instances/bittide-instances.cabal
+++ b/bittide-instances/bittide-instances.cabal
@@ -232,3 +232,20 @@ executable post-vex-riscv-test
     temporary,
 
   other-modules: Paths_bittide_instances
+
+executable post-fullMeshSwCcTest
+  import: common-options
+  ghc-options:
+    -Wall
+    -Wcompat
+    -threaded
+
+  main-is: exe/post-fullMeshSwCcTest/Main.hs
+  build-depends:
+    base,
+    bittide-instances,
+    bytestring,
+    cassava,
+    deepseq,
+    filepath,
+    vector,

--- a/bittide-instances/exe/post-fullMeshSwCcTest/Main.hs
+++ b/bittide-instances/exe/post-fullMeshSwCcTest/Main.hs
@@ -1,0 +1,128 @@
+-- SPDX-FileCopyrightText: 2024 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE TupleSections #-}
+
+-- | This program extracts the UGNs from the last sample of the ila dumps of the fullMeshSwCcTest,
+-- And combines them from both sides of each link to calculate the IGNs.
+module Main where
+import Prelude
+import qualified Clash.Prelude as C
+
+import Control.Monad (forM, forM_,filterM, join)
+import Control.DeepSeq (deepseq)
+import qualified Data.ByteString.Lazy as ByteString
+import Data.Csv
+import Data.Int (Int64)
+import Data.List (intercalate,sort)
+import Data.Maybe (catMaybes)
+import qualified Data.Vector as Vector
+import System.Directory (listDirectory, doesDirectoryExist)
+import System.Environment (getArgs)
+import System.Exit (ExitCode(..))
+import System.FilePath ((</>))
+import System.IO (stderr, hPutStrLn, IOMode (WriteMode), hPutStr, withFile)
+import Text.Read (readMaybe)
+
+import Bittide.Instances.Hitl.Setup (fpgaSetup)
+
+
+type FpgaNo = Int
+type FpgaId = String
+type TestNo = Int
+type LinkNo = Int
+
+data Ugns a = Ugns
+  { probe_ugn0 :: a
+  , probe_ugn1 :: a
+  , probe_ugn2 :: a
+  , probe_ugn3 :: a
+  , probe_ugn4 :: a
+  , probe_ugn5 :: a
+  , probe_ugn6 :: a
+  } deriving (Show, Functor)
+
+ugnsToList :: Ugns a -> [a]
+ugnsToList ugns =
+  [ probe_ugn0 ugns
+  , probe_ugn1 ugns
+  , probe_ugn2 ugns
+  , probe_ugn3 ugns
+  , probe_ugn4 ugns
+  , probe_ugn5 ugns
+  , probe_ugn6 ugns
+  ]
+
+instance FromField a => FromNamedRecord (Ugns a) where
+  parseNamedRecord m = Ugns
+    <$> m .: "probe_ugn0"
+    <*> m .: "probe_ugn1"
+    <*> m .: "probe_ugn2"
+    <*> m .: "probe_ugn3"
+    <*> m .: "probe_ugn4"
+    <*> m .: "probe_ugn5"
+    <*> m .: "probe_ugn6"
+
+fpgaIds :: [FpgaId]
+fpgaIds = C.toList $ fmap fst fpgaSetup
+
+fpgas :: [(FpgaNo,FpgaId)]
+fpgas = zip [(0::FpgaNo)..] fpgaIds
+
+fpgaLinks :: [[Int]]
+fpgaLinks = C.toList $ fmap (C.toList . fmap fromIntegral . snd) fpgaSetup
+
+main :: IO ()
+main = do
+  args <- getArgs
+  case args of
+    [ilaDir,exitCode0] -> case readMaybe @ExitCode exitCode0 of
+      Nothing -> error $ "Couldn't parse second argument (" <> show exitCode0 <> ") as ExitCode"
+      Just exitCode | exitCode /= ExitSuccess -> error $ "Test run failed, got exit code " <> show exitCode
+                    | otherwise -> doIt ilaDir
+    ilaDir : _ -> doIt ilaDir
+    [] -> error "I need the path to the ila-data"
+
+-- | Parses "CCn" to Just n, otherwise Nothing
+parseCCnum :: String -> Maybe TestNo
+parseCCnum str = case splitAt 2 str of
+  ("CC",n) -> readMaybe n
+  _ -> Nothing
+
+doIt :: FilePath -> IO ()
+doIt ilaDir = do
+  dirs :: [FilePath] <- join $ (filterM (\d -> doesDirectoryExist (ilaDir </> d))) <$> listDirectory ilaDir
+  let testNos = sort $ catMaybes $ map parseCCnum dirs
+
+  tests :: [[[Int64]]] <- forM testNos $ \testNo ->
+    forM fpgas $ \(fpgaNo,fpgaId) -> do
+      let filename = ilaDir </> "CC" ++ show testNo </> show fpgaNo ++ "_" ++ fpgaId </>  "fincFdecIla.csv"
+      hPutStrLn stderr $ "Reading " <> filename
+      Right (_, csv0) <- decodeByName @(Ugns String) <$> ByteString.readFile filename
+      let results = ugnsToList $ read @Int64 . ("0x"<>) <$> Vector.last csv0
+      results `deepseq` pure results
+
+  ugns <- forM tests $ \test -> do
+    forM (zip [(0::FpgaNo)..] test) $ \(fpgano, ugns) -> do
+      fmap (fpgano,) $
+        forM (zip [(0::LinkNo)..] ugns) $ \(linkno, ugn) -> do
+          let otherUgn = test !! (fpgaLinks !! fpgano !! linkno) !! linkno
+          pure (linkno, ugn, ugn + otherUgn)
+
+
+  forM_ fpgas $ \(fpgaNo,_) -> do
+    withFile (ilaDir </> "results_fpga_" <> show fpgaNo <> ".csv") WriteMode $ \h -> do
+      let ugns1 = (!!fpgaNo) <$> ugns
+      hPutStr h "testno,"
+      y <- forM [(0::LinkNo)..6] $ \linkNo ->
+        pure $ "ugn" <> show linkNo <> "," <> "ign" <> show linkNo
+      hPutStrLn h (intercalate "," y)
+
+      forM_ (zip testNos ugns1) $ \(testNo, (_fpgaNo, rows)) -> do
+        hPutStr h $ show testNo <> ","
+        x <- forM rows $ \(_linkNo, ugn, ign) -> do
+          pure $ show ugn <> "," <> show ign
+        hPutStrLn h $ intercalate "," x

--- a/bittide-instances/src/Bittide/Instances/Domains.hs
+++ b/bittide-instances/src/Bittide/Instances/Domains.hs
@@ -28,6 +28,8 @@ createDomain vXilinxSystem{vName="Basic50", vPeriod= hzToPeriod 50e6}
 createDomain vXilinxSystem{vName="External", vPeriod=hzToPeriod 200e6}
 createDomain vXilinxSystem{vName="GthRx", vPeriod=hzToPeriod 125e6}
 createDomain vXilinxSystem{vName="GthTx", vPeriod= hzToPeriod 125e6}
+createDomain vXilinxSystem{vName="GthRxS", vPeriod=hzToPeriod 10e9}
+createDomain vXilinxSystem{vName="GthTxS", vPeriod= hzToPeriod 10e9}
 createDomain vXilinxSystem{vName="Internal", vPeriod=hzToPeriod 200e6}
 
 type CccBufferSize = 25 :: Nat

--- a/bittide-instances/src/Bittide/Instances/Hitl/FullMeshHwCc.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/FullMeshHwCc.hs
@@ -98,7 +98,7 @@ fullMeshRiscvCopyTest ::
   Clock dom ->
   Reset dom ->
   Signal dom (CallistoResult (FpgaCount - 1)) ->
-  Vec (FpgaCount - 1) (Signal dom (DataCount 32)) ->
+  Vec (FpgaCount - 1) (Signal dom (RelDataCount 32)) ->
   -- Freq increase / freq decrease request to clock board
   ( "FINC" ::: Signal dom Bool
   , "FDEC" ::: Signal dom Bool
@@ -185,7 +185,7 @@ fullMeshHwTest ::
   , "FINC_FDEC" ::: Signal Basic125 (FINC, FDEC)
   , "CALLISTO_RESULT" ::: Signal Basic125 (CallistoResult (FpgaCount - 1))
   , "CALLISTO_RESET" ::: Reset Basic125
-  , "DATA_COUNTERS" ::: Vec (FpgaCount - 1) (Signal Basic125 (DataCount 32))
+  , "DATA_COUNTERS" ::: Vec (FpgaCount - 1) (Signal Basic125 (RelDataCount 32))
   , "stats" ::: Vec (FpgaCount - 1) (Signal Basic125 ResetManager.Statistics)
   , "spiDone" ::: Signal Basic125 Bool
   , "" :::

--- a/bittide-instances/src/Bittide/Instances/Hitl/FullMeshHwCc.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/FullMeshHwCc.hs
@@ -97,8 +97,8 @@ fullMeshRiscvCopyTest ::
   KnownDomain dom =>
   Clock dom ->
   Reset dom ->
-  Signal dom (CallistoResult (FpgaCount - 1)) ->
-  Vec (FpgaCount - 1) (Signal dom (RelDataCount 32)) ->
+  Signal dom (CallistoResult LinkCount) ->
+  Vec LinkCount (Signal dom (RelDataCount 32)) ->
   -- Freq increase / freq decrease request to clock board
   ( "FINC" ::: Signal dom Bool
   , "FDEC" ::: Signal dom Bool
@@ -177,16 +177,16 @@ fullMeshHwTest ::
   "SMA_MGT_REFCLK_C" ::: Clock Ext200 ->
   "SYSCLK" ::: Clock Basic125 ->
   "ILA_CTRL" ::: IlaControl Basic125 ->
-  "GTH_RX_NS" ::: TransceiverWires GthRxS ->
-  "GTH_RX_PS" ::: TransceiverWires GthRxS ->
+  "GTH_RX_NS" ::: TransceiverWires GthRxS LinkCount ->
+  "GTH_RX_PS" ::: TransceiverWires GthRxS LinkCount ->
   "MISO" ::: Signal Basic125 Bit ->
-  ( "GTH_TX_NS" ::: TransceiverWires GthTxS
-  , "GTH_TX_PS" ::: TransceiverWires GthTxS
+  ( "GTH_TX_NS" ::: TransceiverWires GthTxS LinkCount
+  , "GTH_TX_PS" ::: TransceiverWires GthTxS LinkCount
   , "FINC_FDEC" ::: Signal Basic125 (FINC, FDEC)
-  , "CALLISTO_RESULT" ::: Signal Basic125 (CallistoResult (FpgaCount - 1))
+  , "CALLISTO_RESULT" ::: Signal Basic125 (CallistoResult LinkCount)
   , "CALLISTO_RESET" ::: Reset Basic125
-  , "DATA_COUNTERS" ::: Vec (FpgaCount - 1) (Signal Basic125 (RelDataCount 32))
-  , "stats" ::: Vec (FpgaCount - 1) (Signal Basic125 ResetManager.Statistics)
+  , "DATA_COUNTERS" ::: Vec LinkCount (Signal Basic125 (RelDataCount 32))
+  , "stats" ::: Vec LinkCount (Signal Basic125 ResetManager.Statistics)
   , "spiDone" ::: Signal Basic125 Bool
   , "" :::
       ( "SCLK" ::: Signal Basic125 Bool
@@ -268,7 +268,7 @@ fullMeshHwTest refClk sysClk IlaControl{syncRst = rst, ..} rxNs rxPs miso =
       callistoResult
 
   callistoResult =
-    callistoClockControlWithIla @(FpgaCount - 1) @CccBufferSize
+    callistoClockControlWithIla @LinkCount @CccBufferSize
       (head transceivers.txClocks) sysClk clockControlReset clockControlConfig
       IlaControl{..} availableLinkMask (fmap (fmap resize) domainDiffs)
 
@@ -334,11 +334,11 @@ fullMeshHwCcWithRiscvTest ::
   "SMA_MGT_REFCLK_C" ::: DiffClock Ext200 ->
   "SYSCLK_300" ::: DiffClock Ext300 ->
   "SYNC_IN" ::: Signal Basic125 Bool ->
-  "GTH_RX_NS" ::: TransceiverWires GthRxS ->
-  "GTH_RX_PS" ::: TransceiverWires GthRxS ->
+  "GTH_RX_NS" ::: TransceiverWires GthRxS LinkCount ->
+  "GTH_RX_PS" ::: TransceiverWires GthRxS LinkCount ->
   "MISO" ::: Signal Basic125 Bit ->
-  ( "GTH_TX_NS" ::: TransceiverWires GthTxS
-  , "GTH_TX_PS" ::: TransceiverWires GthTxS
+  ( "GTH_TX_NS" ::: TransceiverWires GthTxS LinkCount
+  , "GTH_TX_PS" ::: TransceiverWires GthTxS LinkCount
   , "" :::
       ( "FINC"      ::: Signal Basic125 Bool
       , "FDEC"      ::: Signal Basic125 Bool
@@ -387,11 +387,11 @@ fullMeshHwCcTest ::
   "SMA_MGT_REFCLK_C" ::: DiffClock Ext200 ->
   "SYSCLK_300" ::: DiffClock Ext300 ->
   "SYNC_IN" ::: Signal Basic125 Bool ->
-  "GTH_RX_NS" ::: TransceiverWires GthRxS ->
-  "GTH_RX_PS" ::: TransceiverWires GthRxS ->
+  "GTH_RX_NS" ::: TransceiverWires GthRxS LinkCount ->
+  "GTH_RX_PS" ::: TransceiverWires GthRxS LinkCount ->
   "MISO" ::: Signal Basic125 Bit ->
-  ( "GTH_TX_NS" ::: TransceiverWires GthTxS
-  , "GTH_TX_PS" ::: TransceiverWires GthTxS
+  ( "GTH_TX_NS" ::: TransceiverWires GthTxS LinkCount
+  , "GTH_TX_PS" ::: TransceiverWires GthTxS LinkCount
   , "" :::
       ( "FINC"      ::: Signal Basic125 Bool
       , "FDEC"      ::: Signal Basic125 Bool

--- a/bittide-instances/src/Bittide/Instances/Hitl/FullMeshHwCc.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/FullMeshHwCc.hs
@@ -177,11 +177,11 @@ fullMeshHwTest ::
   "SMA_MGT_REFCLK_C" ::: Clock Ext200 ->
   "SYSCLK" ::: Clock Basic125 ->
   "ILA_CTRL" ::: IlaControl Basic125 ->
-  "GTH_RX_NS" ::: TransceiverWires GthRx ->
-  "GTH_RX_PS" ::: TransceiverWires GthRx ->
+  "GTH_RX_NS" ::: TransceiverWires GthRxS ->
+  "GTH_RX_PS" ::: TransceiverWires GthRxS ->
   "MISO" ::: Signal Basic125 Bit ->
-  ( "GTH_TX_NS" ::: TransceiverWires GthTx
-  , "GTH_TX_PS" ::: TransceiverWires GthTx
+  ( "GTH_TX_NS" ::: TransceiverWires GthTxS
+  , "GTH_TX_PS" ::: TransceiverWires GthTxS
   , "FINC_FDEC" ::: Signal Basic125 (FINC, FDEC)
   , "CALLISTO_RESULT" ::: Signal Basic125 (CallistoResult (FpgaCount - 1))
   , "CALLISTO_RESET" ::: Reset Basic125
@@ -231,7 +231,7 @@ fullMeshHwTest refClk sysClk IlaControl{syncRst = rst, ..} rxNs rxPs miso =
 
   transceivers =
     transceiverPrbsN
-      @GthTx @GthRx @Ext200 @Basic125 @GthTx @GthRx
+      @GthTx @GthRx @Ext200 @Basic125 @GthTxS @GthRxS
       Transceiver.defConfig
       Transceiver.Inputs
         { clock = sysClk
@@ -334,11 +334,11 @@ fullMeshHwCcWithRiscvTest ::
   "SMA_MGT_REFCLK_C" ::: DiffClock Ext200 ->
   "SYSCLK_300" ::: DiffClock Ext300 ->
   "SYNC_IN" ::: Signal Basic125 Bool ->
-  "GTH_RX_NS" ::: TransceiverWires GthRx ->
-  "GTH_RX_PS" ::: TransceiverWires GthRx ->
+  "GTH_RX_NS" ::: TransceiverWires GthRxS ->
+  "GTH_RX_PS" ::: TransceiverWires GthRxS ->
   "MISO" ::: Signal Basic125 Bit ->
-  ( "GTH_TX_NS" ::: TransceiverWires GthTx
-  , "GTH_TX_PS" ::: TransceiverWires GthTx
+  ( "GTH_TX_NS" ::: TransceiverWires GthTxS
+  , "GTH_TX_PS" ::: TransceiverWires GthTxS
   , "" :::
       ( "FINC"      ::: Signal Basic125 Bool
       , "FDEC"      ::: Signal Basic125 Bool
@@ -387,11 +387,11 @@ fullMeshHwCcTest ::
   "SMA_MGT_REFCLK_C" ::: DiffClock Ext200 ->
   "SYSCLK_300" ::: DiffClock Ext300 ->
   "SYNC_IN" ::: Signal Basic125 Bool ->
-  "GTH_RX_NS" ::: TransceiverWires GthRx ->
-  "GTH_RX_PS" ::: TransceiverWires GthRx ->
+  "GTH_RX_NS" ::: TransceiverWires GthRxS ->
+  "GTH_RX_PS" ::: TransceiverWires GthRxS ->
   "MISO" ::: Signal Basic125 Bit ->
-  ( "GTH_TX_NS" ::: TransceiverWires GthTx
-  , "GTH_TX_PS" ::: TransceiverWires GthTx
+  ( "GTH_TX_NS" ::: TransceiverWires GthTxS
+  , "GTH_TX_PS" ::: TransceiverWires GthTxS
   , "" :::
       ( "FINC"      ::: Signal Basic125 Bool
       , "FDEC"      ::: Signal Basic125 Bool

--- a/bittide-instances/src/Bittide/Instances/Hitl/FullMeshSwCc.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/FullMeshSwCc.hs
@@ -31,6 +31,7 @@ module Bittide.Instances.Hitl.FullMeshSwCc
   , tests
   ) where
 
+import qualified Prelude as P
 import Clash.Prelude (withClockResetEnable)
 import Clash.Explicit.Prelude
 import qualified Clash.Explicit.Prelude as E
@@ -50,7 +51,7 @@ import Bittide.ClockControl.Si5395J
 import Bittide.ClockControl.Si539xSpi (ConfigState(Error, Finished), si539xSpi)
 import Bittide.Counter
 import Bittide.DoubleBufferedRam (InitialContent(Reloadable), ContentType(Blob))
-import Bittide.ElasticBuffer (sticky)
+import Bittide.ElasticBuffer (resettableXilinxElasticBuffer, sticky, Underflow, Overflow)
 import Bittide.Hitl (HitlTestsWithPostProcData, hitlVioBool, allFpgas)
 import Bittide.Instances.Domains
 import Bittide.ProcessingElement (PeConfig(..), processingElement)
@@ -62,13 +63,16 @@ import Bittide.Transceiver (transceiverPrbsN)
 
 
 import Bittide.Instances.Hitl.IlaPlot
-import Bittide.Instances.Hitl.Setup
+import Bittide.Instances.Hitl.Setup hiding (FpgaCount,LinkCount)
 import Project.FilePath
 
 import Clash.Annotations.TH (makeTopEntity)
 import Clash.Class.Counter
 import Clash.Cores.Xilinx.GTH
 import Clash.Cores.Xilinx.Ila (IlaConfig(..), Depth(..), ila, ilaConfig)
+import Clash.Cores.Xilinx.Xpm.Cdc (xpmCdcSingle)
+import Clash.Cores.Xilinx.Xpm.Cdc.Handshake.Extra (xpmCdcMaybeLossy)
+import Clash.Sized.Vector.ToTuple (vecToTuple)
 import Clash.Sized.Extra (unsignedToSigned)
 import Clash.Xilinx.ClockGen
 
@@ -77,7 +81,11 @@ import VexRiscv
 
 import qualified Bittide.Transceiver as Transceiver
 import qualified Bittide.Transceiver.ResetManager as ResetManager
-import qualified Data.Map as Map (singleton)
+import qualified Data.Map as Map
+import Data.String (fromString)
+
+type FpgaCount = 8
+type LinkCount = FpgaCount - 1
 
 clockControlConfig ::
   $(case (instancesClockConfig (Proxy @Basic125)) of { (_ :: t) -> liftTypeQ @t })
@@ -129,6 +137,8 @@ fullMeshRiscvTest clk rst dataCounts = unbundle fIncDec
       (Reloadable $ Blob iMem)
       (Reloadable $ Blob dMem)
 
+type FifoSize = 5  -- = 2^5 = 32
+
 -- | Instantiates a hardware implementation of Callisto and exports its results.
 fullMeshHwTest ::
   "SMA_MGT_REFCLK_C" ::: Clock Ext200 ->
@@ -153,6 +163,7 @@ fullMeshHwTest ::
   , "transceiversFailedAfterUp" ::: Signal Basic125 Bool
   , "ALL_UP" ::: Signal Basic125 Bool
   , "ALL_STABLE"   ::: Signal Basic125 Bool
+  , "ugnsStable" ::: Vec LinkCount (Signal Basic125 Bool)
   )
 fullMeshHwTest refClk sysClk IlaControl{syncRst = rst, ..} rxNs rxPs miso =
   fincFdecIla `hwSeqX`
@@ -167,7 +178,8 @@ fullMeshHwTest refClk sysClk IlaControl{syncRst = rst, ..} rxNs rxPs miso =
   , spiOut
   , transceiversFailedAfterUp
   , allReady
-  , allStable0
+  , allStable1
+  , map (fmap (\(_,_,x,_) -> x)) freeUgnDatas
   )
  where
   syncRst = rst `orReset` (unsafeFromActiveLow (fmap not spiErr))
@@ -188,20 +200,88 @@ fullMeshHwTest refClk sysClk IlaControl{syncRst = rst, ..} rxNs rxPs miso =
 
   transceivers =
     transceiverPrbsN
-      @GthTx @GthRx @Ext200 @Basic125 @GthTxS @GthRxS
+      @GthTx @GthRx @Ext200 @Basic125 @GthTxS @GthRxS @LinkCount
       Transceiver.defConfig
       Transceiver.Inputs
         { clock = sysClk
         , reset = gthAllReset
         , refClock = refClk
-        , channelNames
-        , clockPaths
+        , channelNames = takeI channelNames
+        , clockPaths = takeI clockPaths
         , rxNs
         , rxPs
-        , txDatas = repeat (pure 0)
-        , txReadys = repeat (pure False)
+        , txDatas = txCounters
+        , txReadys = txAllStables
         , rxReadys = repeat (pure True)
         }
+  txAllStables = zipWith (xpmCdcSingle sysClk) transceivers.txClocks (repeat allStable1)
+  allStable1 = sticky sysClk syncRst allStable0
+  txResets2 = zipWith orReset
+    transceivers.txResets
+    (map unsafeFromActiveLow txAllStables)
+
+  txCounters = zipWith txCounter transceivers.txClocks txResets2
+  txCounter txClk txRst = result
+   where
+    result = register txClk txRst enableGen (0xaabbccddeeff1234 :: BitVector 64) (result + 1)
+    -- see NOTE [magic start values]
+
+  -- rxFifos :: Vec LinkCount (_, _, _, _, _Signal GthRx (Maybe (BitVector 64)))
+  rxFifos = zipWith4 go transceivers.txClocks transceivers.rxClocks
+                   txResets2
+                   transceivers.rxDatas
+   where
+    go rClk wClk rRst =
+      resettableXilinxElasticBuffer @FifoSize @_ @_ @(Maybe (BitVector 64)) rClk wClk rRst
+
+  (fillLvls,fifoUnderflowsTx,fifoOverflowsTx,_ebMode,rxCntrs) = unzip5 rxFifos
+
+  fifoOverflowsFree :: Vec LinkCount (Signal Basic125 Overflow)
+  fifoOverflowsFree = zipWith (flip xpmCdcSingle sysClk) transceivers.txClocks fifoOverflowsTx
+  fifoUnderflowsFree :: Vec LinkCount (Signal Basic125 Underflow)
+  fifoUnderflowsFree = zipWith (flip xpmCdcSingle sysClk) transceivers.txClocks fifoUnderflowsTx
+
+
+  ugns :: Vec LinkCount (Signal GthTx (BitVector 64))
+  ugns = zipWith (-) txCounters
+              (map (fmap (fromMaybe 0x1122334411223344)) rxCntrs)
+  -- see NOTE [magic start values]
+
+  -- NOTE [magic start values]
+  -- These values could be anything, but are chosen to be recognisable and help debugging.
+  --   0xaabbccddeeff1234 - 0x1122334411223344 = 0x99999999dddcdef0
+  -- If you ever see the ugn being a constant 0x99999999dddcdef0
+  -- then you know the your counter isn't running and you're receiving 'Nothing',
+  -- If you see 0x99999999.......... and it's counting up, then you're receiving Nothing,
+  -- but your counter is running.
+
+  ugnStable1sec = zipWith3 (stableForMs (SNat @1000)) transceivers.txClocks transceivers.txResets ugns
+
+  freeUgnDatas = zipWith5 go transceivers.txClocks (repeat sysClk) ugns fillLvls ugnStable1sec
+   where
+    go clkIn clkOut ugn fillLvl stable =
+      regMaybe clkOut noReset enableGen (0,0,False, unpack 0) (xpmCdcMaybeLossy clkIn clkOut inp)
+     where
+      fillStat = fillStats clkIn noReset fillLvl
+      inp = (fmap Just $ bundle (ugn,fillLvl,stable,fillStat))
+
+  (ugnD0, ugnD1, ugnD2, ugnD3, ugnD4, ugnD5, ugnD6
+    ) = vecToTuple freeUgnDatas
+  (ugn0,fill0,ugnStable0,fillStats0) = unbundle ugnD0
+  (ugn1,fill1,ugnStable1,fillStats1) = unbundle ugnD1
+  (ugn2,fill2,ugnStable2,fillStats2) = unbundle ugnD2
+  (ugn3,fill3,ugnStable3,fillStats3) = unbundle ugnD3
+  (ugn4,fill4,ugnStable4,fillStats4) = unbundle ugnD4
+  (ugn5,fill5,ugnStable5,fillStats5) = unbundle ugnD5
+  (ugn6,fill6,ugnStable6,fillStats6) = unbundle ugnD6
+
+  FillStats fillMin0 fillMax0 = unbundle fillStats0
+  FillStats fillMin1 fillMax1 = unbundle fillStats1
+  FillStats fillMin2 fillMax2 = unbundle fillStats2
+  FillStats fillMin3 fillMax3 = unbundle fillStats3
+  FillStats fillMin4 fillMax4 = unbundle fillStats4
+  FillStats fillMin5 fillMax5 = unbundle fillStats5
+  FillStats fillMin6 fillMax6 = unbundle fillStats6
 
   allReady = trueFor (SNat @(Milliseconds 500)) sysClk syncRst (and <$> bundle transceivers.linkReadys)
   transceiversFailedAfterUp =
@@ -219,10 +299,12 @@ fullMeshHwTest refClk sysClk IlaControl{syncRst = rst, ..} rxNs rxPs miso =
 
   availableLinkMask = pure maxBound
 
-  (clockMod, _stabilities, allStable0, _allCentered) = unbundle $
+  (clockMod, stabilities, allStable0, _allCentered) = unbundle $
     fmap
       (\CallistoResult{..} -> (maybeSpeedChange, stability, allStable, allSettled))
       callistoResult
+  (stability0, stability1, stability2, stability3, stability4, stability5, stability6
+    ) = vecToTuple $ unbundle stabilities
 
   callistoResult =
     callistoClockControlWithIla @LinkCount @CccBufferSize
@@ -241,10 +323,20 @@ fullMeshHwTest refClk sysClk IlaControl{syncRst = rst, ..} rxNs rxPs miso =
       :> "capture_0"
       :> "probe_milliseconds"
       :> "probe_allStable0"
+      :> "probe_allStable1"
       :> "probe_transceiversFailedAfterUp"
       :> "probe_nFincs"
       :> "probe_nFdecs"
       :> "probe_net_nFincs"
+      :> "probe_ugn0"  :> "probe_ugn1"  :> "probe_ugn2"  :> "probe_ugn3"  :> "probe_ugn4"  :> "probe_ugn5"  :> "probe_ugn6"
+      :> "probe_fill0" :> "probe_fill2" :> "probe_fill1" :> "probe_fill3" :> "probe_fill4" :> "probe_fill5" :> "probe_fill6"
+      :> "probe_fillMin0" :> "probe_fillMin2" :> "probe_fillMin1" :> "probe_fillMin3" :> "probe_fillMin4" :> "probe_fillMin5" :> "probe_fillMin6"
+      :> "probe_fillMax0" :> "probe_fillMax2" :> "probe_fillMax1" :> "probe_fillMax3" :> "probe_fillMax4" :> "probe_fillMax5" :> "probe_fillMax6"
+      :> "stability0" :> "stability2" :> "stability1" :> "stability3" :> "stability4" :> "stability5" :> "stability6"
+      :> "ugnStable0" :> "ugnStable1" :> "ugnStable2" :> "ugnStable3" :> "ugnStable4" :> "ugnStable5" :> "ugnStable6"
+      :> "probe_linkReadys"
+      :> "probe_linkUps"
+      :> "fifoUnderflows" :> "fifoOverflows"
       :> Nil
     ){depth = D16384}
     sysClk
@@ -257,10 +349,21 @@ fullMeshHwTest refClk sysClk IlaControl{syncRst = rst, ..} rxNs rxPs miso =
     -- Debug probes
     milliseconds1
     allStable0
+    allStable1
     transceiversFailedAfterUp
     nFincs
     nFdecs
     (fmap unsignedToSigned nFincs - fmap unsignedToSigned nFdecs)
+    ugn0  ugn1  ugn2  ugn3  ugn4  ugn5  ugn6
+    fill0 fill1 fill2 fill3 fill4 fill5 fill6
+    fillMin0 fillMin1 fillMin2 fillMin3 fillMin4 fillMin5 fillMin6
+    fillMax0 fillMax1 fillMax2 fillMax3 fillMax4 fillMax5 fillMax6
+    stability0 stability1 stability2 stability3 stability4 stability5 stability6
+    ugnStable0 ugnStable1 ugnStable2 ugnStable3 ugnStable4 ugnStable5 ugnStable6
+    (bundle transceivers.linkReadys)
+    (bundle transceivers.linkUps)
+    ((pack . reverse) <$> bundle fifoUnderflowsFree)
+    ((pack . reverse) <$> bundle fifoOverflowsFree)
 
   captureFlag = riseEvery sysClk syncRst enableGen
     (SNat @(PeriodToCycles Basic125 (Milliseconds 1)))
@@ -285,6 +388,62 @@ fullMeshHwTest refClk sysClk IlaControl{syncRst = rst, ..} rxNs rxPs miso =
     domainDiffCounterExt sysClk clockControlReset
       <$> transceivers.rxClocks
       <*> transceivers.txClocks
+
+-- | Tracks the min/max values of the input during the last milliseconds
+--
+-- Updates once per millisecond.
+fillStats :: forall dom a. (KnownDomain dom, Ord a, Num a, Bounded a, NFDataX a) =>
+  Clock dom -> Reset dom ->
+  Signal dom a -> Signal dom (FillStats a)
+fillStats clk rst = moore clk rst enableGen go (\(_,_,x) -> x) (maxBound, mempty, mempty)
+ where
+  go :: (IndexMs dom 1, FillStats a, FillStats a) -> a -> (IndexMs dom 1, FillStats a, FillStats a)
+  go (cntr, prevStats, out) inp
+    | cntr == 0 = (maxBound, mempty, new)
+    | otherwise = (cntr - 1, new, out)
+   where
+    new = mappend prevStats (FillStats inp inp)
+
+data FillStats a = FillStats { fillMin :: a, fillMax :: a } deriving (Generic, NFDataX, BitPack)
+
+instance Bundle (FillStats a) where
+  type Unbundled dom (FillStats a) = FillStats (Signal dom a)
+  bundle (FillStats sigMin sigMax) = liftA2 FillStats sigMin sigMax
+  unbundle x = FillStats { fillMin = fmap fillMin x, fillMax = fmap fillMax x }
+
+instance Ord a => Semigroup (FillStats a) where
+  a <> b =
+    FillStats { fillMin = min (fillMin a) (fillMin b)
+              , fillMax = max (fillMax a) (fillMax b) }
+
+instance (Bounded a, Ord a) => Monoid (FillStats a) where
+  mempty = FillStats { fillMin=maxBound, fillMax=minBound }
+
+-- | Counts how many cycles the input signal has been stable
+--
+-- Stable means equal to its previous value according to the 'Eq' instance.
+-- The 'BitPack' instance is only used as a convenient way of intialization,
+-- it resets to a previous value of @unpack 0@.
+stableFor ::
+  forall n dom a.
+  (KnownNat n, KnownDomain dom, Eq a, BitPack a, NFDataX a) =>
+  Clock dom -> Reset dom -> Signal dom a -> Signal dom (Unsigned n)
+stableFor clk rst = moore clk rst enableGen go snd (unpack 0, 0)
+ where
+  go :: (a,Unsigned n) -> a -> (a,Unsigned n)
+  go (prev,cntr) inp
+    | inp == prev = (prev, satSucc SatBound cntr)
+    | otherwise   = (inp, 0)
+
+-- | Wrapper around 'stableFor' that checks the input has been stable for atleast @ms@ milliseconds
+stableForMs ::
+  forall ms dom a.
+  (KnownNat ms, KnownDomain dom, Eq a, BitPack a, NFDataX a) =>
+  SNat ms -> Clock dom -> Reset dom -> Signal dom a -> Signal dom Bool
+stableForMs SNat clk rst inp =
+  liftA2 (>=) stable (snatToNum (SNat @(PeriodToCycles dom (Milliseconds ms))))
+ where
+  stable = stableFor @(CLog 2 (PeriodToCycles dom (Milliseconds ms))) clk rst inp
 
 -- | Top entity for this test. See module documentation for more information.
 fullMeshSwCcTest ::
@@ -313,14 +472,19 @@ fullMeshSwCcTest refClkDiff sysClkDiff syncIn rxns rxps miso =
  where
   refClk = ibufds_gte3 refClkDiff :: Clock Ext200
   (sysClk, sysRst) = clockWizardDifferential sysClkDiff noReset
-  ilaControl@IlaControl{..} = ilaPlotSetup IlaPlotSetup{..}
+  ilaControl@IlaControl{syncRst,syncOut,syncStart} = ilaPlotSetup IlaPlotSetup{..}
 
   (   txns, txps, _hwFincFdecs, _callistoResult, callistoReset
     , dataCounts, _stats, spiDone, spiOut, transceiversFailedAfterUp, allReady
-    , allStable ) = fullMeshHwTest refClk sysClk ilaControl rxns rxps miso
+    , allStable
+    , ugnsStable
+    ) = fullMeshHwTest refClk sysClk ilaControl rxns rxps miso
 
   (riscvFinc, riscvFdec) =
     fullMeshRiscvTest sysClk callistoReset dataCounts
+
+
+  allUgnsStable = fmap and $ bundle ugnsStable
 
   -- checks that tests are not synchronously start before all
   -- transceivers are up
@@ -328,7 +492,7 @@ fullMeshSwCcTest refClkDiff sysClkDiff syncIn rxns rxps miso =
     (syncStart .&&. ((not <$> allReady) .||. transceiversFailedAfterUp))
 
   endSuccess :: Signal Basic125 Bool
-  endSuccess = trueFor (SNat @(Seconds 5)) sysClk syncRst allStable
+  endSuccess = trueFor (SNat @(Seconds 5)) sysClk syncRst $ allStable .&&. allUgnsStable
 
   startTest :: Signal Basic125 Bool
   startTest =
@@ -339,11 +503,14 @@ fullMeshSwCcTest refClkDiff sysClkDiff syncIn rxns rxps miso =
       (endSuccess .||. transceiversFailedAfterUp .||. startBeforeAllReady)
 
       -- success
-      (not <$> (transceiversFailedAfterUp .||. startBeforeAllReady))
+      (allUgnsStable .&&. not <$> (transceiversFailedAfterUp .||. startBeforeAllReady))
 makeTopEntity 'fullMeshSwCcTest
 
+testsToRun :: Int
+testsToRun = 1
+
 tests :: HitlTestsWithPostProcData () SimConf
-tests = Map.singleton "CC" $
+tests = Map.fromList $ P.zip ["CC" <> fromString (show n) | n <- [0..testsToRun-1]] $ P.repeat
   ( allFpgas ()
   , def { mTopologyType      = Just $ Complete (natToInteger @FpgaCount)
         , samples            = 1000

--- a/bittide-instances/src/Bittide/Instances/Hitl/FullMeshSwCc.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/FullMeshSwCc.hs
@@ -90,7 +90,7 @@ fullMeshRiscvTest ::
   KnownDomain dom =>
   Clock dom ->
   Reset dom ->
-  Vec (FpgaCount - 1) (Signal dom (RelDataCount 32)) ->
+  Vec LinkCount (Signal dom (RelDataCount 32)) ->
   -- Freq increase / freq decrease request to clock board
   ( "FINC" ::: Signal dom Bool
   , "FDEC" ::: Signal dom Bool
@@ -134,16 +134,16 @@ fullMeshHwTest ::
   "SMA_MGT_REFCLK_C" ::: Clock Ext200 ->
   "SYSCLK" ::: Clock Basic125 ->
   "ILA_CTRL" ::: IlaControl Basic125 ->
-  "GTH_RX_NS" ::: TransceiverWires GthRxS ->
-  "GTH_RX_PS" ::: TransceiverWires GthRxS ->
+  "GTH_RX_NS" ::: TransceiverWires GthRxS LinkCount ->
+  "GTH_RX_PS" ::: TransceiverWires GthRxS LinkCount ->
   "MISO" ::: Signal Basic125 Bit ->
-  ( "GTH_TX_NS" ::: TransceiverWires GthTxS
-  , "GTH_TX_PS" ::: TransceiverWires GthTxS
+  ( "GTH_TX_NS" ::: TransceiverWires GthTxS LinkCount
+  , "GTH_TX_PS" ::: TransceiverWires GthTxS LinkCount
   , "FINC_FDEC" ::: Signal Basic125 (FINC, FDEC)
-  , "CALLISTO_RESULT" ::: Signal Basic125 (CallistoResult (FpgaCount - 1))
+  , "CALLISTO_RESULT" ::: Signal Basic125 (CallistoResult LinkCount)
   , "CALLISTO_RESET" ::: Reset Basic125
-  , "DATA_COUNTERS" ::: Vec (FpgaCount - 1) (Signal Basic125 (RelDataCount 32))
-  , "stats" ::: Vec (FpgaCount - 1) (Signal Basic125 ResetManager.Statistics)
+  , "DATA_COUNTERS" ::: Vec LinkCount (Signal Basic125 (RelDataCount 32))
+  , "stats" ::: Vec LinkCount (Signal Basic125 ResetManager.Statistics)
   , "spiDone" ::: Signal Basic125 Bool
   , "" :::
       ( "SCLK" ::: Signal Basic125 Bool
@@ -225,7 +225,7 @@ fullMeshHwTest refClk sysClk IlaControl{syncRst = rst, ..} rxNs rxPs miso =
       callistoResult
 
   callistoResult =
-    callistoClockControlWithIla @(FpgaCount - 1) @CccBufferSize
+    callistoClockControlWithIla @LinkCount @CccBufferSize
       (head transceivers.txClocks) sysClk clockControlReset clockControlConfig
       IlaControl{..} availableLinkMask (fmap (fmap resize) domainDiffs)
 
@@ -291,11 +291,11 @@ fullMeshSwCcTest ::
   "SMA_MGT_REFCLK_C" ::: DiffClock Ext200 ->
   "SYSCLK_300" ::: DiffClock Ext300 ->
   "SYNC_IN" ::: Signal Basic125 Bool ->
-  "GTH_RX_NS" ::: TransceiverWires GthRxS ->
-  "GTH_RX_PS" ::: TransceiverWires GthRxS ->
+  "GTH_RX_NS" ::: TransceiverWires GthRxS LinkCount ->
+  "GTH_RX_PS" ::: TransceiverWires GthRxS LinkCount ->
   "MISO" ::: Signal Basic125 Bit ->
-  ( "GTH_TX_NS" ::: TransceiverWires GthTxS
-  , "GTH_TX_PS" ::: TransceiverWires GthTxS
+  ( "GTH_TX_NS" ::: TransceiverWires GthTxS LinkCount
+  , "GTH_TX_PS" ::: TransceiverWires GthTxS LinkCount
   , "" :::
       ( "FINC"      ::: Signal Basic125 Bool
       , "FDEC"      ::: Signal Basic125 Bool

--- a/bittide-instances/src/Bittide/Instances/Hitl/FullMeshSwCc.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/FullMeshSwCc.hs
@@ -134,11 +134,11 @@ fullMeshHwTest ::
   "SMA_MGT_REFCLK_C" ::: Clock Ext200 ->
   "SYSCLK" ::: Clock Basic125 ->
   "ILA_CTRL" ::: IlaControl Basic125 ->
-  "GTH_RX_NS" ::: TransceiverWires GthRx ->
-  "GTH_RX_PS" ::: TransceiverWires GthRx ->
+  "GTH_RX_NS" ::: TransceiverWires GthRxS ->
+  "GTH_RX_PS" ::: TransceiverWires GthRxS ->
   "MISO" ::: Signal Basic125 Bit ->
-  ( "GTH_TX_NS" ::: TransceiverWires GthTx
-  , "GTH_TX_PS" ::: TransceiverWires GthTx
+  ( "GTH_TX_NS" ::: TransceiverWires GthTxS
+  , "GTH_TX_PS" ::: TransceiverWires GthTxS
   , "FINC_FDEC" ::: Signal Basic125 (FINC, FDEC)
   , "CALLISTO_RESULT" ::: Signal Basic125 (CallistoResult (FpgaCount - 1))
   , "CALLISTO_RESET" ::: Reset Basic125
@@ -188,7 +188,7 @@ fullMeshHwTest refClk sysClk IlaControl{syncRst = rst, ..} rxNs rxPs miso =
 
   transceivers =
     transceiverPrbsN
-      @GthTx @GthRx @Ext200 @Basic125 @GthTx @GthRx
+      @GthTx @GthRx @Ext200 @Basic125 @GthTxS @GthRxS
       Transceiver.defConfig
       Transceiver.Inputs
         { clock = sysClk
@@ -291,11 +291,11 @@ fullMeshSwCcTest ::
   "SMA_MGT_REFCLK_C" ::: DiffClock Ext200 ->
   "SYSCLK_300" ::: DiffClock Ext300 ->
   "SYNC_IN" ::: Signal Basic125 Bool ->
-  "GTH_RX_NS" ::: TransceiverWires GthRx ->
-  "GTH_RX_PS" ::: TransceiverWires GthRx ->
+  "GTH_RX_NS" ::: TransceiverWires GthRxS ->
+  "GTH_RX_PS" ::: TransceiverWires GthRxS ->
   "MISO" ::: Signal Basic125 Bit ->
-  ( "GTH_TX_NS" ::: TransceiverWires GthTx
-  , "GTH_TX_PS" ::: TransceiverWires GthTx
+  ( "GTH_TX_NS" ::: TransceiverWires GthTxS
+  , "GTH_TX_PS" ::: TransceiverWires GthTxS
   , "" :::
       ( "FINC"      ::: Signal Basic125 Bool
       , "FDEC"      ::: Signal Basic125 Bool

--- a/bittide-instances/src/Bittide/Instances/Hitl/FullMeshSwCc.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/FullMeshSwCc.hs
@@ -90,7 +90,7 @@ fullMeshRiscvTest ::
   KnownDomain dom =>
   Clock dom ->
   Reset dom ->
-  Vec (FpgaCount - 1) (Signal dom (DataCount 32)) ->
+  Vec (FpgaCount - 1) (Signal dom (RelDataCount 32)) ->
   -- Freq increase / freq decrease request to clock board
   ( "FINC" ::: Signal dom Bool
   , "FDEC" ::: Signal dom Bool
@@ -142,7 +142,7 @@ fullMeshHwTest ::
   , "FINC_FDEC" ::: Signal Basic125 (FINC, FDEC)
   , "CALLISTO_RESULT" ::: Signal Basic125 (CallistoResult (FpgaCount - 1))
   , "CALLISTO_RESET" ::: Reset Basic125
-  , "DATA_COUNTERS" ::: Vec (FpgaCount - 1) (Signal Basic125 (DataCount 32))
+  , "DATA_COUNTERS" ::: Vec (FpgaCount - 1) (Signal Basic125 (RelDataCount 32))
   , "stats" ::: Vec (FpgaCount - 1) (Signal Basic125 ResetManager.Statistics)
   , "spiDone" ::: Signal Basic125 Bool
   , "" :::

--- a/bittide-instances/src/Bittide/Instances/Hitl/HwCcTopologies.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/HwCcTopologies.hs
@@ -176,7 +176,7 @@ riscvCopyTest ::
   Clock dom ->
   Reset dom ->
   Signal dom (CallistoResult (FpgaCount - 1)) ->
-  Vec (FpgaCount - 1) (Signal dom (DataCount 32)) ->
+  Vec (FpgaCount - 1) (Signal dom (RelDataCount 32)) ->
   -- Freq increase / freq decrease request to clock board
   ( "FINC" ::: Signal dom Bool
   , "FDEC" ::: Signal dom Bool
@@ -263,7 +263,7 @@ topologyTest ::
   , "FINC_FDEC" ::: Signal Basic125 (FINC, FDEC)
   , "CALLISTO_RESULT" ::: Signal Basic125 (CallistoResult (FpgaCount - 1))
   , "CALLISTO_RESET" ::: Reset Basic125
-  , "DATA_COUNTERS" ::: Vec (FpgaCount - 1) (Signal Basic125 (DataCount 32))
+  , "DATA_COUNTERS" ::: Vec (FpgaCount - 1) (Signal Basic125 (RelDataCount 32))
   , "stats" ::: Vec (FpgaCount - 1) (Signal Basic125 ResetManager.Statistics)
   , "spiDone" ::: Signal Basic125 Bool
   , "" :::

--- a/bittide-instances/src/Bittide/Instances/Hitl/HwCcTopologies.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/HwCcTopologies.hs
@@ -254,12 +254,12 @@ topologyTest ::
   "SYSCLK" ::: Clock Basic125 ->
   "SYSRST" ::: Reset Basic125 ->
   "ILA_CTRL" ::: IlaControl Basic125 ->
-  "GTH_RX_NS" ::: TransceiverWires GthRx ->
-  "GTH_RX_PS" ::: TransceiverWires GthRx ->
+  "GTH_RX_NS" ::: TransceiverWires GthRxS ->
+  "GTH_RX_PS" ::: TransceiverWires GthRxS ->
   "MISO" ::: Signal Basic125 Bit ->
   "TEST_CFG" ::: Signal Basic125 TestConfig ->
-  ( "GTH_TX_NS" ::: TransceiverWires GthTx
-  , "GTH_TX_PS" ::: TransceiverWires GthTx
+  ( "GTH_TX_NS" ::: TransceiverWires GthTxS
+  , "GTH_TX_PS" ::: TransceiverWires GthTxS
   , "FINC_FDEC" ::: Signal Basic125 (FINC, FDEC)
   , "CALLISTO_RESULT" ::: Signal Basic125 (CallistoResult (FpgaCount - 1))
   , "CALLISTO_RESET" ::: Reset Basic125
@@ -339,7 +339,7 @@ topologyTest refClk sysClk sysRst IlaControl{syncRst = rst, ..} rxNs rxPs miso c
 
   transceivers =
     transceiverPrbsN
-      @GthTx @GthRx @Ext200 @Basic125 @GthTx @GthRx
+      @GthTx @GthRx @Ext200 @Basic125 @GthTxS @GthRxS
       Transceiver.defConfig
       Transceiver.Inputs
         { clock = sysClk
@@ -511,11 +511,11 @@ hwCcTopologyWithRiscvTest ::
   "SMA_MGT_REFCLK_C" ::: DiffClock Ext200 ->
   "SYSCLK_300" ::: DiffClock Ext300 ->
   "SYNC_IN" ::: Signal Basic125 Bool ->
-  "GTH_RX_NS" ::: TransceiverWires GthRx ->
-  "GTH_RX_PS" ::: TransceiverWires GthRx ->
+  "GTH_RX_NS" ::: TransceiverWires GthRxS ->
+  "GTH_RX_PS" ::: TransceiverWires GthRxS ->
   "MISO" ::: Signal Basic125 Bit ->
-  ( "GTH_TX_NS" ::: TransceiverWires GthTx
-  , "GTH_TX_PS" ::: TransceiverWires GthTx
+  ( "GTH_TX_NS" ::: TransceiverWires GthTxS
+  , "GTH_TX_PS" ::: TransceiverWires GthTxS
   , "" :::
       ( "FINC"      ::: Signal Basic125 Bool
       , "FDEC"      ::: Signal Basic125 Bool
@@ -578,11 +578,11 @@ hwCcTopologyTest ::
   "SMA_MGT_REFCLK_C" ::: DiffClock Ext200 ->
   "SYSCLK_300" ::: DiffClock Ext300 ->
   "SYNC_IN" ::: Signal Basic125 Bool ->
-  "GTH_RX_NS" ::: TransceiverWires GthRx ->
-  "GTH_RX_PS" ::: TransceiverWires GthRx ->
+  "GTH_RX_NS" ::: TransceiverWires GthRxS ->
+  "GTH_RX_PS" ::: TransceiverWires GthRxS ->
   "MISO" ::: Signal Basic125 Bit ->
-  ( "GTH_TX_NS" ::: TransceiverWires GthTx
-  , "GTH_TX_PS" ::: TransceiverWires GthTx
+  ( "GTH_TX_NS" ::: TransceiverWires GthTxS
+  , "GTH_TX_PS" ::: TransceiverWires GthTxS
   , "" :::
       ( "FINC"      ::: Signal Basic125 Bool
       , "FDEC"      ::: Signal Basic125 Bool

--- a/bittide-instances/src/Bittide/Instances/Hitl/HwCcTopologies.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/HwCcTopologies.hs
@@ -157,7 +157,7 @@ data TestConfig =
     , startupDelay :: StartupDelay
       -- ^ Some intial startup delay given in the number of clock
       -- cycles of the stable clock.
-    , mask :: BitVector (FpgaCount - 1)
+    , mask :: BitVector LinkCount
       -- ^ The link mask depending on the selected topology.
     }
   deriving (Generic, NFDataX, BitPack)
@@ -175,8 +175,8 @@ riscvCopyTest ::
   KnownDomain dom =>
   Clock dom ->
   Reset dom ->
-  Signal dom (CallistoResult (FpgaCount - 1)) ->
-  Vec (FpgaCount - 1) (Signal dom (RelDataCount 32)) ->
+  Signal dom (CallistoResult LinkCount) ->
+  Vec LinkCount (Signal dom (RelDataCount 32)) ->
   -- Freq increase / freq decrease request to clock board
   ( "FINC" ::: Signal dom Bool
   , "FDEC" ::: Signal dom Bool
@@ -254,17 +254,17 @@ topologyTest ::
   "SYSCLK" ::: Clock Basic125 ->
   "SYSRST" ::: Reset Basic125 ->
   "ILA_CTRL" ::: IlaControl Basic125 ->
-  "GTH_RX_NS" ::: TransceiverWires GthRxS ->
-  "GTH_RX_PS" ::: TransceiverWires GthRxS ->
+  "GTH_RX_NS" ::: TransceiverWires GthRxS LinkCount ->
+  "GTH_RX_PS" ::: TransceiverWires GthRxS LinkCount ->
   "MISO" ::: Signal Basic125 Bit ->
   "TEST_CFG" ::: Signal Basic125 TestConfig ->
-  ( "GTH_TX_NS" ::: TransceiverWires GthTxS
-  , "GTH_TX_PS" ::: TransceiverWires GthTxS
+  ( "GTH_TX_NS" ::: TransceiverWires GthTxS LinkCount
+  , "GTH_TX_PS" ::: TransceiverWires GthTxS LinkCount
   , "FINC_FDEC" ::: Signal Basic125 (FINC, FDEC)
-  , "CALLISTO_RESULT" ::: Signal Basic125 (CallistoResult (FpgaCount - 1))
+  , "CALLISTO_RESULT" ::: Signal Basic125 (CallistoResult LinkCount)
   , "CALLISTO_RESET" ::: Reset Basic125
-  , "DATA_COUNTERS" ::: Vec (FpgaCount - 1) (Signal Basic125 (RelDataCount 32))
-  , "stats" ::: Vec (FpgaCount - 1) (Signal Basic125 ResetManager.Statistics)
+  , "DATA_COUNTERS" ::: Vec LinkCount (Signal Basic125 (RelDataCount 32))
+  , "stats" ::: Vec LinkCount (Signal Basic125 ResetManager.Statistics)
   , "spiDone" ::: Signal Basic125 Bool
   , "" :::
       ( "SCLK" ::: Signal Basic125 Bool
@@ -386,7 +386,7 @@ topologyTest refClk sysClk sysRst IlaControl{syncRst = rst, ..} rxNs rxPs miso c
       callistoResult
 
   callistoResult =
-    callistoClockControlWithIla @(FpgaCount - 1) @CccBufferSize
+    callistoClockControlWithIla @LinkCount @CccBufferSize
       (head transceivers.txClocks) sysClk clockControlReset clockControlConfig
       IlaControl{..} (mask <$> cfg) (fmap (fmap resize) domainDiffs)
 
@@ -511,11 +511,11 @@ hwCcTopologyWithRiscvTest ::
   "SMA_MGT_REFCLK_C" ::: DiffClock Ext200 ->
   "SYSCLK_300" ::: DiffClock Ext300 ->
   "SYNC_IN" ::: Signal Basic125 Bool ->
-  "GTH_RX_NS" ::: TransceiverWires GthRxS ->
-  "GTH_RX_PS" ::: TransceiverWires GthRxS ->
+  "GTH_RX_NS" ::: TransceiverWires GthRxS LinkCount ->
+  "GTH_RX_PS" ::: TransceiverWires GthRxS LinkCount ->
   "MISO" ::: Signal Basic125 Bit ->
-  ( "GTH_TX_NS" ::: TransceiverWires GthTxS
-  , "GTH_TX_PS" ::: TransceiverWires GthTxS
+  ( "GTH_TX_NS" ::: TransceiverWires GthTxS LinkCount
+  , "GTH_TX_PS" ::: TransceiverWires GthTxS LinkCount
   , "" :::
       ( "FINC"      ::: Signal Basic125 Bool
       , "FDEC"      ::: Signal Basic125 Bool
@@ -578,11 +578,11 @@ hwCcTopologyTest ::
   "SMA_MGT_REFCLK_C" ::: DiffClock Ext200 ->
   "SYSCLK_300" ::: DiffClock Ext300 ->
   "SYNC_IN" ::: Signal Basic125 Bool ->
-  "GTH_RX_NS" ::: TransceiverWires GthRxS ->
-  "GTH_RX_PS" ::: TransceiverWires GthRxS ->
+  "GTH_RX_NS" ::: TransceiverWires GthRxS LinkCount ->
+  "GTH_RX_PS" ::: TransceiverWires GthRxS LinkCount ->
   "MISO" ::: Signal Basic125 Bit ->
-  ( "GTH_TX_NS" ::: TransceiverWires GthTxS
-  , "GTH_TX_PS" ::: TransceiverWires GthTxS
+  ( "GTH_TX_NS" ::: TransceiverWires GthTxS LinkCount
+  , "GTH_TX_PS" ::: TransceiverWires GthTxS LinkCount
   , "" :::
       ( "FINC"      ::: Signal Basic125 Bool
       , "FDEC"      ::: Signal Basic125 Bool
@@ -740,7 +740,7 @@ tests = Map.fromList
                )
           <> [ (fromInteger i, disabled)
              | let n = natToNum @n
-             , i <- [n, n + 1 .. natToNum @(FpgaCount - 1)]
+             , i <- [n, n + 1 .. natToNum @LinkCount]
              ]
       , let
           -- clock period in picoseconds
@@ -774,7 +774,7 @@ tests = Map.fromList
     Index n ->
     InitialClockShift ->
     StartupDelay ->
-    BitVector (FpgaCount - 1) ->
+    BitVector LinkCount ->
     (Index FpgaCount, TestConfig)
   testData i initialClockShift startupDelay mask =
     ( zeroExtend @Index @n @(FpgaCount - n) i

--- a/bittide-instances/src/Bittide/Instances/Hitl/IlaPlot.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/IlaPlot.hs
@@ -52,7 +52,7 @@ import Clash.Explicit.Signal.Extra
 import Clash.Sized.Extra (concatUnsigneds)
 
 import Bittide.Arithmetic.Time (Seconds, Milliseconds, PeriodToCycles, trueFor)
-import Bittide.ClockControl (SpeedChange(..), DataCount, ClockControlConfig)
+import Bittide.ClockControl (SpeedChange(..), RelDataCount, ClockControlConfig)
 import Bittide.ClockControl.Callisto
   (CallistoResult(..), ReframingState(..), callistoClockControl)
 import Bittide.ClockControl.StabilityChecker
@@ -278,7 +278,7 @@ ilaPlotSetup IlaPlotSetup{..} = IlaControl{..}
 -- to be included into a capture.
 data PlotData (n :: Nat) (m :: Nat) =
   PlotData
-    { dEBData        :: Vec n (DataCount m, Maybe Bool, Maybe Bool)
+    { dEBData        :: Vec n (RelDataCount m, Maybe Bool, Maybe Bool)
     , dSpeedChange   :: SpeedChange
     , dRfStageChange :: RfStageChange
     }
@@ -415,7 +415,7 @@ callistoClockControlWithIla ::
   -- ^ Ila trigger and capture conditions
   Signal sys (BitVector n) ->
   -- ^ Link availability mask
-  Vec n (Signal sys (DataCount m)) ->
+  Vec n (Signal sys (RelDataCount m)) ->
   -- ^ Statistics provided by elastic buffers.
   Signal sys (CallistoResult n)
 callistoClockControlWithIla dynClk clk rst ccc IlaControl{..} mask ebs =

--- a/bittide-instances/src/Bittide/Instances/Hitl/LinkConfiguration.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/LinkConfiguration.hs
@@ -101,11 +101,11 @@ transceiversStartAndObserve ::
   "SYSCLK" ::: Clock Basic125 ->
   "RST_LOCAL" ::: Reset Basic125 ->
   "MY_INDEX" ::: Signal Basic125 (Index FpgaCount) ->
-  "GTH_RX_NS" ::: TransceiverWires GthRx ->
-  "GTH_RX_PS" ::: TransceiverWires GthRx ->
+  "GTH_RX_NS" ::: TransceiverWires GthRxS ->
+  "GTH_RX_PS" ::: TransceiverWires GthRxS ->
   "MISO" ::: Signal Basic125 Bit ->
-  ( "GTH_TX_NS" ::: TransceiverWires GthTx
-  , "GTH_TX_PS" ::: TransceiverWires GthTx
+  ( "GTH_TX_NS" ::: TransceiverWires GthTxS
+  , "GTH_TX_PS" ::: TransceiverWires GthTxS
   , "allReady" ::: Signal Basic125 Bool
   , "success" ::: Signal Basic125 Bool
   , "stats" ::: Vec (FpgaCount - 1) (Signal Basic125 ResetManager.Statistics)
@@ -145,7 +145,7 @@ transceiversStartAndObserve refClk sysClk rst myIndex rxNs rxPs miso =
   -- Transceiver setup
   transceivers =
     transceiverPrbsN
-      @GthTx @GthRx @Ext200 @Basic125 @GthTx @GthRx
+      @GthTx @GthRx @Ext200 @Basic125 @GthTxS @GthRxS
       Transceiver.defConfig
       Transceiver.Inputs
         { clock = sysClk
@@ -183,11 +183,11 @@ linkConfigurationTest ::
   "SMA_MGT_REFCLK_C" ::: DiffClock Ext200 ->
   "SYSCLK_300" ::: DiffClock Ext300 ->
   "SYNC_IN" ::: Signal Basic125 Bool ->
-  "GTH_RX_NS" ::: TransceiverWires GthRx ->
-  "GTH_RX_PS" ::: TransceiverWires GthRx ->
+  "GTH_RX_NS" ::: TransceiverWires GthRxS ->
+  "GTH_RX_PS" ::: TransceiverWires GthRxS ->
   "MISO" ::: Signal Basic125 Bit ->
-  ( "GTH_TX_NS" ::: TransceiverWires GthTx
-  , "GTH_TX_PS" ::: TransceiverWires GthTx
+  ( "GTH_TX_NS" ::: TransceiverWires GthTxS
+  , "GTH_TX_PS" ::: TransceiverWires GthTxS
   , "SYNC_OUT" ::: Signal Basic125 Bool
   , "spiDone" ::: Signal Basic125 Bool
   , "" :::

--- a/bittide-instances/src/Bittide/Instances/Hitl/LinkConfiguration.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/LinkConfiguration.hs
@@ -73,7 +73,7 @@ expectedTargetIndex ::
   Signal src (Index FpgaCount) ->
   Clock dst ->
   Reset dst ->
-  Index (FpgaCount - 1) ->
+  Index LinkCount ->
   Signal dst (Maybe (Index FpgaCount))
 expectedTargetIndex srcClk myIndex dstClk dstRst link =
   fmap ((!! link) . snd . (fpgaSetup !!))
@@ -101,14 +101,14 @@ transceiversStartAndObserve ::
   "SYSCLK" ::: Clock Basic125 ->
   "RST_LOCAL" ::: Reset Basic125 ->
   "MY_INDEX" ::: Signal Basic125 (Index FpgaCount) ->
-  "GTH_RX_NS" ::: TransceiverWires GthRxS ->
-  "GTH_RX_PS" ::: TransceiverWires GthRxS ->
+  "GTH_RX_NS" ::: TransceiverWires GthRxS LinkCount ->
+  "GTH_RX_PS" ::: TransceiverWires GthRxS LinkCount ->
   "MISO" ::: Signal Basic125 Bit ->
-  ( "GTH_TX_NS" ::: TransceiverWires GthTxS
-  , "GTH_TX_PS" ::: TransceiverWires GthTxS
+  ( "GTH_TX_NS" ::: TransceiverWires GthTxS LinkCount
+  , "GTH_TX_PS" ::: TransceiverWires GthTxS LinkCount
   , "allReady" ::: Signal Basic125 Bool
   , "success" ::: Signal Basic125 Bool
-  , "stats" ::: Vec (FpgaCount - 1) (Signal Basic125 ResetManager.Statistics)
+  , "stats" ::: Vec LinkCount (Signal Basic125 ResetManager.Statistics)
   , "spiDone" ::: Signal Basic125 Bool
   , "" :::
       ( "SCLK"      ::: Signal Basic125 Bool
@@ -183,11 +183,11 @@ linkConfigurationTest ::
   "SMA_MGT_REFCLK_C" ::: DiffClock Ext200 ->
   "SYSCLK_300" ::: DiffClock Ext300 ->
   "SYNC_IN" ::: Signal Basic125 Bool ->
-  "GTH_RX_NS" ::: TransceiverWires GthRxS ->
-  "GTH_RX_PS" ::: TransceiverWires GthRxS ->
+  "GTH_RX_NS" ::: TransceiverWires GthRxS LinkCount ->
+  "GTH_RX_PS" ::: TransceiverWires GthRxS LinkCount ->
   "MISO" ::: Signal Basic125 Bit ->
-  ( "GTH_TX_NS" ::: TransceiverWires GthTxS
-  , "GTH_TX_PS" ::: TransceiverWires GthTxS
+  ( "GTH_TX_NS" ::: TransceiverWires GthTxS LinkCount
+  , "GTH_TX_PS" ::: TransceiverWires GthTxS LinkCount
   , "SYNC_OUT" ::: Signal Basic125 Bool
   , "spiDone" ::: Signal Basic125 Bool
   , "" :::

--- a/bittide-instances/src/Bittide/Instances/Hitl/Setup.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/Setup.hs
@@ -4,6 +4,7 @@
 
 module Bittide.Instances.Hitl.Setup
   ( FpgaCount
+  , LinkCount
   , TransceiverWires
   , channelNames
   , clockPaths
@@ -21,23 +22,25 @@ import Data.Constraint.Nat (leTrans)
 -- | The number of FPGAs in the current setup
 type FpgaCount = 8 :: Nat
 
+type LinkCount = FpgaCount - 1
+
 -- | Data wires from/to transceivers. No logic should be inserted on these
 -- wires. Should be considered asynchronous to one another - even though their
 -- domain encodes them as related.
-type TransceiverWires dom = Signal dom (BitVector (FpgaCount - 1))
+type TransceiverWires dom n = Signal dom (BitVector n)
 
-channelNames :: Vec (FpgaCount - 1) String
+channelNames :: Vec LinkCount String
 channelNames =
   "X0Y10":> "X0Y9":> "X0Y16" :> "X0Y17" :> "X0Y18" :> "X0Y19" :> "X0Y11" :> Nil
 
-clockPaths :: Vec (FpgaCount - 1) String
+clockPaths :: Vec LinkCount String
 clockPaths =
   "clk0" :> "clk0":> "clk0-2":> "clk0-2":> "clk0-2":> "clk0-2":> "clk0"  :> Nil
 
 -- | Some order of the FPGA ids and a mapping to their connected
 -- neighbors (via the index position in the vector) according to the
 -- different hardware interfaces on the boards.
-fpgaSetup :: Vec FpgaCount (String, Vec (FpgaCount - 1) (Index FpgaCount))
+fpgaSetup :: Vec FpgaCount (String, Vec LinkCount (Index FpgaCount))
 fpgaSetup =
   --   FPGA Id         SFP0    SFP1    J4    J5    J6    J7    SMA
      ( "210308B3B272", 3    :> 2    :> 4  :> 5  :> 6  :> 7  :> 1   :> Nil )

--- a/bittide-instances/src/Bittide/Instances/Hitl/Transceivers.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/Transceivers.hs
@@ -80,14 +80,14 @@ goTransceiversUpTest ::
   "SMA_MGT_REFCLK_C" ::: Clock Ext200 ->
   "SYSCLK" ::: Clock Basic125 ->
   "RST_LOCAL" ::: Reset Basic125 ->
-  "GTH_RX_NS" ::: TransceiverWires GthRxS ->
-  "GTH_RX_PS" ::: TransceiverWires GthRxS ->
+  "GTH_RX_NS" ::: TransceiverWires GthRxS LinkCount ->
+  "GTH_RX_PS" ::: TransceiverWires GthRxS LinkCount ->
   "MISO" ::: Signal Basic125 Bit ->
-  ( "GTH_TX_NS" ::: TransceiverWires GthTxS
-  , "GTH_TX_PS" ::: TransceiverWires GthTxS
+  ( "GTH_TX_NS" ::: TransceiverWires GthTxS LinkCount
+  , "GTH_TX_PS" ::: TransceiverWires GthTxS LinkCount
   , "allUp" ::: Signal Basic125 Bool
   , "anyErrors" ::: Signal Basic125 Bool
-  , "stats" ::: Vec (FpgaCount - 1) (Signal Basic125 ResetManager.Statistics)
+  , "stats" ::: Vec LinkCount (Signal Basic125 ResetManager.Statistics)
   , "spiDone" ::: Signal Basic125 Bool
   , "" :::
       ( "SCLK"      ::: Signal Basic125 Bool
@@ -166,11 +166,11 @@ transceiversUpTest ::
   "SMA_MGT_REFCLK_C" ::: DiffClock Ext200 ->
   "SYSCLK_300" ::: DiffClock Ext300 ->
   "SYNC_IN" ::: Signal Basic125 Bool ->
-  "GTH_RX_NS" ::: TransceiverWires GthRxS ->
-  "GTH_RX_PS" ::: TransceiverWires GthRxS ->
+  "GTH_RX_NS" ::: TransceiverWires GthRxS LinkCount ->
+  "GTH_RX_PS" ::: TransceiverWires GthRxS LinkCount ->
   "MISO" ::: Signal Basic125 Bit ->
-  ( "GTH_TX_NS" ::: TransceiverWires GthTxS
-  , "GTH_TX_PS" ::: TransceiverWires GthTxS
+  ( "GTH_TX_NS" ::: TransceiverWires GthTxS LinkCount
+  , "GTH_TX_PS" ::: TransceiverWires GthTxS LinkCount
   , "SYNC_OUT" ::: Signal Basic125 Bool
   , "spiDone" ::: Signal Basic125 Bool
   , "" :::

--- a/bittide-instances/src/Bittide/Instances/Hitl/Transceivers.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/Transceivers.hs
@@ -80,11 +80,11 @@ goTransceiversUpTest ::
   "SMA_MGT_REFCLK_C" ::: Clock Ext200 ->
   "SYSCLK" ::: Clock Basic125 ->
   "RST_LOCAL" ::: Reset Basic125 ->
-  "GTH_RX_NS" ::: TransceiverWires GthRx ->
-  "GTH_RX_PS" ::: TransceiverWires GthRx ->
+  "GTH_RX_NS" ::: TransceiverWires GthRxS ->
+  "GTH_RX_PS" ::: TransceiverWires GthRxS ->
   "MISO" ::: Signal Basic125 Bit ->
-  ( "GTH_TX_NS" ::: TransceiverWires GthTx
-  , "GTH_TX_PS" ::: TransceiverWires GthTx
+  ( "GTH_TX_NS" ::: TransceiverWires GthTxS
+  , "GTH_TX_PS" ::: TransceiverWires GthTxS
   , "allUp" ::: Signal Basic125 Bool
   , "anyErrors" ::: Signal Basic125 Bool
   , "stats" ::: Vec (FpgaCount - 1) (Signal Basic125 ResetManager.Statistics)
@@ -146,7 +146,7 @@ goTransceiversUpTest fpgaIndex refClk sysClk rst rxNs rxPs miso =
 
   transceivers =
     transceiverPrbsN
-      @GthTx @GthRx @Ext200 @Basic125 @GthTx @GthRx
+      @GthTx @GthRx @Ext200 @Basic125 @GthTxS @GthRxS
       defConfig{debugIla=True, debugFpgaIndex=bitCoerce <$> fpgaIndex}
       Inputs
         { clock = sysClk
@@ -166,11 +166,11 @@ transceiversUpTest ::
   "SMA_MGT_REFCLK_C" ::: DiffClock Ext200 ->
   "SYSCLK_300" ::: DiffClock Ext300 ->
   "SYNC_IN" ::: Signal Basic125 Bool ->
-  "GTH_RX_NS" ::: TransceiverWires GthRx ->
-  "GTH_RX_PS" ::: TransceiverWires GthRx ->
+  "GTH_RX_NS" ::: TransceiverWires GthRxS ->
+  "GTH_RX_PS" ::: TransceiverWires GthRxS ->
   "MISO" ::: Signal Basic125 Bit ->
-  ( "GTH_TX_NS" ::: TransceiverWires GthTx
-  , "GTH_TX_PS" ::: TransceiverWires GthTx
+  ( "GTH_TX_NS" ::: TransceiverWires GthTxS
+  , "GTH_TX_PS" ::: TransceiverWires GthTxS
   , "SYNC_OUT" ::: Signal Basic125 Bool
   , "spiDone" ::: Signal Basic125 Bool
   , "" :::

--- a/bittide-instances/src/Bittide/Instances/Pnr/ClockControl.hs
+++ b/bittide-instances/src/Bittide/Instances/Pnr/ClockControl.hs
@@ -1,4 +1,4 @@
--- SPDX-FileCopyrightText: 2022 Google LLC
+-- SPDX-FileCopyrightText: 2022-2024 Google LLC
 --
 -- SPDX-License-Identifier: Apache-2.0
 
@@ -18,7 +18,7 @@ callisto3 ::
   Reset Basic200 ->
   Enable Basic200 ->
   -- | Data counts from elastic buffers
-  Vec 3 (Signal Basic200 (DataCount 12)) ->
+  Vec 3 (Signal Basic200 (RelDataCount 12)) ->
   -- | Speed change requested from clock multiplier
   Signal Basic200 (CallistoResult 3)
 callisto3 clk rst ena dataCounts =

--- a/bittide-instances/src/Bittide/Instances/Pnr/ElasticBuffer.hs
+++ b/bittide-instances/src/Bittide/Instances/Pnr/ElasticBuffer.hs
@@ -1,4 +1,4 @@
--- SPDX-FileCopyrightText: 2022 Google LLC
+-- SPDX-FileCopyrightText: 2022-2024 Google LLC
 --
 -- SPDX-License-Identifier: Apache-2.0
 {-# OPTIONS_GHC -Wno-orphans #-}
@@ -9,7 +9,7 @@ import Clash.Prelude
 import Clash.Annotations.TH
 
 import Bittide.ElasticBuffer
-import Bittide.ClockControl (DataCount)
+import Bittide.ClockControl (RelDataCount)
 
 createDomain vXilinxSystem{vPeriod=hzToPeriod 201e6, vName="Fast"}
 createDomain vXilinxSystem{vPeriod=hzToPeriod 199e6, vName="Slow"}
@@ -19,7 +19,7 @@ elasticBuffer5 ::
   "clkWriteSlow" :::Clock Slow ->
   "resetRead" ::: Reset Fast ->
   "writeData" ::: Signal Slow (Unsigned 8) ->
-  ( "dataCount" ::: Signal Fast (DataCount 5)
+  ( "dataCount" ::: Signal Fast (RelDataCount 5)
   , "underflow" ::: Signal Fast Underflow
   , "overrflow" ::: Signal Fast Overflow
   , "ebMode" ::: Signal Fast EbMode

--- a/bittide-instances/src/Bittide/Instances/Pnr/StabilityChecker.hs
+++ b/bittide-instances/src/Bittide/Instances/Pnr/StabilityChecker.hs
@@ -1,4 +1,4 @@
--- SPDX-FileCopyrightText: 2022 Google LLC
+-- SPDX-FileCopyrightText: 2022-2024 Google LLC
 --
 -- SPDX-License-Identifier: Apache-2.0
 {-# LANGUAGE TypeApplications #-}
@@ -10,12 +10,12 @@ import Clash.Prelude
 
 import Bittide.ClockControl.StabilityChecker
 import Bittide.Instances.Domains (Basic200)
-import Bittide.ClockControl (DataCount)
+import Bittide.ClockControl (RelDataCount)
 
 stabilityChecker_3_1M ::
   Clock Basic200 ->
   Reset Basic200 ->
-  Signal Basic200 (DataCount 16) ->
+  Signal Basic200 (RelDataCount 16) ->
   Signal Basic200 StabilityIndication
 stabilityChecker_3_1M clk rst =
   withClockResetEnable clk rst enableGen $

--- a/bittide-shake/exe/Main.hs
+++ b/bittide-shake/exe/Main.hs
@@ -201,7 +201,8 @@ targets = map enforceValidTarget
   , testTarget "Bittide.Instances.Hitl.FincFdec.fincFdecTests"
   , testTarget "Bittide.Instances.Hitl.FullMeshHwCc.fullMeshHwCcTest"
   , testTarget "Bittide.Instances.Hitl.FullMeshHwCc.fullMeshHwCcWithRiscvTest"
-  , testTarget "Bittide.Instances.Hitl.FullMeshSwCc.fullMeshSwCcTest"
+  , (testTarget "Bittide.Instances.Hitl.FullMeshSwCc.fullMeshSwCcTest")
+      {targetPostProcess = Just "post-fullMeshSwCcTest"}
   , testTarget "Bittide.Instances.Hitl.HwCcTopologies.hwCcTopologyTest"
   , testTarget "Bittide.Instances.Hitl.LinkConfiguration.linkConfigurationTest"
   , testTarget "Bittide.Instances.Hitl.SyncInSyncOut.syncInSyncOut"

--- a/bittide-tools/clockcontrol/plot/Main.hs
+++ b/bittide-tools/clockcontrol/plot/Main.hs
@@ -179,7 +179,7 @@ data DataPoint (nodeCount :: Nat) (decompressedElasticBufferBits :: Nat) =
     , dpRfStage :: ReframingStage
       -- ^ the reframing stage
     , dpDataCounts :: Vec nodeCount
-                        (Maybe (DataCount decompressedElasticBufferBits))
+                        (Maybe (RelDataCount decompressedElasticBufferBits))
       -- ^ the elastic buffer data counts of the available links
     , dpStability :: Vec nodeCount (Maybe StabilityIndication)
       -- ^ the stability indicators for each of the elastic buffers

--- a/bittide/src/Bittide/ClockControl.hs
+++ b/bittide/src/Bittide/ClockControl.hs
@@ -1,4 +1,4 @@
--- SPDX-FileCopyrightText: 2022 Google LLC
+-- SPDX-FileCopyrightText: 2022-2024 Google LLC
 --
 -- SPDX-License-Identifier: Apache-2.0
 
@@ -10,7 +10,7 @@
 -- | Clock controller types and some constants/defaults.
 module Bittide.ClockControl
   ( ClockControlConfig (..)
-  , DataCount
+  , RelDataCount
   , SettlePeriod
   , SpeedChange (..)
   , defClockConfig
@@ -112,15 +112,15 @@ data ClockControlConfig dom n m c = ClockControlConfig
 -- FIFO's center to be always at @0@.
 --
 -- _(remember to also modify 'targetDataCount' below if the
--- representation of 'DataCount' gets changed.)_
-type DataCount n = Signed n
+-- representation of 'RelDataCount' gets changed.)_
+type RelDataCount n = Signed n
 
 -- | The target data count within a (virtual) FIFO. It is usually set
 -- to be at the FIFO's center.
 --
--- _(recommended values are @0@ if 'DataCount' is 'Signed' and @shiftR
+-- _(recommended values are @0@ if 'RelDataCount' is 'Signed' and @shiftR
 -- maxBound 1 + 1@ if it is 'Unsigned')_
-targetDataCount :: KnownNat n => DataCount n
+targetDataCount :: KnownNat n => RelDataCount n
 targetDataCount = 0
 
 -- | Safer version of FINC/FDEC signals present on the Si5395/Si5391 clock multipliers.

--- a/bittide/src/Bittide/ClockControl/Callisto.hs
+++ b/bittide/src/Bittide/ClockControl/Callisto.hs
@@ -49,7 +49,7 @@ callistoClockControl ::
   -- | Link availability mask
   Signal dom (BitVector n) ->
   -- | Statistics provided by elastic buffers.
-  Vec n (Signal dom (DataCount m)) ->
+  Vec n (Signal dom (RelDataCount m)) ->
   Signal dom (CallistoResult n)
 callistoClockControl clk rst ena ClockControlConfig{..} mask allDataCounts =
   withClockResetEnable clk rst ena $
@@ -110,7 +110,7 @@ callistoClockControl clk rst ena ClockControlConfig{..} mask allDataCounts =
 --
 -- Note that this is an incredibly wasteful implementation: it instantiates
 -- numerous floating point multipliers and adders, even though they're not doing
--- any useful work 99% of the time. Furthermore, 'DataCount' isn't properly
+-- any useful work 99% of the time. Furthermore, 'RelDataCount' isn't properly
 -- scaled to match elastic buffer sizes, resulting in unnecessarily big integer
 -- adders. Optimization work has been postponed because:
 --
@@ -123,7 +123,7 @@ callisto ::
   , KnownNat m
   , 1 <= n
   , 1 <= m
-  -- 'callisto' sums incoming 'DataCount's and feeds them to a Xilinx signed to
+  -- 'callisto' sums incoming 'RelDataCount's and feeds them to a Xilinx signed to
   -- float IP. We can currently only interpret 32 bit signeds to unsigned, so to
   -- make sure we don't overflow any addition we force @n + m <= 32@.
   , n + m <= 32
@@ -135,7 +135,7 @@ callisto ::
   -- | Stability indicators for each of the elastic buffers.
   Signal dom (Vec n StabilityIndication) ->
   -- | Data counts from elastic buffers.
-  Signal dom (Vec n (DataCount m)) ->
+  Signal dom (Vec n (RelDataCount m)) ->
   -- | Current state.
   Signal dom ControlSt ->
   -- | Updated state.

--- a/bittide/src/Bittide/ClockControl/Callisto/Util.hs
+++ b/bittide/src/Bittide/ClockControl/Callisto/Util.hs
@@ -1,4 +1,4 @@
--- SPDX-FileCopyrightText: 2022 Google LLC
+-- SPDX-FileCopyrightText: 2022-2024 Google LLC
 --
 -- SPDX-License-Identifier: Apache-2.0
 
@@ -7,14 +7,14 @@ module Bittide.ClockControl.Callisto.Util where
 
 import Clash.Prelude
 
-import Bittide.ClockControl (DataCount, SpeedChange(..))
+import Bittide.ClockControl (RelDataCount, SpeedChange(..))
 
--- | Safe 'DataCount' to 'Signed' conversion.
--- (works for both: 'DataCount' being 'Signed' or 'Unsigned')
+-- | Safe 'RelDataCount' to 'Signed' conversion.
+-- (works for both: 'RelDataCount' being 'Signed' or 'Unsigned')
 dataCountToSigned ::
   forall n .
   KnownNat n =>
-  DataCount n ->
+  RelDataCount n ->
   Signed (n + 1)
 dataCountToSigned = bitCoerce . extend
 
@@ -32,18 +32,18 @@ wrappingCounter upper = counter
   go n = pred n
 
 -- | A version of 'sum' that is guaranteed not to overflow.
--- (works for both: 'DataCount' being 'Signed' or 'Unsigned')
+-- (works for both: 'RelDataCount' being 'Signed' or 'Unsigned')
 safeSum ::
   ( KnownNat n
   , KnownNat m
   , 1 <= n
   ) =>
-  Vec n (DataCount m) ->
-  DataCount (m + n - 1)
+  Vec n (RelDataCount m) ->
+  RelDataCount (m + n - 1)
 safeSum = sum . map extend
 
--- | Sum a bunch of 'DataCount's to a @Signed 32@, without overflowing.
--- (works for both: 'DataCount' being 'Signed' or 'Unsigned')
+-- | Sum a bunch of 'RelDataCount's to a @Signed 32@, without overflowing.
+-- (works for both: 'RelDataCount' being 'Signed' or 'Unsigned')
 sumTo32 ::
   forall n m .
   ( KnownNat m
@@ -51,7 +51,7 @@ sumTo32 ::
   , (m + n) <= 32
   , 1 <= n
   ) =>
-  Vec n (DataCount m) ->
+  Vec n (RelDataCount m) ->
   Signed 32
 sumTo32 =
     extend @_ @_ @(32 - (m+n))
@@ -68,7 +68,7 @@ safePopCountTo32 ::
   BitVector n ->
   Signed 32
 safePopCountTo32 =
-  sumTo32 . unpack @(Vec n (DataCount 1))
+  sumTo32 . unpack @(Vec n (RelDataCount 1))
 
 type FINC = Bool
 type FDEC = Bool

--- a/bittide/src/Bittide/ClockControl/Foreign/Rust/Callisto.hs
+++ b/bittide/src/Bittide/ClockControl/Foreign/Rust/Callisto.hs
@@ -15,7 +15,7 @@ module Bittide.ClockControl.Foreign.Rust.Callisto
 
 import Clash.Prelude
 
-import Bittide.ClockControl (DataCount)
+import Bittide.ClockControl (RelDataCount)
 import Bittide.ClockControl.Callisto.Types
 import Bittide.ClockControl.StabilityChecker
 
@@ -52,7 +52,7 @@ rustyCallisto ::
   -- | Stability indicators for each of the elastic buffers.
   Signal dom (Vec n StabilityIndication) ->
   -- | Data counts from elastic buffers.
-  Signal dom (Vec n (DataCount m)) ->
+  Signal dom (Vec n (RelDataCount m)) ->
   -- | Current state.
   Signal dom ControlSt ->
   -- | Updated state.
@@ -70,7 +70,7 @@ rustyCallisto config m scs counts st =
 
         poke pVSI $ VecS stabilityChecks
         poke pState state
-        poke pDataCounts $ VecS (DataCountS <$> dataCounts)
+        poke pDataCounts $ VecS (RelDataCountS <$> dataCounts)
         poke pConfig config
 
         callisto_rust
@@ -93,7 +93,7 @@ foreign import ccall safe "__c_callisto_rust" callisto_rust ::
   Ptr (ControlConfig m) ->
   Word32  ->
   Ptr (VecS n StabilityIndication) ->
-  Ptr (VecS n (DataCountS m)) ->
+  Ptr (VecS n (RelDataCountS m)) ->
   Ptr (ControlSt) ->
   IO ()
 #else
@@ -115,7 +115,7 @@ rustyCallisto ::
   -- | Stability indicators for each of the elastic buffers.
   Signal dom (Vec n StabilityIndication) ->
   -- | Data counts from elastic buffers.
-  Signal dom (Vec n (DataCount m)) ->
+  Signal dom (Vec n (RelDataCount m)) ->
   -- | Current state.
   Signal dom ControlSt ->
   -- | Updated state.

--- a/bittide/src/Bittide/ClockControl/Registers.hs
+++ b/bittide/src/Bittide/ClockControl/Registers.hs
@@ -25,7 +25,7 @@ type StableBool = Bool
 type SettledBool = Bool
 
 -- | A wishbone accessible clock control interface.
--- This interface receives the link mask and 'DataCount's from all links.
+-- This interface receives the link mask and 'RelDataCount's from all links.
 -- Furthermore it produces FINC/FDEC pulses for the clock control boards.
 --
 -- The word-aligned address layout of the Wishbone interface is as follows:
@@ -58,7 +58,7 @@ clockControlWb ::
   -- | Link mask
   Signal dom (BitVector nLinks) ->
   -- | Counters
-  Vec nLinks (Signal dom (DataCount m)) ->
+  Vec nLinks (Signal dom (RelDataCount m)) ->
   -- | Wishbone accessible clock control circuitry
   Circuit
     (Wishbone dom 'Standard addrW (BitVector 32))

--- a/bittide/src/Bittide/ClockControl/StabilityChecker.hs
+++ b/bittide/src/Bittide/ClockControl/StabilityChecker.hs
@@ -1,4 +1,4 @@
--- SPDX-FileCopyrightText: 2022 Google LLC
+-- SPDX-FileCopyrightText: 2022-2024 Google LLC
 --
 -- SPDX-License-Identifier: Apache-2.0
 
@@ -12,7 +12,7 @@ import Clash.Prelude
 
 import Foreign.Storable (Storable(..))
 
-import Bittide.ClockControl (DataCount, targetDataCount)
+import Bittide.ClockControl (RelDataCount, targetDataCount)
 import Bittide.ClockControl.Callisto.Util (dataCountToSigned)
 import Bittide.ClockControl.Foreign.Sizes
 
@@ -69,7 +69,7 @@ stabilityChecker ::
   -- must remain within the @margin@ for it to be considered "stable".
   SNat framesize ->
   -- | Incoming buffer occupancy.
-  Signal dom (DataCount n) ->
+  Signal dom (RelDataCount n) ->
   -- | Stability indicators
   Signal dom StabilityIndication
 stabilityChecker SNat SNat = mealy go (0, targetDataCount)
@@ -79,7 +79,7 @@ stabilityChecker SNat SNat = mealy go (0, targetDataCount)
     withinMargin !x !y =
       abs (dataCountToSigned x `sub` dataCountToSigned y) <= (natToNum @margin)
 
-    newState :: (Index (framesize + 1), DataCount n)
+    newState :: (Index (framesize + 1), RelDataCount n)
     newState
       | withinMargin target input = (satSucc SatBound cnt, target)
       | otherwise                 = (0, input)

--- a/bittide/src/Clash/Cores/Extra.hs
+++ b/bittide/src/Clash/Cores/Extra.hs
@@ -68,7 +68,7 @@ safeDffSynchronizer0 clk1 clk2 initVal i = (sOut, dOut)
   sOut = flipflop clk1 i
   flipflop :: KnownDomain dom => Clock dom -> Signal dom a -> Signal dom a
   flipflop clk = delay clk enableGen initVal
-{-# NOINLINE safeDffSynchronizer0 #-}
+{-# OPAQUE safeDffSynchronizer0 #-}
 {-# ANN safeDffSynchronizer0 hasBlackBox #-}
 {-# ANN safeDffSynchronizer0 (
   let

--- a/bittide/src/Clash/Cores/Xilinx/Extra.hs
+++ b/bittide/src/Clash/Cores/Xilinx/Extra.hs
@@ -48,7 +48,7 @@ readDnaPortE2I = hideClockResetEnable readDnaPortE2
 ibufds :: (KnownDomain dom)  => DiffClock dom -> Clock dom
 ibufds !_ = clockGen
 {-# ANN ibufds hasBlackBox #-}
-{-# NOINLINE ibufds #-}
+{-# OPAQUE ibufds #-}
 {-# ANN ibufds (InlineYamlPrimitive [minBound..] [__i|
   BlackBox:
     name: Clash.Cores.Xilinx.Extra.ibufds

--- a/bittide/src/Clash/Cores/Xilinx/GTH/Internal.hs
+++ b/bittide/src/Clash/Cores/Xilinx/GTH/Internal.hs
@@ -69,7 +69,7 @@ gthCore
    , undefined, undefined, undefined, undefined
    , undefined, undefined, undefined, undefined
    )
-{-# NOINLINE gthCore #-}
+{-# OPAQUE gthCore #-}
 {-# ANN gthCore hasBlackBox #-}
 {-# ANN gthCore (
    let primName = 'gthCore
@@ -83,7 +83,7 @@ gthCore
 
 ibufds_gte3 :: KnownDomain dom => DiffClock dom -> Clock dom
 ibufds_gte3 !_clk = clockGen
-{-# NOINLINE ibufds_gte3 #-}
+{-# OPAQUE ibufds_gte3 #-}
 {-# ANN ibufds_gte3 hasBlackBox #-}
 {-# ANN ibufds_gte3 (
    let primName = 'ibufds_gte3

--- a/bittide/tests/Tests/ElasticBuffer.hs
+++ b/bittide/tests/Tests/ElasticBuffer.hs
@@ -14,7 +14,7 @@ import Test.Tasty
 import Test.Tasty.HUnit
 
 import Bittide.ElasticBuffer
-import Bittide.ClockControl (DataCount, targetDataCount)
+import Bittide.ClockControl (RelDataCount, targetDataCount)
 
 import qualified Data.List as L
 
@@ -95,7 +95,7 @@ case_resettableXilinxElasticBufferEq = do
     (dataCounts, underflows, overflows, ebModes, _) = L.unzip5 .
       L.dropWhile (\(_, _, _, eb, _)-> eb == Drain || eb == Fill) $ sampleN 256
         (bundle (resettableXilinxElasticBuffer @5 (clockGen @Slow) (clockGen @Slow) resetGen wData))
-    dataCountBounds = L.all ((< 3) . abs . subtract (toInteger (targetDataCount :: DataCount 5)) . toInteger) dataCounts
+    dataCountBounds = L.all ((< 3) . abs . subtract (toInteger (targetDataCount :: RelDataCount 5)) . toInteger) dataCounts
 
   assertBool "elastic buffer should get out of its Fill state" ((>0) $ L.length ebModes)
   assertBool "elastic buffer should not overflow after stabalising" (not $ or overflows)

--- a/bittide/tests/Tests/StabilityChecker.hs
+++ b/bittide/tests/Tests/StabilityChecker.hs
@@ -60,10 +60,10 @@ stabilityCheckerTest = property $ do
     simOut === golden (snatToNum sMargin) (snatToNum sCyclesStable) dataCounts
 
   -- 'stabilityChecker' reference design
-  golden :: forall n . KnownNat n => Integer -> Integer -> [DataCount n] -> [Bool]
+  golden :: forall n . KnownNat n => Integer -> Integer -> [RelDataCount n] -> [Bool]
   golden margin cyclesStable dataCounts =
     f
-    (0, fromIntegral (targetDataCount :: DataCount n))
+    (0, fromIntegral (targetDataCount :: RelDataCount n))
     (fmap fromIntegral dataCounts)
    where
     f _ [] = []

--- a/host-tools/callisto-lib/src/lib.rs
+++ b/host-tools/callisto-lib/src/lib.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 Google LLC
+// SPDX-FileCopyrightText: 2022-2024 Google LLC
 //
 // SPDX-License-Identifier: Apache-2.0
 use bittide_sys::{callisto, clock_control};
@@ -302,7 +302,7 @@ unsafe fn data_counts_from_ptr<'a>(ptr: *const ()) -> &'a [isize] {
 /// - `stability_checks_ptr` needs to point to a valid memory block holding
 ///   a `VecS n StabilityIndication`
 /// - `data_counts_ptr` needs to point to a valid memory address holding
-///   a `VecS n (DataCountS m)
+///   a `VecS n (RelDataCountS m)
 /// - `control_state_ptr` needs to point to a valid memory address holding
 ///   a `ControlSt`
 #[no_mangle]


### PR DESCRIPTION
This PR implements measuring of the UGNs in the FullMeshSwCc test.

It does this by one local counter per TX domain.
The value of that counter is continuously send out over the corresponding transceiver.
The stream of counter values received from other side of the link first go into a FIFO and what comes out of the FIFO gets subtracted from the stream of local counter values, this produces a stream of UGNs.

The test checks these UGNs are stable for at least 1+5 seconds.
The 1 seconds check is done on the TX domain, to make sure we don't miss any short glitches.
And the 5 second check is done after synchronizing the result of the first check to the shared `Basic125` domain and after all the channels are combined.

Than after the test is done, in post processing, we add the UGNs from both sides of the same link get the IGN (interpreted garbage numbers) for that link.
The IGN is a measure of latency of that link.

![IGNs calc drawio](https://github.com/user-attachments/assets/01c23c91-706e-44f5-bc2e-ae0117741a0e)

# Future work:

- https://github.com/bittide/bittide-hardware/issues/586
- https://github.com/bittide/bittide-hardware/issues/585
- https://github.com/bittide/bittide-hardware/issues/584
