### PR TITLE
Solve the constant crisis by adding memory map description to circuits

### DIFF
--- a/.github/synthesis/debug.json
+++ b/.github/synthesis/debug.json
@@ -1,0 +1,7 @@
+[
+  {
+    "top": "vexRiscvTest",
+    "stage": "test",
+    "targets": "Specific [-1]"
+  }
+]

--- a/bittide-instances/bittide-instances.cabal
+++ b/bittide-instances/bittide-instances.cabal
@@ -85,6 +85,7 @@ common common-options
     clash-lib,
     clash-prelude,
     clash-protocols,
+    clash-protocols-memmap,
     clash-vexriscv,
     constraints >=0.13.3 && <0.15,
     containers,

--- a/bittide-instances/bittide-instances.cabal
+++ b/bittide-instances/bittide-instances.cabal
@@ -111,6 +111,7 @@ library
   import: common-options
   hs-source-dirs: src
   exposed-modules:
+    -- Hardware-in-the-loop tests
     Bittide.Instances.Domains
     Bittide.Instances.Hacks
     Bittide.Instances.Hitl.BoardTest
@@ -128,6 +129,8 @@ library
     Bittide.Instances.Hitl.Tests
     Bittide.Instances.Hitl.Transceivers
     Bittide.Instances.Hitl.VexRiscv
+    Bittide.Instances.MemoryMapLogic
+    Bittide.Instances.MemoryMaps
     Bittide.Instances.Pnr.Calendar
     Bittide.Instances.Pnr.ClockControl
     Bittide.Instances.Pnr.Counter

--- a/bittide-instances/src/Bittide/Instances/MemoryMapLogic.hs
+++ b/bittide-instances/src/Bittide/Instances/MemoryMapLogic.hs
@@ -1,0 +1,115 @@
+-- SPDX-FileCopyrightText: 2024 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE RecordWildCards #-}
+
+{- | Logic for extracting memory maps from circuits in this project.
+This is a separate module from MemoryMaps because of GHC's stage restrictions
+around TemplateHaskell.
+-}
+module Bittide.Instances.MemoryMapLogic where
+
+import Clash.Prelude
+
+import Control.Monad (forM_)
+
+import Bittide.Instances.Hitl.VexRiscv (cpuCircuit)
+import Language.Haskell.TH (Q, reportError, runIO)
+import Project.FilePath (buildDir, findParentContaining)
+import Protocols.MemoryMap (MemoryMap, annotationSnd)
+import Protocols.MemoryMap.Check (
+  CheckConfiguration (..),
+  MemoryMapValidationErrors (..),
+  check,
+  prettyPrintPath,
+  shortLocation,
+ )
+import Protocols.MemoryMap.Check.AbsAddress (AbsAddressValidateError (..))
+import Protocols.MemoryMap.Check.Overlap (OverlapError (..))
+import System.Directory (createDirectoryIfMissing)
+import System.FilePath
+
+import Data.Aeson (encode)
+import qualified Data.ByteString.Lazy as BS
+import qualified Data.List as L
+import Protocols.MemoryMap.Json (memoryMapJson)
+import Text.Printf (printf)
+
+data MemMapProcessing = MemMapProcessing
+  { name :: String
+  , memMap :: MemoryMap
+  , checkConfig :: CheckConfiguration
+  , jsonOutput :: Maybe FilePath
+  }
+
+defaultCheckConfig :: CheckConfiguration
+defaultCheckConfig =
+  CheckConfiguration
+    { startAddr = 0x0000_0000
+    , endAddr = 0xFFFF_FFFF
+    }
+
+unSimOnly :: SimOnly a -> a
+unSimOnly (SimOnly x) = x
+
+memMaps :: [MemMapProcessing]
+memMaps =
+  [ MemMapProcessing
+      { name = "VexRiscv"
+      , memMap = unSimOnly $ annotationSnd @System cpuCircuit
+      , checkConfig = defaultCheckConfig
+      , jsonOutput = Just "vexriscv.json"
+      }
+  ]
+
+processMemoryMaps :: Q ()
+processMemoryMaps = do
+  memMapDir <- runIO $ do
+    root <- findParentContaining "cabal.project"
+    let dir = root </> buildDir </> "memory_maps"
+    createDirectoryIfMissing True dir
+    pure dir
+
+  forM_ memMaps $ \(MemMapProcessing{..}) -> do
+    case check checkConfig memMap of
+      Left MemoryMapValidationErrors{..} -> do
+        let absErrorMsgs = flip L.map absAddrErrors $ \AbsAddressValidateError{..} ->
+              let path' = prettyPrintPath path
+                  component = case componentName of
+                    Just name' -> name'
+                    Nothing -> "interconnect " <> path'
+               in printf
+                    "Expected component %s at %08X but found %08X (%s)"
+                    component
+                    expected
+                    got
+                    (shortLocation location)
+
+        let overlapErrorMsgs = flip L.map overlapErrors $ \case
+              OverlapError{..} ->
+                printf
+                  "Component %s (%08X + %08X) overlaps with %s at address (%08X) (%s)"
+                  (prettyPrintPath path)
+                  startAddr
+                  componentSize
+                  (prettyPrintPath overlapsWith)
+                  overlapsAt
+                  (shortLocation location)
+              SizeExceedsError{..} ->
+                printf
+                  "Component %s (%08X + %08X) exceeds available size %08X (%s)"
+                  (prettyPrintPath path)
+                  startAddr
+                  requestedSize
+                  availableSize
+                  (shortLocation location)
+        reportError (unlines $ absErrorMsgs <> overlapErrorMsgs)
+      Right checkedMemMap -> do
+        case jsonOutput of
+          Nothing -> pure ()
+          Just path -> do
+            let json = memoryMapJson checkedMemMap
+            runIO $ BS.writeFile (memMapDir </> path) (encode json)
+            pure ()
+    pure ()

--- a/bittide-instances/src/Bittide/Instances/MemoryMaps.hs
+++ b/bittide-instances/src/Bittide/Instances/MemoryMaps.hs
@@ -1,0 +1,16 @@
+-- SPDX-FileCopyrightText: 2024 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module Bittide.Instances.MemoryMaps where
+
+import Clash.Prelude
+
+import Bittide.Instances.MemoryMapLogic (processMemoryMaps)
+
+$( do
+    processMemoryMaps
+    pure []
+ )

--- a/bittide/bittide.cabal
+++ b/bittide/bittide.cabal
@@ -100,6 +100,7 @@ library
     clash-lib >=1.6.3 && <1.10,
     clash-prelude >=1.6.3 && <1.10,
     clash-protocols,
+    clash-protocols-memmap,
     clash-vexriscv,
     constraints >=0.13.3 && <0.15,
     containers >=0.4.0 && <0.7,

--- a/bittide/src/Bittide/DoubleBufferedRam.hs
+++ b/bittide/src/Bittide/DoubleBufferedRam.hs
@@ -24,7 +24,15 @@ import Bittide.SharedTypes hiding (delayControls)
 import Data.Constraint.Nat.Extra
 import Data.Typeable
 import GHC.Stack (HasCallStack, callStack, getCallStack)
-import Protocols.MemoryMap (Access (ReadWrite), DeviceDefinition (..), MemoryMap (..), MemoryMapTree (DeviceInstance), MemoryMapped, Name (..), Register (..))
+import Protocols.MemoryMap (
+  Access (ReadWrite),
+  DeviceDefinition (..),
+  MemoryMap (..),
+  MemoryMapTree (DeviceInstance),
+  MemoryMapped,
+  Name (..),
+  Register (..),
+ )
 import Protocols.MemoryMap.FieldType (ToFieldType (toFieldType))
 
 data ContentType n a
@@ -106,6 +114,7 @@ contentGenerator content = case compareSNat d1 (SNat @romSize) of
     element = initializedRam content (bitCoerce <$> romAddr1) (pure Nothing)
   _ -> (pure Nothing, pure True)
 
+-- | Wishbone Dual Port storage component with memory-map information attached.
 wbStorageDPM ::
   forall dom depth awA awB.
   ( HiddenClockResetEnable dom
@@ -244,6 +253,7 @@ wbStorageDP initial aM2S bM2S = (aS2M, bS2M)
 
   noTerminate wb = wb{acknowledge = False, err = False, retry = False, stall = False}
 
+-- | Wishbone storage component with memory map information attached.
 wbStorageM ::
   forall dom depth aw.
   ( HiddenClockResetEnable dom

--- a/bittide/src/Bittide/ProcessingElement.hs
+++ b/bittide/src/Bittide/ProcessingElement.hs
@@ -44,6 +44,7 @@ data PeConfig nBusses where
     InitialContent depthD (Bytes 4) ->
     PeConfig nBusses
 
+-- | Processing Element component with attached memory map information.
 processingElementM ::
   forall dom nBusses depthI depthD.
   ( HasCallStack
@@ -83,9 +84,9 @@ processingElementM iPre initI dPre initD =
 
     ([iMemBus, dMemBus], extBusses) <-
       (splitAtC d2 <| singleMasterInterconnectM Nothing) -< dBus1
-    MM.withPrefix dPre (wbStorageM "" initD) -< dMemBus
+    MM.withPrefix dPre (wbStorageM "Data" initD) -< dMemBus
     iBus2 <- stripPrefix removeMsb -< iBus1 -- XXX: <= This should be handled by an interconnect
-    withPrefixDouble iPre (wbStorageDPM "" initI) -< (iBus2, iMemBus)
+    withPrefixDouble iPre (wbStorageDPM "Instruction" initI) -< (iBus2, iMemBus)
     idC -< extBusses
  where
   removeMsb ::

--- a/bittide/src/Bittide/Wishbone.hs
+++ b/bittide/src/Bittide/Wishbone.hs
@@ -50,6 +50,9 @@ type MemoryMap nSlaves = Vec nSlaves (Unsigned (CLog 2 nSlaves))
 -- | Size of a bus that results from a `singleMasterInterconnect` with `nSlaves` slaves.
 type MappedBusAddrWidth addr nSlaves = addr - CLog 2 nSlaves
 
+{- | Single Master Interconnect component with memory map information attached.
+Prefixes of the sub-components are provided in their back-channels.
+-}
 singleMasterInterconnectM ::
   forall dom nSlaves addrW a.
   ( HiddenClockResetEnable dom
@@ -312,6 +315,7 @@ uartDf baud = Circuit go
    where
     (received, txBit, ack) = uart baud rxBit (Df.dataToMaybe <$> request)
 
+-- | Wishbone UART component with memory map information attached.
 uartM ::
   forall dom addrW nBytes baudRate transmitBufferDepth receiveBufferDepth.
   ( HasCallStack
@@ -666,12 +670,14 @@ wbToVec readableData WishboneM2S{..} = (writtenData, wbS2M)
     | otherwise = repeat Nothing
   wbS2M = (emptyWishboneS2M @(Bytes 4)){acknowledge, readData, err}
 
+-- | Version of 'timeWb' with memory map information attached.
 timeM ::
   forall dom addrW.
   ( HiddenClockResetEnable dom
   , KnownNat addrW
   , 2 <= addrW
   , 1 <= DomainPeriod dom
+  , HasCallStack
   ) =>
   String ->
   Circuit (MemoryMapped (Wishbone dom 'Standard addrW (Bytes 4))) ()

--- a/cabal.project
+++ b/cabal.project
@@ -8,7 +8,6 @@ packages:
   bittide-shake/
   bittide-tools/
   bittide/
-
   clash-protocols-memmap/
   clash-vexriscv/clash-vexriscv/
 

--- a/cabal.project
+++ b/cabal.project
@@ -8,6 +8,8 @@ packages:
   bittide-shake/
   bittide-tools/
   bittide/
+
+  clash-protocols-memmap/
   clash-vexriscv/clash-vexriscv/
 
 write-ghc-environment-files: always

--- a/clash-protocols-memmap/.gitignore
+++ b/clash-protocols-memmap/.gitignore
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Google LLC
+# SPDX-FileCopyrightText: 2024 Google LLC
 #
 # SPDX-License-Identifier: CC0-1.0
 

--- a/clash-protocols-memmap/.gitignore
+++ b/clash-protocols-memmap/.gitignore
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: 2022 Google LLC
+#
+# SPDX-License-Identifier: CC0-1.0
+
+build_out_dir
+vexriscv-test-binaries.tar

--- a/clash-protocols-memmap/app/Example.hs
+++ b/clash-protocols-memmap/app/Example.hs
@@ -18,27 +18,22 @@ import Text.Printf (printf)
 
 import qualified Data.Aeson as Ae
 import qualified Data.ByteString.Lazy as BS
-import qualified Data.List as List
-import qualified Data.Map.Strict as Map
 import Protocols.MemoryMap.Check (
   CheckConfiguration (..),
   MemoryMapValid (..),
   MemoryMapValidationErrors (..),
   check,
-  checkMemoryMap,
+  checkCircuitTH,
  )
 import Protocols.MemoryMap.Check.AbsAddress (AbsAddressValidateError (..))
 import Protocols.MemoryMap.Check.Overlap (OverlapError (..))
-import Protocols.MemoryMap.FieldType (FieldType (..))
-import qualified Protocols.MemoryMap.FieldType as FT
 import Protocols.MemoryMap.Json (memoryMapJson)
-import Protocols.MemoryMap.TypeCollect
 import System.Exit (exitFailure)
 
 checkConfig :: CheckConfiguration
 checkConfig = CheckConfiguration{startAddr = 0x0000_0000, endAddr = 0xFFFF_FFFF}
 
-checkMemoryMap @System
+checkCircuitTH @System
   (CheckConfiguration{startAddr = 0x0000_0000, endAddr = 0xFFFF_FFFF})
   someCircuit
 
@@ -82,142 +77,9 @@ main = do
 
   putStrLn "\n"
 
-  forM_ (Map.toList validTypes) $ \(_name, def') -> do
-    putStrLn $ generateRustTypeDef def'
-
-  forM_ (deviceDefs validMap) $ \def' -> do
-    let rustCode = generateRustDeviceWrapper def'
-    putStrLn rustCode
-
   let json = memoryMapJson mmValid
   BS.putStr (Ae.encode json)
-
--- summary ann'
 
 prettyPrintPath :: ComponentPath -> String
 prettyPrintPath Root = "root"
 prettyPrintPath (InterconnectComponent idx path) = prettyPrintPath path <> "." <> show idx
-
-generateRustTypeDef :: TypeDescription -> String
-generateRustTypeDef TypeDescription{definition = SumOfProductFieldType tyName vars, ..}
-  | [] <- vars = "struct " <> typeName tyName <> generics <> ";"
-  | [var] <- vars =
-      let
-        body = case var of
-          (_name, []) -> "();"
-          (_name, fields@(("", _) : _)) -> "(" <> List.intercalate ", " fields' <> ");"
-           where
-            fields' = generateRustType . snd <$> fields
-          (_name, fields) -> " {\n" <> fields'' <> "\n}"
-           where
-            fields' = (\(name', ty) -> "\t" <> name' <> ": " <> generateRustType ty) <$> fields
-            fields'' = List.intercalate ",\n" fields'
-       in
-        "struct " <> typeName tyName <> generics <> body
-  | otherwise = "enum " <> typeName tyName <> generics <> " {\n\t" <> variants' <> "\n}"
- where
-  variants = generateVariant <$> vars
-  variants' = List.intercalate "\n\t" variants
-  generics = genericListDef nGenerics
-  generateVariant (name', []) = name' <> ","
-  generateVariant (name', fields@(("", _) : _)) = name' <> "(" <> fields'' <> "),"
-   where
-    fields' = generateRustType . snd <$> fields
-    fields'' = List.intercalate ", " fields'
-  generateVariant (name', fields) = name' <> " {" <> fields'' <> " }"
-   where
-    fields' = List.map (\(name'', ty) -> name'' <> ": " <> generateRustType ty) fields
-    fields'' = List.intercalate ", " fields'
-generateRustTypeDef TypeDescription{} = error "unimplemented"
-
-typeName :: FT.TypeName -> String
-typeName (FT.name -> "(,)") = "Pair"
-typeName (FT.name -> "(,,)") = "Tuple3"
-typeName (FT.name -> n) = n
-
-generateRustType :: FieldType -> String
-generateRustType ty = case ty of
-  BoolFieldType -> "bool"
-  BitVectorFieldType n -> "u" <> reprTypeWidth n
-  SignedFieldType n -> "i" <> reprTypeWidth n
-  sop@(SumOfProductFieldType _name _args) -> generateRustType (TypeReference sop []) -- error $ "SOP without TyRef shouldn't happen" <> show name <> show args
-  UnsignedFieldType n -> "u" <> reprTypeWidth n
-  VecFieldType n ty' -> "[" <> generateRustType ty' <> "; " <> show n <> "]"
-  TypeReference (SumOfProductFieldType tyName _) [] ->
-    typeName tyName
-  TypeReference (SumOfProductFieldType tyName _) args ->
-    typeName tyName <> "<" <> List.intercalate ", " args' <> ">"
-   where
-    args' = generateRustType <$> args
-  TypeReference ty' _args' -> generateRustType ty'
-  TypeVariable n -> [genericVars List.!! fromInteger n]
-
-genericVars :: [Char]
-genericVars = ['A' ..]
-
-genericListDef :: Int -> String
-genericListDef 0 = ""
-genericListDef n = "<" <> varNames' <> ">"
- where
-  varNames = List.take n ((: []) <$> genericVars)
-  varNames' = List.intercalate ", " varNames
-
-generateRustDeviceWrapper :: DeviceDefinition -> String
-generateRustDeviceWrapper DeviceDefinition{..} =
-  "pub struct "
-    <> typeName'
-    <> "(*mut u8);\n"
-    <> "\n"
-    <> "impl "
-    <> typeName'
-    <> " {\n"
-    <> "  pub const unsafe fn new(addr: *mut u8) -> Self {\n"
-    <> "    Self(addr)\n"
-    <> "  }\n"
-    <> List.concat regGets
-    <> List.concat regSets
-    <> "}\n"
- where
-  typeName' = Protocols.MemoryMap.name deviceName
-
-  regGets = uncurry3 regGetFunc <$> registers
-  regSets = uncurry3 regSetFunc <$> registers
-
-  uncurry3 f (a, b, c) = f a b c
-
-  regGetFunc Name{..} _ Register{..}
-    -- skip for now
-    | VecFieldType _ _ <- fieldType = ""
-    | WriteOnly <- access = ""
-    | otherwise =
-        "  pub fn "
-          <> name
-          <> "(&self) -> "
-          <> generateRustType fieldType
-          <> " {\n"
-          <> "    unsafe {\n"
-          <> "      *self.0.add("
-          <> printf "0x%X" address
-          <> ").cast()\n"
-          <> "    }\n"
-          <> "  }\n"
-
-  regSetFunc Name{..} _ Register{..}
-    -- skip for now
-    | VecFieldType _ _ <- fieldType = ""
-    | ReadOnly <- access = ""
-    | otherwise =
-        "  pub fn set_"
-          <> name
-          <> "(&mut self, value: "
-          <> generateRustType fieldType
-          <> ") {\n"
-          <> "  }\n"
-
-reprTypeWidth :: (Ord a, Num a) => a -> String
-reprTypeWidth n
-  | n <= 8 = "8"
-  | n <= 16 = "16"
-  | n <= 32 = "32"
-  | n <= 64 = "64"
-  | otherwise = "128"

--- a/clash-protocols-memmap/app/Example.hs
+++ b/clash-protocols-memmap/app/Example.hs
@@ -1,0 +1,228 @@
+-- SPDX-FileCopyrightText: 2022-2024 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE RankNTypes #-}
+{-# OPTIONS_GHC -fplugin Protocols.Plugin #-}
+-- {-# OPTIONS -fplugin-opt=Protocols.Plugin:debug #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE NumericUnderscores #-}
+
+import Clash.Prelude
+
+import Protocols.MemoryMap
+import Internal.HdlTest.UartMock (someCircuit)
+import Control.Monad (forM_, when)
+import Text.Printf (printf)
+
+import qualified Data.Map.Strict as Map
+import qualified Data.List as List
+import qualified Data.Aeson as Ae
+import qualified Data.ByteString.Lazy as BS
+import Protocols.MemoryMap.Check (check, checkMemoryMap, MemoryMapValidationErrors(..), CheckConfiguration (..), MemoryMapValid (..))
+import Protocols.MemoryMap.Check.AbsAddress (AbsAddressValidateError(..))
+import Protocols.MemoryMap.Check.Overlap (OverlapError(..))
+import qualified Protocols.MemoryMap.TypeCollect as Ty
+import GHC.Stack (prettySrcLoc)
+import Protocols.MemoryMap.TypeCollect
+import Protocols.MemoryMap.FieldType (FieldType(..))
+import qualified Protocols.MemoryMap.FieldType as FT
+import System.Exit (exitFailure)
+import Protocols.MemoryMap.Json (memoryMapJson)
+
+checkConfig = CheckConfiguration { startAddr = 0x0000_0000, endAddr = 0xFFFF_FFFF }
+
+checkMemoryMap @System
+  (CheckConfiguration { startAddr = 0x0000_0000, endAddr = 0xFFFF_FFFF })
+  someCircuit
+
+main :: IO ()
+main = do
+  let
+    SimOnly ann = annotation @System someCircuit
+    -- ann' = makeAbsolute 0x0 ann
+    -- validation = validateAbsAddresses Root ann' ann
+
+  mmValid@MemoryMapValid{..} <- case check checkConfig ann of
+      Left MemoryMapValidationErrors{..} -> do
+
+        forM_ absAddrErrors $ \AbsAddressValidateError{..} -> do
+          let path' = prettyPrintPath path
+          let component = case componentName of
+                Just name -> name
+                Nothing -> "interconnect " <> path'
+          printf "Expected component %s at %08X but found %08X\n" component expected got
+
+        forM_ overlapErrors $ \case
+          OverlapError{..} -> do
+            printf "Component %s (%08X + %08X) overlaps with %s at address (%08X)"
+              (prettyPrintPath path) startAddr componentSize
+              (prettyPrintPath overlapsWith) overlapsAt
+          SizeExceedsError{..} -> do
+            printf "Component %s (%08X + %08X) exceeds available size %08X"
+              (prettyPrintPath path) startAddr requestedSize
+              availableSize
+
+        exitFailure
+      Right res -> pure res
+
+  print validTypes
+
+  putStrLn "\n"
+
+  forM_ (Map.toList validTypes) $ \(name, def) -> do
+    putStrLn $ generateRustTypeDef def
+
+  forM_ (deviceDefs validMap) $ \def' -> do
+    let rustCode = generateRustDeviceWrapper def'
+    putStrLn rustCode
+
+  let json = memoryMapJson mmValid
+  BS.putStr (Ae.encode json)
+
+  -- summary ann'
+
+prettyPrintPath :: ComponentPath -> String
+prettyPrintPath Root = "root"
+prettyPrintPath (InterconnectComponent idx path) = prettyPrintPath path <> "." <> show idx
+
+summary :: MemoryMap -> IO ()
+summary MemoryMap{deviceDefs, tree} = do
+  showDeviceDefs (snd <$> Map.toList deviceDefs)
+  putStrLn "\nDevice instances:"
+  showDeviceInstances tree
+
+showDeviceDefs :: [DeviceDefinition] -> IO ()
+showDeviceDefs defs = do
+  putStrLn "Device Definitions"
+
+  forM_ defs $ \DeviceDefinition{..} -> do
+    printf "  %s: %s (%s)\n" (Protocols.MemoryMap.name deviceName) (description deviceName) (prettySrcLoc defLocation)
+
+    forM_ registers $ \(Name{name=regName}, loc, Register{..}) -> do
+      printf "    % 4X %s %s (%s)\n" address (show access) regName (prettySrcLoc loc)
+
+showDeviceInstances :: MemoryMapTree -> IO ()
+showDeviceInstances (Interconnect _ _ comps) = do
+  forM_ comps $ \(_, _, comp) -> showDeviceInstances comp
+showDeviceInstances (DeviceInstance loc addr instanceName typeName) = do
+  let addr' = maybe "??      " (printf "%08X") addr
+  printf "%s %s of type %s (%s)\n" addr' instanceName typeName (prettySrcLoc loc)
+
+
+
+generateRustTypeDef :: TypeDescription -> String
+generateRustTypeDef TypeDescription{definition = SumOfProductFieldType tyName vars, ..}
+  | [] <- vars = "struct " <> typeName tyName <> generics <> ";"
+  | [var] <- vars =
+      let
+        body = case var of
+                (name, []) -> "();"
+                (name, fields@(("", _):_)) -> "(" <> List.intercalate ", " fields' <> ");"
+                  where
+                    fields' = generateRustType . snd <$> fields
+                (name, fields) -> " {\n" <> fields'' <> "\n}"
+                  where
+                    fields' = (\(name, ty) -> "\t" <> name <> ": " <> generateRustType ty) <$>fields
+                    fields'' = List.intercalate ",\n" fields'
+        generics = genericListDef nGenerics
+      in "struct " <> typeName tyName <> generics <> body
+  | otherwise = "enum " <> typeName tyName <> generics <> " {\n\t" <> variants' <> "\n}"
+      where
+        variants = generateVariant <$> vars
+        variants' = List.intercalate "\n\t" variants
+        generics = genericListDef nGenerics
+        generateVariant (name, []) = name <> ","
+        generateVariant (name, fields@(("", _):_)) = name <> "(" <> fields'' <> "),"
+          where
+            fields' = generateRustType . snd <$> fields
+            fields'' = List.intercalate ", " fields'
+        generateVariant (name, fields) = name <> " {" <> fields'' <> " }"
+          where
+            fields' = List.map (\(name, ty) -> name <> ": " <> generateRustType ty) fields
+            fields'' = List.intercalate ", " fields'
+generateRustTypeDef TypeDescription{..} = error "unimplemented"
+
+typeName :: FT.TypeName -> String
+typeName (FT.name -> "(,)") = "Pair"
+typeName (FT.name -> "(,,)") = "Tuple3"
+typeName (FT.name -> n) = n
+
+generateRustType :: FieldType -> String
+generateRustType ty = case ty of
+  BoolFieldType -> "bool"
+  BitVectorFieldType n -> "u" <> reprTypeWidth n
+  SignedFieldType n -> "i" <> reprTypeWidth n
+  sop@(SumOfProductFieldType name args) -> generateRustType (TypeReference sop []) -- error $ "SOP without TyRef shouldn't happen" <> show name <> show args
+  UnsignedFieldType n -> "u" <> reprTypeWidth n
+  VecFieldType n ty' -> "[" <> generateRustType ty' <> "; " <> show n <> "]"
+  TypeReference (SumOfProductFieldType tyName _) [] ->
+    typeName tyName
+  TypeReference (SumOfProductFieldType tyName _) args ->
+    typeName tyName <> "<" <> List.intercalate ", " args'  <> ">"
+      where
+        args' = generateRustType <$> args
+  TypeReference ty' _args' -> generateRustType ty'
+  TypeVariable n -> [genericVars List.!! fromInteger n]
+
+genericVars :: [Char]
+genericVars = ['A'..]
+
+genericListDef :: Int -> String
+genericListDef 0 = ""
+genericListDef n = "<" <> varNames' <> ">"
+  where
+    varNames = List.take n ((:[]) <$> genericVars)
+    varNames' = List.intercalate ", " varNames
+
+
+generateRustDeviceWrapper :: DeviceDefinition -> String
+generateRustDeviceWrapper DeviceDefinition{..} =
+  "pub struct " <> typeName <> "(*mut u8);\n" <>
+  "\n" <>
+  "impl " <> typeName <> " {\n" <>
+    "  pub const unsafe fn new(addr: *mut u8) -> Self {\n" <>
+    "    Self(addr)\n" <>
+    "  }\n" <>
+    List.concat regGets <>
+    List.concat regSets <>
+  "}\n"
+  where
+    typeName = Protocols.MemoryMap.name deviceName
+
+    regGets = uncurry3 regGetFunc <$> registers
+    regSets = uncurry3 regSetFunc <$> registers
+
+    uncurry3 f (a, b, c) = f a b c
+
+    regGetFunc Name{..} _ Register{..}
+      -- skip for now
+      | VecFieldType _ _ <- fieldType = ""
+      | WriteOnly <- access = ""
+      | otherwise =
+        "  pub fn " <> name <> "(&self) -> " <> generateRustType fieldType <> " {\n" <>
+        "    unsafe {\n" <>
+        "      *self.0.add(" <> printf "0x%X" address <>").cast()\n" <>
+        "    }\n" <>
+        "  }\n"
+
+    regSetFunc Name{..} _ Register{..}
+      -- skip for now
+      | VecFieldType _ _ <- fieldType = ""
+      | ReadOnly <- access = ""
+      | otherwise =
+        "  pub fn set_" <> name <> "(&mut self, value: " <>
+            generateRustType fieldType <>
+            ") {\n" <>
+        "  }\n"
+
+
+reprTypeWidth :: (Ord a, Num a) => a -> String
+reprTypeWidth n
+  | n <= 8 = "8"
+  | n <= 16 = "16"
+  | n <= 32 = "32"
+  | n <= 64 = "64"
+  | otherwise = "128"

--- a/clash-protocols-memmap/app/Example.hs
+++ b/clash-protocols-memmap/app/Example.hs
@@ -1,79 +1,89 @@
 -- SPDX-FileCopyrightText: 2022-2024 Google LLC
 --
 -- SPDX-License-Identifier: Apache-2.0
-
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE RankNTypes #-}
-{-# OPTIONS_GHC -fplugin Protocols.Plugin #-}
 -- {-# OPTIONS -fplugin-opt=Protocols.Plugin:debug #-}
 {-# LANGUAGE NamedFieldPuns #-}
-{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# OPTIONS_GHC -fplugin Protocols.Plugin #-}
 
 import Clash.Prelude
 
-import Protocols.MemoryMap
+import Control.Monad (forM_)
 import Internal.HdlTest.UartMock (someCircuit)
-import Control.Monad (forM_, when)
+import Protocols.MemoryMap
 import Text.Printf (printf)
 
-import qualified Data.Map.Strict as Map
-import qualified Data.List as List
 import qualified Data.Aeson as Ae
 import qualified Data.ByteString.Lazy as BS
-import Protocols.MemoryMap.Check (check, checkMemoryMap, MemoryMapValidationErrors(..), CheckConfiguration (..), MemoryMapValid (..))
-import Protocols.MemoryMap.Check.AbsAddress (AbsAddressValidateError(..))
-import Protocols.MemoryMap.Check.Overlap (OverlapError(..))
-import qualified Protocols.MemoryMap.TypeCollect as Ty
-import GHC.Stack (prettySrcLoc)
-import Protocols.MemoryMap.TypeCollect
-import Protocols.MemoryMap.FieldType (FieldType(..))
+import qualified Data.List as List
+import qualified Data.Map.Strict as Map
+import Protocols.MemoryMap.Check (
+  CheckConfiguration (..),
+  MemoryMapValid (..),
+  MemoryMapValidationErrors (..),
+  check,
+  checkMemoryMap,
+ )
+import Protocols.MemoryMap.Check.AbsAddress (AbsAddressValidateError (..))
+import Protocols.MemoryMap.Check.Overlap (OverlapError (..))
+import Protocols.MemoryMap.FieldType (FieldType (..))
 import qualified Protocols.MemoryMap.FieldType as FT
-import System.Exit (exitFailure)
 import Protocols.MemoryMap.Json (memoryMapJson)
+import Protocols.MemoryMap.TypeCollect
+import System.Exit (exitFailure)
 
-checkConfig = CheckConfiguration { startAddr = 0x0000_0000, endAddr = 0xFFFF_FFFF }
+checkConfig :: CheckConfiguration
+checkConfig = CheckConfiguration{startAddr = 0x0000_0000, endAddr = 0xFFFF_FFFF}
 
 checkMemoryMap @System
-  (CheckConfiguration { startAddr = 0x0000_0000, endAddr = 0xFFFF_FFFF })
+  (CheckConfiguration{startAddr = 0x0000_0000, endAddr = 0xFFFF_FFFF})
   someCircuit
 
 main :: IO ()
 main = do
   let
     SimOnly ann = annotation @System someCircuit
-    -- ann' = makeAbsolute 0x0 ann
-    -- validation = validateAbsAddresses Root ann' ann
+  -- ann' = makeAbsolute 0x0 ann
+  -- validation = validateAbsAddresses Root ann' ann
 
   mmValid@MemoryMapValid{..} <- case check checkConfig ann of
-      Left MemoryMapValidationErrors{..} -> do
+    Left MemoryMapValidationErrors{..} -> do
+      forM_ absAddrErrors $ \AbsAddressValidateError{..} -> do
+        let path' = prettyPrintPath path
+        let component = case componentName of
+              Just name -> name
+              Nothing -> "interconnect " <> path'
+        printf "Expected component %s at %08X but found %08X\n" component expected got
 
-        forM_ absAddrErrors $ \AbsAddressValidateError{..} -> do
-          let path' = prettyPrintPath path
-          let component = case componentName of
-                Just name -> name
-                Nothing -> "interconnect " <> path'
-          printf "Expected component %s at %08X but found %08X\n" component expected got
+      forM_ overlapErrors $ \case
+        OverlapError{..} -> do
+          printf
+            "Component %s (%08X + %08X) overlaps with %s at address (%08X)"
+            (prettyPrintPath path)
+            startAddr
+            componentSize
+            (prettyPrintPath overlapsWith)
+            overlapsAt
+        SizeExceedsError{..} -> do
+          printf
+            "Component %s (%08X + %08X) exceeds available size %08X"
+            (prettyPrintPath path)
+            startAddr
+            requestedSize
+            availableSize
 
-        forM_ overlapErrors $ \case
-          OverlapError{..} -> do
-            printf "Component %s (%08X + %08X) overlaps with %s at address (%08X)"
-              (prettyPrintPath path) startAddr componentSize
-              (prettyPrintPath overlapsWith) overlapsAt
-          SizeExceedsError{..} -> do
-            printf "Component %s (%08X + %08X) exceeds available size %08X"
-              (prettyPrintPath path) startAddr requestedSize
-              availableSize
-
-        exitFailure
-      Right res -> pure res
+      exitFailure
+    Right res -> pure res
 
   print validTypes
 
   putStrLn "\n"
 
-  forM_ (Map.toList validTypes) $ \(name, def) -> do
-    putStrLn $ generateRustTypeDef def
+  forM_ (Map.toList validTypes) $ \(_name, def') -> do
+    putStrLn $ generateRustTypeDef def'
 
   forM_ (deviceDefs validMap) $ \def' -> do
     let rustCode = generateRustDeviceWrapper def'
@@ -82,36 +92,11 @@ main = do
   let json = memoryMapJson mmValid
   BS.putStr (Ae.encode json)
 
-  -- summary ann'
+-- summary ann'
 
 prettyPrintPath :: ComponentPath -> String
 prettyPrintPath Root = "root"
 prettyPrintPath (InterconnectComponent idx path) = prettyPrintPath path <> "." <> show idx
-
-summary :: MemoryMap -> IO ()
-summary MemoryMap{deviceDefs, tree} = do
-  showDeviceDefs (snd <$> Map.toList deviceDefs)
-  putStrLn "\nDevice instances:"
-  showDeviceInstances tree
-
-showDeviceDefs :: [DeviceDefinition] -> IO ()
-showDeviceDefs defs = do
-  putStrLn "Device Definitions"
-
-  forM_ defs $ \DeviceDefinition{..} -> do
-    printf "  %s: %s (%s)\n" (Protocols.MemoryMap.name deviceName) (description deviceName) (prettySrcLoc defLocation)
-
-    forM_ registers $ \(Name{name=regName}, loc, Register{..}) -> do
-      printf "    % 4X %s %s (%s)\n" address (show access) regName (prettySrcLoc loc)
-
-showDeviceInstances :: MemoryMapTree -> IO ()
-showDeviceInstances (Interconnect _ _ comps) = do
-  forM_ comps $ \(_, _, comp) -> showDeviceInstances comp
-showDeviceInstances (DeviceInstance loc addr instanceName typeName) = do
-  let addr' = maybe "??      " (printf "%08X") addr
-  printf "%s %s of type %s (%s)\n" addr' instanceName typeName (prettySrcLoc loc)
-
-
 
 generateRustTypeDef :: TypeDescription -> String
 generateRustTypeDef TypeDescription{definition = SumOfProductFieldType tyName vars, ..}
@@ -119,31 +104,31 @@ generateRustTypeDef TypeDescription{definition = SumOfProductFieldType tyName va
   | [var] <- vars =
       let
         body = case var of
-                (name, []) -> "();"
-                (name, fields@(("", _):_)) -> "(" <> List.intercalate ", " fields' <> ");"
-                  where
-                    fields' = generateRustType . snd <$> fields
-                (name, fields) -> " {\n" <> fields'' <> "\n}"
-                  where
-                    fields' = (\(name, ty) -> "\t" <> name <> ": " <> generateRustType ty) <$>fields
-                    fields'' = List.intercalate ",\n" fields'
-        generics = genericListDef nGenerics
-      in "struct " <> typeName tyName <> generics <> body
-  | otherwise = "enum " <> typeName tyName <> generics <> " {\n\t" <> variants' <> "\n}"
-      where
-        variants = generateVariant <$> vars
-        variants' = List.intercalate "\n\t" variants
-        generics = genericListDef nGenerics
-        generateVariant (name, []) = name <> ","
-        generateVariant (name, fields@(("", _):_)) = name <> "(" <> fields'' <> "),"
-          where
+          (_name, []) -> "();"
+          (_name, fields@(("", _) : _)) -> "(" <> List.intercalate ", " fields' <> ");"
+           where
             fields' = generateRustType . snd <$> fields
-            fields'' = List.intercalate ", " fields'
-        generateVariant (name, fields) = name <> " {" <> fields'' <> " }"
-          where
-            fields' = List.map (\(name, ty) -> name <> ": " <> generateRustType ty) fields
-            fields'' = List.intercalate ", " fields'
-generateRustTypeDef TypeDescription{..} = error "unimplemented"
+          (_name, fields) -> " {\n" <> fields'' <> "\n}"
+           where
+            fields' = (\(name', ty) -> "\t" <> name' <> ": " <> generateRustType ty) <$> fields
+            fields'' = List.intercalate ",\n" fields'
+       in
+        "struct " <> typeName tyName <> generics <> body
+  | otherwise = "enum " <> typeName tyName <> generics <> " {\n\t" <> variants' <> "\n}"
+ where
+  variants = generateVariant <$> vars
+  variants' = List.intercalate "\n\t" variants
+  generics = genericListDef nGenerics
+  generateVariant (name', []) = name' <> ","
+  generateVariant (name', fields@(("", _) : _)) = name' <> "(" <> fields'' <> "),"
+   where
+    fields' = generateRustType . snd <$> fields
+    fields'' = List.intercalate ", " fields'
+  generateVariant (name', fields) = name' <> " {" <> fields'' <> " }"
+   where
+    fields' = List.map (\(name'', ty) -> name'' <> ": " <> generateRustType ty) fields
+    fields'' = List.intercalate ", " fields'
+generateRustTypeDef TypeDescription{} = error "unimplemented"
 
 typeName :: FT.TypeName -> String
 typeName (FT.name -> "(,)") = "Pair"
@@ -155,69 +140,79 @@ generateRustType ty = case ty of
   BoolFieldType -> "bool"
   BitVectorFieldType n -> "u" <> reprTypeWidth n
   SignedFieldType n -> "i" <> reprTypeWidth n
-  sop@(SumOfProductFieldType name args) -> generateRustType (TypeReference sop []) -- error $ "SOP without TyRef shouldn't happen" <> show name <> show args
+  sop@(SumOfProductFieldType _name _args) -> generateRustType (TypeReference sop []) -- error $ "SOP without TyRef shouldn't happen" <> show name <> show args
   UnsignedFieldType n -> "u" <> reprTypeWidth n
   VecFieldType n ty' -> "[" <> generateRustType ty' <> "; " <> show n <> "]"
   TypeReference (SumOfProductFieldType tyName _) [] ->
     typeName tyName
   TypeReference (SumOfProductFieldType tyName _) args ->
-    typeName tyName <> "<" <> List.intercalate ", " args'  <> ">"
-      where
-        args' = generateRustType <$> args
+    typeName tyName <> "<" <> List.intercalate ", " args' <> ">"
+   where
+    args' = generateRustType <$> args
   TypeReference ty' _args' -> generateRustType ty'
   TypeVariable n -> [genericVars List.!! fromInteger n]
 
 genericVars :: [Char]
-genericVars = ['A'..]
+genericVars = ['A' ..]
 
 genericListDef :: Int -> String
 genericListDef 0 = ""
 genericListDef n = "<" <> varNames' <> ">"
-  where
-    varNames = List.take n ((:[]) <$> genericVars)
-    varNames' = List.intercalate ", " varNames
-
+ where
+  varNames = List.take n ((: []) <$> genericVars)
+  varNames' = List.intercalate ", " varNames
 
 generateRustDeviceWrapper :: DeviceDefinition -> String
 generateRustDeviceWrapper DeviceDefinition{..} =
-  "pub struct " <> typeName <> "(*mut u8);\n" <>
-  "\n" <>
-  "impl " <> typeName <> " {\n" <>
-    "  pub const unsafe fn new(addr: *mut u8) -> Self {\n" <>
-    "    Self(addr)\n" <>
-    "  }\n" <>
-    List.concat regGets <>
-    List.concat regSets <>
-  "}\n"
-  where
-    typeName = Protocols.MemoryMap.name deviceName
+  "pub struct "
+    <> typeName'
+    <> "(*mut u8);\n"
+    <> "\n"
+    <> "impl "
+    <> typeName'
+    <> " {\n"
+    <> "  pub const unsafe fn new(addr: *mut u8) -> Self {\n"
+    <> "    Self(addr)\n"
+    <> "  }\n"
+    <> List.concat regGets
+    <> List.concat regSets
+    <> "}\n"
+ where
+  typeName' = Protocols.MemoryMap.name deviceName
 
-    regGets = uncurry3 regGetFunc <$> registers
-    regSets = uncurry3 regSetFunc <$> registers
+  regGets = uncurry3 regGetFunc <$> registers
+  regSets = uncurry3 regSetFunc <$> registers
 
-    uncurry3 f (a, b, c) = f a b c
+  uncurry3 f (a, b, c) = f a b c
 
-    regGetFunc Name{..} _ Register{..}
-      -- skip for now
-      | VecFieldType _ _ <- fieldType = ""
-      | WriteOnly <- access = ""
-      | otherwise =
-        "  pub fn " <> name <> "(&self) -> " <> generateRustType fieldType <> " {\n" <>
-        "    unsafe {\n" <>
-        "      *self.0.add(" <> printf "0x%X" address <>").cast()\n" <>
-        "    }\n" <>
-        "  }\n"
+  regGetFunc Name{..} _ Register{..}
+    -- skip for now
+    | VecFieldType _ _ <- fieldType = ""
+    | WriteOnly <- access = ""
+    | otherwise =
+        "  pub fn "
+          <> name
+          <> "(&self) -> "
+          <> generateRustType fieldType
+          <> " {\n"
+          <> "    unsafe {\n"
+          <> "      *self.0.add("
+          <> printf "0x%X" address
+          <> ").cast()\n"
+          <> "    }\n"
+          <> "  }\n"
 
-    regSetFunc Name{..} _ Register{..}
-      -- skip for now
-      | VecFieldType _ _ <- fieldType = ""
-      | ReadOnly <- access = ""
-      | otherwise =
-        "  pub fn set_" <> name <> "(&mut self, value: " <>
-            generateRustType fieldType <>
-            ") {\n" <>
-        "  }\n"
-
+  regSetFunc Name{..} _ Register{..}
+    -- skip for now
+    | VecFieldType _ _ <- fieldType = ""
+    | ReadOnly <- access = ""
+    | otherwise =
+        "  pub fn set_"
+          <> name
+          <> "(&mut self, value: "
+          <> generateRustType fieldType
+          <> ") {\n"
+          <> "  }\n"
 
 reprTypeWidth :: (Ord a, Num a) => a -> String
 reprTypeWidth n

--- a/clash-protocols-memmap/app/Example.hs
+++ b/clash-protocols-memmap/app/Example.hs
@@ -1,4 +1,4 @@
--- SPDX-FileCopyrightText: 2022-2024 Google LLC
+-- SPDX-FileCopyrightText: 2022 Google LLC
 --
 -- SPDX-License-Identifier: Apache-2.0
 {-# LANGUAGE CPP #-}

--- a/clash-protocols-memmap/app/HdlTest.hs
+++ b/clash-protocols-memmap/app/HdlTest.hs
@@ -6,6 +6,5 @@ import Prelude
 
 import qualified Clash.Main as Clash
 
-
 main :: IO ()
 main = Clash.defaultMain ["Internal.HdlTest.UartMock", "-main-is", "topLevel", "--verilog"]

--- a/clash-protocols-memmap/app/HdlTest.hs
+++ b/clash-protocols-memmap/app/HdlTest.hs
@@ -1,0 +1,11 @@
+-- SPDX-FileCopyrightText: 2023-2024 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+
+import Prelude
+
+import qualified Clash.Main as Clash
+
+
+main :: IO ()
+main = Clash.defaultMain ["Internal.HdlTest.UartMock", "-main-is", "topLevel", "--verilog"]

--- a/clash-protocols-memmap/clash-protocols-memmap.cabal
+++ b/clash-protocols-memmap/clash-protocols-memmap.cabal
@@ -1,0 +1,130 @@
+cabal-version:       2.4
+name:                clash-protocols-memmap
+version:             0.1
+License:             Apache-2.0
+license-file:        LICENSE
+author:              QBayLogic B.V.
+maintainer:          devops@qbaylogic.com
+Copyright:           Copyright © 2022 Google LLC
+
+common common-options
+  default-extensions:
+    BangPatterns
+    BinaryLiterals
+    ConstraintKinds
+    DataKinds
+    DefaultSignatures
+    DeriveAnyClass
+    DeriveDataTypeable
+    DeriveFoldable
+    DeriveFunctor
+    DeriveGeneric
+    DeriveLift
+    DeriveTraversable
+    DerivingStrategies
+    InstanceSigs
+    KindSignatures
+    LambdaCase
+    NoStarIsType
+    PolyKinds
+    RankNTypes
+    ScopedTypeVariables
+    StandaloneDeriving
+    TupleSections
+    TypeApplications
+    TypeFamilies
+    TypeOperators
+    ViewPatterns
+
+    -- TemplateHaskell is used to support convenience functions such as
+    -- 'listToVecTH' and 'bLit'.
+    TemplateHaskell
+    QuasiQuotes
+
+    -- Prelude isn't imported by default as Clash offers Clash.Prelude
+    NoImplicitPrelude
+
+  -- See https://github.com/clash-lang/clash-compiler/pull/2511
+  if impl(ghc >= 9.4)
+    CPP-Options: -DCLASH_OPAQUE=OPAQUE
+  else
+    CPP-Options: -DCLASH_OPAQUE=NOINLINE
+
+  ghc-options:
+    -Wall -Wcompat
+
+    -- Plugins to support type-level constraint solving on naturals
+    -fplugin GHC.TypeLits.Extra.Solver
+    -fplugin GHC.TypeLits.Normalise
+    -fplugin GHC.TypeLits.KnownNat.Solver
+
+    -- Clash needs access to the source code in compiled modules
+    -fexpose-all-unfoldings
+
+    -- Worker wrappers introduce unstable names for functions that might have
+    -- blackboxes attached for them. You can disable this, but be sure to add
+    -- a no-specialize pragma to every function with a blackbox.
+    -fno-worker-wrapper
+      -- clash-prelude will set suitable version bounds for the plugins
+  build-depends:
+    base >= 4.14 && < 4.19,
+    clash-prelude >= 1.6 && < 1.10,
+    containers >= 0.6 && < 0.8,
+    ghc-typelits-natnormalise,
+    ghc-typelits-extra,
+    ghc-typelits-knownnat,
+
+library
+  import: common-options
+  hs-source-dirs: src
+  default-language: Haskell2010
+  exposed-modules:
+    BitPackC
+    Protocols.MemoryMap
+    Protocols.MemoryMap.TypeCollect
+    Protocols.MemoryMap.Check
+    Protocols.MemoryMap.Check.AbsAddress
+    Protocols.MemoryMap.Check.Overlap
+    Protocols.MemoryMap.FieldType
+    Protocols.MemoryMap.Json
+    Internal.HdlTest.UartMock
+  build-depends:
+    base,
+    aeson,
+    bytestring >= 0.10 && < 0.13,
+    constraints,
+    clash-prelude,
+    clash-protocols,
+    containers,
+    template-haskell,
+
+-- XXX: Doesn't really belong in clash-vexriscv-SIM
+executable hdl-test
+  import: common-options
+  main-is: app/HdlTest.hs
+  build-Depends:
+    base,
+    clash-ghc,
+    clash-prelude,
+    clash-protocols,
+    clash-protocols-memmap,
+    aeson,
+    bytestring,
+    containers,
+    directory,
+
+executable example
+  import: common-options
+  main-is: Example.hs
+  hs-source-dirs: app
+  default-language: Haskell2010
+  ghc-options: -threaded -rtsopts "-with-rtsopts=-M100M"
+  build-depends:
+    base,
+    clash-prelude,
+    clash-protocols,
+    clash-protocols-memmap,
+    aeson,
+    bytestring,
+    containers,
+    directory,

--- a/clash-protocols-memmap/clash-protocols-memmap.cabal
+++ b/clash-protocols-memmap/clash-protocols-memmap.cabal
@@ -1,14 +1,17 @@
-cabal-version:       2.4
-name:                clash-protocols-memmap
-version:             0.1
-License:             Apache-2.0
-license-file:        LICENSE
-author:              QBayLogic B.V.
-maintainer:          devops@qbaylogic.com
-Copyright:           Copyright © 2022 Google LLC
+cabal-version: 2.4
+name: clash-protocols-memmap
+version: 0.1
+license: Apache-2.0
+license-file: LICENSE
+author: QBayLogic B.V.
+maintainer: devops@qbaylogic.com
+copyright: Copyright © 2024 Google LLC
 
 common common-options
   default-extensions:
+    -- TemplateHaskell is used to support convenience functions such as
+    -- 'listToVecTH' and 'bLit'.
+    -- Prelude isn't imported by default as Clash offers Clash.Prelude
     BangPatterns
     BinaryLiterals
     ConstraintKinds
@@ -25,54 +28,51 @@ common common-options
     InstanceSigs
     KindSignatures
     LambdaCase
+    NoImplicitPrelude
     NoStarIsType
     PolyKinds
+    QuasiQuotes
     RankNTypes
     ScopedTypeVariables
     StandaloneDeriving
+    TemplateHaskell
     TupleSections
     TypeApplications
     TypeFamilies
     TypeOperators
     ViewPatterns
 
-    -- TemplateHaskell is used to support convenience functions such as
-    -- 'listToVecTH' and 'bLit'.
-    TemplateHaskell
-    QuasiQuotes
-
-    -- Prelude isn't imported by default as Clash offers Clash.Prelude
-    NoImplicitPrelude
-
   -- See https://github.com/clash-lang/clash-compiler/pull/2511
   if impl(ghc >= 9.4)
-    CPP-Options: -DCLASH_OPAQUE=OPAQUE
+    cpp-options: -DCLASH_OPAQUE=OPAQUE
   else
-    CPP-Options: -DCLASH_OPAQUE=NOINLINE
+    cpp-options: -DCLASH_OPAQUE=NOINLINE
 
   ghc-options:
-    -Wall -Wcompat
-
     -- Plugins to support type-level constraint solving on naturals
-    -fplugin GHC.TypeLits.Extra.Solver
-    -fplugin GHC.TypeLits.Normalise
-    -fplugin GHC.TypeLits.KnownNat.Solver
-
     -- Clash needs access to the source code in compiled modules
-    -fexpose-all-unfoldings
-
     -- Worker wrappers introduce unstable names for functions that might have
     -- blackboxes attached for them. You can disable this, but be sure to add
     -- a no-specialize pragma to every function with a blackbox.
+    -Wall
+    -Wcompat
+    -fplugin
+    GHC.TypeLits.Extra.Solver
+    -fplugin
+    GHC.TypeLits.Normalise
+    -fplugin
+    GHC.TypeLits.KnownNat.Solver
+    -fexpose-all-unfoldings
     -fno-worker-wrapper
-      -- clash-prelude will set suitable version bounds for the plugins
+
+  -- clash-prelude will set suitable version bounds for the plugins
   build-depends:
-    base >= 4.14 && < 4.19,
-    clash-prelude >= 1.6 && < 1.10,
-    containers >= 0.6 && < 0.8,
-    ghc-typelits-natnormalise,
+    base >=4.14 && <4.19,
+    clash-prelude >=1.6 && <1.10,
+    containers >=0.6 && <0.8,
     ghc-typelits-extra,
     ghc-typelits-knownnat,
+    ghc-typelits-natnormalise,
 
 library
   import: common-options
@@ -80,21 +80,22 @@ library
   default-language: Haskell2010
   exposed-modules:
     BitPackC
+    Internal.HdlTest.UartMock
     Protocols.MemoryMap
-    Protocols.MemoryMap.TypeCollect
     Protocols.MemoryMap.Check
     Protocols.MemoryMap.Check.AbsAddress
     Protocols.MemoryMap.Check.Overlap
     Protocols.MemoryMap.FieldType
     Protocols.MemoryMap.Json
-    Internal.HdlTest.UartMock
+    Protocols.MemoryMap.TypeCollect
+
   build-depends:
-    base,
     aeson,
-    bytestring >= 0.10 && < 0.13,
-    constraints,
+    base,
+    bytestring >=0.10 && <0.13,
     clash-prelude,
     clash-protocols,
+    constraints,
     containers,
     template-haskell,
 
@@ -102,14 +103,14 @@ library
 executable hdl-test
   import: common-options
   main-is: app/HdlTest.hs
-  build-Depends:
+  build-depends:
+    aeson,
     base,
+    bytestring,
     clash-ghc,
     clash-prelude,
     clash-protocols,
     clash-protocols-memmap,
-    aeson,
-    bytestring,
     containers,
     directory,
 
@@ -118,13 +119,17 @@ executable example
   main-is: Example.hs
   hs-source-dirs: app
   default-language: Haskell2010
-  ghc-options: -threaded -rtsopts "-with-rtsopts=-M100M"
+  ghc-options:
+    -threaded
+    -rtsopts
+    -with-rtsopts=-M100M
+
   build-depends:
+    aeson,
     base,
+    bytestring,
     clash-prelude,
     clash-protocols,
     clash-protocols-memmap,
-    aeson,
-    bytestring,
     containers,
     directory,

--- a/clash-protocols-memmap/clash-protocols-memmap.cabal.license
+++ b/clash-protocols-memmap/clash-protocols-memmap.cabal.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 Google LLC
+
+SPDX-License-Identifier: CC0-1.0

--- a/clash-protocols-memmap/src/BitPackC.hs
+++ b/clash-protocols-memmap/src/BitPackC.hs
@@ -1,17 +1,18 @@
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE UndecidableInstances #-}
-{-# LANGUAGE MagicHash #-}
-{-# LANGUAGE UndecidableSuperClasses #-}
-
-{-# OPTIONS_GHC -fconstraint-solver-iterations=15 #-}
+-- SPDX-FileCopyrightText: 2024 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
 {-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE UndecidableSuperClasses #-}
+{-# OPTIONS_GHC -fconstraint-solver-iterations=15 #-}
 
 module BitPackC where
 
 import Clash.Prelude
 import GHC.Generics
-
 
 type SizeInBytes a = DivRU a 8
 type NextPowerOfTwo a = 2 ^ CLog 2 (Max 1 a)
@@ -22,18 +23,19 @@ type AlignmentPadding at needToGoTo = (needToGoTo - at `Mod` needToGoTo) `Mod` n
 
 type TagType nTags = SizeInBytes (CLog 2 nTags)
 
-
 toLittleEndian :: forall n. (KnownNat n) => BitVector (n * 8) -> BitVector (n * 8)
 toLittleEndian bits = pack bytes'
-  where
-    bytes = unpack bits :: Vec n (BitVector 8)
-    bytes' = reverse bytes
+ where
+  bytes = unpack bits :: Vec n (BitVector 8)
+  bytes' = reverse bytes
 
 fromLittleEndian :: forall n. (KnownNat n) => BitVector (n * 8) -> BitVector (n * 8)
 fromLittleEndian = toLittleEndian @n -- hehe
 
-class (KnownNat (ByteSizeC a), KnownNat (AlignmentC a), 1 <= AlignmentC a) =>
-    BitPackC a where
+class
+  (KnownNat (ByteSizeC a), KnownNat (AlignmentC a), 1 <= AlignmentC a) =>
+  BitPackC a
+  where
   type ByteSizeC a :: Nat
   type AlignmentC a :: Nat
 
@@ -48,31 +50,29 @@ class (KnownNat (ByteSizeC a), KnownNat (AlignmentC a), 1 <= AlignmentC a) =>
     a ->
     BitVector (ByteSizeC a * 8)
   packC val = bits
-    where
-      repr = from val
-      bits = gpackCTop repr
+   where
+    repr = from val
+    bits = gpackCTop repr
 
   default unpackC ::
     (Generic a, GBitPackCTop (Rep a), GByteSizeC (Rep a) ~ ByteSizeC a) =>
     BitVector (ByteSizeC a * 8) ->
     a
   unpackC bits = val
-    where
-      val = to repr
-      repr = gunpackCTop bits
-
+   where
+    val = to repr
+    repr = gunpackCTop bits
 
 instance (KnownNat n) => BitPackC (BitVector n) where
   type ByteSizeC (BitVector n) = NextPowerOfTwo (SizeInBytes n)
   type AlignmentC (BitVector n) = ByteSizeC (BitVector n)
 
   packC val = toLittleEndian $ case compareSNat (SNat @n) (SNat @(ByteSizeC (BitVector n) * 8)) of
-        SNatLE -> zeroExtend @_ @n @(ByteSizeC (BitVector n) * 8 - n) val
-        SNatGT -> deepErrorX "shouldn't happen"
+    SNatLE -> zeroExtend @_ @n @(ByteSizeC (BitVector n) * 8 - n) val
+    SNatGT -> deepErrorX "shouldn't happen"
   unpackC bits = case compareSNat (SNat @n) (SNat @(ByteSizeC (BitVector n) * 8)) of
-        SNatLE -> leToPlus @n @(ByteSizeC (BitVector n) * 8) truncateB (fromLittleEndian bits)
-        SNatGT -> deepErrorX "shouldn't happen"
-
+    SNatLE -> leToPlus @n @(ByteSizeC (BitVector n) * 8) truncateB (fromLittleEndian bits)
+    SNatGT -> deepErrorX "shouldn't happen"
 
 instance (KnownNat n) => BitPackC (Unsigned n) where
   type ByteSizeC (Unsigned n) = NextPowerOfTwo (SizeInBytes n)
@@ -86,12 +86,12 @@ instance (KnownNat n) => BitPackC (Signed n) where
   type AlignmentC (Signed n) = ByteSizeC (Signed n)
 
   packC val = toLittleEndian $ case compareSNat (SNat @n) (SNat @(ByteSizeC (Signed n) * 8)) of
-        SNatLE -> bitCoerce $ signExtend @_ @n @(ByteSizeC (Signed n) * 8 - n) val
-        SNatGT -> deepErrorX "shouldn't happen"
+    SNatLE -> bitCoerce $ signExtend @_ @n @(ByteSizeC (Signed n) * 8 - n) val
+    SNatGT -> deepErrorX "shouldn't happen"
   unpackC bits = case compareSNat (SNat @n) (SNat @(ByteSizeC (Signed n) * 8)) of
-        SNatLE -> leToPlus @n @(ByteSizeC (Signed n) * 8) $ bitCoerce (truncateB $ fromLittleEndian bits)
-        SNatGT -> deepErrorX "shouldn't happen"
-
+    SNatLE ->
+      leToPlus @n @(ByteSizeC (Signed n) * 8) $ bitCoerce (truncateB $ fromLittleEndian bits)
+    SNatGT -> deepErrorX "shouldn't happen"
 
 instance BitPackC Bool where
   type ByteSizeC Bool = 1
@@ -102,7 +102,6 @@ instance BitPackC Bool where
 
   unpackC 0 = False
   unpackC _ = True
-
 
 packCwithAlignPadding ::
   forall align a.
@@ -117,61 +116,63 @@ unpackCwithAlignPadding ::
   BitVector (ByteSizeCPaddedTo align a * 8) ->
   a
 unpackCwithAlignPadding bits = unpackC trimmed
-  where
-    (trimmed, _rest) = split bits
+ where
+  (trimmed, _rest) = split bits
 
-instance (KnownNat n, BitPackC a, Mod (ByteSizeC a) (AlignmentC a) <= AlignmentC a) =>
-    BitPackC (Vec n a) where
+instance
+  (KnownNat n, BitPackC a, Mod (ByteSizeC a) (AlignmentC a) <= AlignmentC a) =>
+  BitPackC (Vec n a)
+  where
   type ByteSizeC (Vec n a) = (ByteSizeCPaddedTo (AlignmentC a) a) * n
   type AlignmentC (Vec n a) = AlignmentC a
 
   packC val = pack $ packCwithAlignPadding @(AlignmentC a) <$> val
   unpackC bits = unpackCwithAlignPadding @(AlignmentC a) <$> unpack bits
 
+instance
+  ( BitPackC a
+  , Mod 1 (Max 1 (AlignmentC a)) <= 1
+  , Mod 1 (Max 1 (AlignmentC a)) <= Max 1 (AlignmentC a)
+  ) =>
+  BitPackC (Maybe a)
+instance
+  ( BitPackC a
+  , BitPackC b
+  , 1 <= Max (AlignmentC a) (AlignmentC b)
+  , Mod (ByteSizeC a) (AlignmentC b) <= AlignmentC b
+  , Mod (ByteSizeC a) (AlignmentC b) <= ByteSizeC a
+  , Mod 1 (Max (AlignmentC a) (AlignmentC b))
+      <= Max (AlignmentC a) (AlignmentC b)
+  , Mod 1 (Max (AlignmentC a) (AlignmentC b)) <= 1
+  ) =>
+  BitPackC (Either a b)
 
+instance
+  ( BitPackC a
+  , BitPackC b
+  , 1 <= Max (AlignmentC a) (AlignmentC b)
+  , Mod (ByteSizeC a) (AlignmentC b) <= AlignmentC b
+  , Mod (ByteSizeC a) (AlignmentC b) <= ByteSizeC a
+  ) =>
+  BitPackC (a, b)
 
-
-
-instance ( BitPackC a
-         , Mod 1 (Max 1 (AlignmentC a)) <= 1
-         , Mod 1 (Max 1 (AlignmentC a)) <= Max 1 (AlignmentC a)
-         ) => BitPackC (Maybe a)
-instance ( BitPackC a
-         , BitPackC b
-         , 1 <= Max (AlignmentC a) (AlignmentC b)
-         , Mod (ByteSizeC a) (AlignmentC b) <= AlignmentC b
-         , Mod (ByteSizeC a) (AlignmentC b) <= ByteSizeC a
-         , Mod 1 (Max (AlignmentC a) (AlignmentC b))
-                       <= Max (AlignmentC a) (AlignmentC b)
-         , Mod 1 (Max (AlignmentC a) (AlignmentC b)) <= 1
-         ) => BitPackC (Either a b)
-
-
-instance ( BitPackC a
-         , BitPackC b
-         , 1 <= Max (AlignmentC a) (AlignmentC b)
-         , Mod (ByteSizeC a) (AlignmentC b) <= AlignmentC b
-         , Mod (ByteSizeC a) (AlignmentC b) <= ByteSizeC a
-         ) => BitPackC (a, b)
-
-
-instance ( BitPackC a
-         , BitPackC b
-         , BitPackC c
-         , 1 <= Max (AlignmentC a) (AlignmentC b)
-         , 1 <= Max (AlignmentC b) (AlignmentC c)
-         , 1 <= Max (AlignmentC a) (Max (AlignmentC b) (AlignmentC c))
-         , Mod (ByteSizeC a) (AlignmentC b) <= AlignmentC b
-         , Mod (ByteSizeC a) (AlignmentC b) <= ByteSizeC a
-         , Mod (ByteSizeC b) (AlignmentC c) <= AlignmentC c
-         , Mod (ByteSizeC b) (AlignmentC c) <= ByteSizeC b
-         , Mod (ByteSizeC a) (Max (AlignmentC b) (AlignmentC c))
-                   <= Max (AlignmentC b) (AlignmentC c)
-         , Mod (ByteSizeC a) (Max (AlignmentC b) (AlignmentC c))
-                     <= ByteSizeC a
-         ) => BitPackC (a, b, c)
-
-
+instance
+  ( BitPackC a
+  , BitPackC b
+  , BitPackC c
+  , 1 <= Max (AlignmentC a) (AlignmentC b)
+  , 1 <= Max (AlignmentC b) (AlignmentC c)
+  , 1 <= Max (AlignmentC a) (Max (AlignmentC b) (AlignmentC c))
+  , Mod (ByteSizeC a) (AlignmentC b) <= AlignmentC b
+  , Mod (ByteSizeC a) (AlignmentC b) <= ByteSizeC a
+  , Mod (ByteSizeC b) (AlignmentC c) <= AlignmentC c
+  , Mod (ByteSizeC b) (AlignmentC c) <= ByteSizeC b
+  , Mod (ByteSizeC a) (Max (AlignmentC b) (AlignmentC c))
+      <= Max (AlignmentC b) (AlignmentC c)
+  , Mod (ByteSizeC a) (Max (AlignmentC b) (AlignmentC c))
+      <= ByteSizeC a
+  ) =>
+  BitPackC (a, b, c)
 
 class (KnownNat (GByteSizeC f), KnownNat (GAlignmentC f), 1 <= GAlignmentC f) => GBitPackCTop f where
   type GByteSizeC f :: Nat
@@ -180,7 +181,6 @@ class (KnownNat (GByteSizeC f), KnownNat (GAlignmentC f), 1 <= GAlignmentC f) =>
   gpackCTop :: f a -> BitVector (GByteSizeC f * 8)
   gunpackCTop :: BitVector (GByteSizeC f * 8) -> f a
 
-
 instance (GBitPackCTop inner) => GBitPackCTop (D1 m inner) where
   type GByteSizeC (D1 m inner) = GByteSizeC inner
   type GAlignmentC (D1 m inner) = GAlignmentC inner
@@ -188,8 +188,10 @@ instance (GBitPackCTop inner) => GBitPackCTop (D1 m inner) where
   gpackCTop (M1 x) = gpackCTop x
   gunpackCTop bits = M1 $ gunpackCTop bits
 
-instance (BitPackC inner) =>
- GBitPackCTop (Rec0 inner) where
+instance
+  (BitPackC inner) =>
+  GBitPackCTop (Rec0 inner)
+  where
   type GByteSizeC (Rec0 inner) = ByteSizeC inner
   type GAlignmentC (Rec0 inner) = AlignmentC inner
 
@@ -217,54 +219,61 @@ instance (GBitPackCFields inner) => GBitPackCTop (C1 m inner) where
   gpackCTop (M1 x) = gpackCfields x
   gunpackCTop bits = M1 $ gunpackCfields bits
 
-
-instance ( GBitPackCSums a
-         , GBitPackCSums b
-         , 1 <= Max (GSumAlignment a) (GSumAlignment b)
-         , (Mod
-              (Div
-                (CLog 2 (GNumConstructors a + GNumConstructors b) + 7) 8)
-              (Max (GSumAlignment a) (GSumAlignment b))
-            <= Div
-                  (CLog 2 (GNumConstructors a + GNumConstructors b) + 7) 8)
-        , (Mod
-                    (Div (CLog 2 (GNumConstructors a + GNumConstructors b) + 7) 8)
-                    (Max (GSumAlignment a) (GSumAlignment b))
-                  <= Max (GSumAlignment a) (GSumAlignment b))
-         )
-    => GBitPackCTop (a :+: b) where
-  type GByteSizeC (a :+: b) =
-        TagType (GNumConstructors (a :+: b)) +
-        AlignmentPadding
-          (TagType (GNumConstructors (a :+: b)))
-          (GSumAlignment (a :+: b)) +
-        GSumSize (a :+: b)
+instance
+  ( GBitPackCSums a
+  , GBitPackCSums b
+  , 1 <= Max (GSumAlignment a) (GSumAlignment b)
+  , ( Mod
+        ( Div
+            (CLog 2 (GNumConstructors a + GNumConstructors b) + 7)
+            8
+        )
+        (Max (GSumAlignment a) (GSumAlignment b))
+        <= Div
+            (CLog 2 (GNumConstructors a + GNumConstructors b) + 7)
+            8
+    )
+  , ( Mod
+        (Div (CLog 2 (GNumConstructors a + GNumConstructors b) + 7) 8)
+        (Max (GSumAlignment a) (GSumAlignment b))
+        <= Max (GSumAlignment a) (GSumAlignment b)
+    )
+  ) =>
+  GBitPackCTop (a :+: b)
+  where
+  type
+    GByteSizeC (a :+: b) =
+      TagType (GNumConstructors (a :+: b))
+        + AlignmentPadding
+            (TagType (GNumConstructors (a :+: b)))
+            (GSumAlignment (a :+: b))
+        + GSumSize (a :+: b)
   type GAlignmentC (a :+: b) = GSumAlignment (a :+: b)
 
   gpackCTop x = tag ++# padding ++# payload
-    where
-      tag' = gConstructorTag 0 x
-      tag :: BitVector (TagType (GNumConstructors (a :+: b)) * 8) = fromIntegral tag'
-      padding = 0
-      payload = gpackCsum x
+   where
+    tag' = gConstructorTag 0 x
+    tag :: BitVector (TagType (GNumConstructors (a :+: b)) * 8) = fromIntegral tag'
+    padding = 0
+    payload = gpackCsum x
   gunpackCTop bits = gunpackCsum (fromIntegral tag) payload
-    where
-      ( tag :: BitVector (TagType (GNumConstructors (a :+: b)) * 8)
-        , rest
-        ) = split bits
-      ( _padding
-        , payload :: BitVector (GSumSize (a :+: b) * 8)
-        ) = split rest
+   where
+    ( tag :: BitVector (TagType (GNumConstructors (a :+: b)) * 8)
+      , rest
+      ) = split bits
+    ( _padding
+      , payload :: BitVector (GSumSize (a :+: b) * 8)
+      ) = split rest
 
-
-
-class ( KnownNat (GNumConstructors f)
-      , KnownNat (GSumSize f)
-      , KnownNat (GSumAlignment f)
-      , 1 <= GSumAlignment f
-      , 1 <= GNumConstructors f
-      )
-    => GBitPackCSums f where
+class
+  ( KnownNat (GNumConstructors f)
+  , KnownNat (GSumSize f)
+  , KnownNat (GSumAlignment f)
+  , 1 <= GSumAlignment f
+  , 1 <= GNumConstructors f
+  ) =>
+  GBitPackCSums f
+  where
   type GNumConstructors f :: Nat
   type GSumSize f :: Nat
   type GSumAlignment f :: Nat
@@ -275,10 +284,10 @@ class ( KnownNat (GNumConstructors f)
 
   gunpackCsum :: Int -> BitVector (GSumSize f * 8) -> f a
 
-
-
-instance (GBitPackCSums a, GBitPackCSums b, 1 <= Max (GSumAlignment a) (GSumAlignment b))
-    => GBitPackCSums (a :+: b) where
+instance
+  (GBitPackCSums a, GBitPackCSums b, 1 <= Max (GSumAlignment a) (GSumAlignment b)) =>
+  GBitPackCSums (a :+: b)
+  where
   type GNumConstructors (a :+: b) = GNumConstructors a + GNumConstructors b
   type GSumSize (a :+: b) = Max (GSumSize a) (GSumSize b)
   type GSumAlignment (a :+: b) = Max (GSumAlignment a) (GSumAlignment b)
@@ -287,27 +296,22 @@ instance (GBitPackCSums a, GBitPackCSums b, 1 <= Max (GSumAlignment a) (GSumAlig
   gConstructorTag n (R1 b) = gConstructorTag (n + 1) b
 
   gpackCsum (L1 a) = gpackCsum a ++# padding
-    where
-      padding = 0 :: BitVector ((Max (GSumSize a) (GSumSize b) - GSumSize a) * 8)
-
+   where
+    padding = 0 :: BitVector ((Max (GSumSize a) (GSumSize b) - GSumSize a) * 8)
   gpackCsum (R1 b) = gpackCsum b ++# padding
-      where
-        padding = 0 :: BitVector ((Max (GSumSize a) (GSumSize b) - GSumSize b) * 8)
+   where
+    padding = 0 :: BitVector ((Max (GSumSize a) (GSumSize b) - GSumSize b) * 8)
 
   gunpackCsum 0 bits = L1 $ gunpackCsum 0 bits'
-    where
-      ( bits'
-        , _padding :: BitVector ((Max (GSumSize a) (GSumSize b) - GSumSize a) * 8)
-        ) = split bits
+   where
+    ( bits'
+      , _padding :: BitVector ((Max (GSumSize a) (GSumSize b) - GSumSize a) * 8)
+      ) = split bits
   gunpackCsum n bits = R1 $ gunpackCsum (n - 1) bits'
-    where
-      ( bits'
-        , _padding :: BitVector ((Max (GSumSize a) (GSumSize b) - GSumSize b) * 8)
-        ) = split bits
-
-
-
-
+   where
+    ( bits'
+      , _padding :: BitVector ((Max (GSumSize a) (GSumSize b) - GSumSize b) * 8)
+      ) = split bits
 
 instance (GBitPackCFields inner) => GBitPackCSums (C1 m inner) where
   type GNumConstructors (C1 m inner) = 1
@@ -319,16 +323,15 @@ instance (GBitPackCFields inner) => GBitPackCSums (C1 m inner) where
   gpackCsum (M1 n) = gpackCfields n
   gunpackCsum _ bits = M1 $ gunpackCfields bits
 
-
-
-class (KnownNat (GFieldSize f), KnownNat (GFieldAlignment f), 1 <= GFieldAlignment f) =>
-    GBitPackCFields f where
+class
+  (KnownNat (GFieldSize f), KnownNat (GFieldAlignment f), 1 <= GFieldAlignment f) =>
+  GBitPackCFields f
+  where
   type GFieldSize f :: Nat
   type GFieldAlignment f :: Nat
 
   gpackCfields :: f a -> BitVector (GFieldSize f * 8)
   gunpackCfields :: BitVector (GFieldSize f * 8) -> f a
-
 
 instance GBitPackCFields U1 where
   type GFieldSize U1 = 0
@@ -344,24 +347,29 @@ instance (GBitPackCTop inner) => GBitPackCFields (S1 m inner) where
   gpackCfields (M1 x) = gpackCTop x
   gunpackCfields bits = M1 $ gunpackCTop bits
 
-
-instance ( GBitPackCFields a
-         , GBitPackCFields b
-         , 1 <= Max (GFieldAlignment a) (GFieldAlignment b)
-         , Mod (GFieldSize a) (GFieldAlignment b) <= GFieldAlignment b
-         , (Mod (GFieldSize a) (GFieldAlignment b)
-                   <= GFieldSize a)
-         )
-    => GBitPackCFields (a :*: b) where
-  type GFieldSize (a :*: b) = GFieldSize a + AlignmentPadding (GFieldSize a) (GFieldAlignment b) + GFieldSize b
+instance
+  ( GBitPackCFields a
+  , GBitPackCFields b
+  , 1 <= Max (GFieldAlignment a) (GFieldAlignment b)
+  , Mod (GFieldSize a) (GFieldAlignment b) <= GFieldAlignment b
+  , ( Mod (GFieldSize a) (GFieldAlignment b)
+        <= GFieldSize a
+    )
+  ) =>
+  GBitPackCFields (a :*: b)
+  where
+  type
+    GFieldSize (a :*: b) =
+      GFieldSize a + AlignmentPadding (GFieldSize a) (GFieldAlignment b) + GFieldSize b
   type GFieldAlignment (a :*: b) = Max (GFieldAlignment a) (GFieldAlignment b)
 
   gpackCfields (a :*: b) = gpackCfields a ++# 0 ++# gpackCfields b
 
   gunpackCfields bits = gunpackCfields a' :*: gunpackCfields b'
-    where
-      ( a' :: BitVector (GFieldSize a * 8)
-        , rest) = split bits
-      ( _padding
-        , b' :: BitVector (GFieldSize b * 8)
-        ) = split rest
+   where
+    ( a' :: BitVector (GFieldSize a * 8)
+      , rest
+      ) = split bits
+    ( _padding
+      , b' :: BitVector (GFieldSize b * 8)
+      ) = split rest

--- a/clash-protocols-memmap/src/BitPackC.hs
+++ b/clash-protocols-memmap/src/BitPackC.hs
@@ -1,0 +1,367 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE UndecidableSuperClasses #-}
+
+{-# OPTIONS_GHC -fconstraint-solver-iterations=15 #-}
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE FlexibleInstances #-}
+
+module BitPackC where
+
+import Clash.Prelude
+import GHC.Generics
+
+
+type SizeInBytes a = DivRU a 8
+type NextPowerOfTwo a = 2 ^ CLog 2 (Max 1 a)
+
+type ByteSizeCPaddedTo n a = ByteSizeC a + (n - Mod (ByteSizeC a) n)
+
+type AlignmentPadding at needToGoTo = (needToGoTo - at `Mod` needToGoTo) `Mod` needToGoTo
+
+type TagType nTags = SizeInBytes (CLog 2 nTags)
+
+
+toLittleEndian :: forall n. (KnownNat n) => BitVector (n * 8) -> BitVector (n * 8)
+toLittleEndian bits = pack bytes'
+  where
+    bytes = unpack bits :: Vec n (BitVector 8)
+    bytes' = reverse bytes
+
+fromLittleEndian :: forall n. (KnownNat n) => BitVector (n * 8) -> BitVector (n * 8)
+fromLittleEndian = toLittleEndian @n -- hehe
+
+class (KnownNat (ByteSizeC a), KnownNat (AlignmentC a), 1 <= AlignmentC a) =>
+    BitPackC a where
+  type ByteSizeC a :: Nat
+  type AlignmentC a :: Nat
+
+  type ByteSizeC a = GByteSizeC (Rep a)
+  type AlignmentC a = GAlignmentC (Rep a)
+
+  packC :: a -> BitVector (ByteSizeC a * 8)
+  unpackC :: BitVector (ByteSizeC a * 8) -> a
+
+  default packC ::
+    (Generic a, GBitPackCTop (Rep a), GByteSizeC (Rep a) ~ ByteSizeC a) =>
+    a ->
+    BitVector (ByteSizeC a * 8)
+  packC val = bits
+    where
+      repr = from val
+      bits = gpackCTop repr
+
+  default unpackC ::
+    (Generic a, GBitPackCTop (Rep a), GByteSizeC (Rep a) ~ ByteSizeC a) =>
+    BitVector (ByteSizeC a * 8) ->
+    a
+  unpackC bits = val
+    where
+      val = to repr
+      repr = gunpackCTop bits
+
+
+instance (KnownNat n) => BitPackC (BitVector n) where
+  type ByteSizeC (BitVector n) = NextPowerOfTwo (SizeInBytes n)
+  type AlignmentC (BitVector n) = ByteSizeC (BitVector n)
+
+  packC val = toLittleEndian $ case compareSNat (SNat @n) (SNat @(ByteSizeC (BitVector n) * 8)) of
+        SNatLE -> zeroExtend @_ @n @(ByteSizeC (BitVector n) * 8 - n) val
+        SNatGT -> deepErrorX "shouldn't happen"
+  unpackC bits = case compareSNat (SNat @n) (SNat @(ByteSizeC (BitVector n) * 8)) of
+        SNatLE -> leToPlus @n @(ByteSizeC (BitVector n) * 8) truncateB (fromLittleEndian bits)
+        SNatGT -> deepErrorX "shouldn't happen"
+
+
+instance (KnownNat n) => BitPackC (Unsigned n) where
+  type ByteSizeC (Unsigned n) = NextPowerOfTwo (SizeInBytes n)
+  type AlignmentC (Unsigned n) = ByteSizeC (Unsigned n)
+
+  packC val = packC (bitCoerce val :: BitVector n)
+  unpackC bits = bitCoerce (unpackC bits :: BitVector n)
+
+instance (KnownNat n) => BitPackC (Signed n) where
+  type ByteSizeC (Signed n) = NextPowerOfTwo (SizeInBytes n)
+  type AlignmentC (Signed n) = ByteSizeC (Signed n)
+
+  packC val = toLittleEndian $ case compareSNat (SNat @n) (SNat @(ByteSizeC (Signed n) * 8)) of
+        SNatLE -> bitCoerce $ signExtend @_ @n @(ByteSizeC (Signed n) * 8 - n) val
+        SNatGT -> deepErrorX "shouldn't happen"
+  unpackC bits = case compareSNat (SNat @n) (SNat @(ByteSizeC (Signed n) * 8)) of
+        SNatLE -> leToPlus @n @(ByteSizeC (Signed n) * 8) $ bitCoerce (truncateB $ fromLittleEndian bits)
+        SNatGT -> deepErrorX "shouldn't happen"
+
+
+instance BitPackC Bool where
+  type ByteSizeC Bool = 1
+  type AlignmentC Bool = 1
+
+  packC False = 0
+  packC True = 1
+
+  unpackC 0 = False
+  unpackC _ = True
+
+
+packCwithAlignPadding ::
+  forall align a.
+  (KnownNat align, BitPackC a, 1 <= align, Mod (ByteSizeC a) align <= align) =>
+  a ->
+  BitVector (ByteSizeCPaddedTo align a * 8)
+packCwithAlignPadding val = packC val ++# 0
+
+unpackCwithAlignPadding ::
+  forall align a.
+  (KnownNat align, BitPackC a, 1 <= align, Mod (ByteSizeC a) align <= align) =>
+  BitVector (ByteSizeCPaddedTo align a * 8) ->
+  a
+unpackCwithAlignPadding bits = unpackC trimmed
+  where
+    (trimmed, _rest) = split bits
+
+instance (KnownNat n, BitPackC a, Mod (ByteSizeC a) (AlignmentC a) <= AlignmentC a) =>
+    BitPackC (Vec n a) where
+  type ByteSizeC (Vec n a) = (ByteSizeCPaddedTo (AlignmentC a) a) * n
+  type AlignmentC (Vec n a) = AlignmentC a
+
+  packC val = pack $ packCwithAlignPadding @(AlignmentC a) <$> val
+  unpackC bits = unpackCwithAlignPadding @(AlignmentC a) <$> unpack bits
+
+
+
+
+
+instance ( BitPackC a
+         , Mod 1 (Max 1 (AlignmentC a)) <= 1
+         , Mod 1 (Max 1 (AlignmentC a)) <= Max 1 (AlignmentC a)
+         ) => BitPackC (Maybe a)
+instance ( BitPackC a
+         , BitPackC b
+         , 1 <= Max (AlignmentC a) (AlignmentC b)
+         , Mod (ByteSizeC a) (AlignmentC b) <= AlignmentC b
+         , Mod (ByteSizeC a) (AlignmentC b) <= ByteSizeC a
+         , Mod 1 (Max (AlignmentC a) (AlignmentC b))
+                       <= Max (AlignmentC a) (AlignmentC b)
+         , Mod 1 (Max (AlignmentC a) (AlignmentC b)) <= 1
+         ) => BitPackC (Either a b)
+
+
+instance ( BitPackC a
+         , BitPackC b
+         , 1 <= Max (AlignmentC a) (AlignmentC b)
+         , Mod (ByteSizeC a) (AlignmentC b) <= AlignmentC b
+         , Mod (ByteSizeC a) (AlignmentC b) <= ByteSizeC a
+         ) => BitPackC (a, b)
+
+
+instance ( BitPackC a
+         , BitPackC b
+         , BitPackC c
+         , 1 <= Max (AlignmentC a) (AlignmentC b)
+         , 1 <= Max (AlignmentC b) (AlignmentC c)
+         , 1 <= Max (AlignmentC a) (Max (AlignmentC b) (AlignmentC c))
+         , Mod (ByteSizeC a) (AlignmentC b) <= AlignmentC b
+         , Mod (ByteSizeC a) (AlignmentC b) <= ByteSizeC a
+         , Mod (ByteSizeC b) (AlignmentC c) <= AlignmentC c
+         , Mod (ByteSizeC b) (AlignmentC c) <= ByteSizeC b
+         , Mod (ByteSizeC a) (Max (AlignmentC b) (AlignmentC c))
+                   <= Max (AlignmentC b) (AlignmentC c)
+         , Mod (ByteSizeC a) (Max (AlignmentC b) (AlignmentC c))
+                     <= ByteSizeC a
+         ) => BitPackC (a, b, c)
+
+
+
+class (KnownNat (GByteSizeC f), KnownNat (GAlignmentC f), 1 <= GAlignmentC f) => GBitPackCTop f where
+  type GByteSizeC f :: Nat
+  type GAlignmentC f :: Nat
+
+  gpackCTop :: f a -> BitVector (GByteSizeC f * 8)
+  gunpackCTop :: BitVector (GByteSizeC f * 8) -> f a
+
+
+instance (GBitPackCTop inner) => GBitPackCTop (D1 m inner) where
+  type GByteSizeC (D1 m inner) = GByteSizeC inner
+  type GAlignmentC (D1 m inner) = GAlignmentC inner
+
+  gpackCTop (M1 x) = gpackCTop x
+  gunpackCTop bits = M1 $ gunpackCTop bits
+
+instance (BitPackC inner) =>
+ GBitPackCTop (Rec0 inner) where
+  type GByteSizeC (Rec0 inner) = ByteSizeC inner
+  type GAlignmentC (Rec0 inner) = AlignmentC inner
+
+  gpackCTop (K1 x) = packC x
+  gunpackCTop bits = K1 $ unpackC bits
+
+instance GBitPackCTop U1 where
+  type GByteSizeC U1 = 0
+  type GAlignmentC U1 = 1
+
+  gpackCTop U1 = 0
+  gunpackCTop _bits = U1
+
+instance GBitPackCTop V1 where
+  type GByteSizeC V1 = 0
+  type GAlignmentC V1 = 1
+
+  gpackCTop _ = 0
+  gunpackCTop _bits = error "can't construct a value of type V1"
+
+instance (GBitPackCFields inner) => GBitPackCTop (C1 m inner) where
+  type GByteSizeC (C1 m inner) = GFieldSize inner
+  type GAlignmentC (C1 m inner) = GFieldAlignment inner
+
+  gpackCTop (M1 x) = gpackCfields x
+  gunpackCTop bits = M1 $ gunpackCfields bits
+
+
+instance ( GBitPackCSums a
+         , GBitPackCSums b
+         , 1 <= Max (GSumAlignment a) (GSumAlignment b)
+         , (Mod
+              (Div
+                (CLog 2 (GNumConstructors a + GNumConstructors b) + 7) 8)
+              (Max (GSumAlignment a) (GSumAlignment b))
+            <= Div
+                  (CLog 2 (GNumConstructors a + GNumConstructors b) + 7) 8)
+        , (Mod
+                    (Div (CLog 2 (GNumConstructors a + GNumConstructors b) + 7) 8)
+                    (Max (GSumAlignment a) (GSumAlignment b))
+                  <= Max (GSumAlignment a) (GSumAlignment b))
+         )
+    => GBitPackCTop (a :+: b) where
+  type GByteSizeC (a :+: b) =
+        TagType (GNumConstructors (a :+: b)) +
+        AlignmentPadding
+          (TagType (GNumConstructors (a :+: b)))
+          (GSumAlignment (a :+: b)) +
+        GSumSize (a :+: b)
+  type GAlignmentC (a :+: b) = GSumAlignment (a :+: b)
+
+  gpackCTop x = tag ++# padding ++# payload
+    where
+      tag' = gConstructorTag 0 x
+      tag :: BitVector (TagType (GNumConstructors (a :+: b)) * 8) = fromIntegral tag'
+      padding = 0
+      payload = gpackCsum x
+  gunpackCTop bits = gunpackCsum (fromIntegral tag) payload
+    where
+      ( tag :: BitVector (TagType (GNumConstructors (a :+: b)) * 8)
+        , rest
+        ) = split bits
+      ( _padding
+        , payload :: BitVector (GSumSize (a :+: b) * 8)
+        ) = split rest
+
+
+
+class ( KnownNat (GNumConstructors f)
+      , KnownNat (GSumSize f)
+      , KnownNat (GSumAlignment f)
+      , 1 <= GSumAlignment f
+      , 1 <= GNumConstructors f
+      )
+    => GBitPackCSums f where
+  type GNumConstructors f :: Nat
+  type GSumSize f :: Nat
+  type GSumAlignment f :: Nat
+
+  gConstructorTag :: Int -> f a -> Int
+
+  gpackCsum :: f a -> BitVector (GSumSize f * 8)
+
+  gunpackCsum :: Int -> BitVector (GSumSize f * 8) -> f a
+
+
+
+instance (GBitPackCSums a, GBitPackCSums b, 1 <= Max (GSumAlignment a) (GSumAlignment b))
+    => GBitPackCSums (a :+: b) where
+  type GNumConstructors (a :+: b) = GNumConstructors a + GNumConstructors b
+  type GSumSize (a :+: b) = Max (GSumSize a) (GSumSize b)
+  type GSumAlignment (a :+: b) = Max (GSumAlignment a) (GSumAlignment b)
+
+  gConstructorTag n (L1 _a) = n
+  gConstructorTag n (R1 b) = gConstructorTag (n + 1) b
+
+  gpackCsum (L1 a) = gpackCsum a ++# padding
+    where
+      padding = 0 :: BitVector ((Max (GSumSize a) (GSumSize b) - GSumSize a) * 8)
+
+  gpackCsum (R1 b) = gpackCsum b ++# padding
+      where
+        padding = 0 :: BitVector ((Max (GSumSize a) (GSumSize b) - GSumSize b) * 8)
+
+  gunpackCsum 0 bits = L1 $ gunpackCsum 0 bits'
+    where
+      ( bits'
+        , _padding :: BitVector ((Max (GSumSize a) (GSumSize b) - GSumSize a) * 8)
+        ) = split bits
+  gunpackCsum n bits = R1 $ gunpackCsum (n - 1) bits'
+    where
+      ( bits'
+        , _padding :: BitVector ((Max (GSumSize a) (GSumSize b) - GSumSize b) * 8)
+        ) = split bits
+
+
+
+
+
+instance (GBitPackCFields inner) => GBitPackCSums (C1 m inner) where
+  type GNumConstructors (C1 m inner) = 1
+  type GSumSize (C1 m inner) = GFieldSize inner
+  type GSumAlignment (C1 m inner) = GFieldAlignment inner
+
+  gConstructorTag n _ = n
+
+  gpackCsum (M1 n) = gpackCfields n
+  gunpackCsum _ bits = M1 $ gunpackCfields bits
+
+
+
+class (KnownNat (GFieldSize f), KnownNat (GFieldAlignment f), 1 <= GFieldAlignment f) =>
+    GBitPackCFields f where
+  type GFieldSize f :: Nat
+  type GFieldAlignment f :: Nat
+
+  gpackCfields :: f a -> BitVector (GFieldSize f * 8)
+  gunpackCfields :: BitVector (GFieldSize f * 8) -> f a
+
+
+instance GBitPackCFields U1 where
+  type GFieldSize U1 = 0
+  type GFieldAlignment U1 = 1
+
+  gpackCfields U1 = 0
+  gunpackCfields _ = U1
+
+instance (GBitPackCTop inner) => GBitPackCFields (S1 m inner) where
+  type GFieldSize (S1 m inner) = GByteSizeC inner
+  type GFieldAlignment (S1 m inner) = GAlignmentC inner
+
+  gpackCfields (M1 x) = gpackCTop x
+  gunpackCfields bits = M1 $ gunpackCTop bits
+
+
+instance ( GBitPackCFields a
+         , GBitPackCFields b
+         , 1 <= Max (GFieldAlignment a) (GFieldAlignment b)
+         , Mod (GFieldSize a) (GFieldAlignment b) <= GFieldAlignment b
+         , (Mod (GFieldSize a) (GFieldAlignment b)
+                   <= GFieldSize a)
+         )
+    => GBitPackCFields (a :*: b) where
+  type GFieldSize (a :*: b) = GFieldSize a + AlignmentPadding (GFieldSize a) (GFieldAlignment b) + GFieldSize b
+  type GFieldAlignment (a :*: b) = Max (GFieldAlignment a) (GFieldAlignment b)
+
+  gpackCfields (a :*: b) = gpackCfields a ++# 0 ++# gpackCfields b
+
+  gunpackCfields bits = gunpackCfields a' :*: gunpackCfields b'
+    where
+      ( a' :: BitVector (GFieldSize a * 8)
+        , rest) = split bits
+      ( _padding
+        , b' :: BitVector (GFieldSize b * 8)
+        ) = split rest

--- a/clash-protocols-memmap/src/BitPackC.hs
+++ b/clash-protocols-memmap/src/BitPackC.hs
@@ -32,6 +32,16 @@ toLittleEndian bits = pack bytes'
 fromLittleEndian :: forall n. (KnownNat n) => BitVector (n * 8) -> BitVector (n * 8)
 fromLittleEndian = toLittleEndian @n -- hehe
 
+{- | Typeclass that can be implemented (or derived) to enable C-FFI safe
+representation of Haskell types.
+
+This can be derived automatically as long as 'Generic' is implemented for the
+type.
+Currently there is a high likelihood that more complex types need an unusual
+amount of constraints on the instance. Ideally this won't be necessary when
+@ghc-typelits-extra@ gets extended to automatically discharge those
+constraints.
+-}
 class
   (KnownNat (ByteSizeC a), KnownNat (AlignmentC a), 1 <= AlignmentC a) =>
   BitPackC a

--- a/clash-protocols-memmap/src/Internal/HdlTest/UartMock.hs
+++ b/clash-protocols-memmap/src/Internal/HdlTest/UartMock.hs
@@ -2,23 +2,44 @@
 --
 -- SPDX-License-Identifier: Apache-2.0
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE UndecidableInstances #-}
+--
+{-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
+{-# OPTIONS_GHC -Wno-unused-matches #-}
 -- {-# OPTIONS -fplugin-opt=Protocols.Plugin:debug #-}
 {-# OPTIONS_GHC -fconstraint-solver-iterations=20 #-}
 {-# OPTIONS_GHC -fplugin Protocols.Plugin #-}
 
+{- | Internal module used to test whether memory mapped circuits generate
+valid HDL.
+
+This contains mostly non-sense code to test various features.
+-}
 module Internal.HdlTest.UartMock where
 
 import Clash.Annotations.TH
 import Clash.Prelude
-import Protocols (Circuit, toSignals)
-import Protocols.Wishbone (Wishbone, WishboneM2S, WishboneMode (Standard), WishboneS2M)
 
-import BitPackC (BitPackC (AlignmentC))
-import GHC.Stack (HasCallStack)
+import qualified Data.Map.Strict as Map
+import Data.Maybe (fromMaybe)
+
+import Protocols (Circuit (..), toSignals)
+import Protocols.Wishbone (
+  Wishbone,
+  WishboneM2S (..),
+  WishboneMode (Standard),
+  WishboneS2M (..),
+  emptyWishboneM2S,
+  emptyWishboneS2M,
+ )
+
+import BitPackC
+import GHC.Stack (HasCallStack, callStack, getCallStack)
 import Protocols.MemoryMap
-import Protocols.MemoryMap.FieldType hiding (description, name)
+import Protocols.MemoryMap.FieldType hiding (name)
 
 someCircuit ::
   (HasCallStack, HiddenClockResetEnable dom, HasCallStack) =>
@@ -106,6 +127,359 @@ memory instanceName absAddr access' size' = circuit $ \master -> do
   let name' = Name{name = "Memory_" <> instanceName, description = ""}
   [reg] <- deviceDefinition instanceName absAddr name' -< master
   deviceVecField' "memory" access' 0x0 size' (0 :: BitVector 8) -< reg
+
+--
+-- example components
+--
+
+deviceDef' ::
+  forall dom a n addrWidth.
+  Circuit
+    (MemoryMapped (Wishbone dom 'Standard addrWidth a))
+    (Vec n (Wishbone dom 'Standard addrWidth ()))
+deviceDef' = undefined
+
+deviceDefinition ::
+  forall dom a n addrWidth.
+  ( HasCallStack
+  , ToFieldType a
+  , NFDataX a
+  , KnownNat (BitSize a)
+  , KnownNat n
+  , KnownNat addrWidth
+  , HiddenClockResetEnable dom
+  , 1 <= n
+  ) =>
+  String ->
+  AbsoluteAddress ->
+  Name ->
+  Circuit
+    (MemoryMapped (Wishbone dom 'Standard addrWidth a))
+    ( Vec
+        n
+        ( BackwardAnnotated
+            (BitVector addrWidth, SimOnly (NamedLoc Register))
+            (Wishbone dom 'Standard addrWidth a)
+        )
+    )
+deviceDefinition instanceName absAddr' deviceDesc = Circuit $ \(m2s, bwds) ->
+  let
+    annotations = fst <$> bwds
+    s2ms = bundle $ snd <$> bwds
+    addrs = fst <$> annotations
+    regs = (\(_, SimOnly x) -> x) <$> annotations
+    memMap =
+      MemoryMap
+        { deviceDefs = Map.singleton (name deviceDesc) definition
+        , tree = DeviceInstance instanceLoc absAddr' instanceName (name deviceDesc)
+        }
+    definition =
+      DeviceDefinition
+        { deviceName = deviceDesc
+        , registers = toList regs
+        , defLocation = defLoc
+        }
+
+    (s2m, m2ss) = go addrs m2s s2ms
+   in
+    ((SimOnly memMap, s2m), m2ss)
+ where
+  ((_, defLoc) : (_, instanceLoc) : _) = getCallStack callStack
+
+  go addrs m2s s2ms = (s2m, m2ss)
+   where
+    active :: Signal dom (Maybe (Index n))
+    active = register Nothing newActive
+    (unbundle -> (s2m, unbundle -> m2ss, newActive)) = inner (addrRange addrs) <$> m2s <*> s2ms <*> active
+
+  inner ranges m2s@WishboneM2S{..} s2ms active
+    | not (busCycle && strobe) = (emptyWishboneS2M, m2ss, Nothing)
+    -- no existing transaction, no new transaction
+    -- => ERROR, we're in a cycle but couldn't find a subordinate that matches the address
+    -- which shouldn't ever happen, but if it does it should be an error!
+    | Nothing <- active
+    , Nothing <- newActive =
+        (emptyWishboneS2M{err = True}, m2ss, Nothing)
+    -- no previous transaction, but a new one!
+    | Nothing <- active
+    , Just idx <- newActive =
+        (s2ms !! idx, replace idx m2s m2ss, Just idx)
+    -- have an existing transaction, use that one
+    | Just idx <- active = (s2ms !! idx, replace idx m2s m2ss, active)
+   where
+    m2ss = repeat emptyWishboneM2S
+    newActive = findIndex (\(start, end) -> addr >= start && addr < end) ranges
+
+deviceReg' ::
+  forall dom a addrWidth.
+  ( HasCallStack
+  , ToFieldType a
+  , NFDataX a
+  , BitPackC a
+  , KnownNat addrWidth
+  , HiddenClockResetEnable dom
+  ) =>
+  String ->
+  Access ->
+  BitVector addrWidth ->
+  a ->
+  Circuit
+    ( BackwardAnnotated
+        (BitVector addrWidth, SimOnly (NamedLoc Register))
+        (Wishbone dom 'Standard addrWidth (BitVector 32))
+    )
+    ()
+deviceReg' name' access' addr' def' = Circuit $ \(m2s0, ()) ->
+  (((addr', SimOnly reg'), go m2s0), ())
+ where
+  defBytes :: BitVector 32
+  defBytes = resize $ packC def'
+
+  (_, loc) : _ = getCallStack callStack
+  reg' =
+    ( Name
+        { name = name'
+        , description = ""
+        }
+    , loc
+    , Register
+        { access = access'
+        , address = toInteger addr'
+        , fieldType = toFieldType @a
+        , fieldSize = snatToInteger (SNat @(ByteSizeC a))
+        , reset = Nothing
+        }
+    )
+  go m2s = s2m
+   where
+    registerVal = register defBytes $ fromMaybe <$> registerVal <*> nextVal
+    (unbundle -> (s2m, nextVal)) = inner <$> m2s <*> registerVal
+
+  inner WishboneM2S{..} val
+    | not (busCycle && strobe) = (emptyWishboneS2M, Nothing)
+    | writeEnable = (emptyWishboneS2M{acknowledge = True}, Just writeData)
+    | otherwise = ((emptyWishboneS2M @a){acknowledge = True, readData = 0}, Nothing)
+
+deviceReg ::
+  forall dom a addrWidth.
+  ( HasCallStack
+  , ToFieldType a
+  , NFDataX a
+  , KnownNat addrWidth
+  , HiddenClockResetEnable dom
+  ) =>
+  String ->
+  Access ->
+  BitVector addrWidth ->
+  a ->
+  Circuit
+    ( BackwardAnnotated
+        (BitVector addrWidth, SimOnly (NamedLoc Register))
+        (Wishbone dom 'Standard addrWidth a)
+    )
+    ()
+deviceReg name' access' addr' def' = Circuit $ \(m2s0, ()) ->
+  (((addr', SimOnly reg'), go m2s0), ())
+ where
+  (_, loc) : _ = getCallStack callStack
+  reg' =
+    ( Name
+        { name = name'
+        , description = ""
+        }
+    , loc
+    , Register
+        { access = access'
+        , address = toInteger addr'
+        , fieldType = toFieldType @a
+        , fieldSize = error "use deviceReg' with BitPackC"
+        , reset = Nothing
+        }
+    )
+  go m2s = s2m
+   where
+    registerVal = register def' $ fromMaybe <$> registerVal <*> nextVal
+    (unbundle -> (s2m, nextVal)) = inner <$> m2s <*> registerVal
+
+  inner WishboneM2S{..} val
+    | not (busCycle && strobe) = (emptyWishboneS2M, Nothing)
+    | writeEnable = (emptyWishboneS2M{acknowledge = True}, Just writeData)
+    | otherwise = ((emptyWishboneS2M @a){acknowledge = True, readData = val}, Nothing)
+
+deviceVecField' ::
+  forall dom n a addrWidth.
+  ( HasCallStack
+  , KnownNat n
+  , ToFieldType a
+  , NFDataX a
+  , BitPackC a
+  , BitPackC (Vec n a)
+  , KnownNat addrWidth
+  , HiddenClockResetEnable dom
+  ) =>
+  String ->
+  Access ->
+  BitVector addrWidth ->
+  SNat n ->
+  a ->
+  Circuit
+    ( BackwardAnnotated
+        (BitVector addrWidth, SimOnly (NamedLoc Register))
+        (Wishbone dom 'Standard addrWidth (BitVector 32))
+    )
+    ()
+deviceVecField' name' access' addr' _size def' = Circuit $ \(m2s0, ()) ->
+  (((addr', SimOnly reg'), go m2s0), ())
+ where
+  (_, loc) : _ = getCallStack callStack
+
+  defBytes :: BitVector 32
+  defBytes = resize $ packC def'
+
+  reg' =
+    ( Name
+        { name = name'
+        , description = ""
+        }
+    , loc
+    , Register
+        { access = access'
+        , address = toInteger addr'
+        , fieldType = toFieldType @(Vec n a)
+        , fieldSize = snatToInteger (SNat @(ByteSizeC (Vec n a)))
+        , reset = Nothing
+        }
+    )
+  go m2s = s2m
+   where
+    registerVal = register defBytes $ fromMaybe <$> registerVal <*> nextVal
+    (unbundle -> (s2m, nextVal)) = inner <$> m2s <*> registerVal
+
+  inner WishboneM2S{..} val
+    | not (busCycle && strobe) = (emptyWishboneS2M, Nothing)
+    | writeEnable = (emptyWishboneS2M{acknowledge = True}, Just writeData)
+    | otherwise = ((emptyWishboneS2M @a){acknowledge = True, readData = val}, Nothing)
+
+deviceVecField ::
+  forall dom n a addrWidth.
+  ( HasCallStack
+  , KnownNat n
+  , ToFieldType a
+  , NFDataX a
+  , KnownNat addrWidth
+  , HiddenClockResetEnable dom
+  ) =>
+  String ->
+  Access ->
+  BitVector addrWidth ->
+  SNat n ->
+  a ->
+  Circuit
+    ( BackwardAnnotated
+        (BitVector addrWidth, SimOnly (NamedLoc Register))
+        (Wishbone dom 'Standard addrWidth a)
+    )
+    ()
+deviceVecField name' access' addr' _size def' = Circuit $ \(m2s0, ()) ->
+  (((addr', SimOnly reg'), go m2s0), ())
+ where
+  (_, loc) : _ = getCallStack callStack
+  reg' =
+    ( Name
+        { name = name'
+        , description = ""
+        }
+    , loc
+    , Register
+        { access = access'
+        , address = toInteger addr'
+        , fieldType = toFieldType @(Vec n a)
+        , fieldSize = error "use deviceVecField' with BitPackC"
+        , reset = Nothing
+        }
+    )
+  go m2s = s2m
+   where
+    registerVal = register def' $ fromMaybe <$> registerVal <*> nextVal
+    (unbundle -> (s2m, nextVal)) = inner <$> m2s <*> registerVal
+
+  inner WishboneM2S{..} val
+    | not (busCycle && strobe) = (emptyWishboneS2M, Nothing)
+    | writeEnable = (emptyWishboneS2M{acknowledge = True}, Just writeData)
+    | otherwise = ((emptyWishboneS2M @a){acknowledge = True, readData = val}, Nothing)
+
+interconnect ::
+  forall dom addrWidth a n.
+  ( HasCallStack
+  , KnownNat n
+  , KnownNat addrWidth
+  , NFDataX a
+  , KnownNat (BitSize a)
+  , (CLog 2 n <= addrWidth)
+  , 1 <= n
+  , KnownNat (addrWidth - CLog 2 n)
+  ) =>
+  AbsoluteAddress ->
+  Circuit
+    (MemoryMapped (Wishbone dom 'Standard addrWidth a))
+    ( Vec
+        n
+        ( BackwardAnnotated
+            (BitVector (CLog 2 n), SimOnly MemoryMap)
+            (Wishbone dom 'Standard (addrWidth - CLog 2 n) a)
+        )
+    )
+interconnect absAddr' = Circuit go
+ where
+  (_, loc) : _ = getCallStack callStack
+
+  go ::
+    ( Signal dom (WishboneM2S addrWidth (Div (BitSize a + 7) 8) a)
+    , Vec n ((BitVector (CLog 2 n), SimOnly MemoryMap), Signal dom (WishboneS2M a))
+    ) ->
+    ( (SimOnly MemoryMap, Signal dom (WishboneS2M a))
+    , Vec n (Signal dom (WishboneM2S (addrWidth - CLog 2 n) (Div (BitSize a + 7) 8) a))
+    )
+  go (m2s, unzip -> (unzip -> (prefixes, mmaps), s2ms)) = ((SimOnly memoryMap, s2m), unbundle m2ss)
+   where
+    memoryMap =
+      MemoryMap
+        { deviceDefs = mergeDeviceDefs (deviceDefs . unSim <$> toList mmaps)
+        , tree = Interconnect loc absAddr' (toList descs)
+        }
+
+    size = maxBound :: BitVector (addrWidth - CLog 2 n)
+    relAddrs = prefixToAddr <$> prefixes
+    descs = zip3 relAddrs (repeat (toInteger size)) (tree . unSim <$> mmaps)
+    unSim (SimOnly x) = x
+
+    prefixToAddr :: BitVector (CLog 2 n) -> Address
+    prefixToAddr prefix = toInteger prefix `shiftL` fromInteger shift'
+     where
+      shift' = snatToInteger $ SNat @(addrWidth - CLog 2 n)
+
+    (unbundle -> (s2m, m2ss)) = inner prefixes <$> m2s <*> bundle s2ms
+
+  inner ::
+    Vec n (BitVector (CLog 2 n)) ->
+    WishboneM2S addrWidth (Div (BitSize a + 7) 8) a ->
+    Vec n (WishboneS2M a) ->
+    (WishboneS2M a, Vec n (WishboneM2S (addrWidth - CLog 2 n) (Div (BitSize a + 7) 8) a))
+  inner prefixes m2s@WishboneM2S{..} s2ms
+    | not (busCycle && strobe) = (emptyWishboneS2M, m2ss)
+    -- no valid index selected
+    | Nothing <- selected = (emptyWishboneS2M{err = True}, m2ss)
+    | Just idx <- selected = (s2ms !! idx, replace idx m2sStripped m2ss)
+   where
+    m2ss = repeat emptyWishboneM2S
+    m2sStripped = m2s{addr = internalAddr}
+    (compIdx, internalAddr) = split @_ @(CLog 2 n) @(addrWidth - CLog 2 n) addr
+    selected = elemIndex compIdx prefixes
+
+addrRange :: forall a n. (Bounded a) => Vec n a -> Vec n (a, a)
+addrRange startAddrs = zip startAddrs bounds
+ where
+  bounds = startAddrs <<+ maxBound
 
 topLevel ::
   "CLK" ::: Clock System ->

--- a/clash-protocols-memmap/src/Internal/HdlTest/UartMock.hs
+++ b/clash-protocols-memmap/src/Internal/HdlTest/UartMock.hs
@@ -1,0 +1,114 @@
+{-# LANGUAGE CPP #-}
+{-# OPTIONS_GHC -fplugin Protocols.Plugin #-}
+-- {-# OPTIONS -fplugin-opt=Protocols.Plugin:debug #-}
+{-# OPTIONS_GHC -fconstraint-solver-iterations=20 #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Internal.HdlTest.UartMock where
+
+import Clash.Prelude
+import Clash.Annotations.TH
+import Protocols.Wishbone (Wishbone, WishboneMode(Standard), WishboneM2S, WishboneS2M)
+import Protocols (Circuit, toSignals)
+
+import Protocols.MemoryMap
+import Protocols.MemoryMap.FieldType hiding (description, name)
+import GHC.Stack (HasCallStack)
+import BitPackC (BitPackC (AlignmentC))
+
+someCircuit ::
+    (HasCallStack, HiddenClockResetEnable dom, HasCallStack) =>
+    Circuit (MemoryMapped (Wishbone dom 'Standard 32 (BitVector 32))) ()
+someCircuit = circuit $ \master -> do
+  [iMem, dMem, io] <- interconnect (Just 0x0000_0000) -< master
+  withPrefix 0b01 (memory "instruction_memory" (Just 0x4000_0000) ReadOnly (SNat @(128 * 1024))) -< iMem
+  withPrefix 0b10 (memory "data_memory" (Just 0x8000_0000) ReadWrite (SNat @(128 * 1024))) -< dMem
+
+  [uartEchoBus, uartProgBus, timerBus] <- withPrefix 0b00 (interconnect (Just 0x0000_0000)) -< io
+  withPrefix 0b00 (uart "UART_ECHO" (Just 0x0000_0000)) -< uartEchoBus
+  withPrefix 0b01 (uart "UART_PROG" (Just 0x1000_0000)) -< uartProgBus
+  withPrefix 0b10 (timer "global_timer" (Just 0x2000_0000)) -< timerBus
+
+
+data UartStatus
+  = Transmitting
+  | Full
+  | Ready
+  deriving (NFDataX, Generic, BitPackC, ToFieldType)
+
+data SomeGenericType a
+  = NoData
+  | Pending a
+  | Done (Either (BitVector 8) a)
+  deriving (NFDataX, Generic)
+
+instance
+  ( BitPackC a
+  , Mod 1 (Max 1 (AlignmentC a)) <= 1
+  , 1 <= Max (AlignmentC a) (Max 1 (AlignmentC a))
+  , Mod 1 (AlignmentC a) <= AlignmentC a
+  , Mod 1 (Max 1 (AlignmentC a)) <= Max 1 (AlignmentC a)
+  , Mod 1 (AlignmentC a) <= 1
+  , Mod 1 (Max 1 (Max (AlignmentC a) (Max 1 (AlignmentC a)))) <= 1
+  , Mod 1 (Max 1 (Max (AlignmentC a) (Max 1 (AlignmentC a))))
+        <= Max 1 (Max (AlignmentC a) (Max 1 (AlignmentC a)))
+  ) => BitPackC (SomeGenericType a)
+
+instance (ToFieldType a) => ToFieldType (SomeGenericType a) where
+  type Generics (SomeGenericType a) = 1
+  type WithVars (SomeGenericType a) = SomeGenericType (Var 0)
+  args = toFieldType @a :> Nil
+
+
+uart ::
+  (HasCallStack, HiddenClockResetEnable dom, KnownNat addrWidth) =>
+  String ->
+  AbsoluteAddress ->
+  Circuit (MemoryMapped (Wishbone dom 'Standard addrWidth (BitVector 32))) ()
+uart instanceName absAddr = circuit $ \master -> do
+  let name' = Name { name = "UART", description = "Universal Asynchronous Receiver Transmitter" }
+  [dataReg, status, flag] <- deviceDefinition instanceName absAddr name' -< master
+  deviceReg' "data" ReadWrite 0x0 (0 :: BitVector 32) -< dataReg
+  deviceReg' "status" ReadOnly 0x1 Ready -< status
+  deviceReg' "some_flag" ReadOnly 0x4 (Nothing :: Maybe (BitVector 8, BitVector 8)) -< flag
+
+timer ::
+  (HasCallStack, HiddenClockResetEnable dom, KnownNat addrWidth) =>
+  String ->
+  AbsoluteAddress ->
+  Circuit (MemoryMapped (Wishbone dom 'Standard addrWidth (BitVector 32))) ()
+timer instanceName absAddr = circuit $ \master -> do
+  let name' = Name { name = "Timer", description = "Component that keeps a timing counter" }
+  [timeReg, flagReg, tupleReg, progressReg] <- deviceDefinition instanceName absAddr name' -< master
+  deviceReg' "time" ReadOnly 0x0 (0 :: BitVector 32) -< timeReg
+  deviceReg' "some_flag" ReadOnly 0x4 (Nothing :: Maybe (BitVector 16)) -< flagReg
+  deviceReg' "some_tuple" ReadWrite 0x8 (0 :: BitVector 16, 14 :: Signed 16) -< tupleReg
+  deviceReg' "some_progress" ReadWrite 0xA (Pending (0 :: BitVector 8)) -< progressReg
+
+
+memory ::
+  forall dom addrWidth size .
+  (HasCallStack, HiddenClockResetEnable dom, KnownNat addrWidth, KnownNat size) =>
+  String ->
+  AbsoluteAddress ->
+  Access ->
+  SNat size ->
+  Circuit (MemoryMapped (Wishbone dom 'Standard addrWidth (BitVector 32))) ()
+memory instanceName absAddr access' size' = circuit $ \master -> do
+  let name' = Name { name = "Memory_" <> instanceName, description = "" }
+  [reg] <- deviceDefinition instanceName absAddr name' -< master
+  deviceVecField' "memory" access' 0x0 size' (0 :: BitVector 8) -< reg
+
+topLevel ::
+  "CLK" ::: Clock System ->
+  "RST" ::: Reset System ->
+  "M2S" ::: Signal System (WishboneM2S 32 4 (BitVector 32)) ->
+  "S2M" ::: Signal System (WishboneS2M (BitVector 32))
+topLevel clk rst m2s = withClockResetEnable clk rst enableGen $
+  let f = toSignals someCircuit
+      ((_, x), _) = f (m2s, ())
+  in x
+
+{-# CLASH_OPAQUE topLevel #-}
+makeTopEntity 'topLevel

--- a/clash-protocols-memmap/src/Protocols/MemoryMap.hs
+++ b/clash-protocols-memmap/src/Protocols/MemoryMap.hs
@@ -1,26 +1,32 @@
-{-# LANGUAGE FlexibleContexts #-}
+-- SPDX-FileCopyrightText: 2024 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
 {-# LANGUAGE AllowAmbiguousTypes #-}
-{-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE TypeSynonymInstances #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
-
+{-# LANGUAGE RecordWildCards #-}
 {-# OPTIONS_GHC -fconstraint-solver-iterations=10 #-}
 
 module Protocols.MemoryMap where
 
 import Clash.Prelude
 
-import Protocols
-import Protocols.Wishbone (Wishbone, WishboneMode(Standard), emptyWishboneS2M, emptyWishboneM2S, WishboneM2S (..), WishboneS2M (..))
-import GHC.Natural (Natural)
-import Data.Maybe (fromMaybe)
-import qualified Data.Map.Strict as Map
+import BitPackC (BitPackC (ByteSizeC, packC))
 import qualified Data.List as List
-import GHC.Stack (HasCallStack, CallStack, callStack, getCallStack, SrcLoc)
-import GHC.Generics
-import BitPackC (BitPackC (packC, unpackC, ByteSizeC))
+import qualified Data.Map.Strict as Map
+import Data.Maybe (fromMaybe)
+import GHC.Stack (HasCallStack, SrcLoc, callStack, getCallStack)
+import Protocols
+import Protocols.Wishbone (
+  Wishbone,
+  WishboneM2S (..),
+  WishboneMode (Standard),
+  WishboneS2M (..),
+  emptyWishboneM2S,
+  emptyWishboneS2M,
+ )
 
-import Protocols.MemoryMap.FieldType (ToFieldType(..), FieldType)
+import Protocols.MemoryMap.FieldType (FieldType, ToFieldType (..))
 
 -- | Absolute address or offset in bytes
 type Address = Integer
@@ -28,31 +34,30 @@ type Address = Integer
 -- | Size in bytes
 type Size = Integer
 
--- | A protocol agnostic wrapper for memory mapped protocols. It provides a way
--- for memory mapped subordinates to propagate their memory map to the top level,
--- possibly with interconnects merging multiple memory maps.
---
--- The current implementation has a few objectives:
---
---   1. Provide a way for memory mapped peripherals to define their memory layout
---
---   2. Make it possible for designers to define hardware designs without specifying
---      exact memory addresses if they can be mapped to arbitrary addresses, while
---      not giving up the ability to.
---
---   3. Provide a way to check whether memory maps are valid, i.e. whether
---      perhipherals do not overlap or exceed their allocated space.
---
---   4. Provide a way to generate human readable documentation
---
---   5. Provide a way to generate data structures for target languages. I.e., if
---      a designer instantiates a memory mapped register on type @a@, it should
---      be possible to generate an equivalent data structure in Rust or C.
---
+{- | A protocol agnostic wrapper for memory mapped protocols. It provides a way
+for memory mapped subordinates to propagate their memory map to the top level,
+possibly with interconnects merging multiple memory maps.
 
+The current implementation has a few objectives:
+
+  1. Provide a way for memory mapped peripherals to define their memory layout
+
+  2. Make it possible for designers to define hardware designs without specifying
+     exact memory addresses if they can be mapped to arbitrary addresses, while
+     not giving up the ability to.
+
+  3. Provide a way to check whether memory maps are valid, i.e. whether
+     perhipherals do not overlap or exceed their allocated space.
+
+  4. Provide a way to generate human readable documentation
+
+  5. Provide a way to generate data structures for target languages. I.e., if
+     a designer instantiates a memory mapped register on type @a@, it should
+     be possible to generate an equivalent data structure in Rust or C.
+-}
 data BackwardAnnotated (annotation :: Type) (a :: Type)
 
-instance Protocol a => Protocol (BackwardAnnotated annotation a) where
+instance (Protocol a) => Protocol (BackwardAnnotated annotation a) where
   type Fwd (BackwardAnnotated annotation a) = Fwd a
   type Bwd (BackwardAnnotated annotation a) = (annotation, Bwd a)
 
@@ -62,35 +67,46 @@ type RegisterMapped a = BackwardAnnotated (SimOnly (Named Register)) a
 unAnnotate :: Circuit a (BackwardAnnotated ann a)
 unAnnotate = Circuit $ \(fwd, (_, bwd)) -> (bwd, fwd)
 
-annotation' :: (NFDataX (Fwd a), NFDataX (Bwd b)) => Circuit (BackwardAnnotated ann a) b -> ann
+annotation' ::
+  (NFDataX (Fwd a), NFDataX (Bwd b)) => Circuit (BackwardAnnotated ann a) b -> ann
 annotation' (Circuit f) = ann'
-  where
-    ((ann', _), _) = f (deepErrorX "")
+ where
+  ((ann', _), _) = f (deepErrorX "")
+
+annotationSnd' ::
+  (NFDataX (Fwd a), NFDataX (Fwd b), NFDataX (Bwd c)) =>
+  Circuit (a, BackwardAnnotated ann b) c ->
+  ann
+annotationSnd' (Circuit f) = ann'
+ where
+  ((_, (ann', _)), _) = f (deepErrorX "")
 
 annotation ::
   (KnownDomain dom, NFDataX (Fwd a), NFDataX (Bwd b)) =>
-  ((HiddenClockResetEnable dom) => Circuit (BackwardAnnotated ann a) b)
-  -> ann
+  ((HiddenClockResetEnable dom) => Circuit (BackwardAnnotated ann a) b) ->
+  ann
 annotation circ = ann'
-  where
-    Circuit f = withClockResetEnable clockGen resetGen enableGen circ
-    ((ann', _), _) = f (deepErrorX "")
+ where
+  Circuit f = withClockResetEnable clockGen resetGen enableGen circ
+  ((ann', _), _) = f (deepErrorX "")
 
 data Name = Name
   { name :: String
-    -- ^ Name of the 'thing'. Used as an identifier in generated data structures.
-    --
-    -- TODO: Only allow very basic names here to make sure it can be used in all
-    --       common target languages. Provide a Template Haskell helper to make
-    --       sure the name is valid at compile time?
+  -- ^ Name of the 'thing'. Used as an identifier in generated data structures.
+  --
+  -- TODO: Only allow very basic names here to make sure it can be used in all
+  --       common target languages. Provide a Template Haskell helper to make
+  --       sure the name is valid at compile time?
   , description :: String
   -- ^ Description of the 'thing'. Used in generated documentation.
   }
   deriving (Show, Eq, Ord)
 
--- | Wrapper for \"things\" that have a name and a description. These are used
--- to generate documentation and data structures for target languages.
+{- | Wrapper for \"things\" that have a name and a description. These are used
+to generate documentation and data structures for target languages.
+-}
 type Named a = (Name, a)
+
 type NamedLoc a = (Name, SrcLoc, a)
 
 type AbsoluteAddress = Maybe Address
@@ -110,59 +126,54 @@ data DeviceDefinition = DeviceDefinition
   }
   deriving (Show)
 
--- | A tree structure that describes the memory map of a device. Its definitions
--- are using non-translatable constructs on purpose: Clash is currently pretty
--- bad at propagating contants properly, so designers should only /produce/
--- memory maps, not rely on constant folding to be able to extract addresses
--- from them to use in their designs.
+{- | A tree structure that describes the memory map of a device. Its definitions
+are using non-translatable constructs on purpose: Clash is currently pretty
+bad at propagating contants properly, so designers should only /produce/
+memory maps, not rely on constant folding to be able to extract addresses
+from them to use in their designs.
+-}
 data MemoryMapTree
   = Interconnect SrcLoc AbsoluteAddress [(Address, Size, MemoryMapTree)]
   | DeviceInstance SrcLoc AbsoluteAddress String DeviceName
   deriving (Show)
 
 data Access
-  = ReadOnly
-  -- ^ Managers should only read from this register
-  | WriteOnly
-  -- ^ Managers should only write to this register
-  | ReadWrite
-  -- ^ Managers can read from and write to this register
+  = -- | Managers should only read from this register
+    ReadOnly
+  | -- | Managers should only write to this register
+    WriteOnly
+  | -- | Managers can read from and write to this register
+    ReadWrite
   deriving (Show)
 
 data Register = Register
   { access :: Access
   , address :: Address
-    -- ^ Address / offset of the register
+  -- ^ Address / offset of the register
   , fieldType :: FieldType
-    -- ^ Type of the register. This is used to generate data structures for
-    -- target languages.
+  -- ^ Type of the register. This is used to generate data structures for
+  -- target languages.
   , fieldSize :: Size
-    -- ^ Size of the register in bytes
+  -- ^ Size of the register in bytes
   , reset :: Maybe Natural
-    -- ^ Reset value (if any) of register
+  -- ^ Reset value (if any) of register
   }
   deriving (Show)
-
-
-
-
 
 data ComponentPath
   = Root
   | InterconnectComponent Integer ComponentPath
   deriving (Show)
 
-
-
 deviceDef' ::
-  forall dom a n addrWidth .
+  forall dom a n addrWidth.
   Circuit
     (MemoryMapped (Wishbone dom 'Standard addrWidth a))
     (Vec n (Wishbone dom 'Standard addrWidth ()))
 deviceDef' = undefined
 
 deviceDefinition ::
-  forall dom a n addrWidth .
+  forall dom a n addrWidth.
   ( HasCallStack
   , ToFieldType a
   , NFDataX a
@@ -177,57 +188,63 @@ deviceDefinition ::
   Name ->
   Circuit
     (MemoryMapped (Wishbone dom 'Standard addrWidth a))
-    (Vec n
-      (BackwardAnnotated
-        (BitVector addrWidth, SimOnly (NamedLoc Register))
-        (Wishbone dom 'Standard addrWidth a)
-      )
+    ( Vec
+        n
+        ( BackwardAnnotated
+            (BitVector addrWidth, SimOnly (NamedLoc Register))
+            (Wishbone dom 'Standard addrWidth a)
+        )
     )
 deviceDefinition instanceName absAddr' deviceDesc = Circuit $ \(m2s, bwds) ->
-    let
-      annotations = fst <$> bwds
-      s2ms = bundle $ snd <$> bwds
-      addrs = fst <$> annotations
-      regs = (\(_, SimOnly x) -> x) <$> annotations
-      memMap = MemoryMap
+  let
+    annotations = fst <$> bwds
+    s2ms = bundle $ snd <$> bwds
+    addrs = fst <$> annotations
+    regs = (\(_, SimOnly x) -> x) <$> annotations
+    memMap =
+      MemoryMap
         { deviceDefs = Map.singleton (name deviceDesc) definition
-        , tree = DeviceInstance instanceLoc absAddr' instanceName (name deviceDesc) }
-      definition = DeviceDefinition
-        { deviceName =  deviceDesc
+        , tree = DeviceInstance instanceLoc absAddr' instanceName (name deviceDesc)
+        }
+    definition =
+      DeviceDefinition
+        { deviceName = deviceDesc
         , registers = toList regs
         , defLocation = defLoc
         }
 
-      (s2m, m2ss) = go addrs m2s s2ms
-    in
+    (s2m, m2ss) = go addrs m2s s2ms
+   in
     ((SimOnly memMap, s2m), m2ss)
+ where
+  ((_, defLoc) : (_, instanceLoc) : _) = getCallStack callStack
 
-  where
-    ((_, defLoc):(_, instanceLoc):_) = getCallStack callStack
-    
-    go addrs m2s s2ms = (s2m, m2ss)
-      where
-        active :: Signal dom (Maybe (Index n))
-        active = register Nothing newActive
-        (unbundle -> (s2m, unbundle -> m2ss, newActive)) = inner (addrRange addrs) <$> m2s <*> s2ms <*> active
+  go addrs m2s s2ms = (s2m, m2ss)
+   where
+    active :: Signal dom (Maybe (Index n))
+    active = register Nothing newActive
+    (unbundle -> (s2m, unbundle -> m2ss, newActive)) = inner (addrRange addrs) <$> m2s <*> s2ms <*> active
 
-    inner ranges m2s@WishboneM2S{..} s2ms active
-      | not (busCycle && strobe) = (emptyWishboneS2M, m2ss, Nothing)
-      -- no existing transaction, no new transaction
-      -- => ERROR, we're in a cycle but couldn't find a subordinate that matches the address
-      -- which shouldn't ever happen, but if it does it should be an error!
-      | Nothing <- active, Nothing <- newActive = (emptyWishboneS2M { err = True }, m2ss, Nothing)
-      -- no previous transaction, but a new one!
-      | Nothing <- active, Just idx <- newActive =
-          (s2ms !! idx, replace idx m2s m2ss, Just idx)
-      -- have an existing transaction, use that one
-      | Just idx <- active = (s2ms !! idx, replace idx m2s m2ss, active)
-      where
-        m2ss = repeat emptyWishboneM2S
-        newActive = findIndex (\(start, end) -> addr >= start && addr < end) ranges
+  inner ranges m2s@WishboneM2S{..} s2ms active
+    | not (busCycle && strobe) = (emptyWishboneS2M, m2ss, Nothing)
+    -- no existing transaction, no new transaction
+    -- => ERROR, we're in a cycle but couldn't find a subordinate that matches the address
+    -- which shouldn't ever happen, but if it does it should be an error!
+    | Nothing <- active
+    , Nothing <- newActive =
+        (emptyWishboneS2M{err = True}, m2ss, Nothing)
+    -- no previous transaction, but a new one!
+    | Nothing <- active
+    , Just idx <- newActive =
+        (s2ms !! idx, replace idx m2s m2ss, Just idx)
+    -- have an existing transaction, use that one
+    | Just idx <- active = (s2ms !! idx, replace idx m2s m2ss, active)
+   where
+    m2ss = repeat emptyWishboneM2S
+    newActive = findIndex (\(start, end) -> addr >= start && addr < end) ranges
 
 deviceReg' ::
-  forall dom a addrWidth .
+  forall dom a addrWidth.
   ( HasCallStack
   , ToFieldType a
   , NFDataX a
@@ -240,40 +257,44 @@ deviceReg' ::
   BitVector addrWidth ->
   a ->
   Circuit
-    (BackwardAnnotated
-      (BitVector addrWidth, SimOnly (NamedLoc Register))
-      (Wishbone dom 'Standard addrWidth (BitVector 32)))
+    ( BackwardAnnotated
+        (BitVector addrWidth, SimOnly (NamedLoc Register))
+        (Wishbone dom 'Standard addrWidth (BitVector 32))
+    )
     ()
 deviceReg' name' access' addr' def' = Circuit $ \(m2s0, ()) ->
-    (((addr', SimOnly reg'), go m2s0), ())
-  where
-    defBytes :: BitVector 32
-    defBytes = resize $ packC def'
+  (((addr', SimOnly reg'), go m2s0), ())
+ where
+  defBytes :: BitVector 32
+  defBytes = resize $ packC def'
 
-    (_, loc):_ = getCallStack callStack
-    reg' = (Name
-      { name = name'
-      , description = ""
-      }, loc, Register
+  (_, loc) : _ = getCallStack callStack
+  reg' =
+    ( Name
+        { name = name'
+        , description = ""
+        }
+    , loc
+    , Register
         { access = access'
         , address = toInteger addr'
         , fieldType = toFieldType @a
         , fieldSize = snatToInteger (SNat @(ByteSizeC a))
         , reset = Nothing
         }
-      )
-    go m2s = s2m
-      where
-        registerVal = register defBytes $ fromMaybe <$> registerVal <*> nextVal
-        (unbundle -> (s2m, nextVal)) = inner <$> m2s <*> registerVal
+    )
+  go m2s = s2m
+   where
+    registerVal = register defBytes $ fromMaybe <$> registerVal <*> nextVal
+    (unbundle -> (s2m, nextVal)) = inner <$> m2s <*> registerVal
 
-    inner WishboneM2S{..} val
-      | not (busCycle && strobe) = (emptyWishboneS2M, Nothing)
-      | writeEnable = (emptyWishboneS2M { acknowledge = True }, Just writeData)
-      | otherwise = ((emptyWishboneS2M @a) { acknowledge = True, readData = 0 }, Nothing)
+  inner WishboneM2S{..} val
+    | not (busCycle && strobe) = (emptyWishboneS2M, Nothing)
+    | writeEnable = (emptyWishboneS2M{acknowledge = True}, Just writeData)
+    | otherwise = ((emptyWishboneS2M @a){acknowledge = True, readData = 0}, Nothing)
 
 deviceReg ::
-  forall dom a addrWidth .
+  forall dom a addrWidth.
   ( HasCallStack
   , ToFieldType a
   , NFDataX a
@@ -285,38 +306,41 @@ deviceReg ::
   BitVector addrWidth ->
   a ->
   Circuit
-    (BackwardAnnotated
-      (BitVector addrWidth, SimOnly (NamedLoc Register))
-      (Wishbone dom 'Standard addrWidth a))
+    ( BackwardAnnotated
+        (BitVector addrWidth, SimOnly (NamedLoc Register))
+        (Wishbone dom 'Standard addrWidth a)
+    )
     ()
 deviceReg name' access' addr' def' = Circuit $ \(m2s0, ()) ->
-    (((addr', SimOnly reg'), go m2s0), ())
-  where
-    (_, loc):_ = getCallStack callStack
-    reg' = (Name
-      { name = name'
-      , description = ""
-      }, loc, Register
+  (((addr', SimOnly reg'), go m2s0), ())
+ where
+  (_, loc) : _ = getCallStack callStack
+  reg' =
+    ( Name
+        { name = name'
+        , description = ""
+        }
+    , loc
+    , Register
         { access = access'
         , address = toInteger addr'
         , fieldType = toFieldType @a
         , fieldSize = error "use deviceReg' with BitPackC"
         , reset = Nothing
         }
-      )
-    go m2s = s2m
-      where
-        registerVal = register def' $ fromMaybe <$> registerVal <*> nextVal
-        (unbundle -> (s2m, nextVal)) = inner <$> m2s <*> registerVal
+    )
+  go m2s = s2m
+   where
+    registerVal = register def' $ fromMaybe <$> registerVal <*> nextVal
+    (unbundle -> (s2m, nextVal)) = inner <$> m2s <*> registerVal
 
-    inner WishboneM2S{..} val
-      | not (busCycle && strobe) = (emptyWishboneS2M, Nothing)
-      | writeEnable = (emptyWishboneS2M { acknowledge = True }, Just writeData)
-      | otherwise = ((emptyWishboneS2M @a) { acknowledge = True, readData = val }, Nothing)
-
+  inner WishboneM2S{..} val
+    | not (busCycle && strobe) = (emptyWishboneS2M, Nothing)
+    | writeEnable = (emptyWishboneS2M{acknowledge = True}, Just writeData)
+    | otherwise = ((emptyWishboneS2M @a){acknowledge = True, readData = val}, Nothing)
 
 deviceVecField' ::
-  forall dom n a addrWidth .
+  forall dom n a addrWidth.
   ( HasCallStack
   , KnownNat n
   , ToFieldType a
@@ -332,42 +356,45 @@ deviceVecField' ::
   SNat n ->
   a ->
   Circuit
-    (BackwardAnnotated
-      (BitVector addrWidth, SimOnly (NamedLoc Register))
-      (Wishbone dom 'Standard addrWidth (BitVector 32)))
+    ( BackwardAnnotated
+        (BitVector addrWidth, SimOnly (NamedLoc Register))
+        (Wishbone dom 'Standard addrWidth (BitVector 32))
+    )
     ()
 deviceVecField' name' access' addr' _size def' = Circuit $ \(m2s0, ()) ->
-    (((addr', SimOnly reg'), go m2s0), ())
-  where
-    (_, loc):_ = getCallStack callStack
+  (((addr', SimOnly reg'), go m2s0), ())
+ where
+  (_, loc) : _ = getCallStack callStack
 
-    defBytes :: BitVector 32
-    defBytes = resize $ packC def'
+  defBytes :: BitVector 32
+  defBytes = resize $ packC def'
 
-    reg' = (Name
-      { name = name'
-      , description = ""
-      }, loc, Register
+  reg' =
+    ( Name
+        { name = name'
+        , description = ""
+        }
+    , loc
+    , Register
         { access = access'
         , address = toInteger addr'
         , fieldType = toFieldType @(Vec n a)
         , fieldSize = snatToInteger (SNat @(ByteSizeC (Vec n a)))
         , reset = Nothing
         }
-      )
-    go m2s = s2m
-      where
-        registerVal = register defBytes $ fromMaybe <$> registerVal <*> nextVal
-        (unbundle -> (s2m, nextVal)) = inner <$> m2s <*> registerVal
+    )
+  go m2s = s2m
+   where
+    registerVal = register defBytes $ fromMaybe <$> registerVal <*> nextVal
+    (unbundle -> (s2m, nextVal)) = inner <$> m2s <*> registerVal
 
-    inner WishboneM2S{..} val
-      | not (busCycle && strobe) = (emptyWishboneS2M, Nothing)
-      | writeEnable = (emptyWishboneS2M { acknowledge = True }, Just writeData)
-      | otherwise = ((emptyWishboneS2M @a) { acknowledge = True, readData = val }, Nothing)
-
+  inner WishboneM2S{..} val
+    | not (busCycle && strobe) = (emptyWishboneS2M, Nothing)
+    | writeEnable = (emptyWishboneS2M{acknowledge = True}, Just writeData)
+    | otherwise = ((emptyWishboneS2M @a){acknowledge = True, readData = val}, Nothing)
 
 deviceVecField ::
-  forall dom n a addrWidth .
+  forall dom n a addrWidth.
   ( HasCallStack
   , KnownNat n
   , ToFieldType a
@@ -381,46 +408,56 @@ deviceVecField ::
   SNat n ->
   a ->
   Circuit
-    (BackwardAnnotated
-      (BitVector addrWidth, SimOnly (NamedLoc Register))
-      (Wishbone dom 'Standard addrWidth a))
+    ( BackwardAnnotated
+        (BitVector addrWidth, SimOnly (NamedLoc Register))
+        (Wishbone dom 'Standard addrWidth a)
+    )
     ()
 deviceVecField name' access' addr' _size def' = Circuit $ \(m2s0, ()) ->
-    (((addr', SimOnly reg'), go m2s0), ())
-  where
-    (_, loc):_ = getCallStack callStack
-    reg' = (Name
-      { name = name'
-      , description = ""
-      }, loc, Register
+  (((addr', SimOnly reg'), go m2s0), ())
+ where
+  (_, loc) : _ = getCallStack callStack
+  reg' =
+    ( Name
+        { name = name'
+        , description = ""
+        }
+    , loc
+    , Register
         { access = access'
         , address = toInteger addr'
         , fieldType = toFieldType @(Vec n a)
         , fieldSize = error "use deviceVecField' with BitPackC"
         , reset = Nothing
         }
-      )
-    go m2s = s2m
-      where
-        registerVal = register def' $ fromMaybe <$> registerVal <*> nextVal
-        (unbundle -> (s2m, nextVal)) = inner <$> m2s <*> registerVal
+    )
+  go m2s = s2m
+   where
+    registerVal = register def' $ fromMaybe <$> registerVal <*> nextVal
+    (unbundle -> (s2m, nextVal)) = inner <$> m2s <*> registerVal
 
-    inner WishboneM2S{..} val
-      | not (busCycle && strobe) = (emptyWishboneS2M, Nothing)
-      | writeEnable = (emptyWishboneS2M { acknowledge = True }, Just writeData)
-      | otherwise = ((emptyWishboneS2M @a) { acknowledge = True, readData = val }, Nothing)
-
+  inner WishboneM2S{..} val
+    | not (busCycle && strobe) = (emptyWishboneS2M, Nothing)
+    | writeEnable = (emptyWishboneS2M{acknowledge = True}, Just writeData)
+    | otherwise = ((emptyWishboneS2M @a){acknowledge = True, readData = val}, Nothing)
 
 withPrefix ::
-  HasCallStack =>
+  (HasCallStack) =>
   BitVector n ->
   Circuit (BackwardAnnotated ann a) b ->
   Circuit (BackwardAnnotated (BitVector n, ann) a) b
 withPrefix p (Circuit f) = Circuit $ \(fwd, bwd) ->
-    let
-      ((ann, bwd'), fwd') = f (fwd, bwd)
-    in (((p, ann), bwd'), fwd')
+  let
+    ((ann, bwd'), fwd') = f (fwd, bwd)
+   in
+    (((p, ann), bwd'), fwd')
 
+passAnn ::
+  Circuit a b ->
+  Circuit (BackwardAnnotated ann a) (BackwardAnnotated ann b)
+passAnn (Circuit f) = Circuit $ \(fwd, (ann, bwd)) ->
+  let (bwd', fwd') = f (fwd, bwd)
+   in ((ann, bwd'), fwd')
 
 interconnect ::
   forall dom addrWidth a n.
@@ -434,65 +471,69 @@ interconnect ::
   , KnownNat (addrWidth - CLog 2 n)
   ) =>
   AbsoluteAddress ->
-  Circuit (MemoryMapped (Wishbone dom 'Standard addrWidth a))
-  (Vec n (BackwardAnnotated (BitVector (CLog 2 n), SimOnly MemoryMap) (Wishbone dom 'Standard (addrWidth - CLog 2 n) a)))
+  Circuit
+    (MemoryMapped (Wishbone dom 'Standard addrWidth a))
+    ( Vec
+        n
+        ( BackwardAnnotated
+            (BitVector (CLog 2 n), SimOnly MemoryMap)
+            (Wishbone dom 'Standard (addrWidth - CLog 2 n) a)
+        )
+    )
 interconnect absAddr' = Circuit go
-  where
-    (_, loc):_ = getCallStack callStack
+ where
+  (_, loc) : _ = getCallStack callStack
 
-    go ::
-      ( Signal dom (WishboneM2S addrWidth (Div (BitSize a + 7) 8) a)
-      , Vec n ((BitVector (CLog 2 n), SimOnly MemoryMap), Signal dom (WishboneS2M a)))
-      ->
-      ( (SimOnly MemoryMap, Signal dom (WishboneS2M a))
-      , Vec n (Signal dom (WishboneM2S (addrWidth - CLog 2 n) (Div (BitSize a + 7) 8) a)))
-    go (m2s, unzip -> (unzip -> (prefixes, mmaps), s2ms)) = ((SimOnly memoryMap, s2m), unbundle m2ss)
-      where
+  go ::
+    ( Signal dom (WishboneM2S addrWidth (Div (BitSize a + 7) 8) a)
+    , Vec n ((BitVector (CLog 2 n), SimOnly MemoryMap), Signal dom (WishboneS2M a))
+    ) ->
+    ( (SimOnly MemoryMap, Signal dom (WishboneS2M a))
+    , Vec n (Signal dom (WishboneM2S (addrWidth - CLog 2 n) (Div (BitSize a + 7) 8) a))
+    )
+  go (m2s, unzip -> (unzip -> (prefixes, mmaps), s2ms)) = ((SimOnly memoryMap, s2m), unbundle m2ss)
+   where
+    memoryMap =
+      MemoryMap
+        { deviceDefs = mergeDeviceDefs (deviceDefs . unSim <$> toList mmaps)
+        , tree = Interconnect loc absAddr' (toList descs)
+        }
 
-        memoryMap = MemoryMap
-          { deviceDefs = unionAll (deviceDefs . unSim <$> toList mmaps)
-          , tree = Interconnect loc absAddr' (toList descs) }
+    size = maxBound :: BitVector (addrWidth - CLog 2 n)
+    relAddrs = prefixToAddr <$> prefixes
+    descs = zip3 relAddrs (repeat (toInteger size)) (tree . unSim <$> mmaps)
+    unSim (SimOnly x) = x
 
+    prefixToAddr :: BitVector (CLog 2 n) -> Address
+    prefixToAddr prefix = toInteger prefix `shiftL` fromInteger shift'
+     where
+      shift' = snatToInteger $ SNat @(addrWidth - CLog 2 n)
 
-        unionAll :: [Map.Map String DeviceDefinition] -> Map.Map String DeviceDefinition
-        unionAll = List.foldl Map.union Map.empty
+    (unbundle -> (s2m, m2ss)) = inner prefixes <$> m2s <*> bundle s2ms
 
-        size = maxBound :: BitVector (addrWidth - CLog 2 n)
-        relAddrs = prefixToAddr <$> prefixes 
-        descs = zip3 relAddrs (repeat (toInteger size)) (tree . unSim <$> mmaps)
-        unSim (SimOnly x) = x
+  inner ::
+    Vec n (BitVector (CLog 2 n)) ->
+    WishboneM2S addrWidth (Div (BitSize a + 7) 8) a ->
+    Vec n (WishboneS2M a) ->
+    (WishboneS2M a, Vec n (WishboneM2S (addrWidth - CLog 2 n) (Div (BitSize a + 7) 8) a))
+  inner prefixes m2s@WishboneM2S{..} s2ms
+    | not (busCycle && strobe) = (emptyWishboneS2M, m2ss)
+    -- no valid index selected
+    | Nothing <- selected = (emptyWishboneS2M{err = True}, m2ss)
+    | Just idx <- selected = (s2ms !! idx, replace idx m2sStripped m2ss)
+   where
+    m2ss = repeat emptyWishboneM2S
+    m2sStripped = m2s{addr = internalAddr}
+    (compIdx, internalAddr) = split @_ @(CLog 2 n) @(addrWidth - CLog 2 n) addr
+    selected = elemIndex compIdx prefixes
 
-        prefixToAddr :: BitVector (CLog 2 n) -> Address
-        prefixToAddr prefix = toInteger prefix `shiftL` fromInteger shift'
-          where
-            shift' = snatToInteger $ SNat @(addrWidth - CLog 2 n) 
+mergeDeviceDefs :: [Map.Map String DeviceDefinition] -> Map.Map String DeviceDefinition
+mergeDeviceDefs = List.foldl Map.union Map.empty
 
-        (unbundle -> (s2m, m2ss)) = inner prefixes <$> m2s <*> bundle s2ms
-
-    inner ::
-      Vec n (BitVector (CLog 2 n)) ->
-      WishboneM2S addrWidth (Div (BitSize a + 7) 8) a ->
-        Vec n (WishboneS2M a) ->
-        (WishboneS2M a, Vec n (WishboneM2S (addrWidth - CLog 2 n) (Div (BitSize a + 7) 8) a))
-    inner prefixes m2s@WishboneM2S{..} s2ms
-      | not (busCycle && strobe) = (emptyWishboneS2M, m2ss)
-      -- no valid index selected
-      | Nothing <- selected = (emptyWishboneS2M { err = True }, m2ss)
-      | Just idx <- selected = (s2ms !! idx, replace idx m2sStripped m2ss)
-
-      where
-        m2ss = repeat emptyWishboneM2S
-        m2sStripped = m2s { addr = internalAddr }
-        (compIdx, internalAddr) = split @_ @(CLog 2 n) @(addrWidth - CLog 2 n) addr
-        selected = elemIndex compIdx prefixes
-
-
-
-addrRange :: forall a n . (Bounded a) => Vec n a -> Vec n (a, a)
+addrRange :: forall a n. (Bounded a) => Vec n a -> Vec n (a, a)
 addrRange startAddrs = zip startAddrs bounds
-  where
-    bounds = startAddrs <<+ maxBound
-
+ where
+  bounds = startAddrs <<+ maxBound
 
 {-
 -- | Remove memory map information from a circuit
@@ -507,7 +548,7 @@ memoryMapped mm = Circuit $ \(fwdA, bwdA) -> ((SimOnly mm, bwdA), fwdA)
 -- lazy enough: if the memory map depends on any signals, this function will
 -- error.
 extractMemoryMap :: (NFDataX (Fwd a), NFDataX (Bwd b)) => Circuit (MemoryMapped a) b -> Named MemoryMap
-extractMemoryMap (Circuit f) = 
+extractMemoryMap (Circuit f) =
   let ((SimOnly mm, _), _) = f (deepErrorX "") in
   mm
 

--- a/clash-protocols-memmap/src/Protocols/MemoryMap.hs
+++ b/clash-protocols-memmap/src/Protocols/MemoryMap.hs
@@ -1,0 +1,514 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TypeSynonymInstances #-}
+{-# LANGUAGE FlexibleInstances #-}
+
+{-# OPTIONS_GHC -fconstraint-solver-iterations=10 #-}
+
+module Protocols.MemoryMap where
+
+import Clash.Prelude
+
+import Protocols
+import Protocols.Wishbone (Wishbone, WishboneMode(Standard), emptyWishboneS2M, emptyWishboneM2S, WishboneM2S (..), WishboneS2M (..))
+import GHC.Natural (Natural)
+import Data.Maybe (fromMaybe)
+import qualified Data.Map.Strict as Map
+import qualified Data.List as List
+import GHC.Stack (HasCallStack, CallStack, callStack, getCallStack, SrcLoc)
+import GHC.Generics
+import BitPackC (BitPackC (packC, unpackC, ByteSizeC))
+
+import Protocols.MemoryMap.FieldType (ToFieldType(..), FieldType)
+
+-- | Absolute address or offset in bytes
+type Address = Integer
+
+-- | Size in bytes
+type Size = Integer
+
+-- | A protocol agnostic wrapper for memory mapped protocols. It provides a way
+-- for memory mapped subordinates to propagate their memory map to the top level,
+-- possibly with interconnects merging multiple memory maps.
+--
+-- The current implementation has a few objectives:
+--
+--   1. Provide a way for memory mapped peripherals to define their memory layout
+--
+--   2. Make it possible for designers to define hardware designs without specifying
+--      exact memory addresses if they can be mapped to arbitrary addresses, while
+--      not giving up the ability to.
+--
+--   3. Provide a way to check whether memory maps are valid, i.e. whether
+--      perhipherals do not overlap or exceed their allocated space.
+--
+--   4. Provide a way to generate human readable documentation
+--
+--   5. Provide a way to generate data structures for target languages. I.e., if
+--      a designer instantiates a memory mapped register on type @a@, it should
+--      be possible to generate an equivalent data structure in Rust or C.
+--
+
+data BackwardAnnotated (annotation :: Type) (a :: Type)
+
+instance Protocol a => Protocol (BackwardAnnotated annotation a) where
+  type Fwd (BackwardAnnotated annotation a) = Fwd a
+  type Bwd (BackwardAnnotated annotation a) = (annotation, Bwd a)
+
+type MemoryMapped a = BackwardAnnotated (SimOnly MemoryMap) a
+type RegisterMapped a = BackwardAnnotated (SimOnly (Named Register)) a
+
+unAnnotate :: Circuit a (BackwardAnnotated ann a)
+unAnnotate = Circuit $ \(fwd, (_, bwd)) -> (bwd, fwd)
+
+annotation' :: (NFDataX (Fwd a), NFDataX (Bwd b)) => Circuit (BackwardAnnotated ann a) b -> ann
+annotation' (Circuit f) = ann'
+  where
+    ((ann', _), _) = f (deepErrorX "")
+
+annotation ::
+  (KnownDomain dom, NFDataX (Fwd a), NFDataX (Bwd b)) =>
+  ((HiddenClockResetEnable dom) => Circuit (BackwardAnnotated ann a) b)
+  -> ann
+annotation circ = ann'
+  where
+    Circuit f = withClockResetEnable clockGen resetGen enableGen circ
+    ((ann', _), _) = f (deepErrorX "")
+
+data Name = Name
+  { name :: String
+    -- ^ Name of the 'thing'. Used as an identifier in generated data structures.
+    --
+    -- TODO: Only allow very basic names here to make sure it can be used in all
+    --       common target languages. Provide a Template Haskell helper to make
+    --       sure the name is valid at compile time?
+  , description :: String
+  -- ^ Description of the 'thing'. Used in generated documentation.
+  }
+  deriving (Show, Eq, Ord)
+
+-- | Wrapper for \"things\" that have a name and a description. These are used
+-- to generate documentation and data structures for target languages.
+type Named a = (Name, a)
+type NamedLoc a = (Name, SrcLoc, a)
+
+type AbsoluteAddress = Maybe Address
+
+type DeviceName = String
+
+data MemoryMap = MemoryMap
+  { deviceDefs :: Map.Map DeviceName DeviceDefinition
+  , tree :: MemoryMapTree
+  }
+  deriving (Show)
+
+data DeviceDefinition = DeviceDefinition
+  { deviceName :: Name
+  , registers :: [NamedLoc Register]
+  , defLocation :: SrcLoc
+  }
+  deriving (Show)
+
+-- | A tree structure that describes the memory map of a device. Its definitions
+-- are using non-translatable constructs on purpose: Clash is currently pretty
+-- bad at propagating contants properly, so designers should only /produce/
+-- memory maps, not rely on constant folding to be able to extract addresses
+-- from them to use in their designs.
+data MemoryMapTree
+  = Interconnect SrcLoc AbsoluteAddress [(Address, Size, MemoryMapTree)]
+  | DeviceInstance SrcLoc AbsoluteAddress String DeviceName
+  deriving (Show)
+
+data Access
+  = ReadOnly
+  -- ^ Managers should only read from this register
+  | WriteOnly
+  -- ^ Managers should only write to this register
+  | ReadWrite
+  -- ^ Managers can read from and write to this register
+  deriving (Show)
+
+data Register = Register
+  { access :: Access
+  , address :: Address
+    -- ^ Address / offset of the register
+  , fieldType :: FieldType
+    -- ^ Type of the register. This is used to generate data structures for
+    -- target languages.
+  , fieldSize :: Size
+    -- ^ Size of the register in bytes
+  , reset :: Maybe Natural
+    -- ^ Reset value (if any) of register
+  }
+  deriving (Show)
+
+
+
+
+
+data ComponentPath
+  = Root
+  | InterconnectComponent Integer ComponentPath
+  deriving (Show)
+
+
+
+deviceDef' ::
+  forall dom a n addrWidth .
+  Circuit
+    (MemoryMapped (Wishbone dom 'Standard addrWidth a))
+    (Vec n (Wishbone dom 'Standard addrWidth ()))
+deviceDef' = undefined
+
+deviceDefinition ::
+  forall dom a n addrWidth .
+  ( HasCallStack
+  , ToFieldType a
+  , NFDataX a
+  , KnownNat (BitSize a)
+  , KnownNat n
+  , KnownNat addrWidth
+  , HiddenClockResetEnable dom
+  , 1 <= n
+  ) =>
+  String ->
+  AbsoluteAddress ->
+  Name ->
+  Circuit
+    (MemoryMapped (Wishbone dom 'Standard addrWidth a))
+    (Vec n
+      (BackwardAnnotated
+        (BitVector addrWidth, SimOnly (NamedLoc Register))
+        (Wishbone dom 'Standard addrWidth a)
+      )
+    )
+deviceDefinition instanceName absAddr' deviceDesc = Circuit $ \(m2s, bwds) ->
+    let
+      annotations = fst <$> bwds
+      s2ms = bundle $ snd <$> bwds
+      addrs = fst <$> annotations
+      regs = (\(_, SimOnly x) -> x) <$> annotations
+      memMap = MemoryMap
+        { deviceDefs = Map.singleton (name deviceDesc) definition
+        , tree = DeviceInstance instanceLoc absAddr' instanceName (name deviceDesc) }
+      definition = DeviceDefinition
+        { deviceName =  deviceDesc
+        , registers = toList regs
+        , defLocation = defLoc
+        }
+
+      (s2m, m2ss) = go addrs m2s s2ms
+    in
+    ((SimOnly memMap, s2m), m2ss)
+
+  where
+    ((_, defLoc):(_, instanceLoc):_) = getCallStack callStack
+    
+    go addrs m2s s2ms = (s2m, m2ss)
+      where
+        active :: Signal dom (Maybe (Index n))
+        active = register Nothing newActive
+        (unbundle -> (s2m, unbundle -> m2ss, newActive)) = inner (addrRange addrs) <$> m2s <*> s2ms <*> active
+
+    inner ranges m2s@WishboneM2S{..} s2ms active
+      | not (busCycle && strobe) = (emptyWishboneS2M, m2ss, Nothing)
+      -- no existing transaction, no new transaction
+      -- => ERROR, we're in a cycle but couldn't find a subordinate that matches the address
+      -- which shouldn't ever happen, but if it does it should be an error!
+      | Nothing <- active, Nothing <- newActive = (emptyWishboneS2M { err = True }, m2ss, Nothing)
+      -- no previous transaction, but a new one!
+      | Nothing <- active, Just idx <- newActive =
+          (s2ms !! idx, replace idx m2s m2ss, Just idx)
+      -- have an existing transaction, use that one
+      | Just idx <- active = (s2ms !! idx, replace idx m2s m2ss, active)
+      where
+        m2ss = repeat emptyWishboneM2S
+        newActive = findIndex (\(start, end) -> addr >= start && addr < end) ranges
+
+deviceReg' ::
+  forall dom a addrWidth .
+  ( HasCallStack
+  , ToFieldType a
+  , NFDataX a
+  , BitPackC a
+  , KnownNat addrWidth
+  , HiddenClockResetEnable dom
+  ) =>
+  String ->
+  Access ->
+  BitVector addrWidth ->
+  a ->
+  Circuit
+    (BackwardAnnotated
+      (BitVector addrWidth, SimOnly (NamedLoc Register))
+      (Wishbone dom 'Standard addrWidth (BitVector 32)))
+    ()
+deviceReg' name' access' addr' def' = Circuit $ \(m2s0, ()) ->
+    (((addr', SimOnly reg'), go m2s0), ())
+  where
+    defBytes :: BitVector 32
+    defBytes = resize $ packC def'
+
+    (_, loc):_ = getCallStack callStack
+    reg' = (Name
+      { name = name'
+      , description = ""
+      }, loc, Register
+        { access = access'
+        , address = toInteger addr'
+        , fieldType = toFieldType @a
+        , fieldSize = snatToInteger (SNat @(ByteSizeC a))
+        , reset = Nothing
+        }
+      )
+    go m2s = s2m
+      where
+        registerVal = register defBytes $ fromMaybe <$> registerVal <*> nextVal
+        (unbundle -> (s2m, nextVal)) = inner <$> m2s <*> registerVal
+
+    inner WishboneM2S{..} val
+      | not (busCycle && strobe) = (emptyWishboneS2M, Nothing)
+      | writeEnable = (emptyWishboneS2M { acknowledge = True }, Just writeData)
+      | otherwise = ((emptyWishboneS2M @a) { acknowledge = True, readData = 0 }, Nothing)
+
+deviceReg ::
+  forall dom a addrWidth .
+  ( HasCallStack
+  , ToFieldType a
+  , NFDataX a
+  , KnownNat addrWidth
+  , HiddenClockResetEnable dom
+  ) =>
+  String ->
+  Access ->
+  BitVector addrWidth ->
+  a ->
+  Circuit
+    (BackwardAnnotated
+      (BitVector addrWidth, SimOnly (NamedLoc Register))
+      (Wishbone dom 'Standard addrWidth a))
+    ()
+deviceReg name' access' addr' def' = Circuit $ \(m2s0, ()) ->
+    (((addr', SimOnly reg'), go m2s0), ())
+  where
+    (_, loc):_ = getCallStack callStack
+    reg' = (Name
+      { name = name'
+      , description = ""
+      }, loc, Register
+        { access = access'
+        , address = toInteger addr'
+        , fieldType = toFieldType @a
+        , fieldSize = error "use deviceReg' with BitPackC"
+        , reset = Nothing
+        }
+      )
+    go m2s = s2m
+      where
+        registerVal = register def' $ fromMaybe <$> registerVal <*> nextVal
+        (unbundle -> (s2m, nextVal)) = inner <$> m2s <*> registerVal
+
+    inner WishboneM2S{..} val
+      | not (busCycle && strobe) = (emptyWishboneS2M, Nothing)
+      | writeEnable = (emptyWishboneS2M { acknowledge = True }, Just writeData)
+      | otherwise = ((emptyWishboneS2M @a) { acknowledge = True, readData = val }, Nothing)
+
+
+deviceVecField' ::
+  forall dom n a addrWidth .
+  ( HasCallStack
+  , KnownNat n
+  , ToFieldType a
+  , NFDataX a
+  , BitPackC a
+  , BitPackC (Vec n a)
+  , KnownNat addrWidth
+  , HiddenClockResetEnable dom
+  ) =>
+  String ->
+  Access ->
+  BitVector addrWidth ->
+  SNat n ->
+  a ->
+  Circuit
+    (BackwardAnnotated
+      (BitVector addrWidth, SimOnly (NamedLoc Register))
+      (Wishbone dom 'Standard addrWidth (BitVector 32)))
+    ()
+deviceVecField' name' access' addr' _size def' = Circuit $ \(m2s0, ()) ->
+    (((addr', SimOnly reg'), go m2s0), ())
+  where
+    (_, loc):_ = getCallStack callStack
+
+    defBytes :: BitVector 32
+    defBytes = resize $ packC def'
+
+    reg' = (Name
+      { name = name'
+      , description = ""
+      }, loc, Register
+        { access = access'
+        , address = toInteger addr'
+        , fieldType = toFieldType @(Vec n a)
+        , fieldSize = snatToInteger (SNat @(ByteSizeC (Vec n a)))
+        , reset = Nothing
+        }
+      )
+    go m2s = s2m
+      where
+        registerVal = register defBytes $ fromMaybe <$> registerVal <*> nextVal
+        (unbundle -> (s2m, nextVal)) = inner <$> m2s <*> registerVal
+
+    inner WishboneM2S{..} val
+      | not (busCycle && strobe) = (emptyWishboneS2M, Nothing)
+      | writeEnable = (emptyWishboneS2M { acknowledge = True }, Just writeData)
+      | otherwise = ((emptyWishboneS2M @a) { acknowledge = True, readData = val }, Nothing)
+
+
+deviceVecField ::
+  forall dom n a addrWidth .
+  ( HasCallStack
+  , KnownNat n
+  , ToFieldType a
+  , NFDataX a
+  , KnownNat addrWidth
+  , HiddenClockResetEnable dom
+  ) =>
+  String ->
+  Access ->
+  BitVector addrWidth ->
+  SNat n ->
+  a ->
+  Circuit
+    (BackwardAnnotated
+      (BitVector addrWidth, SimOnly (NamedLoc Register))
+      (Wishbone dom 'Standard addrWidth a))
+    ()
+deviceVecField name' access' addr' _size def' = Circuit $ \(m2s0, ()) ->
+    (((addr', SimOnly reg'), go m2s0), ())
+  where
+    (_, loc):_ = getCallStack callStack
+    reg' = (Name
+      { name = name'
+      , description = ""
+      }, loc, Register
+        { access = access'
+        , address = toInteger addr'
+        , fieldType = toFieldType @(Vec n a)
+        , fieldSize = error "use deviceVecField' with BitPackC"
+        , reset = Nothing
+        }
+      )
+    go m2s = s2m
+      where
+        registerVal = register def' $ fromMaybe <$> registerVal <*> nextVal
+        (unbundle -> (s2m, nextVal)) = inner <$> m2s <*> registerVal
+
+    inner WishboneM2S{..} val
+      | not (busCycle && strobe) = (emptyWishboneS2M, Nothing)
+      | writeEnable = (emptyWishboneS2M { acknowledge = True }, Just writeData)
+      | otherwise = ((emptyWishboneS2M @a) { acknowledge = True, readData = val }, Nothing)
+
+
+withPrefix ::
+  HasCallStack =>
+  BitVector n ->
+  Circuit (BackwardAnnotated ann a) b ->
+  Circuit (BackwardAnnotated (BitVector n, ann) a) b
+withPrefix p (Circuit f) = Circuit $ \(fwd, bwd) ->
+    let
+      ((ann, bwd'), fwd') = f (fwd, bwd)
+    in (((p, ann), bwd'), fwd')
+
+
+interconnect ::
+  forall dom addrWidth a n.
+  ( HasCallStack
+  , KnownNat n
+  , KnownNat addrWidth
+  , NFDataX a
+  , KnownNat (BitSize a)
+  , (CLog 2 n <= addrWidth)
+  , 1 <= n
+  , KnownNat (addrWidth - CLog 2 n)
+  ) =>
+  AbsoluteAddress ->
+  Circuit (MemoryMapped (Wishbone dom 'Standard addrWidth a))
+  (Vec n (BackwardAnnotated (BitVector (CLog 2 n), SimOnly MemoryMap) (Wishbone dom 'Standard (addrWidth - CLog 2 n) a)))
+interconnect absAddr' = Circuit go
+  where
+    (_, loc):_ = getCallStack callStack
+
+    go ::
+      ( Signal dom (WishboneM2S addrWidth (Div (BitSize a + 7) 8) a)
+      , Vec n ((BitVector (CLog 2 n), SimOnly MemoryMap), Signal dom (WishboneS2M a)))
+      ->
+      ( (SimOnly MemoryMap, Signal dom (WishboneS2M a))
+      , Vec n (Signal dom (WishboneM2S (addrWidth - CLog 2 n) (Div (BitSize a + 7) 8) a)))
+    go (m2s, unzip -> (unzip -> (prefixes, mmaps), s2ms)) = ((SimOnly memoryMap, s2m), unbundle m2ss)
+      where
+
+        memoryMap = MemoryMap
+          { deviceDefs = unionAll (deviceDefs . unSim <$> toList mmaps)
+          , tree = Interconnect loc absAddr' (toList descs) }
+
+
+        unionAll :: [Map.Map String DeviceDefinition] -> Map.Map String DeviceDefinition
+        unionAll = List.foldl Map.union Map.empty
+
+        size = maxBound :: BitVector (addrWidth - CLog 2 n)
+        relAddrs = prefixToAddr <$> prefixes 
+        descs = zip3 relAddrs (repeat (toInteger size)) (tree . unSim <$> mmaps)
+        unSim (SimOnly x) = x
+
+        prefixToAddr :: BitVector (CLog 2 n) -> Address
+        prefixToAddr prefix = toInteger prefix `shiftL` fromInteger shift'
+          where
+            shift' = snatToInteger $ SNat @(addrWidth - CLog 2 n) 
+
+        (unbundle -> (s2m, m2ss)) = inner prefixes <$> m2s <*> bundle s2ms
+
+    inner ::
+      Vec n (BitVector (CLog 2 n)) ->
+      WishboneM2S addrWidth (Div (BitSize a + 7) 8) a ->
+        Vec n (WishboneS2M a) ->
+        (WishboneS2M a, Vec n (WishboneM2S (addrWidth - CLog 2 n) (Div (BitSize a + 7) 8) a))
+    inner prefixes m2s@WishboneM2S{..} s2ms
+      | not (busCycle && strobe) = (emptyWishboneS2M, m2ss)
+      -- no valid index selected
+      | Nothing <- selected = (emptyWishboneS2M { err = True }, m2ss)
+      | Just idx <- selected = (s2ms !! idx, replace idx m2sStripped m2ss)
+
+      where
+        m2ss = repeat emptyWishboneM2S
+        m2sStripped = m2s { addr = internalAddr }
+        (compIdx, internalAddr) = split @_ @(CLog 2 n) @(addrWidth - CLog 2 n) addr
+        selected = elemIndex compIdx prefixes
+
+
+
+addrRange :: forall a n . (Bounded a) => Vec n a -> Vec n (a, a)
+addrRange startAddrs = zip startAddrs bounds
+  where
+    bounds = startAddrs <<+ maxBound
+
+
+{-
+-- | Remove memory map information from a circuit
+unMemoryMapped :: Circuit a (MemoryMapped a)
+unMemoryMapped = Circuit $ \(fwdA, (_mm, bwdA)) -> (bwdA, fwdA)
+
+-- | Add memory map information to a circuit
+memoryMapped :: Named MemoryMap -> Circuit (MemoryMapped a) a
+memoryMapped mm = Circuit $ \(fwdA, bwdA) -> ((SimOnly mm, bwdA), fwdA)
+
+-- | Extract the memory map from a circuit. Note that the circuit needs to be
+-- lazy enough: if the memory map depends on any signals, this function will
+-- error.
+extractMemoryMap :: (NFDataX (Fwd a), NFDataX (Bwd b)) => Circuit (MemoryMapped a) b -> Named MemoryMap
+extractMemoryMap (Circuit f) = 
+  let ((SimOnly mm, _), _) = f (deepErrorX "") in
+  mm
+
+-}

--- a/clash-protocols-memmap/src/Protocols/MemoryMap/Check.hs
+++ b/clash-protocols-memmap/src/Protocols/MemoryMap/Check.hs
@@ -1,0 +1,101 @@
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE FlexibleContexts #-}
+module Protocols.MemoryMap.Check where
+
+import Clash.Prelude
+
+import Protocols
+
+import Protocols.MemoryMap
+import Protocols.MemoryMap.FieldType (TypeName)
+import Protocols.MemoryMap.Check.AbsAddress
+import Protocols.MemoryMap.Check.Overlap
+import Protocols.MemoryMap.TypeCollect
+
+import Language.Haskell.TH hiding (location)
+import Text.Printf (printf)
+import GHC.Stack (SrcLoc (..))
+
+import qualified Data.List as L
+import qualified Data.Map.Strict as Map
+
+data MemoryMapValid = MemoryMapValid
+  { validMap :: MemoryMap
+  , validTypes :: Map.Map TypeName TypeDescription
+  }
+  deriving (Show)
+
+data MemoryMapValidationErrors = MemoryMapValidationErrors
+  { absAddrErrors :: [AbsAddressValidateError]
+  , overlapErrors :: [OverlapError]
+  }
+  deriving (Show)
+
+data CheckConfiguration = CheckConfiguration
+  { startAddr :: Address
+  , endAddr :: Address
+  }
+
+check :: CheckConfiguration -> MemoryMap -> Either MemoryMapValidationErrors MemoryMapValid
+check CheckConfiguration{..} mm@MemoryMap{..} =
+  if not (null absErrors) || not (null overlapErrors) then
+    Left $ MemoryMapValidationErrors
+            { absAddrErrors = absErrors
+            , overlapErrors
+            }
+  else
+    Right $ MemoryMapValid { validMap = mm { tree = absTree }, validTypes = types }
+  where
+    absMm = mm { tree = absTree }
+    absTree = makeAbsolute 0x0 tree
+    absErrors = validateAbsAddresses Root absTree tree
+    overlapErrors = checkOverlap (startAddr, endAddr) absMm
+    types = collect absMm
+
+shortLocation :: SrcLoc -> String
+shortLocation SrcLoc{..} = srcLocFile <> ":" <> show srcLocStartLine <> ":" <> show srcLocStartCol
+
+checkMemoryMap ::
+  forall dom a b .
+  (KnownDomain dom, NFDataX (Fwd a), NFDataX (Bwd b)) =>
+  CheckConfiguration ->
+  ((HiddenClockResetEnable dom) => Circuit (MemoryMapped a) b) ->
+  DecsQ
+checkMemoryMap config circuitFn = do
+  let
+    SimOnly ann = annotation @dom circuitFn
+  
+  case check config ann of
+    Right _mmValid -> pure []
+    Left MemoryMapValidationErrors{..} -> do
+      let absErrorMsgs = flip L.map absAddrErrors $ \AbsAddressValidateError{..} ->
+            let path' = prettyPrintPath path
+                component = case componentName of
+                  Just name -> name
+                  Nothing -> "interconnect " <> path'
+            in
+            printf "Expected component %s at %08X but found %08X (%s)" component expected got (shortLocation location)
+
+      let overlapErrorMsgs = flip L.map overlapErrors $ \case
+            OverlapError{..} ->
+              printf "Component %s (%08X + %08X) overlaps with %s at address (%08X) (%s)"
+                    (prettyPrintPath path) startAddr componentSize
+                    (prettyPrintPath overlapsWith) overlapsAt
+                    (shortLocation location)
+            SizeExceedsError{..} ->
+              printf "Component %s (%08X + %08X) exceeds available size %08X (%s)"
+                    (prettyPrintPath path) startAddr requestedSize
+                    availableSize
+                    (shortLocation location)
+
+      reportError (unlines $ absErrorMsgs <> overlapErrorMsgs)
+
+      pure []
+
+
+    -- fail "Something wrong with the MemoryMap"
+  where
+    prettyPrintPath :: ComponentPath -> String
+    prettyPrintPath Root = "root"
+    prettyPrintPath (InterconnectComponent idx path) = prettyPrintPath path <> "." <> show idx

--- a/clash-protocols-memmap/src/Protocols/MemoryMap/Check.hs
+++ b/clash-protocols-memmap/src/Protocols/MemoryMap/Check.hs
@@ -1,6 +1,10 @@
-{-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE NamedFieldPuns #-}
+-- SPDX-FileCopyrightText: 2024 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE RecordWildCards #-}
+
 module Protocols.MemoryMap.Check where
 
 import Clash.Prelude
@@ -8,14 +12,14 @@ import Clash.Prelude
 import Protocols
 
 import Protocols.MemoryMap
-import Protocols.MemoryMap.FieldType (TypeName)
 import Protocols.MemoryMap.Check.AbsAddress
 import Protocols.MemoryMap.Check.Overlap
+import Protocols.MemoryMap.FieldType (TypeName)
 import Protocols.MemoryMap.TypeCollect
 
+import GHC.Stack (SrcLoc (..))
 import Language.Haskell.TH hiding (location)
 import Text.Printf (printf)
-import GHC.Stack (SrcLoc (..))
 
 import qualified Data.List as L
 import qualified Data.Map.Strict as Map
@@ -37,27 +41,29 @@ data CheckConfiguration = CheckConfiguration
   , endAddr :: Address
   }
 
-check :: CheckConfiguration -> MemoryMap -> Either MemoryMapValidationErrors MemoryMapValid
+check ::
+  CheckConfiguration -> MemoryMap -> Either MemoryMapValidationErrors MemoryMapValid
 check CheckConfiguration{..} mm@MemoryMap{..} =
-  if not (null absErrors) || not (null overlapErrors) then
-    Left $ MemoryMapValidationErrors
-            { absAddrErrors = absErrors
-            , overlapErrors
-            }
-  else
-    Right $ MemoryMapValid { validMap = mm { tree = absTree }, validTypes = types }
-  where
-    absMm = mm { tree = absTree }
-    absTree = makeAbsolute 0x0 tree
-    absErrors = validateAbsAddresses Root absTree tree
-    overlapErrors = checkOverlap (startAddr, endAddr) absMm
-    types = collect absMm
+  if not (null absErrors) || not (null overlapErrors)
+    then
+      Left
+        $ MemoryMapValidationErrors
+          { absAddrErrors = absErrors
+          , overlapErrors
+          }
+    else Right $ MemoryMapValid{validMap = mm{tree = absTree}, validTypes = types}
+ where
+  absMm = mm{tree = absTree}
+  absTree = makeAbsolute 0x0 tree
+  absErrors = validateAbsAddresses Root absTree tree
+  overlapErrors = checkOverlap (startAddr, endAddr) absMm
+  types = collect absMm
 
 shortLocation :: SrcLoc -> String
 shortLocation SrcLoc{..} = srcLocFile <> ":" <> show srcLocStartLine <> ":" <> show srcLocStartCol
 
 checkMemoryMap ::
-  forall dom a b .
+  forall dom a b.
   (KnownDomain dom, NFDataX (Fwd a), NFDataX (Bwd b)) =>
   CheckConfiguration ->
   ((HiddenClockResetEnable dom) => Circuit (MemoryMapped a) b) ->
@@ -65,7 +71,7 @@ checkMemoryMap ::
 checkMemoryMap config circuitFn = do
   let
     SimOnly ann = annotation @dom circuitFn
-  
+
   case check config ann of
     Right _mmValid -> pure []
     Left MemoryMapValidationErrors{..} -> do
@@ -74,28 +80,38 @@ checkMemoryMap config circuitFn = do
                 component = case componentName of
                   Just name -> name
                   Nothing -> "interconnect " <> path'
-            in
-            printf "Expected component %s at %08X but found %08X (%s)" component expected got (shortLocation location)
+             in printf
+                  "Expected component %s at %08X but found %08X (%s)"
+                  component
+                  expected
+                  got
+                  (shortLocation location)
 
       let overlapErrorMsgs = flip L.map overlapErrors $ \case
             OverlapError{..} ->
-              printf "Component %s (%08X + %08X) overlaps with %s at address (%08X) (%s)"
-                    (prettyPrintPath path) startAddr componentSize
-                    (prettyPrintPath overlapsWith) overlapsAt
-                    (shortLocation location)
+              printf
+                "Component %s (%08X + %08X) overlaps with %s at address (%08X) (%s)"
+                (prettyPrintPath path)
+                startAddr
+                componentSize
+                (prettyPrintPath overlapsWith)
+                overlapsAt
+                (shortLocation location)
             SizeExceedsError{..} ->
-              printf "Component %s (%08X + %08X) exceeds available size %08X (%s)"
-                    (prettyPrintPath path) startAddr requestedSize
-                    availableSize
-                    (shortLocation location)
+              printf
+                "Component %s (%08X + %08X) exceeds available size %08X (%s)"
+                (prettyPrintPath path)
+                startAddr
+                requestedSize
+                availableSize
+                (shortLocation location)
 
       reportError (unlines $ absErrorMsgs <> overlapErrorMsgs)
 
       pure []
+ where
+  -- fail "Something wrong with the MemoryMap"
 
-
-    -- fail "Something wrong with the MemoryMap"
-  where
-    prettyPrintPath :: ComponentPath -> String
-    prettyPrintPath Root = "root"
-    prettyPrintPath (InterconnectComponent idx path) = prettyPrintPath path <> "." <> show idx
+  prettyPrintPath :: ComponentPath -> String
+  prettyPrintPath Root = "root"
+  prettyPrintPath (InterconnectComponent idx path) = prettyPrintPath path <> "." <> show idx

--- a/clash-protocols-memmap/src/Protocols/MemoryMap/Check/AbsAddress.hs
+++ b/clash-protocols-memmap/src/Protocols/MemoryMap/Check/AbsAddress.hs
@@ -1,15 +1,18 @@
-{-# LANGUAGE RecordWildCards #-}
+-- SPDX-FileCopyrightText: 2024 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
 {-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE RecordWildCards #-}
+
 module Protocols.MemoryMap.Check.AbsAddress where
 
 import Prelude
 
-import Protocols.MemoryMap
-import Data.Maybe (fromJust, catMaybes)
+import Data.Maybe (catMaybes, fromJust)
 import GHC.Stack (SrcLoc)
+import Protocols.MemoryMap
 
 type AddressWidth = Integer
-
 
 makeAbsolute :: Address -> MemoryMapTree -> MemoryMapTree
 makeAbsolute currAddr mmap =
@@ -20,12 +23,12 @@ makeAbsolute currAddr mmap =
         makeAbsComp (addr, size, comp) =
           (addr, size, makeAbsolute (currAddr + addr) comp)
         comps' = makeAbsComp <$> comps
-      in
-      Interconnect loc (Just currAddr) comps'
+       in
+        Interconnect loc (Just currAddr) comps'
 
-
--- | Check if a (guaranteed 'Just') address unifies with a
--- user specified 'AbsoluteAddress' 
+{- | Check if a (guaranteed 'Just') address unifies with a
+user specified 'AbsoluteAddress'
+-}
 checkAbsAddr :: AbsoluteAddress -> AbsoluteAddress -> Bool
 checkAbsAddr (Just _) Nothing = True
 checkAbsAddr (Just a) (Just b) = a == b
@@ -37,7 +40,8 @@ data AbsAddressValidateError = AbsAddressValidateError
   , expected :: Integer
   , got :: Integer
   , location :: SrcLoc
-  } deriving (Show)
+  }
+  deriving (Show)
 
 validateAbsAddresses ::
   ComponentPath ->
@@ -45,35 +49,36 @@ validateAbsAddresses ::
   MemoryMapTree ->
   [AbsAddressValidateError]
 validateAbsAddresses path (DeviceInstance loc a name _) (DeviceInstance _ b _ _) =
-  if checkAbsAddr a b then
-    []
-  else
-    [AbsAddressValidateError
+  if checkAbsAddr a b
+    then []
+    else
+      [ AbsAddressValidateError
           { path = path
           , componentName = Just name
           , expected = fromJust a
           , got = fromJust b
           , location = loc
-          }]
+          }
+      ]
 validateAbsAddresses path (Interconnect loc a compsA) (Interconnect _ b compsB) =
-  if checkAbsAddr a b then
-    results
-  else
-    AbsAddressValidateError
-      { path = path
-      , componentName = Nothing
-      , expected = fromJust a
-      , got = fromJust b
-      , location = loc
-      } : results
-  where
-    results = concatMap checkComps comps
-    comps = zip3 [0..] compsA compsB
-    checkComps (i, (_, _, compA'), (_, _, compB')) =
-      let
-        path' = InterconnectComponent i path
-        compRes = validateAbsAddresses path' compA' compB'
-      in compRes
-
-
+  if checkAbsAddr a b
+    then results
+    else
+      AbsAddressValidateError
+        { path = path
+        , componentName = Nothing
+        , expected = fromJust a
+        , got = fromJust b
+        , location = loc
+        }
+        : results
+ where
+  results = concatMap checkComps comps
+  comps = zip3 [0 ..] compsA compsB
+  checkComps (i, (_, _, compA'), (_, _, compB')) =
+    let
+      path' = InterconnectComponent i path
+      compRes = validateAbsAddresses path' compA' compB'
+     in
+      compRes
 validateAbsAddresses _ _ _ = error "should not happen"

--- a/clash-protocols-memmap/src/Protocols/MemoryMap/Check/AbsAddress.hs
+++ b/clash-protocols-memmap/src/Protocols/MemoryMap/Check/AbsAddress.hs
@@ -1,0 +1,79 @@
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE NamedFieldPuns #-}
+module Protocols.MemoryMap.Check.AbsAddress where
+
+import Prelude
+
+import Protocols.MemoryMap
+import Data.Maybe (fromJust, catMaybes)
+import GHC.Stack (SrcLoc)
+
+type AddressWidth = Integer
+
+
+makeAbsolute :: Address -> MemoryMapTree -> MemoryMapTree
+makeAbsolute currAddr mmap =
+  case mmap of
+    DeviceInstance loc _ name typeName -> DeviceInstance loc (Just currAddr) name typeName
+    Interconnect loc _ comps ->
+      let
+        makeAbsComp (addr, size, comp) =
+          (addr, size, makeAbsolute (currAddr + addr) comp)
+        comps' = makeAbsComp <$> comps
+      in
+      Interconnect loc (Just currAddr) comps'
+
+
+-- | Check if a (guaranteed 'Just') address unifies with a
+-- user specified 'AbsoluteAddress' 
+checkAbsAddr :: AbsoluteAddress -> AbsoluteAddress -> Bool
+checkAbsAddr (Just _) Nothing = True
+checkAbsAddr (Just a) (Just b) = a == b
+checkAbsAddr Nothing _ = error "shouldn't happen"
+
+data AbsAddressValidateError = AbsAddressValidateError
+  { path :: ComponentPath
+  , componentName :: Maybe String
+  , expected :: Integer
+  , got :: Integer
+  , location :: SrcLoc
+  } deriving (Show)
+
+validateAbsAddresses ::
+  ComponentPath ->
+  MemoryMapTree ->
+  MemoryMapTree ->
+  [AbsAddressValidateError]
+validateAbsAddresses path (DeviceInstance loc a name _) (DeviceInstance _ b _ _) =
+  if checkAbsAddr a b then
+    []
+  else
+    [AbsAddressValidateError
+          { path = path
+          , componentName = Just name
+          , expected = fromJust a
+          , got = fromJust b
+          , location = loc
+          }]
+validateAbsAddresses path (Interconnect loc a compsA) (Interconnect _ b compsB) =
+  if checkAbsAddr a b then
+    results
+  else
+    AbsAddressValidateError
+      { path = path
+      , componentName = Nothing
+      , expected = fromJust a
+      , got = fromJust b
+      , location = loc
+      } : results
+  where
+    results = concatMap checkComps comps
+    comps = zip3 [0..] compsA compsB
+    checkComps (i, (_, _, compA'), (_, _, compB')) =
+      let
+        path' = InterconnectComponent i path
+        compRes = validateAbsAddresses path' compA' compB'
+      in compRes
+
+
+validateAbsAddresses _ _ _ = error "should not happen"

--- a/clash-protocols-memmap/src/Protocols/MemoryMap/Check/Overlap.hs
+++ b/clash-protocols-memmap/src/Protocols/MemoryMap/Check/Overlap.hs
@@ -1,0 +1,93 @@
+{-# LANGUAGE NamedFieldPuns #-}
+module Protocols.MemoryMap.Check.Overlap where
+
+
+import Prelude
+
+import Protocols.MemoryMap
+import Protocols.MemoryMap.FieldType
+import qualified Data.List as L
+import qualified Data.Map.Strict as M
+import Data.Maybe (fromJust)
+import GHC.Stack (SrcLoc)
+
+data OverlapError
+  = SizeExceedsError
+    { startAddr :: Address
+    , availableSize :: Size
+    , requestedSize :: Size
+    , path :: ComponentPath
+    , location :: SrcLoc
+    }
+  | OverlapError
+    { startAddr :: Address
+    , componentSize :: Size
+    , path :: ComponentPath
+    , overlapsWith :: ComponentPath
+    , overlapsAt :: Address
+    , location :: SrcLoc
+    }
+    deriving (Show)
+
+checkOverlap :: (Address, Address) -> MemoryMap -> [OverlapError]
+checkOverlap availableRange MemoryMap{deviceDefs=M.map deviceSize -> dss, tree} =
+  walk Root availableRange tree
+ where
+  walk _ _ (Interconnect _ _ []) = []
+  walk path (start, end) (Interconnect loc _ comps) =
+    interconnectSizeError <> overlapErrors <> concat componentErrors
+   where
+    comps1 = zip (L.map (`InterconnectComponent` path) [0..]) comps
+    comps2 = L.sortOn (\(_, (addr, _, _)) -> addr) comps1
+    (_, (addr, size, _)) = L.last comps2
+    interconnectSize = addr + size
+    availableSize = end - start
+    overlapErrors = checkAllOverlaps loc comps2
+    interconnectSizeError =
+        [ SizeExceedsError
+          { startAddr = start
+          , availableSize
+          , requestedSize = interconnectSize
+          , path
+          , location = loc
+          } | interconnectSize > availableSize
+        ]
+    componentErrors = flip map comps2 $ \(path, (addr, size, comp)) -> walk path (start + addr, start + addr + size) comp
+  walk path (start, end) (DeviceInstance loc _ _instanceName deviceName) =
+    let
+      defSize = fromJust $ M.lookup deviceName dss
+      availableSize = end - start
+    in
+      [SizeExceedsError
+        { startAddr = start
+        , availableSize
+        , requestedSize = defSize
+        , path
+        , location = loc
+        } | defSize > availableSize]
+
+checkAllOverlaps :: SrcLoc -> [(ComponentPath, (Address, Size, MemoryMapTree))] -> [OverlapError]
+checkAllOverlaps _ [] = []
+checkAllOverlaps _ [_] = []
+checkAllOverlaps loc ((aName, (aStart, aLen, _)):b@(bName, (bStart, _, _)):rest)
+  | bStart < aStart + aLen =
+      OverlapError
+      { startAddr = aStart
+      , componentSize = aLen
+      , path = aName
+      , overlapsWith = bName
+      , overlapsAt = bStart
+      , location = loc
+      } : checkAllOverlaps loc (b:rest)
+  | otherwise = checkAllOverlaps loc (b:rest)
+
+deviceSize :: DeviceDefinition -> Size
+deviceSize DeviceDefinition{registers=map (\(_, _, x) -> x) -> regs} = snd fullRange
+ where
+  fullRange = L.foldl' mergeRange (0, 0) ranges
+  ranges = map walk regs
+  walk Register{address, fieldSize} = (address, address + fieldSize)
+
+
+  mergeRange :: (Address, Address) -> (Address, Address) -> (Address, Address)
+  mergeRange (start0, end0) (start1, end1) = (min start0 start1, max end0 end1)

--- a/clash-protocols-memmap/src/Protocols/MemoryMap/Check/Overlap.hs
+++ b/clash-protocols-memmap/src/Protocols/MemoryMap/Check/Overlap.hs
@@ -1,93 +1,100 @@
+-- SPDX-FileCopyrightText: 2024 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
 {-# LANGUAGE NamedFieldPuns #-}
-module Protocols.MemoryMap.Check.Overlap where
 
+module Protocols.MemoryMap.Check.Overlap where
 
 import Prelude
 
-import Protocols.MemoryMap
-import Protocols.MemoryMap.FieldType
 import qualified Data.List as L
 import qualified Data.Map.Strict as M
 import Data.Maybe (fromJust)
 import GHC.Stack (SrcLoc)
+import Protocols.MemoryMap
+import Protocols.MemoryMap.FieldType
 
 data OverlapError
   = SizeExceedsError
-    { startAddr :: Address
-    , availableSize :: Size
-    , requestedSize :: Size
-    , path :: ComponentPath
-    , location :: SrcLoc
-    }
+      { startAddr :: Address
+      , availableSize :: Size
+      , requestedSize :: Size
+      , path :: ComponentPath
+      , location :: SrcLoc
+      }
   | OverlapError
-    { startAddr :: Address
-    , componentSize :: Size
-    , path :: ComponentPath
-    , overlapsWith :: ComponentPath
-    , overlapsAt :: Address
-    , location :: SrcLoc
-    }
-    deriving (Show)
+      { startAddr :: Address
+      , componentSize :: Size
+      , path :: ComponentPath
+      , overlapsWith :: ComponentPath
+      , overlapsAt :: Address
+      , location :: SrcLoc
+      }
+  deriving (Show)
 
 checkOverlap :: (Address, Address) -> MemoryMap -> [OverlapError]
-checkOverlap availableRange MemoryMap{deviceDefs=M.map deviceSize -> dss, tree} =
+checkOverlap availableRange MemoryMap{deviceDefs = M.map deviceSize -> dss, tree} =
   walk Root availableRange tree
  where
   walk _ _ (Interconnect _ _ []) = []
   walk path (start, end) (Interconnect loc _ comps) =
     interconnectSizeError <> overlapErrors <> concat componentErrors
    where
-    comps1 = zip (L.map (`InterconnectComponent` path) [0..]) comps
+    comps1 = zip (L.map (`InterconnectComponent` path) [0 ..]) comps
     comps2 = L.sortOn (\(_, (addr, _, _)) -> addr) comps1
     (_, (addr, size, _)) = L.last comps2
     interconnectSize = addr + size
     availableSize = end - start
     overlapErrors = checkAllOverlaps loc comps2
     interconnectSizeError =
-        [ SizeExceedsError
-          { startAddr = start
-          , availableSize
-          , requestedSize = interconnectSize
-          , path
-          , location = loc
-          } | interconnectSize > availableSize
-        ]
+      [ SizeExceedsError
+        { startAddr = start
+        , availableSize
+        , requestedSize = interconnectSize
+        , path
+        , location = loc
+        }
+      | interconnectSize > availableSize
+      ]
     componentErrors = flip map comps2 $ \(path, (addr, size, comp)) -> walk path (start + addr, start + addr + size) comp
   walk path (start, end) (DeviceInstance loc _ _instanceName deviceName) =
     let
       defSize = fromJust $ M.lookup deviceName dss
       availableSize = end - start
-    in
-      [SizeExceedsError
+     in
+      [ SizeExceedsError
         { startAddr = start
         , availableSize
         , requestedSize = defSize
         , path
         , location = loc
-        } | defSize > availableSize]
+        }
+      | defSize > availableSize
+      ]
 
-checkAllOverlaps :: SrcLoc -> [(ComponentPath, (Address, Size, MemoryMapTree))] -> [OverlapError]
+checkAllOverlaps ::
+  SrcLoc -> [(ComponentPath, (Address, Size, MemoryMapTree))] -> [OverlapError]
 checkAllOverlaps _ [] = []
 checkAllOverlaps _ [_] = []
-checkAllOverlaps loc ((aName, (aStart, aLen, _)):b@(bName, (bStart, _, _)):rest)
+checkAllOverlaps loc ((aName, (aStart, aLen, _)) : b@(bName, (bStart, _, _)) : rest)
   | bStart < aStart + aLen =
       OverlapError
-      { startAddr = aStart
-      , componentSize = aLen
-      , path = aName
-      , overlapsWith = bName
-      , overlapsAt = bStart
-      , location = loc
-      } : checkAllOverlaps loc (b:rest)
-  | otherwise = checkAllOverlaps loc (b:rest)
+        { startAddr = aStart
+        , componentSize = aLen
+        , path = aName
+        , overlapsWith = bName
+        , overlapsAt = bStart
+        , location = loc
+        }
+        : checkAllOverlaps loc (b : rest)
+  | otherwise = checkAllOverlaps loc (b : rest)
 
 deviceSize :: DeviceDefinition -> Size
-deviceSize DeviceDefinition{registers=map (\(_, _, x) -> x) -> regs} = snd fullRange
+deviceSize DeviceDefinition{registers = map (\(_, _, x) -> x) -> regs} = snd fullRange
  where
   fullRange = L.foldl' mergeRange (0, 0) ranges
   ranges = map walk regs
   walk Register{address, fieldSize} = (address, address + fieldSize)
-
 
   mergeRange :: (Address, Address) -> (Address, Address) -> (Address, Address)
   mergeRange (start0, end0) (start1, end1) = (min start0 start1, max end0 end1)

--- a/clash-protocols-memmap/src/Protocols/MemoryMap/FieldType.hs
+++ b/clash-protocols-memmap/src/Protocols/MemoryMap/FieldType.hs
@@ -1,0 +1,180 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE AllowAmbiguousTypes #-}
+module Protocols.MemoryMap.FieldType where
+
+import Clash.Prelude
+import GHC.Generics hiding (moduleName, packageName)
+import qualified GHC.Generics
+import Data.Word
+import Data.Int
+
+data TypeName = TypeName
+  { name :: String
+  , moduleName :: String
+  , packageName :: String
+  , isNewType :: Bool
+  }
+  deriving (Show, Eq, Ord)
+
+type Named a = (String, a)
+
+data FieldType
+  = BoolFieldType
+  | BitVectorFieldType Word
+  | SignedFieldType Word
+  | SumOfProductFieldType TypeName [Named [Named FieldType]]
+  | UnsignedFieldType Word
+  | VecFieldType Word FieldType
+  | TypeReference FieldType [FieldType]
+  | TypeVariable Integer
+  deriving (Show, Eq)
+
+class (KnownNat (Generics a)) => ToFieldType (a :: Type) where
+  type Generics a :: Nat
+  type Generics a = 0
+
+  type WithVars a :: Type
+  type WithVars a = a
+
+  generics :: SNat (Generics a)
+  generics = SNat @(Generics a)
+
+  toFieldType :: FieldType
+
+  args :: Vec (Generics a) FieldType
+  args = repeat undefined
+
+  default toFieldType :: (Generic (WithVars a), GToFieldType (Rep (WithVars a))) => FieldType
+  toFieldType = case (gToFieldType @(Rep (WithVars a)), toList (args @a)) of
+    (ft, []) -> ft
+    (TypeReference _ft _args', _args'') -> error "shouldn't happen!??"
+    (ft, args') -> TypeReference ft args'
+
+newtype Var (n :: Nat) = Var Integer
+
+instance (KnownNat n) => ToFieldType (Var n) where
+  type Generics (Var n) = 0
+  type WithVars (Var n) = Var n
+
+  toFieldType = TypeVariable $ snatToInteger (SNat @n)
+
+instance ToFieldType ()
+
+instance (ToFieldType a) => ToFieldType (Maybe a) where
+  type Generics (Maybe a) = 1
+  type WithVars (Maybe a) = Maybe (Var 0)
+  args = toFieldType @a :> Nil
+
+instance (ToFieldType a, ToFieldType b) => ToFieldType (a, b) where
+  type Generics (a, b) = 2
+  type WithVars (a, b) = (Var 0, Var 1)
+  args = toFieldType @a :> toFieldType @b :> Nil
+
+instance (ToFieldType a, ToFieldType b, ToFieldType c) => ToFieldType (a, b, c) where
+  type Generics (a, b, c) = 3
+  type WithVars (a, b, c) = (Var 0, Var 1, Var 2)
+  args = toFieldType @a :> toFieldType @b :> toFieldType @c :> Nil
+
+instance (ToFieldType a, ToFieldType b, ToFieldType c, ToFieldType d) => ToFieldType (a, b, c, d) where
+  type Generics (a, b, c, d) = 4
+  type WithVars (a, b, c, d) = (Var 0, Var 1, Var 2, Var 3)
+  args = toFieldType @a :> toFieldType @b :> toFieldType @c :> toFieldType @d :> Nil
+
+instance (ToFieldType a, ToFieldType b) => ToFieldType (Either a b) where
+  type Generics (Either a b) = 2
+  type WithVars (Either a b) = Either (Var 0) (Var 1)
+  args = toFieldType @a :> toFieldType @b :> Nil
+
+
+
+data MyTestType
+  = SomeVar
+  | AnotherVar (Maybe (BitVector 8))
+  | YetAnotherVar Bool (Either (Signed 8) (Unsigned 8))
+  deriving (Generic, ToFieldType)
+
+data MyTestGen a
+  = Yep
+  | UhOh (Maybe a)
+  deriving (Generic)
+
+instance (ToFieldType a) => ToFieldType (MyTestGen a) where
+  type Generics (MyTestGen a) = 1
+  type WithVars (MyTestGen a) = MyTestGen (Var 0)
+
+  args = toFieldType @a :> Nil
+
+
+instance ToFieldType Bool where
+  toFieldType = BoolFieldType
+
+instance ToFieldType Bit where
+  toFieldType = BitVectorFieldType 1
+
+instance forall n . (KnownNat n) => ToFieldType (BitVector n) where
+  toFieldType = BitVectorFieldType (fromIntegral $ snatToInteger $ SNat @n)
+
+instance forall n . (KnownNat n) => ToFieldType (Signed n) where
+  toFieldType = SignedFieldType (fromIntegral $ snatToInteger $ SNat @n)
+
+instance forall n . (KnownNat n) => ToFieldType (Unsigned n) where
+  toFieldType = SignedFieldType (fromIntegral $ snatToInteger $ SNat @n)
+
+instance forall n a . (KnownNat n, ToFieldType a) => ToFieldType (Vec n a) where
+  toFieldType = VecFieldType (fromIntegral $ snatToInteger $ SNat @n) (toFieldType @a)
+
+instance ToFieldType Word8 where toFieldType = UnsignedFieldType 8
+instance ToFieldType Word16 where toFieldType = UnsignedFieldType 16
+instance ToFieldType Word32 where toFieldType = UnsignedFieldType 32
+instance ToFieldType Word64 where toFieldType = UnsignedFieldType 64
+instance ToFieldType Int8 where toFieldType = SignedFieldType 8
+instance ToFieldType Int16 where toFieldType = SignedFieldType 16
+instance ToFieldType Int32 where toFieldType = SignedFieldType 32
+instance ToFieldType Int64 where toFieldType = SignedFieldType 64
+
+instance ToFieldType Int where toFieldType = SignedFieldType 32
+
+class GToFieldType f where
+  gToFieldType :: FieldType
+
+instance (Datatype m, GFieldTypeCons inner) => GToFieldType (D1 m inner) where
+  gToFieldType = SumOfProductFieldType name' $ gToFieldTypeCons @inner
+    where
+      name' = TypeName { name = tyName, moduleName = mod', packageName = pck, isNewType = newtype' }
+      mod' = GHC.Generics.moduleName @m undefined
+      tyName = datatypeName @m undefined
+      newtype' = isNewtype @m undefined
+      pck = GHC.Generics.packageName @m undefined
+
+instance (ToFieldType inner) => GToFieldType (Rec0 inner) where
+  gToFieldType = toFieldType @inner
+
+class GFieldTypeCons f where
+  gToFieldTypeCons :: [Named [Named FieldType]]
+
+instance GFieldTypeCons V1 where
+  gToFieldTypeCons = []
+
+instance (Constructor m, GFieldTypeFields inner) => GFieldTypeCons (C1 m inner) where
+  gToFieldTypeCons = [(conName', gFieldTypeFields @inner)]
+    where
+      conName' = conName @m undefined
+
+instance (GFieldTypeCons a, GFieldTypeCons b) => GFieldTypeCons (a :+: b) where
+  gToFieldTypeCons = gToFieldTypeCons @a <> gToFieldTypeCons @b
+
+
+class GFieldTypeFields f where
+  gFieldTypeFields :: [Named FieldType]
+
+instance GFieldTypeFields U1 where
+  gFieldTypeFields = []
+
+instance (Selector m, GToFieldType inner) => GFieldTypeFields (S1 m inner) where
+  gFieldTypeFields = [(fieldName, gToFieldType @inner)]
+    where
+      fieldName = selName @m undefined
+
+instance (GFieldTypeFields a, GFieldTypeFields b) => GFieldTypeFields (a :*: b) where
+  gFieldTypeFields = gFieldTypeFields @a <> gFieldTypeFields @b

--- a/clash-protocols-memmap/src/Protocols/MemoryMap/Json.hs
+++ b/clash-protocols-memmap/src/Protocols/MemoryMap/Json.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 
+-- | Generate a JSON representation of a 'MemoryMapValid'
 module Protocols.MemoryMap.Json where
 
 import Clash.Prelude
@@ -23,8 +24,9 @@ import Protocols.MemoryMap.TypeCollect
 
 import Data.Aeson.Key (fromString)
 import qualified Data.Map.Strict as Map
-import GHC.Stack (SrcLoc (..), prettySrcLoc)
+import GHC.Stack (SrcLoc (..))
 
+-- | Generate a JSON representation of a 'MemoryMapValid'
 memoryMapJson :: MemoryMapValid -> Value
 memoryMapJson MemoryMapValid{..} =
   object
@@ -34,12 +36,12 @@ memoryMapJson MemoryMapValid{..} =
     ]
  where
   devicesVal =
-    (\(name, def) -> fromString name .= generateDeviceDef def)
+    (\(name, def') -> fromString name .= generateDeviceDef def')
       <$> Map.toList (deviceDefs validMap)
 
   validTree = tree validMap
   types =
-    (\(name, def) -> fromString (FT.name name) .= generateTypeDesc def)
+    (\(name, def') -> fromString (FT.name name) .= generateTypeDesc def')
       <$> Map.toList validTypes
 
 generateTypeDesc :: TypeDescription -> Value
@@ -61,7 +63,7 @@ generateTypeDef ft = case ft of
   FT.BoolFieldType -> "bool"
   FT.BitVectorFieldType n -> toJSON ["bitvector", toJSON n]
   FT.SignedFieldType n -> toJSON ["signed", toJSON n]
-  FT.SumOfProductFieldType tyName def ->
+  FT.SumOfProductFieldType tyName def' ->
     object
       [ "name" .= FT.name tyName
       , "meta"
@@ -70,7 +72,7 @@ generateTypeDef ft = case ft of
             , "package" .= FT.packageName tyName
             , "is_newtype" .= FT.isNewType tyName
             ]
-      , "variants" .= (genVariant <$> def)
+      , "variants" .= (genVariant <$> def')
       ]
    where
     genVariant :: FT.Named [FT.Named FT.FieldType] -> Value

--- a/clash-protocols-memmap/src/Protocols/MemoryMap/Json.hs
+++ b/clash-protocols-memmap/src/Protocols/MemoryMap/Json.hs
@@ -1,0 +1,136 @@
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Protocols.MemoryMap.Json where
+
+import Clash.Prelude
+
+import Data.Aeson
+import Protocols.MemoryMap.Check (MemoryMapValid(..))
+import Protocols.MemoryMap (MemoryMap(..), MemoryMapTree(..), DeviceDefinition(..), Name(..), Register (..), Access (ReadOnly, WriteOnly, ReadWrite))
+import Protocols.MemoryMap.TypeCollect
+import qualified Protocols.MemoryMap.FieldType as FT
+
+import qualified Data.Map.Strict as Map
+import Data.Aeson.Key (fromString)
+import GHC.Stack (prettySrcLoc, SrcLoc (..))
+
+memoryMapJson :: MemoryMapValid -> Value
+memoryMapJson MemoryMapValid{..} =
+    object
+      [ "devices" .= object devicesVal
+      , "types" .= object types
+      , "tree" .= generateTree validTree ]
+  where
+    devicesVal =
+      (\(name, def) -> fromString name .= generateDeviceDef def)
+      <$> Map.toList (deviceDefs validMap)
+
+    validTree = tree validMap
+    types = (\(name, def) -> fromString (FT.name name) .= generateTypeDesc def) <$> Map.toList validTypes
+
+generateTypeDesc :: TypeDescription -> Value
+generateTypeDesc TypeDescription{name=tyName, ..} =
+  object
+    [ "name" .= toJSON (FT.name tyName)
+    , "meta" .= object
+        [ "module" .= FT.moduleName tyName
+        , "package" .= FT.packageName tyName
+        , "is_newtype" .= FT.isNewType tyName
+        ]
+    , "generics" .= nGenerics
+    , "definition" .= generateTypeDef definition
+    ]
+
+generateTypeDef :: FT.FieldType -> Value
+generateTypeDef ft = case ft of
+  FT.BoolFieldType -> "bool"
+  FT.BitVectorFieldType n -> toJSON ["bitvector", toJSON n]
+  FT.SignedFieldType n -> toJSON ["signed", toJSON n]
+  FT.SumOfProductFieldType tyName def ->
+    object
+      [ "name" .= FT.name tyName
+      , "meta" .= object
+        [ "module" .= FT.moduleName tyName
+        , "package" .= FT.packageName tyName
+        , "is_newtype" .= FT.isNewType tyName
+        ]
+      , "variants" .= (genVariant <$> def)
+      ]
+    where
+      genVariant :: FT.Named [FT.Named FT.FieldType] -> Value
+      genVariant (n, fields) =
+        object
+          [ "name" .= n
+          , "fields" .= (genField <$> fields) ]
+
+      genField :: FT.Named FT.FieldType -> Value
+      genField (name, field) = object [ "name" .= name, "type" .= generateTypeDef field ]
+  FT.UnsignedFieldType n -> toJSON ["unsigned", toJSON n]
+  FT.VecFieldType n ty -> toJSON ["vector", toJSON n, generateTypeDef ty]
+  FT.TypeReference (FT.SumOfProductFieldType tyName _def) args ->
+    toJSON ["reference", toJSON (FT.name tyName), toJSON (generateTypeDef <$> args)]
+  FT.TypeReference ty [] -> generateTypeDef ty
+  FT.TypeReference ty args -> error $ "shouldn't happen: " <> show ty <> show args
+  FT.TypeVariable n -> toJSON ["variable", toJSON n]
+
+generateTree :: MemoryMapTree -> Value
+generateTree (Interconnect loc (Just absAddr) comps) =
+  object [ "interconnect" .=
+    object
+      [ "src_location" .= location loc
+      , "absolute_address" .= absAddr
+      , "components" .= (generateComp <$> comps)
+      ]
+  ]
+  where
+    generateComp (addr, size, tree) = object
+      [ "relative_address" .= addr
+      , "size" .= size
+      , "tree" .= generateTree tree
+      ]
+generateTree (DeviceInstance loc (Just absAddr) instanceName deviceName) =
+  object [ "device_instance" .=
+    object
+    [ "instance_name" .= instanceName
+    , "device_name" .= deviceName
+    , "src_location" .= location loc
+    , "absolute_address" .= absAddr
+    ]
+  ]
+generateTree _ = error "memory map tree should have absolute addresses"
+
+generateDeviceDef :: DeviceDefinition -> Value
+generateDeviceDef DeviceDefinition{..} =
+  object
+    [ "name" .= Protocols.MemoryMap.name deviceName
+    , "description" .= description deviceName
+    , "src_location" .= location defLocation
+    , "registers" .= (generateRegister <$> registers)
+    ]
+  where
+    generateRegister (regName, srcLoc, Register{..}) =
+      object
+        [ "name" .= Protocols.MemoryMap.name regName
+        , "description" .= description regName
+        , "src_location" .= location srcLoc
+        , "address" .= address
+        , "access" .= case access of
+            ReadOnly -> "read_only" :: String
+            WriteOnly -> "write_only"
+            ReadWrite -> "read_write"
+        , "type" .= generateTypeDef fieldType
+        , "size" .= fieldSize
+        , "reset" .= maybe Null toJSON reset
+        ]
+
+location :: SrcLoc -> Value
+location SrcLoc{..} = object
+  [ "package" .= srcLocPackage
+  , "module" .= srcLocModule
+  , "file" .= srcLocFile
+  , "start_line" .= srcLocStartLine
+  , "start_col" .= srcLocStartCol
+  , "end_line" .= srcLocEndLine
+  , "end_col" .= srcLocEndCol
+  ]

--- a/clash-protocols-memmap/src/Protocols/MemoryMap/TypeCollect.hs
+++ b/clash-protocols-memmap/src/Protocols/MemoryMap/TypeCollect.hs
@@ -3,6 +3,7 @@
 -- SPDX-License-Identifier: Apache-2.0
 {-# LANGUAGE RecordWildCards #-}
 
+-- | Collect all types referenced in a 'MemoryMap' and create a type-map.
 module Protocols.MemoryMap.TypeCollect where
 
 import Clash.Prelude hiding (def)
@@ -20,13 +21,14 @@ data TypeDescription = TypeDescription
   }
   deriving (Show)
 
+-- | Collect all referenced types in a 'MemoryMap' into a type map.
+collect :: MemoryMap -> Map.Map TypeName TypeDescription
+collect mm = typeMap $ collectTypeDefsFromMM mm
+
 typeMap :: [(TypeName, TypeDescription)] -> Map.Map TypeName TypeDescription
 typeMap = L.foldl go Map.empty
  where
   go m (name, def) = Map.insert name def m
-
-collect :: MemoryMap -> Map.Map TypeName TypeDescription
-collect mm = typeMap $ collectTypeDefsFromMM mm
 
 collectTypeDefsFromMM :: MemoryMap -> [(TypeName, TypeDescription)]
 collectTypeDefsFromMM MemoryMap{..} = go $ snd <$> Map.toList deviceDefs

--- a/clash-protocols-memmap/src/Protocols/MemoryMap/TypeCollect.hs
+++ b/clash-protocols-memmap/src/Protocols/MemoryMap/TypeCollect.hs
@@ -1,0 +1,49 @@
+{-# LANGUAGE RecordWildCards #-}
+module Protocols.MemoryMap.TypeCollect where
+
+import Clash.Prelude hiding (def)
+
+import qualified Data.List as L
+
+import Protocols.MemoryMap (MemoryMap (..), DeviceDefinition(..), Register(..))
+import Protocols.MemoryMap.FieldType (FieldType(..), TypeName)
+import qualified Data.Map.Strict as Map
+
+data TypeDescription = TypeDescription
+  { name :: TypeName
+  , nGenerics :: Int
+  , definition :: FieldType
+  }
+  deriving (Show)
+
+typeMap :: [(TypeName, TypeDescription)] -> Map.Map TypeName TypeDescription
+typeMap = L.foldl go Map.empty
+  where
+    go m (name, def) = Map.insert name def m
+
+collect :: MemoryMap -> Map.Map TypeName TypeDescription
+collect mm = typeMap $ collectTypeDefsFromMM mm
+
+collectTypeDefsFromMM :: MemoryMap -> [(TypeName, TypeDescription)]
+collectTypeDefsFromMM MemoryMap{..} = go $ snd <$> Map.toList deviceDefs
+  where
+    go [] = []
+    go (deviceDef:devs) = goRegisters (registers deviceDef) <> go devs
+
+    goRegisters [] = []
+    goRegisters ((_, _, Register{..}):regs) = collectDefs fieldType <> goRegisters regs
+
+collectDefs :: FieldType -> [(TypeName, TypeDescription)]
+collectDefs fieldType = case fieldType of
+    sop@(SumOfProductFieldType name variants) ->
+      let
+        def = TypeDescription name 0 sop
+        inner = L.concat $ L.concatMap (\(_name, fields) -> L.map collectDefs $ snd <$> fields) variants
+      in (name, def) : inner
+    TypeReference inner@(SumOfProductFieldType tyName variants) args' ->
+      let
+        def = TypeDescription tyName (L.length args') inner
+        variantInner = L.concat $ L.concatMap (\(_name, fields) -> L.map collectDefs $ snd <$> fields) variants
+      in (tyName, def) : variantInner
+    TypeReference ty args' -> collectDefs ty <> L.concatMap collectDefs args'
+    _ -> []

--- a/clash-protocols-memmap/src/Protocols/MemoryMap/TypeCollect.hs
+++ b/clash-protocols-memmap/src/Protocols/MemoryMap/TypeCollect.hs
@@ -1,13 +1,17 @@
+-- SPDX-FileCopyrightText: 2024 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
 {-# LANGUAGE RecordWildCards #-}
+
 module Protocols.MemoryMap.TypeCollect where
 
 import Clash.Prelude hiding (def)
 
 import qualified Data.List as L
 
-import Protocols.MemoryMap (MemoryMap (..), DeviceDefinition(..), Register(..))
-import Protocols.MemoryMap.FieldType (FieldType(..), TypeName)
 import qualified Data.Map.Strict as Map
+import Protocols.MemoryMap (DeviceDefinition (..), MemoryMap (..), Register (..))
+import Protocols.MemoryMap.FieldType (FieldType (..), TypeName)
 
 data TypeDescription = TypeDescription
   { name :: TypeName
@@ -18,32 +22,36 @@ data TypeDescription = TypeDescription
 
 typeMap :: [(TypeName, TypeDescription)] -> Map.Map TypeName TypeDescription
 typeMap = L.foldl go Map.empty
-  where
-    go m (name, def) = Map.insert name def m
+ where
+  go m (name, def) = Map.insert name def m
 
 collect :: MemoryMap -> Map.Map TypeName TypeDescription
 collect mm = typeMap $ collectTypeDefsFromMM mm
 
 collectTypeDefsFromMM :: MemoryMap -> [(TypeName, TypeDescription)]
 collectTypeDefsFromMM MemoryMap{..} = go $ snd <$> Map.toList deviceDefs
-  where
-    go [] = []
-    go (deviceDef:devs) = goRegisters (registers deviceDef) <> go devs
+ where
+  go [] = []
+  go (deviceDef : devs) = goRegisters (registers deviceDef) <> go devs
 
-    goRegisters [] = []
-    goRegisters ((_, _, Register{..}):regs) = collectDefs fieldType <> goRegisters regs
+  goRegisters [] = []
+  goRegisters ((_, _, Register{..}) : regs) = collectDefs fieldType <> goRegisters regs
 
 collectDefs :: FieldType -> [(TypeName, TypeDescription)]
 collectDefs fieldType = case fieldType of
-    sop@(SumOfProductFieldType name variants) ->
-      let
-        def = TypeDescription name 0 sop
-        inner = L.concat $ L.concatMap (\(_name, fields) -> L.map collectDefs $ snd <$> fields) variants
-      in (name, def) : inner
-    TypeReference inner@(SumOfProductFieldType tyName variants) args' ->
-      let
-        def = TypeDescription tyName (L.length args') inner
-        variantInner = L.concat $ L.concatMap (\(_name, fields) -> L.map collectDefs $ snd <$> fields) variants
-      in (tyName, def) : variantInner
-    TypeReference ty args' -> collectDefs ty <> L.concatMap collectDefs args'
-    _ -> []
+  sop@(SumOfProductFieldType name variants) ->
+    let
+      def = TypeDescription name 0 sop
+      inner =
+        L.concat $ L.concatMap (\(_name, fields) -> L.map collectDefs $ snd <$> fields) variants
+     in
+      (name, def) : inner
+  TypeReference inner@(SumOfProductFieldType tyName variants) args' ->
+    let
+      def = TypeDescription tyName (L.length args') inner
+      variantInner =
+        L.concat $ L.concatMap (\(_name, fields) -> L.map collectDefs $ snd <$> fields) variants
+     in
+      (tyName, def) : variantInner
+  TypeReference ty args' -> collectDefs ty <> L.concatMap collectDefs args'
+  _ -> []

--- a/firmware-binaries/Cargo.lock
+++ b/firmware-binaries/Cargo.lock
@@ -154,9 +154,16 @@ name = "hello"
 version = "0.1.0"
 dependencies = [
  "bittide-sys",
+ "memmap-generate",
  "riscv-rt",
  "ufmt",
 ]
+
+[[package]]
+name = "itoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "lazy_static"
@@ -185,6 +192,16 @@ name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
+name = "memmap-generate"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "nb"
@@ -297,7 +314,7 @@ checksum = "f38509d7b17c2f604ceab3e5ff8ac97bb8cd2f544688c512be75c715edaf4daf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -320,6 +337,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -330,6 +353,37 @@ name = "semver"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
+
+[[package]]
+name = "serde"
+version = "1.0.164"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.164"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.20",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.99"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46266871c240a00b8f503b877622fe33430b3c7d963bdc0f2adc511e54a1eae3"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
 
 [[package]]
 name = "spin"
@@ -351,6 +405,17 @@ name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcb8d4cebc40aa517dfb69618fa647a346562e67228e2236ae0042ee6ac14775"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -384,7 +449,7 @@ checksum = "d337d3be617449165cb4633c8dece429afd83f84051024079f97ad32a9663716"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/firmware-binaries/examples/hello/.gitignore
+++ b/firmware-binaries/examples/hello/.gitignore
@@ -2,6 +2,4 @@
 #
 # SPDX-License-Identifier: CC0-1.0
 
-[workspace]
-members = ["bittide-sys", "memmap-generate"]
-resolver = "2"
+src/wrappers/memory_map.rs

--- a/firmware-binaries/examples/hello/Cargo.toml
+++ b/firmware-binaries/examples/hello/Cargo.toml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 Google LLC
+# SPDX-FileCopyrightText: 2022 Google LLC
 #
 # SPDX-License-Identifier: CC0-1.0
 

--- a/firmware-binaries/examples/hello/Cargo.toml
+++ b/firmware-binaries/examples/hello/Cargo.toml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Google LLC
+# SPDX-FileCopyrightText: 2024 Google LLC
 #
 # SPDX-License-Identifier: CC0-1.0
 
@@ -15,3 +15,6 @@ authors = ["Google LLC"]
 riscv-rt = "0.11.0"
 bittide-sys = { path = "../../../firmware-support/bittide-sys" }
 ufmt = "0.2.0"
+
+[build-dependencies]
+memmap-generate = { path = "../../../firmware-support/memmap-generate" }

--- a/firmware-binaries/examples/hello/build.rs
+++ b/firmware-binaries/examples/hello/build.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 Google LLC
+// SPDX-FileCopyrightText: 2024 Google LLC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -6,17 +6,72 @@ use std::env;
 use std::fs;
 use std::path::Path;
 
+use memmap_generate as mm;
+use memmap_generate::generators::{
+    generate_rust_wrappers, types::DebugDerive, GenerateConfig, ItemScopeMode,
+};
+
 /// Put the linker script somewhere the linker can find it.
 fn main() {
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+    let manifest_dir = Path::new(&manifest_dir);
+    let src_dir = manifest_dir.join("src");
+    let build_dir = manifest_dir.join("../../../_build");
+    let mm_dir = build_dir.join("memory_maps");
+
     let out_dir = env::var("OUT_DIR").expect("No out dir");
-    let dest_path = Path::new(&out_dir).join("memory.x");
+    let out_dir = Path::new(&out_dir);
+
+    // read memory map for the hardware this program will run on and generate
+    // wrappers.
+
+    let memory_map = mm_dir.join("vexriscv.json");
+
+    eprintln!("memory map path: {}", memory_map.display());
+    let mm_src = std::fs::read_to_string(&memory_map).unwrap();
+
+    let memory_map = mm::parse(&mm_src).unwrap();
+
+    let generate_config = GenerateConfig {
+        debug_derive_mode: DebugDerive::None,
+        item_scope_mode: ItemScopeMode::OneFile,
+    };
+    let wrappers = generate_rust_wrappers(&memory_map, &generate_config);
+    let wrapper_code = {
+        let mut s = String::new();
+
+        s += r#"
+        #![allow(non_camel_case_types)]
+        #![allow(non_snake_case)]
+        #![allow(dead_code)]
+
+        "#;
+
+        for (_, ty_src) in &wrappers.type_defs {
+            s += &ty_src.to_string();
+        }
+        for (_, dev_src) in &wrappers.device_defs {
+            s += &dev_src.to_string();
+        }
+        s += &wrappers.device_instances_struct.to_string();
+        s
+    };
+
+    let wrapper_src_path = src_dir.join("wrappers");
+    let _ = std::fs::create_dir(&wrapper_src_path);
+
+    let memory_map_wrapper_path = wrapper_src_path.join("memory_map.rs");
+
+    std::fs::write(&memory_map_wrapper_path, wrapper_code).unwrap();
+
+    let dest_path = out_dir.join("memory.x");
     fs::write(dest_path, include_bytes!("memory.x")).expect("Could not write file");
 
     if env::var("CARGO_CFG_TARGET_ARCH").unwrap() == "riscv32" {
         println!("cargo:rustc-link-arg=-Tmemory.x");
         println!("cargo:rustc-link-arg=-Tlink.x"); // linker script from riscv-rt
     }
-    println!("cargo:rustc-link-search={out_dir}");
+    println!("cargo:rustc-link-search={}", out_dir.display());
 
     println!("cargo:rerun-if-changed=memory.x");
     println!("cargo:rerun-if-changed=build.rs");

--- a/firmware-binaries/examples/hello/build.rs
+++ b/firmware-binaries/examples/hello/build.rs
@@ -8,8 +8,10 @@ use std::path::Path;
 
 use memmap_generate as mm;
 use memmap_generate::generators::{
-    generate_rust_wrappers, types::DebugDerive, GenerateConfig, ItemScopeMode,
+    generate_rust_wrappers, DebugDerive, GenerateConfig, ItemScopeMode,
 };
+use mm::parse::MemoryMapTree;
+use mm::MemoryMapDesc;
 
 /// Put the linker script somewhere the linker can find it.
 fn main() {
@@ -47,10 +49,10 @@ fn main() {
 
         "#;
 
-        for (_, ty_src) in &wrappers.type_defs {
+        for ty_src in wrappers.type_defs.values() {
             s += &ty_src.to_string();
         }
-        for (_, dev_src) in &wrappers.device_defs {
+        for dev_src in wrappers.device_defs.values() {
             s += &dev_src.to_string();
         }
         s += &wrappers.device_instances_struct.to_string();
@@ -62,10 +64,21 @@ fn main() {
 
     let memory_map_wrapper_path = wrapper_src_path.join("memory_map.rs");
 
-    std::fs::write(&memory_map_wrapper_path, wrapper_code).unwrap();
+    std::fs::write(memory_map_wrapper_path, wrapper_code).unwrap();
 
     let dest_path = out_dir.join("memory.x");
-    fs::write(dest_path, include_bytes!("memory.x")).expect("Could not write file");
+    {
+        let (imem_start, imem_size) = storage_info(&memory_map, "Instruction").unwrap();
+        let (dmem_start, dmem_size) = storage_info(&memory_map, "Data").unwrap();
+
+        let mut input = fs::read_to_string("memory.x").unwrap();
+        input = input.replace("{imem_start}", &format!("{}", imem_start));
+        input = input.replace("{dmem_start}", &format!("{}", dmem_start));
+        input = input.replace("{imem_size}", &format!("{}", imem_size));
+        input = input.replace("{dmem_size}", &format!("{}", dmem_size));
+
+        fs::write(dest_path, &input).expect("Could not write file");
+    }
 
     if env::var("CARGO_CFG_TARGET_ARCH").unwrap() == "riscv32" {
         println!("cargo:rustc-link-arg=-Tmemory.x");
@@ -75,4 +88,49 @@ fn main() {
 
     println!("cargo:rerun-if-changed=memory.x");
     println!("cargo:rerun-if-changed=build.rs");
+}
+
+fn storage_info(mmap: &MemoryMapDesc, instance_name: &str) -> Option<(u64, u64)> {
+    fn find<'t>(tree: &'t MemoryMapTree, inst_name: &str) -> Option<(u64, &'t String)> {
+        match tree {
+            MemoryMapTree::Interconnect {
+                absolute_address: _,
+                components,
+                src_location: _,
+            } => {
+                for comp in components {
+                    let res = find(&comp.tree, inst_name);
+                    if res.is_some() {
+                        return res;
+                    } else {
+                        continue;
+                    }
+                }
+                None
+            }
+            MemoryMapTree::DeviceInstance {
+                absolute_address,
+                device_name,
+                instance_name,
+                src_location: _,
+            } => {
+                if instance_name == inst_name {
+                    Some((*absolute_address, device_name))
+                } else {
+                    None
+                }
+            }
+        }
+    }
+
+    let (addr, device_name) = find(&mmap.tree, instance_name)?;
+
+    let device_desc = mmap.devices.get(device_name)?;
+    let size = device_desc
+        .registers
+        .iter()
+        .map(|reg| reg.address + reg.size)
+        .max()?;
+
+    Some((addr, size))
 }

--- a/firmware-binaries/examples/hello/memory.x
+++ b/firmware-binaries/examples/hello/memory.x
@@ -6,8 +6,8 @@ SPDX-License-Identifier: CC0-1.0
 
 MEMORY
 {
-  IMEM : ORIGIN = 0x80000000, LENGTH = 64K
-  DMEM : ORIGIN = 0x40000000, LENGTH = 64K
+  IMEM : ORIGIN = {imem_start}, LENGTH = {imem_size}
+  DMEM : ORIGIN = {dmem_start}, LENGTH = {dmem_size}
 }
 
 REGION_ALIAS("REGION_TEXT", IMEM);

--- a/firmware-binaries/examples/hello/src/wrappers/mod.rs
+++ b/firmware-binaries/examples/hello/src/wrappers/mod.rs
@@ -1,0 +1,7 @@
+// SPDX-FileCopyrightText: 2024 Google LLC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod memory_map;
+
+pub use memory_map::*;

--- a/firmware-support/Cargo.lock
+++ b/firmware-support/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
-version = "0.7.6"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
 dependencies = [
  "getrandom",
  "once_cell",
@@ -21,9 +21,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.1.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "bit-set"
@@ -39,12 +39,6 @@ name = "bit-vec"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -70,10 +64,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "cc"
-version = "1.0.79"
+name = "byteorder"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cfg-if"
@@ -83,42 +77,28 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "crc32fast"
-version = "1.3.2"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "errno"
-version = "0.3.1"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
+checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
 dependencies = [
- "errno-dragonfly",
  "libc",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
-dependencies = [
- "cc",
- "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "fastrand"
-version = "1.9.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
-dependencies = [
- "instant",
-]
+checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 
 [[package]]
 name = "fdt"
@@ -128,9 +108,9 @@ checksum = "784a4df722dc6267a04af36895398f59d21d07dce47232adf31ec0ff2fa45e67"
 
 [[package]]
 name = "flate2"
-version = "1.0.26"
+version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b9429470923de8e8cbd4d2dc513535400b4b3fef0319fb5c4e1f520a7bef743"
+checksum = "7f211bbe8e69bbd0cfdea405084f128ae8b4aaa6b0b522fc8f2b009084797920"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -144,9 +124,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "getrandom"
-version = "0.2.9"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
@@ -189,12 +169,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hermit-abi"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
-
-[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -205,26 +179,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "instant"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
-name = "io-lifetimes"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -232,39 +186,39 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "lazy_static"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.145"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc86cde3ff845662b8f4ef6cb50ea0e20c524eb3d29ae048287e06a1b3fa6a81"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "libm"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
+checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.8"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
+checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "log"
-version = "0.4.21"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "memchr"
-version = "2.5.0"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "memmap-generate"
@@ -278,18 +232,18 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.1"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
 dependencies = [
  "adler",
 ]
 
 [[package]]
 name = "num-traits"
-version = "0.2.15"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
@@ -310,15 +264,18 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.17"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -337,7 +294,7 @@ checksum = "b4c2511913b88df1637da85cc8d96ec8e43a3f8bb8ccb71ee1ac240d6f3df58d"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.6.0",
+ "bitflags",
  "lazy_static",
  "num-traits",
  "rand",
@@ -404,15 +361,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
 name = "regex-syntax"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -420,16 +368,15 @@ checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "rustix"
-version = "0.37.25"
+version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4eb579851244c2c03e7c24f501c3432bed80b8f720af1d6e5b0e0f01555a035"
+checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "errno",
- "io-lifetimes",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -445,52 +392,48 @@ dependencies = [
 ]
 
 [[package]]
-<<<<<<< HEAD
-name = "stable_deref_trait"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
-
-[[package]]
-name = "structmeta"
-version = "0.1.6"
-=======
 name = "ryu"
 version = "1.0.18"
->>>>>>> 33cd0ed1 (Clean up)
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "serde"
-version = "1.0.185"
+version = "1.0.206"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be9b6f69f1dfd54c3b568ffa45c310d6973a5e5148fd40cf515acaf38cf5bc31"
+checksum = "5b3e4cd94123dd520a128bcd11e34d9e9e423e7e3e50425cb1b4b1e3549d0284"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.185"
+version = "1.0.206"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc59dfdcbad1437773485e0367fea4b090a2e0a16d9ffc46af47764536a298ec"
+checksum = "fabfb6138d2383ea8208cf98ccf69cdfb1aff4088460681d84189aa259762f97"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.74",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.109"
+version = "1.0.124"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb0652c533506ad7a2e353cce269330d6afd8bdfb6d75e0ace5b35aacbd7b9e9"
+checksum = "66ad62847a56b3dba58cc891acd13884b9c61138d330c0d7b6181713d4fce38d"
 dependencies = [
  "itoa",
+ "memchr",
  "ryu",
  "serde",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "structmeta"
@@ -501,7 +444,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "structmeta-derive",
- "syn 2.0.71",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -512,7 +455,7 @@ checksum = "152a0b65a590ff6c3da95cabe2353ee04e6167c896b28e3b14478c2636c922fc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -528,9 +471,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.71"
+version = "2.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b146dcf730474b4bcd16c311627b31ede9ab149045db4d6088b3becaea046462"
+checksum = "1fceb41e3d546d0bd83421d3409b1460cc7444cd389341a4c880fe7a042cb3d7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -539,15 +482,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.5.0"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
+checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
 dependencies = [
  "cfg-if",
  "fastrand",
- "redox_syscall",
+ "once_cell",
  "rustix",
- "windows-sys 0.45.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -559,7 +502,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "structmeta",
- "syn 2.0.71",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -597,15 +540,15 @@ checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.9"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "version_check"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wait-timeout"
@@ -624,132 +567,103 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.42.2",
+ "windows-targets",
 ]
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.48.0",
+ "windows-targets",
 ]
 
 [[package]]
 name = "windows-targets"
-version = "0.42.2"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.0",
- "windows_aarch64_msvc 0.48.0",
- "windows_i686_gnu 0.48.0",
- "windows_i686_msvc 0.48.0",
- "windows_x86_64_gnu 0.48.0",
- "windows_x86_64_gnullvm 0.48.0",
- "windows_x86_64_msvc 0.48.0",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.2"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.48.0"
+name = "windows_i686_gnullvm"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.2"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.2"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.0"
+name = "zerocopy"
+version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.74",
+]

--- a/firmware-support/Cargo.lock
+++ b/firmware-support/Cargo.lock
@@ -47,6 +47,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+
+[[package]]
 name = "bittide-sys"
 version = "0.1.0"
 dependencies = [
@@ -62,12 +68,6 @@ dependencies = [
  "test-strategy",
  "ufmt",
 ]
-
-[[package]]
-name = "byteorder"
-version = "1.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "cc"
@@ -225,6 +225,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -259,6 +265,16 @@ name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
+name = "memmap-generate"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "miniz_oxide"
@@ -306,22 +322,22 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.59"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aeca18b86b413c660b781aa319e4e2648a3e6f9eadc9b47e9038e6fe9f3451b"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "proptest"
-version = "1.2.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e35c06b98bf36aba164cc17cb25f7e232f5c4aeea73baa14b8a9f0d92dbfa65"
+checksum = "b4c2511913b88df1637da85cc8d96ec8e43a3f8bb8ccb71ee1ac240d6f3df58d"
 dependencies = [
  "bit-set",
- "bitflags",
- "byteorder",
+ "bit-vec",
+ "bitflags 2.6.0",
  "lazy_static",
  "num-traits",
  "rand",
@@ -341,9 +357,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.28"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
@@ -393,14 +409,14 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.29"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
+checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "rustix"
@@ -408,7 +424,7 @@ version = "0.37.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4eb579851244c2c03e7c24f501c3432bed80b8f720af1d6e5b0e0f01555a035"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno",
  "io-lifetimes",
  "libc",
@@ -429,6 +445,7 @@ dependencies = [
 ]
 
 [[package]]
+<<<<<<< HEAD
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -437,24 +454,65 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 [[package]]
 name = "structmeta"
 version = "0.1.6"
+=======
+name = "ryu"
+version = "1.0.18"
+>>>>>>> 33cd0ed1 (Clean up)
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "104842d6278bf64aa9d2f182ba4bde31e8aec7a131d29b7f444bb9b344a09e2a"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+
+[[package]]
+name = "serde"
+version = "1.0.185"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be9b6f69f1dfd54c3b568ffa45c310d6973a5e5148fd40cf515acaf38cf5bc31"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.185"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc59dfdcbad1437773485e0367fea4b090a2e0a16d9ffc46af47764536a298ec"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.71",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb0652c533506ad7a2e353cce269330d6afd8bdfb6d75e0ace5b35aacbd7b9e9"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "structmeta"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e1575d8d40908d70f6fd05537266b90ae71b15dbbe7a8b7dffa2b759306d329"
 dependencies = [
  "proc-macro2",
  "quote",
  "structmeta-derive",
- "syn",
+ "syn 2.0.71",
 ]
 
 [[package]]
 name = "structmeta-derive"
-version = "0.1.6"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24420be405b590e2d746d83b01f09af673270cf80e9b003a5fa7b651c58c7d93"
+checksum = "152a0b65a590ff6c3da95cabe2353ee04e6167c896b28e3b14478c2636c922fc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -462,6 +520,17 @@ name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.71"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b146dcf730474b4bcd16c311627b31ede9ab149045db4d6088b3becaea046462"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -483,14 +552,14 @@ dependencies = [
 
 [[package]]
 name = "test-strategy"
-version = "0.2.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62d6408d1406657be2f9d1701fbae379331d30d2f6e92050710edb0d34eeb480"
+checksum = "2bf41af45e3f54cc184831d629d41d5b2bda8297e29c81add7ae4f362ed5e01b"
 dependencies = [
  "proc-macro2",
  "quote",
  "structmeta",
- "syn",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -511,7 +580,7 @@ checksum = "d337d3be617449165cb4633c8dece429afd83f84051024079f97ad32a9663716"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/firmware-support/bittide-sys/Cargo.toml
+++ b/firmware-support/bittide-sys/Cargo.toml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022 Google LLC
+# SPDX-FileCopyrightText: 2024 Google LLC
 #
 # SPDX-License-Identifier: CC0-1.0
 
@@ -23,10 +23,10 @@ rand = {version = "0.8.3", features = ["small_rng"], default-features = false }
 ufmt = "0.2.0"
 
 [dev-dependencies]
-proptest = "1.0"
+proptest = "1.5"
 object = { version = "0.28", features = ["write"] }
 libc = "0.2"
-test-strategy = "0.2.0"
+test-strategy = "0.4"
 rand = "0.8"
 lazy_static = "1.0"
 tempfile = "3"

--- a/firmware-support/bittide-sys/src/time.rs
+++ b/firmware-support/bittide-sys/src/time.rs
@@ -314,8 +314,8 @@ impl Clock {
         unsafe {
             Clock {
                 freeze_count: addr.cast_mut(),
-                counter: addr.add(1).cast::<u64>(),
-                frequency: addr.add(3).cast::<u64>(),
+                counter: addr.add(2).cast::<u64>(),
+                frequency: addr.add(4).cast::<u64>(),
             }
         }
     }

--- a/firmware-support/memmap-generate/Cargo.toml
+++ b/firmware-support/memmap-generate/Cargo.toml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: 2024 Google LLC
+#
+# SPDX-License-Identifier: CC0-1.0
+
+[package]
+name = "memmap-generate"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+quote = "1.0"
+proc-macro2 = "1.0"

--- a/firmware-support/memmap-generate/src/generators/device_instances.rs
+++ b/firmware-support/memmap-generate/src/generators/device_instances.rs
@@ -1,0 +1,84 @@
+// SPDX-FileCopyrightText: 2024 Google LLC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use quote::quote;
+
+use crate::{
+    generators::ident,
+    parse::{MemoryMapDesc, MemoryMapTree, SourceLocation},
+};
+
+pub fn generate_device_instances_struct(desc: &MemoryMapDesc) -> proc_macro2::TokenStream {
+    let mut instances: Vec<(u64, &str, &str, &SourceLocation)> = vec![];
+    gather_device_instances(&desc.tree, &mut instances);
+
+    let field_defs = instances
+        .iter()
+        .map(|(_, device_name, instance_name, _)| {
+            let dev_name_ident = ident(*device_name);
+            let instance_name_ident = ident(*instance_name);
+            quote! {
+                pub #instance_name_ident: #dev_name_ident,
+            }
+        })
+        .collect::<Vec<_>>();
+
+    let field_inits = instances
+        .iter()
+        .map(|(addr, device_name, instance_name, _src_loc)| {
+            let dev_name_ident = ident(*device_name);
+            let instance_name_ident = ident(*instance_name);
+
+            quote! {
+                #instance_name_ident: unsafe { #dev_name_ident::new(#addr as *mut u8) },
+            }
+        })
+        .collect::<Vec<_>>();
+
+    quote! {
+        pub struct DeviceInstances {
+            #(#field_defs)*
+        }
+
+        impl DeviceInstances {
+            pub const unsafe fn new() -> Self {
+                DeviceInstances {
+                    #(#field_inits)*
+                }
+            }
+        }
+    }
+}
+
+fn gather_device_instances<'tree, 'vec>(
+    tree: &'tree MemoryMapTree,
+    instances: &'vec mut Vec<(u64, &'tree str, &'tree str, &'tree SourceLocation)>,
+) {
+    match tree {
+        MemoryMapTree::Interconnect {
+            absolute_address: _,
+            components,
+            src_location: _,
+        } => {
+            for comp in components {
+                gather_device_instances(&comp.tree, instances)
+            }
+        }
+
+        MemoryMapTree::DeviceInstance {
+            absolute_address,
+            device_name,
+            instance_name,
+            src_location,
+        } => {
+            let item = (
+                *absolute_address,
+                device_name.as_str(),
+                instance_name.as_str(),
+                src_location,
+            );
+            instances.push(item);
+        }
+    }
+}

--- a/firmware-support/memmap-generate/src/generators/device_types.rs
+++ b/firmware-support/memmap-generate/src/generators/device_types.rs
@@ -1,0 +1,124 @@
+// SPDX-FileCopyrightText: 2024 Google LLC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use quote::quote;
+
+use crate::{
+    generators::{ident, types::generate_type_ref},
+    parse::{DeviceDesc, RegisterAccess, Type},
+};
+
+pub fn generate_device_type(desc: &DeviceDesc) -> proc_macro2::TokenStream {
+    let name = ident(&desc.name);
+    let description = &desc.description;
+
+    let get_funcs = desc
+        .registers
+        .iter()
+        .map(|reg| {
+            let can_read =
+                reg.access == RegisterAccess::ReadOnly || reg.access == RegisterAccess::ReadWrite;
+            if !can_read {
+                return quote! {};
+            }
+
+            let name = ident(&reg.name);
+            let offset = reg.address as usize;
+
+            if let Type::Vec(len, inner) = &reg.reg_type {
+                let unchecked_name = ident(format!("{}_unchecked", &reg.name));
+                let scalar_ty = generate_type_ref(&inner);
+                let size = *len as usize;
+
+                quote! {
+                    pub fn #name(&self, idx: usize) -> Option<#scalar_ty> {
+                        if idx >= #size {
+                            None
+                        } else {
+                            Some(unsafe { self.#unchecked_name(idx)})
+                        }
+                    }
+
+                    pub unsafe fn #unchecked_name(&self, idx: usize) -> #scalar_ty {
+                        let ptr = self.0.add(#offset).cast::<#scalar_ty>();
+
+                        ptr.add(idx).read_volatile()
+                    }
+                }
+            } else {
+                let ty = generate_type_ref(&reg.reg_type);
+                quote! {
+                    pub fn #name(&self) -> #ty {
+                        unsafe {
+                            self.0.add(#offset).cast::<#ty>().read_volatile()
+                        }
+                    }
+                }
+            }
+        })
+        .collect::<Vec<_>>();
+
+    let set_funcs = desc
+        .registers
+        .iter()
+        .map(|reg| {
+            let can_write =
+                reg.access == RegisterAccess::WriteOnly || reg.access == RegisterAccess::ReadWrite;
+
+            if !can_write {
+                return quote! {};
+            }
+
+            let name = ident(format!("set_{}", &reg.name));
+            let offset = reg.address as usize;
+
+            if let Type::Vec(len, inner) = &reg.reg_type {
+                let unchecked_name = ident(format!("set_{}_unchecked", &reg.name));
+                let scalar_ty = generate_type_ref(&inner);
+                let size = *len as usize;
+
+                quote! {
+                    pub fn #name(&self, idx: usize, val: #scalar_ty) -> Option<()> {
+                        if idx >= #size {
+                            None
+                        } else {
+                            unsafe { self.#unchecked_name(idx, val) };
+                            Some(())
+                        }
+                    }
+
+                    pub unsafe fn #unchecked_name(&self, idx: usize, val: #scalar_ty) {
+                        let ptr = self.0.add(#offset).cast::<#scalar_ty>();
+
+                        ptr.add(idx).write_volatile(val);
+                    }
+                }
+            } else {
+                let ty = generate_type_ref(&reg.reg_type);
+                quote! {
+                    pub fn #name(&self, val: #ty) -> () {
+                        unsafe {
+                            self.0.add(#offset).cast::<#ty>().write_volatile(val)
+                        }
+                    }
+                }
+            }
+        })
+        .collect::<Vec<_>>();
+
+    quote! {
+        #[doc = #description]
+        pub struct #name(pub *mut u8);
+
+        impl #name {
+            pub const unsafe fn new(addr: *mut u8) -> Self {
+                Self(addr)
+            }
+
+            #(#get_funcs)*
+
+            #(#set_funcs)*
+        }
+    }
+}

--- a/firmware-support/memmap-generate/src/generators/mod.rs
+++ b/firmware-support/memmap-generate/src/generators/mod.rs
@@ -1,0 +1,83 @@
+// SPDX-FileCopyrightText: 2024 Google LLC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::BTreeMap;
+
+use device_instances::generate_device_instances_struct;
+use device_types::generate_device_type;
+use proc_macro2::{Ident, Span, TokenStream};
+use types::generate_type_def;
+
+use crate::parse::MemoryMapDesc;
+
+pub mod device_instances;
+pub mod device_types;
+pub mod types;
+
+pub(crate) fn ident(n: impl AsRef<str>) -> Ident {
+    // TODO handle things like CamelCase/snake_case conversion?
+    let s = match n.as_ref() {
+        "(,)" => "Pair",
+        "(,,)" => "Thruple",
+        "(,,,)" => "FourTuple",
+        "(,,,,)" => "FiveTuple",
+        s => s,
+    };
+
+    Ident::new(s, Span::call_site())
+}
+
+pub(crate) fn generic_name(idx: u64) -> Ident {
+    ident(format!("{}", 'A' as u64 + idx))
+}
+
+pub struct RustWrappers {
+    pub device_defs: BTreeMap<String, TokenStream>,
+    pub type_defs: BTreeMap<String, TokenStream>,
+    pub device_instances_struct: TokenStream,
+}
+
+pub enum ItemScopeMode {
+    OneFile,
+    // SeparateModules, // TODO
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum DebugDerive {
+    None,
+    Std,
+    Ufmt,
+}
+
+pub struct GenerateConfig {
+    pub debug_derive_mode: DebugDerive,
+    pub item_scope_mode: ItemScopeMode,
+}
+
+pub fn generate_rust_wrappers(desc: &MemoryMapDesc, config: &GenerateConfig) -> RustWrappers {
+    let device_defs = desc
+        .devices
+        .iter()
+        .map(|(name, device_desc)| (name.clone(), generate_device_type(device_desc)))
+        .collect();
+
+    let type_defs = desc
+        .types
+        .iter()
+        .map(|(name, type_desc)| {
+            (
+                name.clone(),
+                generate_type_def(type_desc, config.debug_derive_mode),
+            )
+        })
+        .collect();
+
+    let device_instances_struct = generate_device_instances_struct(desc);
+
+    RustWrappers {
+        device_defs,
+        type_defs,
+        device_instances_struct,
+    }
+}

--- a/firmware-support/memmap-generate/src/generators/types.rs
+++ b/firmware-support/memmap-generate/src/generators/types.rs
@@ -1,0 +1,233 @@
+// SPDX-FileCopyrightText: 2024 Google LLC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    generators::{generic_name, ident, DebugDerive},
+    parse::{Type, TypeDefinition, VariantDesc},
+};
+
+use proc_macro2::{Ident, Span};
+use quote::{quote, ToTokens};
+
+fn next_pw2(n: &u64) -> u64 {
+    n.next_power_of_two().max(8)
+}
+
+pub fn generate_type_ref(ty: &Type) -> proc_macro2::TokenStream {
+    match ty {
+        Type::Bool => quote! { bool },
+        Type::BitVector(n) | Type::Unsigned(n) => {
+            let ty_name = ident(format!("u{}", next_pw2(n)));
+            quote! { #ty_name }
+        }
+        Type::Signed(n) => {
+            let ty_name = ident(format!("i{}", next_pw2(n)));
+            quote! { #ty_name }
+        }
+        Type::Vec(n, ty) => {
+            let inner = generate_type_ref(&ty);
+            quote! { [#inner; #n] }
+        }
+        Type::Reference(name, args) => {
+            let ty_name = ident(name);
+            let args = args.into_iter().map(generate_type_ref).collect::<Vec<_>>();
+            if args.is_empty() {
+                quote! { #ty_name }
+            } else {
+                quote! { #ty_name < #(#args,)* > }
+            }
+        }
+        Type::Variable(i) => generic_name(*i).to_token_stream(),
+        Type::SumOfProducts { .. } => panic!("SOP definitions can't be references"),
+    }
+}
+
+pub fn generate_type_def(ty: &TypeDefinition, debug: DebugDerive) -> proc_macro2::TokenStream {
+    let name = ident(&ty.name);
+
+    let repr = generate_repr(ty);
+    let derives = match debug {
+        DebugDerive::None => quote! {
+            #[derive(Copy, Clone, PartialEq, Eq)]
+        },
+        DebugDerive::Std => quote! {
+            #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+        },
+        DebugDerive::Ufmt => quote! {
+            #[derive(uDebug, Copy, Clone, PartialEq, Eq)]
+        },
+    };
+
+    let attrs = quote! { #repr #derives };
+
+    let generics = if ty.generics > 0 {
+        let names = (0..ty.generics).map(generic_name).collect::<Vec<_>>();
+        quote! { < #(#names,)* > }
+    } else {
+        quote! {}
+    };
+
+    if let Type::SumOfProducts {
+        name: _name,
+        meta: _,
+        variants,
+    } = &ty.definition
+    {
+        match variants.as_slice() {
+            [] => quote! {
+                #attrs
+                pub struct #name #generics;
+            },
+            [var @ VariantDesc {
+                name: var_name,
+                fields,
+            }] => match fields.as_slice() {
+                [] => {
+                    if &ty.name == var_name {
+                        quote! {
+                            #attrs
+                            pub struct #name #generics;
+                        }
+                    } else {
+                        panic!("Single-constructor data types are required to have the constructor name match the type name.")
+                        // let var_name = Ident::new(var_name, Span::call_site());
+                        // quote! {
+                        //     #attrs
+                        //     pub enum #name #generics {
+                        //         #var_name
+                        //     }
+                        // }
+                    }
+                }
+                xs => {
+                    if &ty.name == var_name {
+                        let no_names = xs.iter().all(|v| v.name.is_empty());
+                        let all_names = xs.iter().all(|v| !v.name.is_empty());
+
+                        if no_names == all_names && !xs.is_empty() {
+                            panic!("Variant fields must either ALL be named or NONE be named.");
+                        }
+
+                        if no_names {
+                            let fields = xs
+                                .iter()
+                                .map(|f| generate_type_ref(&f.type_))
+                                .collect::<Vec<_>>();
+                            quote! {
+                                #attrs
+                                pub struct #name #generics (#(pub #fields,)*);
+                            }
+                        } else {
+                            let fields = xs
+                                .iter()
+                                .map(|f| {
+                                    let name = Ident::new(&f.name, Span::call_site());
+                                    let ty = generate_type_ref(&f.type_);
+                                    quote! { pub #name: #ty, }
+                                })
+                                .collect::<Vec<_>>();
+                            quote! {
+                                #attrs
+                                pub struct #name #generics {
+                                    #(#fields)*
+                                }
+                            }
+                        }
+                    } else {
+                        let var = generate_variant(var);
+                        quote! {
+                            #attrs
+                            pub enum #name #generics {
+                                #var
+                            }
+                        }
+                    }
+                }
+            },
+            vars => {
+                let variants = vars.iter().map(generate_variant).collect::<Vec<_>>();
+                quote! {
+                    #attrs
+                    pub enum #name #generics {
+                        #(#variants)*
+                    }
+                }
+            }
+        }
+    } else {
+        let inner = generate_type_ref(&ty.definition);
+        quote! {
+            #attrs
+            pub struct #name #generics(pub #inner);
+        }
+    }
+}
+
+fn generate_repr(ty: &TypeDefinition) -> proc_macro2::TokenStream {
+    if let Type::SumOfProducts {
+        name: _,
+        meta: _,
+        variants,
+    } = &ty.definition
+    {
+        match variants.as_slice() {
+            [] => quote! {},
+            [x] => {
+                if &x.name == &ty.name {
+                    quote! { #[repr(C)] }
+                } else {
+                    panic!("Single-constructor data types are required to have the constructor name match the type name.")
+                    // quote! { #[repr(u8)] }
+                }
+            }
+            vars => {
+                let n = next_pw2(&(vars.len() as u64));
+                let repr = ident(format!("u{}", n));
+                quote! { #[repr(#repr)] }
+            }
+        }
+    } else {
+        quote! {}
+    }
+}
+
+fn generate_variant(v: &VariantDesc) -> proc_macro2::TokenStream {
+    let name = ident(&v.name);
+
+    let no_names = v.fields.iter().all(|f| f.name.is_empty());
+    let all_names = v.fields.iter().all(|f| !f.name.is_empty());
+
+    if no_names == all_names && !v.fields.is_empty() {
+        panic!("Variant fields must either ALL be named or NONE be named.");
+    }
+    if v.fields.is_empty() {
+        quote! {
+            #name,
+        }
+    } else if no_names {
+        let fields = v
+            .fields
+            .iter()
+            .map(|f| generate_type_ref(&f.type_))
+            .collect::<Vec<_>>();
+        quote! {
+            #name (#(#fields,)*),
+        }
+    } else {
+        let fields = v
+            .fields
+            .iter()
+            .map(|f| {
+                let name = ident(&f.name);
+                let ty = generate_type_ref(&f.type_);
+                quote! { #name: #ty, }
+            })
+            .collect::<Vec<_>>();
+        quote! {
+            #name {
+                #(#fields)*
+            }
+        }
+    }
+}

--- a/firmware-support/memmap-generate/src/lib.rs
+++ b/firmware-support/memmap-generate/src/lib.rs
@@ -1,0 +1,454 @@
+// SPDX-FileCopyrightText: 2024 Google LLC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod generators;
+pub mod parse;
+
+pub use crate::generators::{
+    generate_rust_wrappers, DebugDerive, GenerateConfig, ItemScopeMode, RustWrappers,
+};
+pub use crate::parse::{parse, MemoryMapDesc};
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    fn test_generators() {
+        let mm = parse(TEST_SRC).unwrap();
+        let config = GenerateConfig {
+            debug_derive_mode: DebugDerive::Ufmt,
+            item_scope_mode: ItemScopeMode::OneFile,
+        };
+        let wrappers = generate_rust_wrappers(&mm, &config);
+
+        for (dev_name, dev_src) in &wrappers.device_defs {
+            // println!("==========");
+            // println!("{dev_name}.rs");
+            // println!("==========");
+            // println!();
+
+            println!("{}", dev_src.to_string());
+        }
+
+        for (type_name, ty_src) in &wrappers.type_defs {
+            // println!("==========");
+            // println!("{type_name}.rs");
+            // println!("==========");
+            // println!();
+
+            println!("{}", ty_src.to_string());
+        }
+    }
+
+    const TEST_SRC: &'static str = r#"
+{
+  "devices": {
+    "StatusReg": {
+      "description": "",
+      "name": "StatusReg",
+      "registers": [
+        {
+          "access": "write_only",
+          "address": 0,
+          "description": "",
+          "name": "status",
+          "reset": null,
+          "size": 1,
+          "src_location": {
+            "end_col": 44,
+            "end_line": 77,
+            "file": "src/Bittide/Instances/Hitl/VexRiscv.hs",
+            "module": "Bittide.Instances.Hitl.VexRiscv",
+            "package": "bittide-instances-0.1-inplace",
+            "start_col": 34,
+            "start_line": 77
+          },
+          "type": [
+            "reference",
+            "TestStatus",
+            []
+          ]
+        }
+      ],
+      "src_location": {
+        "end_col": 44,
+        "end_line": 77,
+        "file": "src/Bittide/Instances/Hitl/VexRiscv.hs",
+        "module": "Bittide.Instances.Hitl.VexRiscv",
+        "package": "bittide-instances-0.1-inplace",
+        "start_col": 34,
+        "start_line": 77
+      }
+    },
+    "Storage_Data": {
+      "description": "",
+      "name": "Storage_Data",
+      "registers": [
+        {
+          "access": "read_write",
+          "address": 0,
+          "description": "",
+          "name": "data",
+          "reset": null,
+          "size": 65536,
+          "src_location": {
+            "end_col": 35,
+            "end_line": 234,
+            "file": "src/Bittide/ProcessingElement.hs",
+            "module": "Bittide.ProcessingElement",
+            "package": "bittide-0.1-inplace",
+            "start_col": 25,
+            "start_line": 234
+          },
+          "type": [
+            "vector",
+            16384,
+            [
+              "bitvector",
+              32
+            ]
+          ]
+        }
+      ],
+      "src_location": {
+        "end_col": 35,
+        "end_line": 234,
+        "file": "src/Bittide/ProcessingElement.hs",
+        "module": "Bittide.ProcessingElement",
+        "package": "bittide-0.1-inplace",
+        "start_col": 25,
+        "start_line": 234
+      }
+    },
+    "Storage_Instruction": {
+      "description": "",
+      "name": "Storage_Instruction",
+      "registers": [
+        {
+          "access": "read_write",
+          "address": 0,
+          "description": "",
+          "name": "data",
+          "reset": null,
+          "size": 65536,
+          "src_location": {
+            "end_col": 40,
+            "end_line": 236,
+            "file": "src/Bittide/ProcessingElement.hs",
+            "module": "Bittide.ProcessingElement",
+            "package": "bittide-0.1-inplace",
+            "start_col": 28,
+            "start_line": 236
+          },
+          "type": [
+            "vector",
+            16384,
+            [
+              "bitvector",
+              32
+            ]
+          ]
+        }
+      ],
+      "src_location": {
+        "end_col": 40,
+        "end_line": 236,
+        "file": "src/Bittide/ProcessingElement.hs",
+        "module": "Bittide.ProcessingElement",
+        "package": "bittide-0.1-inplace",
+        "start_col": 28,
+        "start_line": 236
+      }
+    },
+    "Timer": {
+      "description": "Circuit that contains a free running 64 bit counter. We can observe this counter to get a sense of time, overflows should be accounted for by the master.",
+      "name": "Timer",
+      "registers": [
+        {
+          "access": "write_only",
+          "address": 0,
+          "description": "",
+          "name": "freeze_count",
+          "reset": null,
+          "size": 1,
+          "src_location": {
+            "end_col": 0,
+            "end_line": 0,
+            "file": "",
+            "module": "",
+            "package": "",
+            "start_col": 0,
+            "start_line": 0
+          },
+          "type": [
+            "bitvector",
+            1
+          ]
+        },
+        {
+          "access": "read_only",
+          "address": 8,
+          "description": "",
+          "name": "counter",
+          "reset": null,
+          "size": 8,
+          "src_location": {
+            "end_col": 0,
+            "end_line": 0,
+            "file": "",
+            "module": "",
+            "package": "",
+            "start_col": 0,
+            "start_line": 0
+          },
+          "type": [
+            "bitvector",
+            64
+          ]
+        },
+        {
+          "access": "read_only",
+          "address": 16,
+          "description": "",
+          "name": "frequency",
+          "reset": null,
+          "size": 8,
+          "src_location": {
+            "end_col": 0,
+            "end_line": 0,
+            "file": "",
+            "module": "",
+            "package": "",
+            "start_col": 0,
+            "start_line": 0
+          },
+          "type": [
+            "bitvector",
+            64
+          ]
+        }
+      ],
+      "src_location": {
+        "end_col": 26,
+        "end_line": 74,
+        "file": "src/Bittide/Instances/Hitl/VexRiscv.hs",
+        "module": "Bittide.Instances.Hitl.VexRiscv",
+        "package": "bittide-instances-0.1-inplace",
+        "start_col": 21,
+        "start_line": 74
+      }
+    },
+    "UART": {
+      "description": "",
+      "name": "UART",
+      "registers": [
+        {
+          "access": "read_write",
+          "address": 0,
+          "description": "",
+          "name": "data",
+          "reset": null,
+          "size": 1,
+          "src_location": {
+            "end_col": 0,
+            "end_line": 0,
+            "file": "",
+            "module": "",
+            "package": "",
+            "start_col": 0,
+            "start_line": 0
+          },
+          "type": [
+            "bitvector",
+            8
+          ]
+        },
+        {
+          "access": "read_only",
+          "address": 4,
+          "description": "",
+          "name": "status",
+          "reset": null,
+          "size": 1,
+          "src_location": {
+            "end_col": 0,
+            "end_line": 0,
+            "file": "",
+            "module": "",
+            "package": "",
+            "start_col": 0,
+            "start_line": 0
+          },
+          "type": [
+            "bitvector",
+            2
+          ]
+        }
+      ],
+      "src_location": {
+        "end_col": 11,
+        "end_line": 76,
+        "file": "src/Bittide/Instances/Hitl/VexRiscv.hs",
+        "module": "Bittide.Instances.Hitl.VexRiscv",
+        "package": "bittide-instances-0.1-inplace",
+        "start_col": 6,
+        "start_line": 76
+      }
+    }
+  },
+  "tree": {
+    "interconnect": {
+      "absolute_address": 0,
+      "components": [
+        {
+          "relative_address": 2147483648,
+          "size": 536870911,
+          "tree": {
+            "device_instance": {
+              "absolute_address": 2147483648,
+              "device_name": "Storage_Instruction",
+              "instance_name": "Instruction",
+              "src_location": {
+                "end_col": 62,
+                "end_line": 71,
+                "file": "src/Bittide/Instances/Hitl/VexRiscv.hs",
+                "module": "Bittide.Instances.Hitl.VexRiscv",
+                "package": "bittide-instances-0.1-inplace",
+                "start_col": 44,
+                "start_line": 71
+              }
+            }
+          }
+        },
+        {
+          "relative_address": 1073741824,
+          "size": 536870911,
+          "tree": {
+            "device_instance": {
+              "absolute_address": 1073741824,
+              "device_name": "Storage_Data",
+              "instance_name": "Data",
+              "src_location": {
+                "end_col": 24,
+                "end_line": 435,
+                "file": "src/Protocols/MemoryMap.hs",
+                "module": "Protocols.MemoryMap",
+                "package": "clash-protocols-memmap-0.1-inplace",
+                "start_col": 15,
+                "start_line": 435
+              }
+            }
+          }
+        },
+        {
+          "relative_address": 2684354560,
+          "size": 536870911,
+          "tree": {
+            "device_instance": {
+              "absolute_address": 2684354560,
+              "device_name": "Timer",
+              "instance_name": "Timer",
+              "src_location": {
+                "end_col": 24,
+                "end_line": 435,
+                "file": "src/Protocols/MemoryMap.hs",
+                "module": "Protocols.MemoryMap",
+                "package": "clash-protocols-memmap-0.1-inplace",
+                "start_col": 15,
+                "start_line": 435
+              }
+            }
+          }
+        },
+        {
+          "relative_address": 3221225472,
+          "size": 536870911,
+          "tree": {
+            "device_instance": {
+              "absolute_address": 3221225472,
+              "device_name": "UART",
+              "instance_name": "UART",
+              "src_location": {
+                "end_col": 60,
+                "end_line": 45,
+                "file": "src/Bittide/Instances/MemoryMapLogic.hs",
+                "module": "Bittide.Instances.MemoryMapLogic",
+                "package": "bittide-instances-0.1-inplace",
+                "start_col": 50,
+                "start_line": 45
+              }
+            }
+          }
+        },
+        {
+          "relative_address": 3758096384,
+          "size": 536870911,
+          "tree": {
+            "device_instance": {
+              "absolute_address": 3758096384,
+              "device_name": "StatusReg",
+              "instance_name": "StatusReg",
+              "src_location": {
+                "end_col": 24,
+                "end_line": 435,
+                "file": "src/Protocols/MemoryMap.hs",
+                "module": "Protocols.MemoryMap",
+                "package": "clash-protocols-memmap-0.1-inplace",
+                "start_col": 15,
+                "start_line": 435
+              }
+            }
+          }
+        }
+      ],
+      "src_location": {
+        "end_col": 48,
+        "end_line": 233,
+        "file": "src/Bittide/ProcessingElement.hs",
+        "module": "Bittide.ProcessingElement",
+        "package": "bittide-0.1-inplace",
+        "start_col": 23,
+        "start_line": 233
+      }
+    }
+  },
+  "types": {
+    "TestStatus": {
+      "definition": {
+        "meta": {
+          "is_newtype": false,
+          "module": "Bittide.Instances.Hitl.VexRiscv",
+          "package": "bittide-instances-0.1-inplace"
+        },
+        "name": "TestStatus",
+        "variants": [
+          {
+            "fields": [],
+            "name": "Running"
+          },
+          {
+            "fields": [],
+            "name": "Success"
+          },
+          {
+            "fields": [],
+            "name": "Fail"
+          }
+        ]
+      },
+      "generics": 0,
+      "meta": {
+        "is_newtype": false,
+        "module": "Bittide.Instances.Hitl.VexRiscv",
+        "package": "bittide-instances-0.1-inplace"
+      },
+      "name": "TestStatus"
+    }
+  }
+}
+
+    "#;
+}

--- a/firmware-support/memmap-generate/src/parse.rs
+++ b/firmware-support/memmap-generate/src/parse.rs
@@ -1,0 +1,567 @@
+// SPDX-FileCopyrightText: 2024 Google LLC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::HashMap;
+
+use serde::Deserialize;
+use serde_json::Value;
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct MemoryMapDesc {
+    pub devices: HashMap<String, DeviceDesc>,
+    pub types: HashMap<String, TypeDefinition>,
+    pub tree: MemoryMapTree,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct DeviceDesc {
+    pub name: String,
+    pub description: String,
+    pub registers: Vec<RegisterDesc>,
+    pub src_location: SourceLocation,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct TypeDefinition {
+    pub name: String,
+    pub meta: TypeMeta,
+    pub generics: u64,
+    pub definition: Type,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+// #[serde(rename = "snake_case")]
+pub enum MemoryMapTree {
+    #[serde(rename = "interconnect")]
+    Interconnect {
+        absolute_address: u64,
+        components: Vec<InterconnectComponent>,
+        src_location: SourceLocation,
+    },
+    #[serde(rename = "device_instance")]
+    DeviceInstance {
+        absolute_address: u64,
+        device_name: String,
+        instance_name: String,
+        src_location: SourceLocation,
+    },
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct InterconnectComponent {
+    pub relative_address: u64,
+    pub size: u64,
+    pub tree: MemoryMapTree,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct RegisterDesc {
+    pub name: String,
+    pub description: String,
+    pub reset: Option<u64>,
+    pub access: RegisterAccess,
+    pub address: u64,
+    pub size: u64,
+    #[serde(rename = "type")]
+    pub reg_type: Type,
+    pub src_location: SourceLocation,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RegisterAccess {
+    ReadWrite,
+    ReadOnly,
+    WriteOnly,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct TypeMeta {
+    pub module: String,
+    pub package: String,
+    pub is_newtype: bool,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(try_from = "Value")]
+pub enum Type {
+    Bool,
+    BitVector(u64),
+    Signed(u64),
+    Unsigned(u64),
+    Vec(u64, Box<Type>),
+    Reference(String, Vec<Type>),
+    Variable(u64),
+    SumOfProducts {
+        name: String,
+        meta: TypeMeta,
+        variants: Vec<VariantDesc>,
+    },
+}
+
+impl TryFrom<Value> for Type {
+    type Error = String;
+
+    fn try_from(value: Value) -> Result<Self, Self::Error> {
+        match value.clone() {
+            Value::String(x) if x == "bool" => Ok(Self::Bool),
+            Value::Array(a) if a.len() == 2 => {
+                let Ok([a, b]) = <[Value; 2]>::try_from(a) else { panic!() };
+                match (a.as_str(), b.as_u64()) {
+                    (Some("bitvector"), Some(n)) => Ok(Self::BitVector(n)),
+                    (Some("signed"), Some(n)) => Ok(Self::Signed(n)),
+                    (Some("unsigned"), Some(n)) => Ok(Self::Unsigned(n)),
+                    (Some("variable"), Some(n)) => Ok(Self::Variable(n)),
+                    _ => Err(format!("Invalid type, found [{a:?}, {b:?}]")),
+                }
+            }
+            Value::Array(a) if a.len() == 3 => {
+                let Ok([a, b, c]) = <[Value; 3]>::try_from(a) else { panic!() };
+                match a.as_str() {
+                    Some("vector") => {
+                        let Some(n) = b.as_u64() else {
+                            return Err(format!("Invalid type, expected [\"vector\", <integer>, <another type>], found {value:?}"))
+                        };
+                        let inner = c.try_into()?;
+                        Ok(Self::Vec(n, Box::new(inner)))
+                    }
+                    Some("reference") => {
+                        let Some(name) = b.as_str() else {
+                            return Err(format!("Invalid type, expected [\"reference\", <name>, <array of type>], found {value:?}"))
+                        };
+                        let args = match serde_json::from_value(c) {
+                            Ok(val) => val,
+                            Err(err) => {
+                                return Err(format!(
+                                    "error when parsing type reference arguments: {err}"
+                                ))
+                            }
+                        };
+                        Ok(Self::Reference(name.to_string(), args))
+                    }
+                    _ => Err(format!("Invalid type, found [{a:?}, {b:?}, {c:?}]")),
+                }
+            }
+            x @ Value::Object(_) => {
+                #[derive(Debug, Clone, Deserialize)]
+                pub struct SopDefintion {
+                    pub name: String,
+                    pub meta: TypeMeta,
+                    pub variants: Vec<VariantDesc>,
+                }
+
+                match serde_json::from_value::<SopDefintion>(x) {
+                    Ok(def) => Ok(Self::SumOfProducts {
+                        name: def.name,
+                        meta: def.meta,
+                        variants: def.variants,
+                    }),
+                    Err(err) => Err(format!("Invalid sum-of-products type definition: {err}")),
+                }
+            }
+            x => Err(format!("Invalid type, found {x:?}")),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct VariantDesc {
+    pub name: String,
+    pub fields: Vec<VariantFieldDesc>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct VariantFieldDesc {
+    pub name: String,
+    #[serde(rename = "type")]
+    pub type_: Type,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct SourceLocation {
+    pub file: String,
+    pub module: String,
+    pub start_line: u64,
+    pub end_line: u64,
+    pub start_col: u64,
+    pub end_col: u64,
+}
+
+/// Parse a memory map description from JSON.
+pub fn parse(src: &str) -> Result<MemoryMapDesc, serde_json::Error> {
+    serde_json::from_str(src)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TEST_SRC: &'static str = r#"
+{
+  "devices": {
+    "StatusReg": {
+      "description": "",
+      "name": "StatusReg",
+      "registers": [],
+      "src_location": {
+        "end_col": 44,
+        "end_line": 75,
+        "file": "src/Bittide/Instances/Hitl/VexRiscv.hs",
+        "module": "Bittide.Instances.Hitl.VexRiscv",
+        "package": "bittide-instances-0.1-inplace",
+        "start_col": 34,
+        "start_line": 75
+      }
+    },
+    "Storage_Data": {
+      "description": "",
+      "name": "Storage_Data",
+      "registers": [
+        {
+          "access": "read_write",
+          "address": 0,
+          "description": "",
+          "name": "data",
+          "reset": null,
+          "size": 65536,
+          "src_location": {
+            "end_col": 35,
+            "end_line": 234,
+            "file": "src/Bittide/ProcessingElement.hs",
+            "module": "Bittide.ProcessingElement",
+            "package": "bittide-0.1-inplace",
+            "start_col": 25,
+            "start_line": 234
+          },
+          "type": [
+            "vector",
+            16384,
+            [
+              "bitvector",
+              32
+            ]
+          ]
+        }
+      ],
+      "src_location": {
+        "end_col": 35,
+        "end_line": 234,
+        "file": "src/Bittide/ProcessingElement.hs",
+        "module": "Bittide.ProcessingElement",
+        "package": "bittide-0.1-inplace",
+        "start_col": 25,
+        "start_line": 234
+      }
+    },
+    "Storage_Instruction": {
+      "description": "",
+      "name": "Storage_Instruction",
+      "registers": [
+        {
+          "access": "read_write",
+          "address": 0,
+          "description": "",
+          "name": "data",
+          "reset": null,
+          "size": 65536,
+          "src_location": {
+            "end_col": 40,
+            "end_line": 236,
+            "file": "src/Bittide/ProcessingElement.hs",
+            "module": "Bittide.ProcessingElement",
+            "package": "bittide-0.1-inplace",
+            "start_col": 28,
+            "start_line": 236
+          },
+          "type": [
+            "vector",
+            16384,
+            [
+              "bitvector",
+              32
+            ]
+          ]
+        }
+      ],
+      "src_location": {
+        "end_col": 40,
+        "end_line": 236,
+        "file": "src/Bittide/ProcessingElement.hs",
+        "module": "Bittide.ProcessingElement",
+        "package": "bittide-0.1-inplace",
+        "start_col": 28,
+        "start_line": 236
+      }
+    },
+    "Timer": {
+      "description": "Circuit that contains a free running 64 bit counter. We can observe this counter to get a sense of time, overflows should be accounted for by the master.",
+      "name": "Timer",
+      "registers": [
+        {
+          "access": "write_only",
+          "address": 0,
+          "description": "",
+          "name": "freeze_count",
+          "reset": null,
+          "size": 1,
+          "src_location": {
+            "end_col": 0,
+            "end_line": 0,
+            "file": "",
+            "module": "",
+            "package": "",
+            "start_col": 0,
+            "start_line": 0
+          },
+          "type": [
+            "bitvector",
+            1
+          ]
+        },
+        {
+          "access": "read_only",
+          "address": 8,
+          "description": "",
+          "name": "counter",
+          "reset": null,
+          "size": 8,
+          "src_location": {
+            "end_col": 0,
+            "end_line": 0,
+            "file": "",
+            "module": "",
+            "package": "",
+            "start_col": 0,
+            "start_line": 0
+          },
+          "type": [
+            "bitvector",
+            64
+          ]
+        },
+        {
+          "access": "read_only",
+          "address": 16,
+          "description": "",
+          "name": "frequency",
+          "reset": null,
+          "size": 8,
+          "src_location": {
+            "end_col": 0,
+            "end_line": 0,
+            "file": "",
+            "module": "",
+            "package": "",
+            "start_col": 0,
+            "start_line": 0
+          },
+          "type": [
+            "bitvector",
+            64
+          ]
+        }
+      ],
+      "src_location": {
+        "end_col": 26,
+        "end_line": 72,
+        "file": "src/Bittide/Instances/Hitl/VexRiscv.hs",
+        "module": "Bittide.Instances.Hitl.VexRiscv",
+        "package": "bittide-instances-0.1-inplace",
+        "start_col": 21,
+        "start_line": 72
+      }
+    },
+    "UART": {
+      "description": "",
+      "name": "UART",
+      "registers": [
+        {
+          "access": "read_write",
+          "address": 0,
+          "description": "",
+          "name": "data",
+          "reset": null,
+          "size": 1,
+          "src_location": {
+            "end_col": 0,
+            "end_line": 0,
+            "file": "",
+            "module": "",
+            "package": "",
+            "start_col": 0,
+            "start_line": 0
+          },
+          "type": [
+            "bitvector",
+            8
+          ]
+        },
+        {
+          "access": "read_only",
+          "address": 4,
+          "description": "",
+          "name": "status",
+          "reset": null,
+          "size": 1,
+          "src_location": {
+            "end_col": 0,
+            "end_line": 0,
+            "file": "",
+            "module": "",
+            "package": "",
+            "start_col": 0,
+            "start_line": 0
+          },
+          "type": [
+            "bitvector",
+            2
+          ]
+        }
+      ],
+      "src_location": {
+        "end_col": 11,
+        "end_line": 74,
+        "file": "src/Bittide/Instances/Hitl/VexRiscv.hs",
+        "module": "Bittide.Instances.Hitl.VexRiscv",
+        "package": "bittide-instances-0.1-inplace",
+        "start_col": 6,
+        "start_line": 74
+      }
+    }
+  },
+  "types": {},
+  "tree": {
+    "interconnect": {
+      "absolute_address": 0,
+      "components": [
+        {
+          "relative_address": 2147483648,
+          "size": 536870911,
+          "tree": {
+            "device_instance": {
+              "absolute_address": 2147483648,
+              "device_name": "Storage_Instruction",
+              "instance_name": "Instruction",
+              "src_location": {
+                "end_col": 62,
+                "end_line": 69,
+                "file": "src/Bittide/Instances/Hitl/VexRiscv.hs",
+                "module": "Bittide.Instances.Hitl.VexRiscv",
+                "package": "bittide-instances-0.1-inplace",
+                "start_col": 44,
+                "start_line": 69
+              }
+            }
+          }
+        },
+        {
+          "relative_address": 1073741824,
+          "size": 536870911,
+          "tree": {
+            "device_instance": {
+              "absolute_address": 1073741824,
+              "device_name": "Storage_Data",
+              "instance_name": "Data",
+              "src_location": {
+                "end_col": 24,
+                "end_line": 435,
+                "file": "src/Protocols/MemoryMap.hs",
+                "module": "Protocols.MemoryMap",
+                "package": "clash-protocols-memmap-0.1-inplace",
+                "start_col": 15,
+                "start_line": 435
+              }
+            }
+          }
+        },
+        {
+          "relative_address": 2684354560,
+          "size": 536870911,
+          "tree": {
+            "device_instance": {
+              "absolute_address": 2684354560,
+              "device_name": "Timer",
+              "instance_name": "Timer",
+              "src_location": {
+                "end_col": 24,
+                "end_line": 435,
+                "file": "src/Protocols/MemoryMap.hs",
+                "module": "Protocols.MemoryMap",
+                "package": "clash-protocols-memmap-0.1-inplace",
+                "start_col": 15,
+                "start_line": 435
+              }
+            }
+          }
+        },
+        {
+          "relative_address": 3221225472,
+          "size": 536870911,
+          "tree": {
+            "device_instance": {
+              "absolute_address": 3221225472,
+              "device_name": "UART",
+              "instance_name": "UART",
+              "src_location": {
+                "end_col": 60,
+                "end_line": 45,
+                "file": "src/Bittide/Instances/MemoryMapLogic.hs",
+                "module": "Bittide.Instances.MemoryMapLogic",
+                "package": "bittide-instances-0.1-inplace",
+                "start_col": 50,
+                "start_line": 45
+              }
+            }
+          }
+        },
+        {
+          "relative_address": 3758096384,
+          "size": 536870911,
+          "tree": {
+            "device_instance": {
+              "absolute_address": 3758096384,
+              "device_name": "StatusReg",
+              "instance_name": "StatusReg",
+              "src_location": {
+                "end_col": 24,
+                "end_line": 435,
+                "file": "src/Protocols/MemoryMap.hs",
+                "module": "Protocols.MemoryMap",
+                "package": "clash-protocols-memmap-0.1-inplace",
+                "start_col": 15,
+                "start_line": 435
+              }
+            }
+          }
+        }
+      ],
+      "src_location": {
+        "end_col": 48,
+        "end_line": 233,
+        "file": "src/Bittide/ProcessingElement.hs",
+        "module": "Bittide.ProcessingElement",
+        "package": "bittide-0.1-inplace",
+        "start_col": 23,
+        "start_line": 233
+      }
+    }
+  }
+}
+
+"#;
+
+    #[test]
+    fn register_access() {
+        let src = "\"read_only\"";
+        let x: RegisterAccess = serde_json::from_str(src).unwrap();
+        assert_eq!(x, RegisterAccess::ReadOnly);
+    }
+
+    #[test]
+    fn test_deserialise_memmap() {
+        let memmap: MemoryMapDesc = serde_json::from_str(TEST_SRC).unwrap();
+
+        dbg!(&memmap);
+    }
+}


### PR DESCRIPTION
This implements #481 

There's a few noteworthy parts to this PR:
- the description of memory maps and their validation (`Protocols.MemoryMap`/`.Check`)
- the `BitPackC` type class
- the `ToFieldType` type class
- a generator for Rust wrappers based on the memory map `firmware-support/memmap-generate`