### PR TITLE
Don't hardcode IP addresses in CI scripts

### DIFF
--- a/.github/scripts/cache.py
+++ b/.github/scripts/cache.py
@@ -44,7 +44,7 @@ PWD = os.getcwd()
 GITHUB_ORG="bittide"
 GITHUB_REPO="bittide-hardware"
 
-CACHE_URL="http://192.168.102.234:9000"
+CACHE_URL="http://hertme.local:9000"
 CACHE_USER="root"
 CACHE_BUCKET=f"github.org/{GITHUB_ORG}/{GITHUB_REPO}"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,10 +28,7 @@ on:
         - 'main'
 
 env:
-  # Local machine connected to the bittide demonstrator is called
-  # 'hoeve'. But the docker container of the runner cannot resolve
-  # DNS, so we use its local IP address instead.
-  HW_SERVER_URL: 192.168.102.130:3121
+  HW_SERVER_URL: hoeve.local:3121
   S3_PASSWORD: ${{ secrets.S3_PASSWORD }}
   SYNTHESIS_BOARD: xilinx.com:kcu105:part0:1.7
 


### PR DESCRIPTION
Apparently the comment about the container being unable to resolve names isn't true (anymore), as it just works.
And this is less fragile.