### PR TITLE
Fix SPDX header formatting fallout

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -2,3 +2,4 @@
 #
 # SPDX-License-Identifier: CC0-1.0
 a4e4b4b8833acdc0d1f9c488d01e827a04598d98
+6badd2b35a5b8c36e527cd25db2812cfaf687ca2

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -2,4 +2,4 @@
 #
 # SPDX-License-Identifier: CC0-1.0
 a4e4b4b8833acdc0d1f9c488d01e827a04598d98
-6badd2b35a5b8c36e527cd25db2812cfaf687ca2
+54ca5d2cd0088f7d683ff8ab4be5d627d47a32f6

--- a/.github/scripts/fix_spdx_header.py
+++ b/.github/scripts/fix_spdx_header.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""
+Make sure the SPDX header is at the top of a given file. This is currently
+hardcoded to look for the SPDX header formatted in a Haskell comment. This works
+around an issue where Fourmolu thinks an SPDX header is part of a comment on a
+language pragma, and wrongly produces formatting issues.
+"""
+
+# SPDX-FileCopyrightText: 2024 Google LLC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import sys
+
+SPDX_START = "-- SPDX-FileCopyrightText"
+SPDX_END = "-- SPDX-License-Identifier"
+
+def format(fp_src, fp_dst):
+    source_lines = []
+    spdx_lines = []
+
+    for line in fp_src:
+        if line.startswith(SPDX_START):
+            # Collect SPDX header
+            spdx_lines.append(line)
+            for line in fp_src:
+                spdx_lines.append(line)
+                if line.startswith(SPDX_END):
+                    break
+            break
+        else:
+            # Collect non-SPDX header lines
+            source_lines.append(line)
+
+    # Write out SPDX header
+    for spdx_line in spdx_lines:
+        fp_dst.write(spdx_line)
+
+    # Write out all non-SPDX header lines
+    for source_line in source_lines:
+        fp_dst.write(source_line)
+
+    # Write out rest of the file
+    for line in fp_src:
+        fp_dst.write(line)
+
+def main(paths):
+    for path in paths:
+        with open(path) as fp_src:
+            with open(path + ".fix-spdx-header", "w") as fp_dst:
+                format(fp_src, fp_dst)
+        os.rename(path + ".fix-spdx-header", path)
+
+if __name__ == '__main__':
+    main(sys.argv[1:])

--- a/.github/scripts/fourmolu.sh
+++ b/.github/scripts/fourmolu.sh
@@ -4,6 +4,14 @@
 # SPDX-License-Identifier: Apache-2.0
 set -euf -o pipefail
 
+cd "$(git rev-parse --show-toplevel)"
+
+echo "Fourmolu.."
 git ls-files *.hs \
   | grep --extended-regexp --invert-match '^clash-vexriscv/' \
   | xargs --max-procs=0 -I {} fourmolu --quiet --mode inplace "{}"
+
+echo "Fixing SPDX headers.."
+git ls-files *.hs \
+  | grep --extended-regexp --invert-match '^clash-vexriscv/' \
+  | xargs --max-procs=0 -I {} python3 .github/scripts/fix_spdx_header.py "{}"

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ We follow a standard GitHub development flow. Our development branch is called `
 
   * The full (expensive) test suite only runs nightly on `staging`. If you want to run the full test suite on a PR, add `[force_expensive_checks]` to your commit message.
   * While debugging, we often only want one bittide instance to be tested with our hardware-in-the-loop infrastructure. With the increasing number of bittide instances with are synthesized and tested, these CI runs take a long time. You can add a file `.github/synthesis/debug.json`, with only the instances you want CI to synthesize/test. The CI run will always fail on the 'all' job when this file exists to prevent a premature merge.
+  * You can run `format` in the Nix shell to format all Cabal, Haskell, and Rust files.
 
 # About Bittide
 Bittide is a novel distributed system architecture based on the idea

--- a/bittide-experiments/src/Bittide/Report/ClockControl.hs
+++ b/bittide-experiments/src/Bittide/Report/ClockControl.hs
@@ -1,7 +1,7 @@
-{-# LANGUAGE RecordWildCards #-}
 -- SPDX-FileCopyrightText: 2024 Google LLC
 --
 -- SPDX-License-Identifier: Apache-2.0
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ImplicitPrelude #-}
 
 module Bittide.Report.ClockControl (

--- a/bittide-experiments/src/Bittide/Simulate/Config.hs
+++ b/bittide-experiments/src/Bittide/Simulate/Config.hs
@@ -1,7 +1,7 @@
-{-# LANGUAGE RecordWildCards #-}
 -- SPDX-FileCopyrightText: 2024 Google LLC
 --
 -- SPDX-License-Identifier: Apache-2.0
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ImplicitPrelude #-}
 
 module Bittide.Simulate.Config (

--- a/bittide-instances/exe/post-fullMeshSwCcTest/Main.hs
+++ b/bittide-instances/exe/post-fullMeshSwCcTest/Main.hs
@@ -1,9 +1,9 @@
-{-# LANGUAGE DeriveFunctor #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TupleSections #-}
 -- SPDX-FileCopyrightText: 2024 Google LLC
 --
 -- SPDX-License-Identifier: Apache-2.0
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeApplications #-}
 
 {- | This program extracts the UGNs from the last sample of the ila dumps of the fullMeshSwCcTest,

--- a/bittide-instances/src/Bittide/Instances/Hitl/IlaPlot.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/IlaPlot.hs
@@ -1,7 +1,7 @@
-{-# LANGUAGE FlexibleContexts #-}
 -- SPDX-FileCopyrightText: 2023 Google LLC
 --
 -- SPDX-License-Identifier: Apache-2.0
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MultiWayIf #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE UndecidableInstances #-}

--- a/bittide-instances/src/Bittide/Instances/Hitl/VexRiscv.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/VexRiscv.hs
@@ -1,7 +1,7 @@
-{-# LANGUAGE FlexibleContexts #-}
 -- SPDX-FileCopyrightText: 2022 Google LLC
 --
 -- SPDX-License-Identifier: Apache-2.0
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# OPTIONS_GHC -fplugin=Protocols.Plugin #-}

--- a/bittide-instances/src/Bittide/Instances/Pnr/Ethernet.hs
+++ b/bittide-instances/src/Bittide/Instances/Pnr/Ethernet.hs
@@ -1,7 +1,7 @@
-{-# LANGUAGE FlexibleContexts #-}
 -- SPDX-FileCopyrightText: 2024 Google LLC
 --
 -- SPDX-License-Identifier: Apache-2.0
+{-# LANGUAGE FlexibleContexts #-}
 {-# OPTIONS -fplugin=Protocols.Plugin #-}
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE RecordWildCards #-}

--- a/bittide-instances/src/Bittide/Instances/Pnr/StabilityChecker.hs
+++ b/bittide-instances/src/Bittide/Instances/Pnr/StabilityChecker.hs
@@ -1,7 +1,7 @@
-{-# LANGUAGE NumericUnderscores #-}
 -- SPDX-FileCopyrightText: 2022 Google LLC
 --
 -- SPDX-License-Identifier: Apache-2.0
+{-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE TypeApplications #-}
 
 module Bittide.Instances.Pnr.StabilityChecker where

--- a/bittide-shake/src/Clash/Shake/Flags.hs
+++ b/bittide-shake/src/Clash/Shake/Flags.hs
@@ -1,7 +1,7 @@
-{-# LANGUAGE DeriveAnyClass #-}
 -- SPDX-FileCopyrightText: 2023 Google LLC
 --
 -- SPDX-License-Identifier: Apache-2.0
+{-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
 
 -- | Flags used by Shake

--- a/bittide-tools/clockcontrol/sim/src/Main.hs
+++ b/bittide-tools/clockcontrol/sim/src/Main.hs
@@ -1,7 +1,7 @@
-{-# LANGUAGE ImplicitParams #-}
 -- SPDX-FileCopyrightText: 2022 Google LLC
 --
 -- SPDX-License-Identifier: Apache-2.0
+{-# LANGUAGE ImplicitParams #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}

--- a/bittide/src/Bittide/Calendar.hs
+++ b/bittide/src/Bittide/Calendar.hs
@@ -1,12 +1,12 @@
+-- SPDX-FileCopyrightText: 2022 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE UndecidableInstances #-}
--- SPDX-FileCopyrightText: 2022 Google LLC
---
--- SPDX-License-Identifier: Apache-2.0
 {-# OPTIONS_GHC -fconstraint-solver-iterations=8 #-}
 
 {- |

--- a/bittide/src/Bittide/ClockControl.hs
+++ b/bittide/src/Bittide/ClockControl.hs
@@ -1,7 +1,7 @@
-{-# LANGUAGE NamedFieldPuns #-}
 -- SPDX-FileCopyrightText: 2022 Google LLC
 --
 -- SPDX-License-Identifier: Apache-2.0
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans -fconstraint-solver-iterations=10 #-}

--- a/bittide/src/Bittide/ClockControl/Callisto/Types.hs
+++ b/bittide/src/Bittide/ClockControl/Callisto/Types.hs
@@ -1,9 +1,9 @@
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE RecordWildCards #-}
 -- SPDX-FileCopyrightText: 2023 Google LLC
 --
 -- SPDX-License-Identifier: Apache-2.0
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Bittide.ClockControl.Callisto.Types (

--- a/bittide/src/Bittide/ClockControl/Si539xSpi.hs
+++ b/bittide/src/Bittide/ClockControl/Si539xSpi.hs
@@ -1,11 +1,11 @@
+-- SPDX-FileCopyrightText: 2022 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE UndecidableInstances #-}
--- SPDX-FileCopyrightText: 2022 Google LLC
---
--- SPDX-License-Identifier: Apache-2.0
 {-# OPTIONS_GHC -fconstraint-solver-iterations=15 #-}
 
 module Bittide.ClockControl.Si539xSpi where

--- a/bittide/src/Bittide/DoubleBufferedRam.hs
+++ b/bittide/src/Bittide/DoubleBufferedRam.hs
@@ -1,11 +1,11 @@
+-- SPDX-FileCopyrightText: 2022 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TypeApplications #-}
--- SPDX-FileCopyrightText: 2022 Google LLC
---
--- SPDX-License-Identifier: Apache-2.0
 {-# OPTIONS_GHC -fconstraint-solver-iterations=7 #-}
 
 module Bittide.DoubleBufferedRam where

--- a/bittide/src/Bittide/Link.hs
+++ b/bittide/src/Bittide/Link.hs
@@ -1,11 +1,11 @@
+-- SPDX-FileCopyrightText: 2022 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE PartialTypeSignatures #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
--- SPDX-FileCopyrightText: 2022 Google LLC
---
--- SPDX-License-Identifier: Apache-2.0
 {-# OPTIONS_GHC -fconstraint-solver-iterations=10 #-}
 
 {- | A unidirectional communication primitive that moves a fixed-rate stream of frames

--- a/bittide/src/Bittide/Node.hs
+++ b/bittide/src/Bittide/Node.hs
@@ -1,7 +1,7 @@
-{-# LANGUAGE GADTs #-}
 -- SPDX-FileCopyrightText: 2022 Google LLC
 --
 -- SPDX-License-Identifier: Apache-2.0
+{-# LANGUAGE GADTs #-}
 {-# OPTIONS_GHC -fconstraint-solver-iterations=6 #-}
 
 module Bittide.Node where

--- a/bittide/src/Bittide/SharedTypes.hs
+++ b/bittide/src/Bittide/SharedTypes.hs
@@ -1,3 +1,6 @@
+-- SPDX-FileCopyrightText: 2022 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
@@ -6,9 +9,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE UndecidableInstances #-}
--- SPDX-FileCopyrightText: 2022 Google LLC
---
--- SPDX-License-Identifier: Apache-2.0
 {-# OPTIONS_GHC -fconstraint-solver-iterations=8 #-}
 
 module Bittide.SharedTypes where

--- a/bittide/src/Bittide/Wishbone.hs
+++ b/bittide/src/Bittide/Wishbone.hs
@@ -1,10 +1,10 @@
+-- SPDX-FileCopyrightText: 2022 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE PartialTypeSignatures #-}
 {-# LANGUAGE RecordWildCards #-}
--- SPDX-FileCopyrightText: 2022 Google LLC
---
--- SPDX-License-Identifier: Apache-2.0
 {-# OPTIONS_GHC -fconstraint-solver-iterations=100 #-}
 {-# OPTIONS_GHC -fplugin Protocols.Plugin #-}
 

--- a/bittide/tests/Tests/Axi4/Generators.hs
+++ b/bittide/tests/Tests/Axi4/Generators.hs
@@ -1,8 +1,8 @@
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE OverloadedStrings #-}
 -- SPDX-FileCopyrightText: 2023 Google LLC
 --
 -- SPDX-License-Identifier: Apache-2.0
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 
 module Tests.Axi4.Generators where

--- a/bittide/tests/Tests/Axi4/Types.hs
+++ b/bittide/tests/Tests/Axi4/Types.hs
@@ -1,7 +1,7 @@
-{-# LANGUAGE FlexibleContexts #-}
 -- SPDX-FileCopyrightText: 2024 Google LLC
 --
 -- SPDX-License-Identifier: Apache-2.0
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE RecordWildCards #-}
 
 module Tests.Axi4.Types where

--- a/bittide/tests/Tests/Calendar.hs
+++ b/bittide/tests/Tests/Calendar.hs
@@ -1,12 +1,12 @@
+-- SPDX-FileCopyrightText: 2022 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
--- SPDX-FileCopyrightText: 2022 Google LLC
---
--- SPDX-License-Identifier: Apache-2.0
 {-# OPTIONS_GHC -Wno-orphans #-}
 {-# OPTIONS_GHC -fconstraint-solver-iterations=10 #-}
 

--- a/bittide/tests/Tests/ClockControl/Si539xSpi.hs
+++ b/bittide/tests/Tests/ClockControl/Si539xSpi.hs
@@ -1,7 +1,7 @@
-{-# LANGUAGE NumericUnderscores #-}
 -- SPDX-FileCopyrightText: 2022 Google LLC
 --
 -- SPDX-License-Identifier: Apache-2.0
+{-# LANGUAGE NumericUnderscores #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Tests.ClockControl.Si539xSpi where

--- a/bittide/tests/Tests/Link.hs
+++ b/bittide/tests/Tests/Link.hs
@@ -1,11 +1,11 @@
+-- SPDX-FileCopyrightText: 2022 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
 {-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PartialTypeSignatures #-}
--- SPDX-FileCopyrightText: 2022 Google LLC
---
--- SPDX-License-Identifier: Apache-2.0
 {-# OPTIONS_GHC -fconstraint-solver-iterations=5 #-}
 
 module Tests.Link where

--- a/bittide/tests/Tests/ScatterGather.hs
+++ b/bittide/tests/Tests/ScatterGather.hs
@@ -1,3 +1,6 @@
+-- SPDX-FileCopyrightText: 2022 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -6,9 +9,6 @@
 {-# LANGUAGE ViewPatterns #-}
 -- For Show (SNatLE a b)
 {-# OPTIONS_GHC -Wno-orphans #-}
--- SPDX-FileCopyrightText: 2022 Google LLC
---
--- SPDX-License-Identifier: Apache-2.0
 {-# OPTIONS_GHC -fconstraint-solver-iterations=10 #-}
 
 module Tests.ScatterGather (tests) where

--- a/bittide/tests/Tests/Switch.hs
+++ b/bittide/tests/Tests/Switch.hs
@@ -1,10 +1,10 @@
+-- SPDX-FileCopyrightText: 2022 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
--- SPDX-FileCopyrightText: 2022 Google LLC
---
--- SPDX-License-Identifier: Apache-2.0
 {-# OPTIONS_GHC -fconstraint-solver-iterations=5 #-}
 
 module Tests.Switch (tests) where

--- a/bittide/tests/Tests/Wishbone.hs
+++ b/bittide/tests/Tests/Wishbone.hs
@@ -1,11 +1,11 @@
+-- SPDX-FileCopyrightText: 2022 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PartialTypeSignatures #-}
 {-# LANGUAGE RecordWildCards #-}
--- SPDX-FileCopyrightText: 2022 Google LLC
---
--- SPDX-License-Identifier: Apache-2.0
 {-# OPTIONS_GHC -fconstraint-solver-iterations=5 #-}
 {-# OPTIONS_GHC -fplugin Protocols.Plugin #-}
 


### PR DESCRIPTION
Fix fallout from https://github.com/bittide/bittide-hardware/pull/595. This works around an issue where Fourmolu would format:

```haskell
-- SPDX header

{-# LANGUAGE MultiWayIf #-}
{-# LANGUAGE FlexibleContexts #-}
```

as 

```haskell
{-# LANGUAGE FlexibleContexts #-}
-- SPDX header
{-# LANGUAGE MultiWayIf #-}
```

because it thinks the comment is part of the `MultiWayIf` pragma.