### PR TITLE
Shift Y-axis according to clock offsets

### DIFF
--- a/bittide-experiments/src/Bittide/Report/ClockControl.hs
+++ b/bittide-experiments/src/Bittide/Report/ClockControl.hs
@@ -18,8 +18,7 @@ import Data.Bool (bool)
 import Data.List (intercalate)
 import Data.List.Extra (chunksOf)
 import Data.Proxy (Proxy (..))
-import GHC.Float.RealFracMethods (roundDoubleInteger)
-import Numeric.Extra (floatToDouble)
+import GHC.Float.RealFracMethods (roundFloatInteger)
 import System.Directory (doesDirectoryExist, doesFileExist, findExecutable)
 import System.Environment (lookupEnv)
 import System.FilePath (takeFileName, (</>))
@@ -340,7 +339,7 @@ toLatex refDom datetime runref header clocksPdf ebsPdf topTikz ids SimConf{..} =
  where
   formatOffsets =
     intercalate "; "
-      . (fmap (qtyPpm . roundDoubleInteger . fsToPpm refDom . floatToDouble))
+      . (fmap (qtyPpm . roundFloatInteger . fsToPpm refDom))
 
   qtyMs ms = "\\qty{" <> show ms <> "}{\\milli\\second}"
   qtyPpm ppm = "\\qty{" <> show ppm <> "}{\\ppm}"

--- a/bittide-experiments/src/Bittide/Simulate.hs
+++ b/bittide-experiments/src/Bittide/Simulate.hs
@@ -211,7 +211,7 @@ simPlot# simSettings ccc t = do
 
   case mode of
     PDF ->
-      plot (Proxy @dom) dir t $
+      plot (Proxy @dom) Nothing dir t $
         fmap (fmap (\(a, b, c, d) -> (a, b, fromRfState c, d))) simResult
     CSV -> dumpCsv simResult
 

--- a/bittide-tools/clockcontrol/plot/Main.hs
+++ b/bittide-tools/clockcontrol/plot/Main.hs
@@ -696,7 +696,7 @@ plotTest refDom testDir cfg dir globalOutDir = do
 
         -- Calculate offset correction for readability purposes. See:
         -- https://github.com/bittide/bittide-hardware/issues/607
-        (maybeError, _maybeOffsetCorrection) <-
+        (maybeError, maybeOffsetCorrection) <-
           case cfg.clockOffsets of
             Nothing -> pure (Nothing, Nothing)
             Just (Vec.unsafeFromList -> offsets) ->
@@ -705,7 +705,7 @@ plotTest refDom testDir cfg dir globalOutDir = do
                 Right correction -> pure (Nothing, Just correction)
 
         createDirectoryIfMissing True outDir
-        plot refDom outDir t postProcessDataVec
+        plot refDom maybeOffsetCorrection outDir t postProcessDataVec
 
         let
           allStable =


### PR DESCRIPTION
Fixes #607

Also replaces `Double` with `Float` to prevent some (senseless) conversion between the two.

# TODO
- [x] Merge https://github.com/bittide/bittide-hardware/pull/605
- [x] Wait for clock report https://github.com/bittide/bittide-hardware/actions/runs/10485835077