### PR TITLE
Remove unit juggling

### DIFF
--- a/bittide-experiments/src/Bittide/Report/ClockControl.hs
+++ b/bittide-experiments/src/Bittide/Report/ClockControl.hs
@@ -34,6 +34,7 @@ import System.IO (
 import System.IO.Temp (withSystemTempDirectory)
 import System.Process (callProcess, readProcess)
 
+import Bittide.Arithmetic.PartsPer (toPpm)
 import Bittide.Arithmetic.Time (PeriodToCycles)
 import Bittide.Plot
 import Bittide.Simulate.Config (CcConf (..), simTopologyFileName)
@@ -189,7 +190,7 @@ toLatex ::
   -- | The utilized simulation configuration
   CcConf ->
   String
-toLatex refDom datetime runref header clocksPdf ebsPdf topTikz ids CcConf{..} =
+toLatex _refDom datetime runref header clocksPdf ebsPdf topTikz ids CcConf{..} =
   unlines
     [ "\\documentclass[landscape]{article}"
     , ""
@@ -339,7 +340,7 @@ toLatex refDom datetime runref header clocksPdf ebsPdf topTikz ids CcConf{..} =
  where
   formatOffsets =
     intercalate "; "
-      . (fmap (qtyPpm . roundFloatInteger . fsToPpm refDom))
+      . (fmap (qtyPpm . roundFloatInteger . toPpm))
 
   qtyMs ms = "\\qty{" <> show ms <> "}{\\milli\\second}"
   qtyPpm ppm = "\\qty{" <> show ppm <> "}{\\ppm}"

--- a/bittide-experiments/src/Bittide/Simulate/Config.hs
+++ b/bittide-experiments/src/Bittide/Simulate/Config.hs
@@ -11,6 +11,7 @@ module Bittide.Simulate.Config (
   saveCcConfig,
 ) where
 
+import Bittide.Arithmetic.PartsPer (PartsPer)
 import Bittide.Topology (STop (..), TopologyType (..), toDot)
 
 import Data.Aeson (FromJSON (..), ToJSON (..), encode)
@@ -59,7 +60,7 @@ data CcConf = CcConf
   , stopAfterStable :: Maybe Int
   -- ^ Stop simulation after all buffers have been stable for
   -- at least the given number of clock cycles.
-  , clockOffsets :: Maybe [Float]
+  , clockOffsets :: Maybe [PartsPer]
   -- ^ The initital clock offsets in Femtoseconds
   -- (randomly generated if missing).
   , startupDelays :: [Int]

--- a/bittide-instances/src/Bittide/Instances/Hitl/HwCcTopologies.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/HwCcTopologies.hs
@@ -111,14 +111,14 @@ data StepSizeSelect
   | PPB_10
   | PPB_100
   | PPM_1
-  deriving (Generic, NFDataX, BitPack, Eq, Enum, Bounded)
+  deriving (Generic, NFDataX, BitPack, Eq, Enum, Bounded, Show)
 
 -- | Calibration stages
 data CCCalibrationStage
   = NoCCCalibration
   | CCCalibrate
   | CCCalibrationValidation
-  deriving (Generic, NFDataX, BitPack, Eq, Enum, Bounded)
+  deriving (Generic, NFDataX, BitPack, Eq, Enum, Bounded, Show)
 
 {- | The step size, as it is used by all tests. Note that changing the
 step size for individual tests requires recalibration of the clock
@@ -173,7 +173,7 @@ data TestConfig = TestConfig
   , mask :: BitVector LinkCount
   -- ^ The link mask depending on the selected topology.
   }
-  deriving (Generic, NFDataX, BitPack)
+  deriving (Generic, NFDataX, BitPack, Show)
 
 clockControlConfig ::
   $(case (instancesClockConfig (Proxy @Basic125)) of (_ :: t) -> liftTypeQ @t)

--- a/bittide-instances/src/Bittide/Instances/Hitl/HwCcTopologies.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/HwCcTopologies.hs
@@ -40,10 +40,12 @@ import Data.Bifunctor (bimap)
 import Data.Maybe (fromMaybe, isJust)
 import Data.Proxy
 import Data.String (fromString)
+import GHC.Float.RealFracMethods (roundFloatInteger)
 import Language.Haskell.TH (runIO)
 import LiftType (liftTypeQ)
 import System.FilePath
 
+import Bittide.Arithmetic.PartsPer (PartsPer, ppm)
 import Bittide.Arithmetic.Time
 import Bittide.ClockControl
 import Bittide.ClockControl.Callisto
@@ -84,6 +86,7 @@ import Protocols hiding (SimulationConfig)
 import Protocols.Wishbone
 import VexRiscv
 
+import qualified Bittide.Arithmetic.PartsPer as PartsPer
 import qualified Bittide.Transceiver as Transceiver
 import qualified Bittide.Transceiver.ResetManager as ResetManager
 import qualified Data.Map.Strict as Map (fromList)
@@ -93,12 +96,8 @@ type AllStablePeriod = Seconds 5
 {- | The number of FINCs (if positive) or FDECs (if negative) applied
 prior to the test start leading to some desired initial clock
 offset.
-
-Note that the value is limited to fit within 16 bits right now to
-avoid the generation of YAML files with integers that are larger
-than 63 bits.
 -}
-type InitialClockShift = Signed 32
+type FincFdecCount = Signed 32
 
 {- | The number of clock cycles to wait before starting clock control
 according to the local, but stable system clock of a node.
@@ -115,9 +114,15 @@ data StepSizeSelect
 
 -- | Calibration stages
 data CCCalibrationStage
-  = NoCCCalibration
-  | CCCalibrate
-  | CCCalibrationValidation
+  = -- | Apply previously measured clock offsets.
+    NoCCCalibration
+  | -- | Measure \"natural\" clock offsets.
+    CCCalibrate
+  | -- | Verify that the clocks still have similar \"natural\" offsets as when
+    -- they were calibrated. If this is not the case, the clock frequencies
+    -- shifted during the test, invalidating the results. Also see
+    -- 'acceptableNoiseLevel'.
+    CCCalibrationValidation
   deriving (Generic, NFDataX, BitPack, Eq, Enum, Bounded, Show)
 
 {- | The step size, as it is used by all tests. Note that changing the
@@ -126,6 +131,17 @@ offsets, which is why we fix it to a single and common value here.
 -}
 commonStepSizeSelect :: StepSizeSelect
 commonStepSizeSelect = PPB_10
+
+commonStepSizePartsPer :: PartsPer
+commonStepSizePartsPer = case commonStepSizeSelect of
+  PPB_1 -> PartsPer.ppb 1
+  PPB_10 -> PartsPer.ppb 10
+  PPB_100 -> PartsPer.ppb 100
+  PPM_1 -> PartsPer.ppm 1
+
+partsPerToSteps :: PartsPer -> FincFdecCount
+partsPerToSteps =
+  fromIntegral . roundFloatInteger . PartsPer.toSteps commonStepSizePartsPer
 
 commonSpiConfig :: TestConfig6_200_on_0a_RegisterMap
 commonSpiConfig = case commonStepSizeSelect of
@@ -137,7 +153,7 @@ commonSpiConfig = case commonStepSizeSelect of
 {- | Accepted noise between the inital clock control calibration run
 and the last calibration verifiction run.
 -}
-acceptableNoiseLevel :: InitialClockShift
+acceptableNoiseLevel :: FincFdecCount
 acceptableNoiseLevel = 6
 
 disabled :: TestConfig
@@ -162,11 +178,9 @@ data TestConfig = TestConfig
   -- synchronization, needs to stay alive.
   , calibrate :: CCCalibrationStage
   -- ^ Indicates the selected calibration stage.
-  , initialClockShift :: Maybe InitialClockShift
-  -- ^ Some artificical clock shift applied prior to the test
-  -- start. The shift is given in FINCs (if positive) or FDECs (if
-  -- negative) and, thus, depdends on 'stepSizeSelect'. If 'Nothing',
-  -- no shift is applied.
+  , initialClockShift :: Maybe FincFdecCount
+  -- ^ Artificical clock shift applied prior to the test start, expressed as
+  -- number of FINCs (if positive) or FDECs (if negative).
   , startupDelay :: StartupDelay
   -- ^ Some intial startup delay given in the number of clock
   -- cycles of the stable clock.
@@ -297,8 +311,8 @@ topologyTest ::
   , "transceiversFailedAfterUp" ::: Signal Basic125 Bool
   , "ALL_READY" ::: Signal Basic125 Bool
   , "ALL_STABLE" ::: Signal Basic125 Bool
-  , "CALIB_I" ::: Signal Basic125 InitialClockShift
-  , "CALIB_E" ::: Signal Basic125 InitialClockShift
+  , "CALIB_I" ::: Signal Basic125 FincFdecCount
+  , "CALIB_E" ::: Signal Basic125 FincFdecCount
   )
 topologyTest refClk sysClk sysRst IlaControl{syncRst = rst, ..} rxNs rxPs miso cfg =
   fincFdecIla
@@ -473,7 +487,7 @@ topologyTest refClk sysClk sysRst IlaControl{syncRst = rst, ..} rxNs rxPs miso c
       sysClk
       sysRst
       enableGen
-      (0 :: InitialClockShift)
+      (0 :: FincFdecCount)
       (notInCCReset .&&. (== CCCalibrate) . calibrate <$> cfg)
       (clockShiftUpd <$> clockMod <*> clockShift)
 
@@ -493,7 +507,7 @@ topologyTest refClk sysClk sysRst IlaControl{syncRst = rst, ..} rxNs rxPs miso c
       sysClk
       sysRst
       enableGen
-      (0 :: InitialClockShift)
+      (0 :: FincFdecCount)
       (notInCCReset .&&. (== CCCalibrationValidation) . calibrate <$> cfg)
       (clockShiftUpd <$> clockMod <*> validationClockShift)
 
@@ -521,7 +535,7 @@ topologyTest refClk sysClk sysRst IlaControl{syncRst = rst, ..} rxNs rxPs miso c
       sysClk
       adjustRst
       enableGen
-      (0 :: InitialClockShift)
+      (0 :: FincFdecCount)
       adjusting
       $ flip upd
       <$> adjustCount
@@ -779,25 +793,25 @@ tests =
  where
   m = 1_000_000
 
-  icsDiamond = -1000 :> -500 :> 2000 :> 3000 :> Nil
+  icsDiamond = map ppm $ -10 :> -5 :> 20 :> 30 :> Nil
   sdDiamond = 0 :> 10 :> 200 :> 3 :> Nil
 
-  icsComplete = -10000 :> 0 :> 10000 :> Nil
+  icsComplete = map ppm $ -100 :> 0 :> 100 :> Nil
   sdComplete = 200 :> 0 :> 200 :> Nil
 
-  icsCyclic = 0 :> 500 :> 1000 :> 1500 :> 2000 :> Nil
+  icsCyclic = map ppm $ 0 :> 5 :> 10 :> 15 :> 20 :> Nil
   sdCyclic = 0 :> 10 :> 0 :> 100 :> 0 :> Nil
 
-  icsTorus = -3000 :> -3500 :> -4000 :> 4000 :> 3500 :> 3000 :> Nil
+  icsTorus = map ppm $ -30 :> -35 :> -40 :> 40 :> 35 :> 30 :> Nil
   sdTorus = 0 :> 0 :> 0 :> 100 :> 100 :> 100 :> Nil
 
-  icsStar = 0 :> 1000 :> -1000 :> 2000 :> -2000 :> 3000 :> -3000 :> 4000 :> Nil
+  icsStar = map ppm $ 0 :> 10 :> -10 :> 20 :> -20 :> 30 :> -30 :> 40 :> Nil
   sdStar = 0 :> 40 :> 80 :> 120 :> 160 :> 200 :> 240 :> 280 :> Nil
 
-  icsLine = 10000 :> 0 :> 0 :> -10000 :> Nil
+  icsLine = map ppm $ 100 :> 0 :> 0 :> -100 :> Nil
   sdLine = 200 :> 0 :> 0 :> 200 :> Nil
 
-  icsHourglass = -10000 :> 10000 :> -10000 :> 10000 :> -10000 :> 10000 :> Nil
+  icsHourglass = map ppm $ -100 :> 100 :> -100 :> 100 :> -100 :> 100 :> Nil
   sdHourglass = 0 :> 200 :> 0 :> 200 :> 0 :> 200 :> Nil
 
   ClockControlConfig{..} = clockControlConfig
@@ -846,7 +860,7 @@ tests =
   tt ::
     forall n.
     (KnownNat n, n <= FpgaCount) =>
-    Maybe (Vec n InitialClockShift) ->
+    Maybe (Vec n PartsPer) ->
     Vec n StartupDelay ->
     Topology n ->
     (TestName, (Probes TestConfig, CcConf))
@@ -857,7 +871,7 @@ tests =
           ( zipWith4
               testData
               indicesI
-              (maybeVecToVecMaybe clockShifts)
+              (maybeVecToVecMaybe (map partsPerToSteps <$> clockShifts))
               startDelays
               (linkMasks @n t)
           )
@@ -865,30 +879,11 @@ tests =
              | let n = natToNum @n
              , i <- [n, n + 1 .. natToNum @LinkCount]
              ]
-      , let
-          -- clock period in picoseconds
-          clkPeriodPs :: (Num a) => a
-          clkPeriodPs = case clockControlConfig of
-            (_ :: ClockControlConfig dom a b c) ->
-              snatToNum (clockPeriod @dom)
-          -- a 1000 times the factor of the selected parts-per-x scale
-          -- ratio, where the reduction by a factor of 1000 accounts
-          -- to the required conversion of from Picoseconds to
-          -- Femtoseconds for 'clkPeriodPs' already applied at this
-          -- point to reduce the loss-op-presion introduced otherwise.
-          stepSizeDiv = case commonStepSizeSelect of
-            PPB_1 -> 1_000_000
-            PPB_10 -> 100_000
-            PPB_100 -> 10_000
-            PPM_1 -> 1_000
-
-          fincFdecToFs = ((-1) *) . (/ stepSizeDiv) . (* clkPeriodPs) . fromIntegral
-         in
-          defSimCfg
-            { ccTopologyType = topologyType t
-            , clockOffsets = fmap fincFdecToFs . toList <$> clockShifts
-            , startupDelays = fromIntegral <$> toList startDelays
-            }
+      , defSimCfg
+          { ccTopologyType = topologyType t
+          , clockOffsets = toList <$> clockShifts
+          , startupDelays = fromIntegral <$> toList startDelays
+          }
       )
     )
 
@@ -901,7 +896,7 @@ tests =
     forall n.
     (KnownNat n, n <= FpgaCount) =>
     Index n ->
-    Maybe InitialClockShift ->
+    Maybe FincFdecCount ->
     StartupDelay ->
     BitVector LinkCount ->
     (Index FpgaCount, TestConfig)

--- a/bittide/bittide.cabal
+++ b/bittide/bittide.cabal
@@ -118,6 +118,7 @@ library
     text,
 
   exposed-modules:
+    Bittide.Arithmetic.PartsPer
     Bittide.Arithmetic.Time
     Bittide.Axi4
     Bittide.Axi4.Internal

--- a/bittide/src/Bittide/Arithmetic/PartsPer.hs
+++ b/bittide/src/Bittide/Arithmetic/PartsPer.hs
@@ -1,0 +1,110 @@
+-- SPDX-FileCopyrightText: 2024 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE NumericUnderscores #-}
+
+{- | A more-or-less ad-hoc collection of definitions to work with measuring
+clock frequency differences without loss-of-precision.
+-}
+module Bittide.Arithmetic.PartsPer where
+
+import Bittide.Arithmetic.Time (PeriodToCycles)
+import Clash.Prelude hiding (PeriodToCycles)
+import Data.Aeson (FromJSON (..), ToJSON (..))
+import Data.Data (Proxy (..))
+
+{- $setup
+>>> import Clash.Prelude
+-}
+
+{- | A relative measure of frequency. E.g., a 'PartsPer' of @1 ppm@ of some ideal
+frequency means that for every million ticks in an ideal frequency, there are
+a million and one ticks in the observed frequency.
+
+It is internally represented as a 64-bit signed integer, representing
+_parts per trillion_.
+-}
+newtype PartsPer = Ppt (Signed 64)
+  deriving (Show, Eq, Ord)
+  deriving newtype (Num)
+
+instance ToJSON PartsPer where
+  toJSON (Ppt x) = toJSON (toInteger x)
+
+instance FromJSON PartsPer where
+  parseJSON = fmap (Ppt . fromInteger) . parseJSON
+
+ppt :: Signed 64 -> PartsPer
+ppt = Ppt . (* 1)
+
+ppb :: Signed 64 -> PartsPer
+ppb = Ppt . (* 1_000)
+
+ppm :: Signed 64 -> PartsPer
+ppm = Ppt . (* 1_000_000)
+
+toPpt :: PartsPer -> Float
+toPpt = toSteps (ppt 1)
+
+toPpb :: PartsPer -> Float
+toPpb = toSteps (ppb 1)
+
+toPpm :: PartsPer -> Float
+toPpm = toSteps (ppm 1)
+
+{- | Convert a 'PartsPer' to a 'Float'. Useful for pretty printing 'PartsPer' to
+a human-readable step size (usually, 1 ppm). Has no representation in hardware.
+
+>>> toSteps (ppb 1) (ppm 3)
+3000.0
+>>> toSteps (ppm 1) (cyclesToPartsPer (125_000_000 :: Integer) 125_000_879)
+7.032
+-}
+toSteps ::
+  -- | Step size
+  PartsPer ->
+  -- | Value
+  PartsPer ->
+  -- | Number of steps to get to the value
+  Float
+toSteps (Ppt stepSize) (Ppt value) = fromIntegral value / fromIntegral stepSize
+
+{- | Given an ideal number of clock cycles - passed indirectly using a combination
+of a domain and a measurement period - and an observed number of clock cycles,
+calculate the difference in 'PartsPer'. Has no representation in hardware.
+-}
+cyclesToPartsPerI ::
+  forall dom ps a.
+  (KnownDomain dom, KnownNat ps, Integral a) =>
+  -- | Clock domain. Proxy for an ideal frequency.
+  Proxy dom ->
+  -- | Period observed for in picoseconds (see 'Seconds', 'Milliseconds', etc.). E.g.,
+  -- if you want to pass in 1 millisecond, you would pass in:
+  --
+  -- > cyclesToPartsPerI (Proxy @dom) (Proxy @(Milliseconds 1))
+  Proxy ps ->
+  -- | Observed number of clock cycles
+  a ->
+  PartsPer
+cyclesToPartsPerI _ _ = cyclesToPartsPer (natToNum @(PeriodToCycles dom ps))
+
+{- | Given an ideal number of clock cycles and an observed number of clock cycles,
+calculate the difference in 'PartsPer'. Has no representation in hardware.
+
+>>> cyclesToPartsPer 125_000_000 125_000_250
+Ppt 2000000
+>>> toPpm (cyclesToPartsPer 125_000_000 125_000_250)
+2.0
+-}
+cyclesToPartsPer ::
+  (Integral a) =>
+  -- | Ideal number of clock cycles
+  a ->
+  -- | Observed number of clock cycles
+  a ->
+  PartsPer
+cyclesToPartsPer (toInteger -> ideal) (toInteger -> observed) =
+  Ppt (fromInteger (((observed * factor) `div` ideal) - factor))
+ where
+  factor = 1_000_000_000_000


### PR DESCRIPTION
This helped me convince myself that https://github.com/bittide/bittide-hardware/issues/611 was indeed a fundamental issue, and not a rounding issue in one of the type/unit juggle parts. I'll leave it up for reviewers to judge whether this actually simplifies things.

# Concrete results
The clock plots seem more stable. The reports show this for every plot, but it is most obvious for plots with small clock offsets. (Thanks to the eagle-eyed @hiddemoll for spotting this.) For example:

<details>
  <summary>Calibration (old then new)</summary>

![Screenshot from 2024-08-26 16-00-46](https://github.com/user-attachments/assets/f64ace0c-1bfc-42b1-922a-569fb419b5d7)

![Screenshot from 2024-08-26 16-01-00](https://github.com/user-attachments/assets/6502a96f-b71f-4015-964d-3c4c589c6e3a)
</details>

<details>
  <summary>Diamond (old then new)</summary>

![Screenshot from 2024-08-26 16-01-48](https://github.com/user-attachments/assets/569624a9-6b6a-4de0-b794-5509d529f6e0)

![Screenshot from 2024-08-26 16-02-09](https://github.com/user-attachments/assets/72794114-e92f-422c-b49e-2aad9f9466c1)
</details>

# TODO
- [x] Wait for https://github.com/bittide/bittide-hardware/actions/runs/10560644666
- [x] Investigate whether we can remove `Maybe PartsPer` in favor of `PartsPer` again