### PR TITLE
Add label to Y-axis for buffer occupancy plots

### DIFF
--- a/bittide-experiments/src/Bittide/Plot.hs
+++ b/bittide-experiments/src/Bittide/Plot.hs
@@ -219,6 +219,7 @@ matplotWrite dir maybeCorrection clockDats ebDats = do
     file (dir </> plotElasticBuffersFileName) $
       constrained
         ( xlabel "Time (ms)"
+            % ylabel "Occupancy count"
             % foldPlots (Vec.toList ebDats)
         )
  where


### PR DESCRIPTION
Bikeshed away! Mostly because I want to use it in context where the title of the plot disappears.

Example of how it looks:

![Screenshot from 2024-08-26 16-13-57](https://github.com/user-attachments/assets/a7cedf51-46f0-4af2-94e0-1355adc87ed6)

Current proposal:

 - **Occupancy count**
