### PR TITLE
 Align value of `k_p` with Julia implementation of Callisto 

### DIFF
--- a/bittide-instances/src/Bittide/Instances/Hitl/FullMeshHwCc.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/FullMeshHwCc.hs
@@ -46,7 +46,6 @@ import Bittide.ClockControl
 import Bittide.ClockControl.Callisto
 import Bittide.ClockControl.Callisto.Util (FDEC, FINC, speedChangeToPins, stickyBits)
 import Bittide.ClockControl.Registers (clockControlWb)
-import Bittide.ClockControl.Si5395J
 import Bittide.ClockControl.Si539xSpi (ConfigState (Error, Finished), si539xSpi)
 import Bittide.Counter
 import Bittide.DoubleBufferedRam (
@@ -65,6 +64,7 @@ import Bittide.Simulate.Config (CcConf (..))
 import Bittide.Topology (TopologyType (..))
 import Bittide.Transceiver (transceiverPrbsN)
 
+import Bittide.Instances.Hitl.HwCcTopologies (commonSpiConfig)
 import Bittide.Instances.Hitl.IlaPlot
 import Bittide.Instances.Hitl.Setup
 import Project.FilePath
@@ -234,7 +234,7 @@ fullMeshHwTest refClk sysClk IlaControl{syncRst = rst, ..} rxNs rxPs miso =
 
   (_, _, spiState, spiOut) =
     withClockResetEnable sysClk syncRst enableGen
-      $ si539xSpi testConfig6_200_on_0a_10ppb (SNat @(Microseconds 10)) (pure Nothing) miso
+      $ si539xSpi commonSpiConfig (SNat @(Microseconds 10)) (pure Nothing) miso
 
   -- Transceiver setup
   gthAllReset = unsafeFromActiveLow spiDone

--- a/bittide-instances/src/Bittide/Instances/Hitl/FullMeshSwCc.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/FullMeshSwCc.hs
@@ -47,7 +47,6 @@ import Bittide.ClockControl
 import Bittide.ClockControl.Callisto
 import Bittide.ClockControl.Callisto.Util (FDEC, FINC, speedChangeToPins, stickyBits)
 import Bittide.ClockControl.Registers (clockControlWb)
-import Bittide.ClockControl.Si5395J
 import Bittide.ClockControl.Si539xSpi (ConfigState (Error, Finished), si539xSpi)
 import Bittide.Counter
 import Bittide.DoubleBufferedRam (ContentType (Blob), InitialContent (Reloadable))
@@ -61,6 +60,7 @@ import Bittide.Simulate.Config (CcConf (..))
 import Bittide.Topology (TopologyType (..))
 import Bittide.Transceiver (transceiverPrbsN)
 
+import Bittide.Instances.Hitl.HwCcTopologies (commonSpiConfig)
 import Bittide.Instances.Hitl.IlaPlot
 import Bittide.Instances.Hitl.Setup hiding (FpgaCount, LinkCount)
 import Project.FilePath
@@ -198,7 +198,7 @@ fullMeshHwTest refClk sysClk IlaControl{syncRst = rst, ..} rxNs rxPs miso =
 
   (_, _, spiState, spiOut) =
     withClockResetEnable sysClk syncRst enableGen
-      $ si539xSpi testConfig6_200_on_0a_10ppb (SNat @(Microseconds 10)) (pure Nothing) miso
+      $ si539xSpi commonSpiConfig (SNat @(Microseconds 10)) (pure Nothing) miso
 
   -- Transceiver setup
   gthAllReset = unsafeFromActiveLow spiDone

--- a/bittide-instances/src/Bittide/Instances/Hitl/HwCcTopologies.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/HwCcTopologies.hs
@@ -29,6 +29,7 @@ module Bittide.Instances.Hitl.HwCcTopologies (
   hwCcTopologyWithRiscvTest,
   hwCcTopologyTest,
   clockControlConfig,
+  commonSpiConfig,
   tests,
 ) where
 
@@ -131,7 +132,10 @@ step size for individual tests requires recalibration of the clock
 offsets, which is why we fix it to a single and common value here.
 -}
 commonStepSizeSelect :: StepSizeSelect
-commonStepSizeSelect = PPB_10
+commonStepSizeSelect =
+  -- Don't forget to update the value of f_step this value in "Callisto.hs" and
+  -- "callisto.rs".
+  PPB_100
 
 commonStepSizePartsPer :: PartsPer
 commonStepSizePartsPer = case commonStepSizeSelect of

--- a/bittide/src/Bittide/ClockControl/Callisto.hs
+++ b/bittide/src/Bittide/ClockControl/Callisto.hs
@@ -163,12 +163,16 @@ callisto ControlConfig{..} mask scs dataCounts state =
   steadyStateTarget = D.fromSignal (_steadyStateTarget <$> state)
 
   -- see clock control algorithm simulation here:
+  --
   -- https://github.com/bittide/Callisto.jl/blob/e47139fca128995e2e64b2be935ad588f6d4f9fb/demo/pulsecontrol.jl#L24
   --
-  -- the constants here are chosen to match the above code.
+  -- `k_p` (proportional gain) is copied from the Julia implementation. `fStep` should
+  -- match the step size of the clock boards. For all our HITL tests this is set by
+  -- `HwCcTopologies.commonStepSizeSelect`.
+  --
   k_p, fStep :: forall d. DSignal dom d Float
-  k_p = pure 2e-4
-  fStep = pure 5e-4
+  k_p = pure 2e-8
+  fStep = pure 100e-9
 
   r_k :: DSignal dom F.FromS32DefDelay Float
   r_k =

--- a/firmware-support/bittide-sys/src/callisto.rs
+++ b/firmware-support/bittide-sys/src/callisto.rs
@@ -111,8 +111,15 @@ pub fn callisto(
     data_counts: impl Iterator<Item = isize>,
     state: &mut ControlSt,
 ) {
-    const K_P: f32 = 2e-4;
-    const FSTEP: f32 = 5e-4;
+    // see clock control algorithm simulation here:
+    //
+    // https://github.com/bittide/Callisto.jl/blob/e47139fca128995e2e64b2be935ad588f6d4f9fb/demo/pulsecontrol.jl#L24
+    //
+    // `k_p` (proportional gain) is copied from the Julia implementation. `fStep` should
+    // match the step size of the clock boards. For all our HITL tests this is set by
+    // `HwCcTopologies.commonStepSizeSelect`.
+    const K_P: f32 = 2e-8;
+    const FSTEP: f32 = 100e-9;
 
     let n_buffers = availability_mask.count_ones();
     let measured_sum = data_counts.sum::<isize>() as i32;


### PR DESCRIPTION
If we want to fully match the Julia code we should build a clock config for 500 PPB. **Edit**: Added in https://github.com/bittide/bittide-hardware/pull/633. Switching to 500 PPB makes clock synchronize very fast though, making for uninteresting plots.

See `freq_step` at https://github.com/bittide/Callisto.jl/blob/e47139fca128995e2e64b2be935ad588f6d4f9fb/demo/pulsecontrol.jl#L41

# TODO
- [x] Wait for https://github.com/bittide/bittide-hardware/actions/runs/10690296339. View report by clicking on "Generate clock control report" and downloading the report uploaded in step "Upload reports".