### PR TITLE
Switch from the 300MHz onboard sysclk to the 125MHz one

### DIFF
--- a/bittide-instances/data/constraints/fullMeshHwCcTest.xdc
+++ b/bittide-instances/data/constraints/fullMeshHwCcTest.xdc
@@ -2,8 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-set_property BOARD_PART_PIN sysclk_300_n [get_ports SYSCLK_300_n]
-set_property BOARD_PART_PIN sysclk_300_p [get_ports SYSCLK_300_p]
+set_property BOARD_PART_PIN sysclk_125_n [get_ports SYSCLK_125_n]
+set_property BOARD_PART_PIN sysclk_125_p [get_ports SYSCLK_125_p]
 set_property BOARD_PART_PIN sma_mgt_refclk_n [get_ports SMA_MGT_REFCLK_C_n]
 set_property BOARD_PART_PIN sma_mgt_refclk_p [get_ports SMA_MGT_REFCLK_C_p]
 
@@ -11,7 +11,7 @@ set_property BOARD_PART_PIN GPIO_LED_0_LS [get_ports spiDone]
 
 set_clock_groups \
   -asynchronous \
-  -group [get_clocks -include_generated_clocks {SYSCLK_300_p}] \
+  -group [get_clocks -include_generated_clocks {SYSCLK_125_p}] \
   -group [get_clocks -include_generated_clocks {SMA_MGT_REFCLK_C_p}]
 
 # Color   | FPGA pin      | LVLSHFT       | Connection

--- a/bittide-instances/data/constraints/linkConfigurationTest.xdc
+++ b/bittide-instances/data/constraints/linkConfigurationTest.xdc
@@ -2,8 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-set_property BOARD_PART_PIN sysclk_300_n [get_ports SYSCLK_300_n]
-set_property BOARD_PART_PIN sysclk_300_p [get_ports SYSCLK_300_p]
+set_property BOARD_PART_PIN sysclk_125_n [get_ports SYSCLK_125_n]
+set_property BOARD_PART_PIN sysclk_125_p [get_ports SYSCLK_125_p]
 set_property BOARD_PART_PIN sma_mgt_refclk_n [get_ports SMA_MGT_REFCLK_C_n]
 set_property BOARD_PART_PIN sma_mgt_refclk_p [get_ports SMA_MGT_REFCLK_C_p]
 
@@ -11,7 +11,7 @@ set_property BOARD_PART_PIN GPIO_LED_0_LS [get_ports spiDone]
 
 set_clock_groups \
   -asynchronous \
-  -group [get_clocks -include_generated_clocks {SYSCLK_300_p}] \
+  -group [get_clocks -include_generated_clocks {SYSCLK_125_p}] \
   -group [get_clocks -include_generated_clocks {SMA_MGT_REFCLK_C_p}]
 
 # Color   | FPGA pin      | LVLSHFT       | Connection

--- a/bittide-instances/data/constraints/syncInSyncOut.xdc
+++ b/bittide-instances/data/constraints/syncInSyncOut.xdc
@@ -2,8 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-set_property BOARD_PART_PIN sysclk_300_n [get_ports SYSCLK_300_n]
-set_property BOARD_PART_PIN sysclk_300_p [get_ports SYSCLK_300_p]
+set_property BOARD_PART_PIN sysclk_125_n [get_ports SYSCLK_125_n]
+set_property BOARD_PART_PIN sysclk_125_p [get_ports SYSCLK_125_p]
 
 # USER SMA GPIO_P
 set_property -dict {IOSTANDARD LVCMOS18 PACKAGE_PIN H27} [get_ports {SYNC_IN}]

--- a/bittide-instances/data/constraints/transceiversUpTest.xdc
+++ b/bittide-instances/data/constraints/transceiversUpTest.xdc
@@ -2,8 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-set_property BOARD_PART_PIN sysclk_300_n [get_ports SYSCLK_300_n]
-set_property BOARD_PART_PIN sysclk_300_p [get_ports SYSCLK_300_p]
+set_property BOARD_PART_PIN sysclk_125_n [get_ports SYSCLK_125_n]
+set_property BOARD_PART_PIN sysclk_125_p [get_ports SYSCLK_125_p]
 set_property BOARD_PART_PIN sma_mgt_refclk_n [get_ports SMA_MGT_REFCLK_C_n]
 set_property BOARD_PART_PIN sma_mgt_refclk_p [get_ports SMA_MGT_REFCLK_C_p]
 
@@ -11,7 +11,7 @@ set_property BOARD_PART_PIN GPIO_LED_0_LS [get_ports spiDone]
 
 set_clock_groups \
   -asynchronous \
-  -group [get_clocks -include_generated_clocks {SYSCLK_300_p}] \
+  -group [get_clocks -include_generated_clocks {SYSCLK_125_p}] \
   -group [get_clocks -include_generated_clocks {SMA_MGT_REFCLK_C_p}]
 
 # Color   | FPGA pin      | LVLSHFT       | Connection

--- a/bittide-instances/src/Bittide/Instances/Domains.hs
+++ b/bittide-instances/src/Bittide/Instances/Domains.hs
@@ -19,12 +19,10 @@ createDomain vXilinxSystem{vName="Basic125A", vPeriod= hzToPeriod 125e6}
 createDomain vXilinxSystem{vName="Basic125B", vPeriod= hzToPeriod 125e6}
 createDomain vXilinxSystem{vName="Basic199", vPeriod=hzToPeriod 199e6}
 createDomain vXilinxSystem{vName="Basic200", vPeriod=hzToPeriod 200e6}
-createDomain vXilinxSystem{vName="Basic300", vPeriod=hzToPeriod 300e6}
 createDomain vXilinxSystem{vName="Basic625", vPeriod=hzToPeriod 625e6, vResetKind=Asynchronous}
 
 createDomain vXilinxSystem{vName="Ext125", vPeriod= hzToPeriod 125e6, vResetKind=Asynchronous}
 createDomain vXilinxSystem{vName="Ext200", vPeriod=hzToPeriod 200e6, vResetKind=Asynchronous}
-createDomain vXilinxSystem{vName="Ext300", vPeriod=hzToPeriod 300e6, vResetKind=Asynchronous}
 
 createDomain vXilinxSystem{vName="GthRx", vPeriod=hzToPeriod 125e6}
 createDomain vXilinxSystem{vName="GthTx", vPeriod= hzToPeriod 125e6}

--- a/bittide-instances/src/Bittide/Instances/Hitl/FullMeshHwCc.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/FullMeshHwCc.hs
@@ -368,7 +368,7 @@ fullMeshHwTest refClk sysClk IlaControl{syncRst = rst, ..} rxNs rxPs miso =
 -- | Top entity for this test. See module documentation for more information.
 fullMeshHwCcWithRiscvTest ::
   "SMA_MGT_REFCLK_C" ::: DiffClock Ext200 ->
-  "SYSCLK_300" ::: DiffClock Ext300 ->
+  "SYSCLK_125" ::: DiffClock Ext125 ->
   "SYNC_IN" ::: Signal Basic125 Bool ->
   "GTH_RX_NS" ::: TransceiverWires GthRxS LinkCount ->
   "GTH_RX_PS" ::: TransceiverWires GthRxS LinkCount ->
@@ -435,7 +435,7 @@ makeTopEntity 'fullMeshHwCcWithRiscvTest
 -- | Top entity for this test. See module documentation for more information.
 fullMeshHwCcTest ::
   "SMA_MGT_REFCLK_C" ::: DiffClock Ext200 ->
-  "SYSCLK_300" ::: DiffClock Ext300 ->
+  "SYSCLK_125" ::: DiffClock Ext125 ->
   "SYNC_IN" ::: Signal Basic125 Bool ->
   "GTH_RX_NS" ::: TransceiverWires GthRxS LinkCount ->
   "GTH_RX_PS" ::: TransceiverWires GthRxS LinkCount ->

--- a/bittide-instances/src/Bittide/Instances/Hitl/FullMeshSwCc.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/FullMeshSwCc.hs
@@ -595,7 +595,7 @@ stableForMs SNat clk rst inp =
 -- | Top entity for this test. See module documentation for more information.
 fullMeshSwCcTest ::
   "SMA_MGT_REFCLK_C" ::: DiffClock Ext200 ->
-  "SYSCLK_300" ::: DiffClock Ext300 ->
+  "SYSCLK_125" ::: DiffClock Ext125 ->
   "SYNC_IN" ::: Signal Basic125 Bool ->
   "GTH_RX_NS" ::: TransceiverWires GthRxS LinkCount ->
   "GTH_RX_PS" ::: TransceiverWires GthRxS LinkCount ->

--- a/bittide-instances/src/Bittide/Instances/Hitl/HwCcTopologies.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/HwCcTopologies.hs
@@ -583,7 +583,7 @@ topologyTest refClk sysClk sysRst IlaControl{syncRst = rst, ..} rxNs rxPs miso c
 -- | Top entity for this test. See module documentation for more information.
 hwCcTopologyWithRiscvTest ::
   "SMA_MGT_REFCLK_C" ::: DiffClock Ext200 ->
-  "SYSCLK_300" ::: DiffClock Ext300 ->
+  "SYSCLK_125" ::: DiffClock Ext125 ->
   "SYNC_IN" ::: Signal Basic125 Bool ->
   "GTH_RX_NS" ::: TransceiverWires GthRxS LinkCount ->
   "GTH_RX_PS" ::: TransceiverWires GthRxS LinkCount ->
@@ -683,7 +683,7 @@ makeTopEntity 'hwCcTopologyWithRiscvTest
 -- | Top entity for this test. See module documentation for more information.
 hwCcTopologyTest ::
   "SMA_MGT_REFCLK_C" ::: DiffClock Ext200 ->
-  "SYSCLK_300" ::: DiffClock Ext300 ->
+  "SYSCLK_125" ::: DiffClock Ext125 ->
   "SYNC_IN" ::: Signal Basic125 Bool ->
   "GTH_RX_NS" ::: TransceiverWires GthRxS LinkCount ->
   "GTH_RX_PS" ::: TransceiverWires GthRxS LinkCount ->

--- a/bittide-instances/src/Bittide/Instances/Hitl/LinkConfiguration.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/LinkConfiguration.hs
@@ -209,7 +209,7 @@ transceiversStartAndObserve refClk sysClk rst myIndex rxNs rxPs miso =
 -- | Top entity for this test. See module documentation for more information.
 linkConfigurationTest ::
   "SMA_MGT_REFCLK_C" ::: DiffClock Ext200 ->
-  "SYSCLK_300" ::: DiffClock Ext300 ->
+  "SYSCLK_125" ::: DiffClock Ext125 ->
   "SYNC_IN" ::: Signal Basic125 Bool ->
   "GTH_RX_NS" ::: TransceiverWires GthRxS LinkCount ->
   "GTH_RX_PS" ::: TransceiverWires GthRxS LinkCount ->

--- a/bittide-instances/src/Bittide/Instances/Hitl/SyncInSyncOut.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/SyncInSyncOut.hs
@@ -72,8 +72,8 @@ import Clash.Annotations.TH
 import Clash.Cores.Xilinx.Xpm.Cdc.Single
 import Clash.Xilinx.ClockGen
 
--- | An 'Index' counting to /n/ seconds on 'Basic300'
-type IndexSeconds n = Index (PeriodToCycles Basic300 (Seconds n))
+-- | An 'Index' counting to /n/ seconds on 'Basic125'
+type IndexSeconds n = Index (PeriodToCycles Basic125 (Seconds n))
 
 -- | Status of test. Used to communicate test success/failure to host computer.
 data TestStatus
@@ -133,9 +133,9 @@ testStatusToDoneSuccess = \case
 
 -- | Entry point for test. See module documentation for more information.
 syncInSyncOut ::
-  "SYSCLK_300" ::: DiffClock Ext300 ->
-  "SYNC_IN" ::: Signal Basic300 Bool ->
-  "SYNC_OUT" ::: Signal Basic300 Bool
+  "SYSCLK_125" ::: DiffClock Ext125 ->
+  "SYNC_IN" ::: Signal Basic125 Bool ->
+  "SYNC_OUT" ::: Signal Basic125 Bool
 syncInSyncOut sysClkDiff syncIn0 = syncOut
  where
   (sysClk, sysRst) = clockWizardDifferential sysClkDiff noReset
@@ -152,7 +152,7 @@ syncInSyncOut sysClkDiff syncIn0 = syncOut
   syncOut =
     delay sysClk enableGen False
       $ mealy sysClk testRst enableGen genFsm GInReset (pure ()) -- << filter glitches in output
-  startTest :: Signal Basic300 Bool
+  startTest :: Signal Basic125 Bool
   startTest = hitlVioBool sysClk testDone testSuccess
 
 makeTopEntity 'syncInSyncOut

--- a/bittide-instances/src/Bittide/Instances/Hitl/Transceivers.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/Transceivers.hs
@@ -174,7 +174,7 @@ goTransceiversUpTest fpgaIndex refClk sysClk rst rxNs rxPs miso =
 -- | Top entity for this test. See module documentation for more information.
 transceiversUpTest ::
   "SMA_MGT_REFCLK_C" ::: DiffClock Ext200 ->
-  "SYSCLK_300" ::: DiffClock Ext300 ->
+  "SYSCLK_125" ::: DiffClock Ext125 ->
   "SYNC_IN" ::: Signal Basic125 Bool ->
   "GTH_RX_NS" ::: TransceiverWires GthRxS LinkCount ->
   "GTH_RX_PS" ::: TransceiverWires GthRxS LinkCount ->

--- a/bittide-instances/src/Bittide/Instances/Pnr/Ethernet.hs
+++ b/bittide-instances/src/Bittide/Instances/Pnr/Ethernet.hs
@@ -153,8 +153,8 @@ vexRiscEthernet sysClk sysRst sgmiiPhyClk (jtagin, uartIn, sgmiiIn) =
   (uartOut, gmiiOut, jtagOut, gpioOut) = vexRiscGmii SNat sysClk sysRst rxClk rxRst rxClk rxRst (uartIn, bridgeGmiiRx, jtagin)
 
 vexRiscEthernetTop ::
-  "CLK_300MHZ" ::: DiffClock Ext300 ->
-  "CPU_RESET" ::: Reset Ext300 ->
+  "CLK_125MHZ" ::: DiffClock Ext125 ->
+  "CPU_RESET" ::: Reset Ext125 ->
   "sgmii_phyclk" ::: DiffClock Basic625 ->
   ( "JTAG" ::: Signal Basic125B JtagIn
   , "USB_UART_TXD" ::: Signal Basic125B Bit

--- a/bittide-instances/src/Bittide/Instances/Pnr/ProcessingElement.hs
+++ b/bittide-instances/src/Bittide/Instances/Pnr/ProcessingElement.hs
@@ -28,7 +28,7 @@ import Project.FilePath
 Runs the `hello` binary from `firmware-binaries`.
 -}
 vexRiscUartHello ::
-  "SYSCLK_300" ::: DiffClock Ext300 ->
+  "SYSCLK_125" ::: DiffClock Ext125 ->
   "CPU_RESET" ::: Reset Basic200 ->
   ( ""
       ::: ( "USB_UART_TX" ::: Signal Basic200 Bit

--- a/bittide-instances/tests/Wishbone/Axi.hs
+++ b/bittide-instances/tests/Wishbone/Axi.hs
@@ -69,7 +69,7 @@ dut ::
   forall dom baud.
   (KnownDomain dom, ValidBaud dom baud) =>
   SNat baud ->
-  "SYSCLK_300" ::: DiffClock Ext300 ->
+  "SYSCLK_125" ::: DiffClock Ext125 ->
   "CPU_RESET" ::: Reset dom ->
   ("USB_UART_TX" ::: Signal dom Bit, Signal dom ()) ->
   (Signal dom (), "USB_UART_RX" ::: Signal dom Bit)

--- a/bittide-instances/tests/Wishbone/DnaPortE2.hs
+++ b/bittide-instances/tests/Wishbone/DnaPortE2.hs
@@ -61,7 +61,7 @@ dut ::
   forall dom baud.
   (KnownDomain dom, ValidBaud dom baud) =>
   SNat baud ->
-  "SYSCLK_300" ::: DiffClock Ext300 ->
+  "SYSCLK_125" ::: DiffClock Ext125 ->
   "CPU_RESET" ::: Reset dom ->
   "USB_UART_TX" ::: Signal dom Bit ->
   "USB_UART_RX" ::: Signal dom Bit

--- a/bittide-instances/tests/Wishbone/Time.hs
+++ b/bittide-instances/tests/Wishbone/Time.hs
@@ -61,7 +61,7 @@ dut ::
   forall dom baud.
   (KnownDomain dom, ValidBaud dom baud) =>
   SNat baud ->
-  "SYSCLK_300" ::: DiffClock Ext300 ->
+  "SYSCLK_125" ::: DiffClock Ext125 ->
   "CPU_RESET" ::: Reset dom ->
   "USB_UART_TX" ::: Signal dom Bit ->
   "USB_UART_RX" ::: Signal dom Bit


### PR DESCRIPTION
As discovered by @martijnbastiaan the period of the 300MHz can't be represented by clash, causing rounding errors.
When converted back into a frequency to as input to the clock wizard, it gets rendered as a `300.030` MHz.
Then from that the clock wizard is asked to create an 125MHz clock, but can't do that exactly, creating 124.991 MHz instead.

These together account for 172ppm out of ~180ppm of difference we used to measure between the onboard clocks and the external clocks.

By using instead using the onboard 125MHz clock, which can be represented exactly, we don't have these issues.
And the both come from the same clock generator and crystal so they should have the same accuracy.