### PR TITLE
Identify all serial devices

### DIFF
--- a/.github/synthesis/all.json
+++ b/.github/synthesis/all.json
@@ -14,6 +14,7 @@
 
   {"top": "boardTestExtended",             "stage": "test"},
   {"top": "boardTestSimple",               "stage": "test"},
+  {"top": "dnaOverSerial",                 "stage": "test"},
   {"top": "fincFdecTests",                 "stage": "test"},
   {"top": "fullMeshHwCcTest",              "stage": "test"},
   {"top": "fullMeshHwCcWithRiscvTest",     "stage": "test"},

--- a/.github/synthesis/staging.json
+++ b/.github/synthesis/staging.json
@@ -1,9 +1,10 @@
 [
+  {"top": "safeDffSynchronizer",           "stage": "hdl" },
+
   {"top": "fullMeshHwCcTest",              "stage": "test"},
   {"top": "fullMeshSwCcTest",              "stage": "test"},
   {"top": "linkConfigurationTest",         "stage": "test"},
-  {"top": "safeDffSynchronizer",           "stage": "hdl"},
   {"top": "transceiversUpTest",            "stage": "test"},
-  {"top": "vexRiscvTest",                  "stage": "test"},
-  {"top": "vexRiscvTcpTest",               "stage": "test"}
+  {"top": "vexRiscvTcpTest",               "stage": "test"},
+  {"top": "vexRiscvTest",                  "stage": "test"}
 ]

--- a/bittide-instances/bittide-instances.cabal
+++ b/bittide-instances/bittide-instances.cabal
@@ -126,6 +126,7 @@ library
     Bittide.Instances.Domains
     Bittide.Instances.Hacks
     Bittide.Instances.Hitl.BoardTest
+    Bittide.Instances.Hitl.DnaOverSerial
     Bittide.Instances.Hitl.Ethernet
     Bittide.Instances.Hitl.FincFdec
     Bittide.Instances.Hitl.FullMeshHwCc
@@ -289,3 +290,20 @@ executable post-fullMeshSwCcTest
     deepseq,
     filepath,
     vector,
+
+executable post-dna-over-serial
+  import: common-options
+  ghc-options:
+    -Wall
+    -Wcompat
+    -threaded
+
+  main-is: exe/post-dna-over-serial/Main.hs
+  build-depends:
+    bittide-instances,
+    process,
+    tasty,
+    tasty-hunit,
+    tasty-th,
+
+  other-modules: Paths_bittide_instances

--- a/bittide-instances/data/constraints/dnaOverSerial.xdc
+++ b/bittide-instances/data/constraints/dnaOverSerial.xdc
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: 2022 Google LLC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+
+# CLK_125MHZ
+set_property BOARD_PART_PIN sysclk_125_p [get_ports {CLK_125MHZ_p}]
+set_property BOARD_PART_PIN sysclk_125_n [get_ports {CLK_125MHZ_n}]
+
+set_property -dict {IOSTANDARD LVCMOS12 PACKAGE_PIN AL14} [get_ports {USB_UART_RXD}]
+set_property -dict {IOSTANDARD LVCMOS12 PACKAGE_PIN AM14} [get_ports {USB_UART_TXD}]
+
+set_clock_groups \
+  -asynchronous \
+  -group [get_clocks -include_generated_clocks {CLK_125MHZ_p}]

--- a/bittide-instances/exe/post-dna-over-serial/Main.hs
+++ b/bittide-instances/exe/post-dna-over-serial/Main.hs
@@ -1,0 +1,71 @@
+-- SPDX-FileCopyrightText: 2024 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+{-# LANGUAGE NumericUnderscores #-}
+{-# OPTIONS_GHC -Wno-unused-do-bind #-}
+
+module Main where
+
+import Clash.Prelude
+import Prelude ()
+
+import Bittide.Instances.Hitl.Setup
+import Control.Monad.Extra
+import qualified Data.List as L
+import Data.Maybe
+import Numeric
+import Project.Handle
+import System.Environment (withArgs)
+import System.IO
+import System.Process
+import System.Timeout
+import Test.Tasty.HUnit
+import Test.Tasty.TH
+
+{- | Test that all FPGAs that are programmed with `dnaOverSerial` transmit the
+DNA that we expect based on `deviceIdDnaPairs` and `deviceIdSerialPairs`.
+-}
+case_dnaOverSerial :: Assertion
+case_dnaOverSerial = do
+  putStrLn "Expecting specific DNAs for all serial ports"
+  putStrLn "Serial ports:"
+  mapM_ (putStrLn . snd) deviceIdSerialPairs
+  results <-
+    mapM (uncurry checkDna)
+      $ L.zipWith (\(_, p) (_, d) -> (p, d)) deviceIdSerialPairs deviceIdDnaPairs
+  print results
+  assertBool "Not all FPGAs transmitted the expected DNA" (and results)
+ where
+  checkDna :: FilePath -> BitVector 96 -> IO Bool
+  checkDna uartPath dna = do
+    let
+      picocomProc =
+        (proc "picocom" ["--baud", "9600", "--imap", "lfcrlf", "--omap", "lfcrlf", uartPath])
+          { std_out = CreatePipe
+          , std_in = CreatePipe
+          , std_err = CreatePipe
+          , new_session = True -- Seems to be required for picocom to work
+          }
+    withCreateProcess picocomProc $ \_ maybePicocomStdOut _maybePicocomStdErr _ -> do
+      let
+        picocomStdOutHandle = fromJust maybePicocomStdOut
+
+      terminalReadyResult <-
+        timeout 10_000_000 $ waitForLine picocomStdOutHandle "Terminal ready"
+      when (isNothing terminalReadyResult) $ do
+        assertFailure "Timeout waiting for \"Terminal ready\""
+
+      _ <- hGetLine picocomStdOutHandle -- Discard a potentially incomplete line
+      receivedDna <- hGetLine picocomStdOutHandle
+      let
+        expected = showHex dna ""
+        differences = L.zipWith (\e a -> if e == a then ' ' else '^') expected receivedDna
+        match = read ("0x" <> receivedDna) == (read ("0x" <> expected) :: Int)
+      putStrLn $ "Serial path: " <> uartPath
+      putStrLn $ "Expected DNA: " <> expected
+      putStrLn $ "Received DNA: " <> receivedDna
+      putStrLn $ "Differences:  " <> differences
+      pure match
+
+main :: IO ()
+main = withArgs [] $defaultMainGenerator

--- a/bittide-instances/exe/post-vex-riscv-tcp-test/Main.hs
+++ b/bittide-instances/exe/post-vex-riscv-tcp-test/Main.hs
@@ -164,9 +164,9 @@ runTcpTest (sock, sockAddr) = do
       <> " sent "
       <> show size
       <> " bytes in "
-      <> show diff
+      <> show (round diff :: Integer)
       <> " seconds ("
-      <> show speed
+      <> show (round speed :: Integer)
       <> " bytes/s)"
   assertEqual
     "Expected and actual bytestring are not equal"

--- a/bittide-instances/src/Bittide/Instances/Hitl/DnaOverSerial.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/DnaOverSerial.hs
@@ -1,0 +1,103 @@
+-- SPDX-FileCopyrightText: 2024 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
+
+{-# HLINT ignore "Use head" #-}
+
+module Bittide.Instances.Hitl.DnaOverSerial where
+
+import Bittide.Hitl
+import Bittide.Instances.Domains
+import Bittide.Instances.Hitl.Setup
+import Clash.Annotations.TH (makeTopEntity)
+import Clash.Cores.UART
+import Clash.Cores.Xilinx.Extra (ibufds)
+import Clash.Cores.Xilinx.Unisim.DnaPortE2
+import Clash.Explicit.Reset
+import Clash.Functor.Extra
+import Clash.Prelude
+import Data.Char
+import qualified Data.List as L
+import Data.Maybe
+
+dnaOverSerial ::
+  "CLK_125MHZ" ::: DiffClock Ext125 ->
+  "USB_UART_TXD" ::: Signal Ext125 Bit ->
+  "USB_UART_RXD" ::: Signal Ext125 Bit
+dnaOverSerial diffClk serialIn = serialOut
+ where
+  clk = ibufds diffClk
+  (_rxData, serialOut, ack) = withClockResetEnable clk testRst enableGen $ uart baud serialIn txData
+  baud = SNat @9600
+
+  dna = readDnaPortE2 clk testRst enableGen simDna2
+  txData = withClockResetEnable clk testRst enableGen shiftRegister (dnaToAscii <<$>> dna) ack
+  testStart = hitlVioBool clk testDone testSuccess
+  testDone = testStart
+  testSuccess = testStart
+  testRst = unsafeFromActiveLow testStart
+
+-- | Convert the DNA to ASCII and prepend a newline character.
+dnaToAscii :: BitVector 96 -> Vec 25 (BitVector 8)
+dnaToAscii x = resize (bitCoerce $ ord '\n') :> fmap bv4ToHexChar (unpack x)
+
+-- | Convert a 4-bit bitvector to a hex character.
+bv4ToHexChar :: BitVector 4 -> BitVector 8
+bv4ToHexChar x = resize x + offset
+ where
+  offset
+    | x < 10 = resize $ bitCoerce (ord '0')
+    | otherwise = resize (bitCoerce $ ord 'a') - 10
+
+simShiftRegister :: [Maybe (BitVector 8)]
+simShiftRegister = sampleN 50 dut
+ where
+  dut =
+    withClockResetEnable clockGen resetGen enableGen $ shiftRegister dataIn ack
+  dataIn :: Signal System (Maybe (BitVector 64))
+  dataIn = fromList $ L.replicate 5 Nothing L.++ [Just 1243786952] L.++ L.repeat Nothing
+  ack = fromList $ cycle [True, False, False, True, True]
+
+shiftRegister ::
+  forall dom n m a.
+  (HiddenClockResetEnable dom, KnownNat n, KnownNat m, 1 <= n, BitPack a, BitSize a ~ n * m) =>
+  Signal dom (Maybe a) ->
+  Signal dom Bool ->
+  Signal dom (Maybe (BitVector m))
+shiftRegister dataInS ackS =
+  mealy go (repeat 0 :: Vec n (BitVector m), 0 :: Index (n + 1)) $ bundle (dataInS, ackS)
+ where
+  go ::
+    (Vec n (BitVector m), Index (n + 1)) ->
+    (Maybe a, Bool) ->
+    ((Vec n (BitVector m), Index (n + 1)), Maybe (BitVector m))
+  go (vecOld, nElementsOld) (dataIn, ack) = ((vecNew, nElementsNew), dataOut)
+   where
+    (vecNew, nElementsNew)
+      | nElementsOld == 0 && isJust dataIn = (bitCoerce $ fromJust dataIn, maxBound)
+      | ack = (vecOld <<+ 0, satPred SatZero nElementsOld)
+      | otherwise = (vecOld, nElementsOld)
+
+    dataOut
+      | nElementsOld == 0 = Nothing
+      | otherwise = Just $ vecOld !! (0 :: Int)
+
+makeTopEntity 'dnaOverSerial
+
+tests :: HitlTestGroup
+tests =
+  HitlTestGroup
+    { topEntity = 'dnaOverSerial
+    , extraXdcFiles = []
+    , externalHdl = []
+    , testCases =
+        [ HitlTestCase
+            { name = "DnaOverSerial"
+            , parameters = paramForHwTargets allHwTargets ()
+            , postProcData = ()
+            }
+        ]
+    , mPostProc = Just "post-dna-over-serial"
+    }

--- a/bittide-instances/src/Bittide/Instances/Hitl/Setup.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/Setup.hs
@@ -3,10 +3,13 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 module Bittide.Instances.Hitl.Setup (
+  -- * Constants
   FpgaCount,
   LinkCount,
   FpgaId,
   TransceiverWires,
+
+  -- * Topology
   allHwTargets,
   channelNames,
   clockPaths,
@@ -15,6 +18,8 @@ module Bittide.Instances.Hitl.Setup (
   knownFpgaIdsVec,
   linkMask,
   linkMasks,
+  deviceIdDnaPairs,
+  deviceIdSerialPairs,
 ) where
 
 import Clash.Prelude
@@ -118,3 +123,27 @@ linkMasks g = smap (const . linkMask') indicesI
   linkMask' i@SNat = case compareSNat (SNat @(i + 1)) (SNat @n) of
     SNatLE -> linkMask g i
     _ -> error "impossible"
+
+deviceIdDnaPairs :: [(String, BitVector 96)]
+deviceIdDnaPairs =
+  [ ("210308B3B272", 0x400200010169c040044164c5)
+  , ("210308B0992E", 0x40020001815160e805108285)
+  , ("210308B0AE73", 0x4002000101695ce72c808445)
+  , ("210308B0AE6D", 0x4002000101695ce72c702305)
+  , ("210308B0AFD4", 0x40020001016ba8e52581a285)
+  , ("210308B0AE65", 0x400200010157f4862d01c345)
+  , ("210308B3A22D", 0x400200010169c04004308185)
+  , ("210308B0B0C2", 0x40020001015664862d20e405)
+  ]
+
+deviceIdSerialPairs :: [(String, String)]
+deviceIdSerialPairs =
+  [ ("210308B3B272", "/dev/serial/by-path/pci-0000:00:14.0-usb-0:5.4.4.2:1.1-port0")
+  , ("210308B0992E", "/dev/serial/by-path/pci-0000:00:14.0-usb-0:5.4.4.1:1.1-port0")
+  , ("210308B0AE73", "/dev/serial/by-path/pci-0000:00:14.0-usb-0:5.4.3:1.1-port0")
+  , ("210308B0AE6D", "/dev/serial/by-path/pci-0000:00:14.0-usb-0:5.4.2:1.1-port0")
+  , ("210308B0AFD4", "/dev/serial/by-path/pci-0000:00:14.0-usb-0:5.4.1:1.1-port0")
+  , ("210308B0AE65", "/dev/serial/by-path/pci-0000:00:14.0-usb-0:5.3:1.1-port0")
+  , ("210308B3A22D", "/dev/serial/by-path/pci-0000:00:14.0-usb-0:5.2:1.1-port0")
+  , ("210308B0B0C2", "/dev/serial/by-path/pci-0000:00:14.0-usb-0:5.1:1.1-port0")
+  ]

--- a/bittide-instances/src/Bittide/Instances/Hitl/Tests.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/Tests.hs
@@ -22,6 +22,7 @@ module Bittide.Instances.Hitl.Tests (
 import Bittide.Hitl (ClashTargetName, HitlTestCase (..), HitlTestGroup (..))
 
 import qualified Bittide.Instances.Hitl.BoardTest as BoardTest
+import qualified Bittide.Instances.Hitl.DnaOverSerial as DnaOverSerial
 import qualified Bittide.Instances.Hitl.Ethernet as Ethernet
 import qualified Bittide.Instances.Hitl.FincFdec as FincFdec
 import qualified Bittide.Instances.Hitl.FullMeshHwCc as FullMeshHwCc
@@ -37,15 +38,16 @@ hitlTests :: [HitlTestGroup]
 hitlTests =
   [ BoardTest.testSimple
   , BoardTest.testExtended
+  , DnaOverSerial.tests
+  , Ethernet.tests
   , FincFdec.tests
   , FullMeshHwCc.fullMeshHwCcTest'
   , FullMeshHwCc.fullMeshHwCcWithRiscvTest'
   , FullMeshSwCc.tests
   , HwCcTopologies.tests
   , LinkConfiguration.tests
-  , TemperatureMonitor.tests
   , SyncInSyncOut.tests
+  , TemperatureMonitor.tests
   , Transceivers.tests
   , VexRiscv.tests
-  , Ethernet.tests
   ]

--- a/firmware-binaries/examples/smoltcp_client/src/main.rs
+++ b/firmware-binaries/examples/smoltcp_client/src/main.rs
@@ -15,7 +15,7 @@ use bittide_sys::smoltcp::{set_local, set_unicast};
 use bittide_sys::time::{Clock, Duration, Instant};
 use bittide_sys::uart::log::LOGGER;
 use bittide_sys::uart::Uart;
-use log::{debug, info, LevelFilter};
+use log::{debug, error, info, LevelFilter};
 
 #[cfg(not(test))]
 use riscv_rt::entry;
@@ -181,7 +181,7 @@ fn panic_handler(info: &core::panic::PanicInfo) -> ! {
     let mut uart = unsafe { Uart::new(UART_ADDR) };
 
     uwriteln!(uart, "Panicked!").unwrap();
-    debug!("{}", info);
+    error!("{}", info);
     uwriteln!(uart, "Looping forever now").unwrap();
     loop {
         continue;


### PR DESCRIPTION
Before this pull request we had no idea which serial port connects to which FPGA.

This PR introduces:
- A listing of each FPGA ID and the static path to its serial port (This stays consistent as long as the setup does not change)
- A listing of each FPGA ID with its corresponding DNA. (Verified by hand, there is no check for this and we will not introduce it in this PR)
- A Hardware In The Loop test that verifies that we receive the correct DNA over from the serial ports. 

If one of the serial ports stop working or is connected to the wrong FPGA, we have a way to verify.