### PR TITLE
Update ILA plotting circuitry to be agnostic over what is doing clock control

### DIFF
--- a/bittide-instances/src/Bittide/Instances/Hitl/FullMeshHwCc.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/FullMeshHwCc.hs
@@ -307,6 +307,7 @@ fullMeshHwTest refClk sysClk IlaControl{syncRst = rst, ..} rxNs rxPs miso =
       sysClk
       clockControlReset
       clockControlConfig
+      callistoClockControl
       IlaControl{..}
       availableLinkMask
       (fmap (fmap resize) domainDiffs)

--- a/bittide-instances/src/Bittide/Instances/Hitl/FullMeshSwCc.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/FullMeshSwCc.hs
@@ -370,6 +370,7 @@ fullMeshHwTest refClk sysClk IlaControl{syncRst = rst, ..} rxNs rxPs miso =
       sysClk
       clockControlReset
       clockControlConfig
+      callistoClockControl
       IlaControl{..}
       availableLinkMask
       (fmap (fmap resize) domainDiffs)

--- a/bittide-instances/src/Bittide/Instances/Hitl/HwCcTopologies.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/HwCcTopologies.hs
@@ -451,6 +451,7 @@ topologyTest refClk sysClk sysRst IlaControl{syncRst = rst, ..} rxNs rxPs miso c
       sysClk
       clockControlReset
       clockControlConfig
+      callistoClockControl
       IlaControl{..}
       (mask <$> cfg)
       (fmap (fmap resize) domainDiffs)

--- a/bittide-instances/src/Bittide/Instances/Hitl/IlaPlot.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/IlaPlot.hs
@@ -475,7 +475,17 @@ callistoClockControlWithIla ::
   (HasCallStack) =>
   (KnownDomain dyn, KnownDomain sys, HasSynchronousReset sys) =>
   (KnownNat n, KnownNat m) =>
-  (1 <= n, 1 <= m, n + m <= 32, 6 + n * (m + 4) <= 1024) =>
+  {- Reasoning for the '6 + n * (m + 4) <= 1024' bound:
+
+  In short, it's the upper bound on the data stored in 'PlotData n m'.
+
+  The details:
+    - 6 bits for 'dSpeedChange' plus 'dRfStateChange'
+    - 4 bits for the two 'Maybe Bool's
+    - 'm' bits for the 'RelDataCount m'
+    - 'n * (4 + m)' bits for 'dEBData'
+  -}
+  (1 <= n, 1 <= m, 6 + n * (m + 4) <= 1024) =>
   (CompressedBufferSize <= m) =>
   Clock dyn ->
   Clock sys ->


### PR DESCRIPTION
This PR changes the API of `callistoClockControlWithIla` by adding in two new parameters to the function:
- `callistoCfg :: cfg`, which contains the configuration type for the clock control function
- `callistoCc :: CallistoCc n m sys cfg`, which is the clock control function itself (as a type alias).

This should make it fairly easy to slot in a new clock control function in the future (cough cough software clock control cough cough).