### PR TITLE
Allow bypassing of serial in simulation

### DIFF
--- a/bittide-instances/src/Bittide/Instances/Hitl/VexRiscv.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/VexRiscv.hs
@@ -63,7 +63,8 @@ vexRiscvInner jtagIn0 uartRx =
 
   Circuit circuitFn = circuit $ \(uartRx, jtag) -> do
     [timeBus, uartBus, statusRegisterBus] <- processingElement peConfig -< jtag
-    (uartTx, _uartStatus) <- uartWb @dom d16 d16 (SNat @921600) -< (uartBus, uartRx)
+    (uartTx, _uartStatus) <-
+      uartInterfaceWb @dom d16 d16 (uartDf $ SNat @921600) -< (uartBus, uartRx)
     timeWb -< timeBus
     testResult <- statusRegister -< statusRegisterBus
     idC -< (testResult, uartTx)

--- a/bittide-instances/src/Bittide/Instances/Pnr/Ethernet.hs
+++ b/bittide-instances/src/Bittide/Instances/Pnr/Ethernet.hs
@@ -100,7 +100,7 @@ vexRiscGmii SNat sysClk sysRst rxClk rxRst txClk txRst fwd =
       txClkEna
       rxClkEna
   macStatIf = wcre $ macStatusInterfaceWb d16
-  uart = wcre uartWb d32 d2 baud
+  uart = wcre $ uartInterfaceWb d32 d2 (uartDf baud)
   pe = wcre processingElement peConfig
   wbToAxiTx' = wcre wbToAxiTx
   wbAxiRxBuffer = wcre wbAxisRxBufferCircuit (SNat @2048)

--- a/bittide-instances/src/Bittide/Instances/Pnr/ProcessingElement.hs
+++ b/bittide-instances/src/Bittide/Instances/Pnr/ProcessingElement.hs
@@ -48,7 +48,8 @@ vexRiscUartHello diffClk rst_in =
     $ circuit
     $ \(uartRx, jtag) -> do
       [uartBus, timeBus] <- processingElement @Basic200 peConfig -< jtag
-      (uartTx, _uartStatus) <- uartWb d16 d16 (SNat @921600) -< (uartBus, uartRx)
+      (uartTx, _uartStatus) <-
+        uartInterfaceWb d16 d16 (uartDf $ SNat @921600) -< (uartBus, uartRx)
       timeWb -< timeBus
       idC -< uartTx
  where


### PR DESCRIPTION
Previously we used to simulate the serial connection of our uart peripheral. By separating implementation and interface we can add a `uartSim` implementation that communicates in `BitVector 8` instead of serializing the data over UART which allows for great simulation speedups

Before:
```
Unittests
  Wishbone.CaptureUgn
    capture ugn self test:     OK (0.79s)
  Wishbone.DnaPortE2
    dna port self test:        OK (4.20s)
  Wishbone.Time
    time rust self test:       OK (13.51s)
  Wishbone.Axi
    axi stream rust self test: OK (21.76s)
    parseTestResults:          OK

All 5 tests passed (40.26s)
```
After:
```
 lucas@lonneker:~/bittide-hardware$ cabal run bittide-instances:unittests -- -p Wishbone
Unittests
  Wishbone.CaptureUgn
    capture ugn self test:     OK (0.51s)
  Wishbone.DnaPortE2
    dna port self test:        OK (3.11s)
  Wishbone.Time
    time rust self test:       OK (8.27s)
  Wishbone.Axi
    axi stream rust self test: OK (17.19s)
    parseTestResults:          OK

All 5 tests passed (29.10s)
```