### PR TITLE
Add TH function to generate `HasField` instances for `Signal dom Record`

### DIFF
--- a/bittide/bittide.cabal
+++ b/bittide/bittide.cabal
@@ -165,6 +165,7 @@ library
     Clash.Cores.Xilinx.Xpm.Cdc.Handshake.Extra
     Clash.Explicit.Reset.Extra
     Clash.Functor.Extra
+    Clash.Signal.TH.Extra
     Clash.Sized.Extra
     Data.Constraint.Nat.Extra
     System.IO.Temp.Extra

--- a/bittide/src/Bittide/ClockControl/StabilityChecker.hs
+++ b/bittide/src/Bittide/ClockControl/StabilityChecker.hs
@@ -11,6 +11,7 @@ import Clash.Prelude
 
 import Bittide.ClockControl (RelDataCount, targetDataCount)
 import Bittide.ClockControl.Callisto.Util (dataCountToSigned)
+import Clash.Signal.TH.Extra
 
 -- | Stability results to be returned by the 'stabilityChecker'.
 data StabilityIndication = StabilityIndication
@@ -21,6 +22,8 @@ data StabilityIndication = StabilityIndication
   -- 'targetDataCount'.
   }
   deriving (Generic, NFDataX, BitPack)
+
+deriveSignalHasFields ''StabilityIndication
 
 {- | Checks whether the @Signal@ of buffer occupancies from an elastic
 buffer is stable and settled. The @Signal@ is considered to be

--- a/bittide/src/Clash/Signal/TH/Extra.hs
+++ b/bittide/src/Clash/Signal/TH/Extra.hs
@@ -1,0 +1,54 @@
+-- SPDX-FileCopyrightText: 2024 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+module Clash.Signal.TH.Extra where
+
+import Prelude
+
+import Clash.Signal
+import Data.String.Interpolate
+import GHC.Records (HasField (..))
+import Language.Haskell.TH
+
+{- | Derive instances of 'HasField' for a Signals of Records:
+
+Example:
+
+> data MyRecord n = MyRecord { field1 :: BitVector n, field2 :: BitVector n (Unsigned 8) }
+
+Will generate the following instances:
+
+> instance HasField "field1" (Signal dom (MyRecord n)) (Signal dom (BitVector n)) where
+>   getField = fmap field1
+> instance HasField "field2" (Signal dom (MyRecord n)) (Signal dom (Vec n (Unsigned 8))) where
+>   getField = fmap field2
+-}
+deriveSignalHasFields :: Name -> Q [Dec]
+deriveSignalHasFields recordName = do
+  -- Extract information
+  info <- reify recordName
+  case info of
+    -- If the name refers to a record type, generate instances for each field
+    TyConI (DataD _ _ tvb _ [RecC _ fields] _) -> do
+      let
+        recordType = foldl appT (conT recordName) recordTyInputs
+        recordTyInputs = varT . go <$> tvb
+         where
+          go (PlainTV n _) = n
+          go (KindedTV n _ _) = n
+        mkInstance :: (Name, Bang, Type) -> Q [Dec]
+        mkInstance (fieldName, _fieldBang, fieldType) =
+          [d|
+            instance HasField $fieldStr (Signal dom $recordType) (Signal dom $(pure fieldType)) where
+              getField = fmap $(varE fieldName)
+            |]
+         where
+          fieldStr = litT (strTyLit (nameBase fieldName))
+      concat <$> mapM mkInstance fields
+    -- If the name refers to something else, throw an error
+    _ ->
+      error
+        [__i|
+          Expected a record type, but got something else.
+          The name '#{recordName}' refers to a different kind of type, namely '#{info}'.
+          |]


### PR DESCRIPTION
I noticed someone wanting to use `HasField` instances for Signals of Records. So I looked into automatically generating instances to be able to:
```haskell
data MyRecord = MyRecord {myField :: ()}
deriveSignalHasFields ''MyRecord

record :: Signal System MyRecord
record = pure $ MyRecord ()

-- Before we'd use have to map (.myField) to obtain the signal of the field
before = (.myField) <$> record
before2 = fmap (.myField) record

-- Now we can use the overloaded record dot
now :: Signal System ()
now = record.myField