### PR TITLE
Handle types with type arguments

### DIFF
--- a/bittide/src/Clash/Signal/TH/Extra.hs
+++ b/bittide/src/Clash/Signal/TH/Extra.hs
@@ -11,14 +11,37 @@ import GHC.Records (HasField (..))
 import Language.Haskell.TH
 
 {- | Derive instances of 'HasField' for a Signals of Records:
+
 Example:
+
+@
 data MyRecord = MyRecord { field1 :: Int, field2 :: Bool }
 deriveSignalHasFields ''MyRecord
+@
+
 This will generate the following instances:
+
+@
 instance HasField "field1" (Signal dom MyRecord) (Signal dom Int) where
   getField = fmap field1
 instance HasField "field2" (Signal dom MyRecord) (Signal dom Bool) where
   getField = fmap field2
+@
+
+The record type may also take type arguments. For instance, this type:
+
+@
+data MyRecord n = MyRecord { field1 :: BitVector n, field2 :: BitVector n (Unsigned 8) }
+@
+
+Will generate the following instances:
+
+@
+instance HasField "field1" (Signal dom (MyRecord n)) (Signal dom (BitVector n)) where
+  getField = fmap field1
+instance HasField "field2" (Signal dom (MyRecord n)) (Signal dom (Vec n (Unsigned 8))) where
+  getField = fmap field2
+@
 -}
 deriveSignalHasFields :: Name -> Q [Dec]
 deriveSignalHasFields recordName = do
@@ -26,13 +49,22 @@ deriveSignalHasFields recordName = do
   info <- reify recordName
   case info of
     -- If the name refers to a record type, generate instances for each field
-    TyConI (DataD _ _ _ _ [RecC _ fields] _) -> do
+    TyConI (DataD _ _ tvb _ [RecC _ fields] _) -> do
+      runIO $ mapM_ print tvb
       let
         recordType = conT recordName
+        recordTyInputs = varT . go <$> tvb
+         where
+          go (PlainTV n _) = n
+          go (KindedTV n _ _) = n
+        recordAppT = go recordType recordTyInputs
+         where
+          go ty [] = ty
+          go ty (h : t) = go (appT ty h) t
         mkInstance :: (Name, Bang, Type) -> Q [Dec]
         mkInstance (fieldName, _fieldBang, fieldType) =
           [d|
-            instance HasField $fieldStr (Signal dom $recordType) (Signal dom $(pure fieldType)) where
+            instance HasField $fieldStr (Signal dom $recordAppT) (Signal dom $(pure fieldType)) where
               getField = fmap $(varE fieldName)
             |]
          where


### PR DESCRIPTION
The current version in #659 fails if the type provided as an argument takes any other types as an argument. For instance, trying to do `deriveSignalHasFields ''ClockControlConfig` would give
```
src/Bittide/ClockControl.hs:68:1: error: [GHC-83865]
    • Expecting four more arguments to ‘ClockControlConfig’
      Expected a type,
      but ‘ClockControlConfig’ has kind
      ‘k -> Nat -> Nat -> Nat -> Type’
    • In the second argument of ‘Signal’, namely ‘ClockControlConfig’
      In the second argument of ‘GHC.Records.HasField’, namely
        ‘(Signal dom_an2D ClockControlConfig)’
      In the instance declaration for
        ‘GHC.Records.HasField "cccReframingWaitTime" (Signal dom_an2D ClockControlConfig) (Signal dom_an2D (Unsigned 32))’
   |
68 | deriveSignalHasFields ''ClockControlConfig 
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```
This PR resolves this issue.