### PR TITLE
Add timing fence to clock control component

### DIFF
--- a/bittide-instances/tests/Wishbone/Time.hs
+++ b/bittide-instances/tests/Wishbone/Time.hs
@@ -36,6 +36,12 @@ import Text.Parsec.String
 -- Qualified
 import qualified Protocols.Df as Df
 
+sim :: IO ()
+sim = putStrLn simResult
+ where
+  simResult = chr . fromIntegral <$> mapMaybe Df.dataToMaybe uartStream
+  uartStream = sampleC def dut
+
 {- | Run the timing module self test with processingElement and inspect it's uart output.
 The test returns names of tests and a boolean indicating if the test passed.
 -}

--- a/bittide/src/Bittide/Wishbone.hs
+++ b/bittide/src/Bittide/Wishbone.hs
@@ -2,6 +2,7 @@
 --
 -- SPDX-License-Identifier: Apache-2.0
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE PartialTypeSignatures #-}
@@ -29,6 +30,7 @@ import Data.Maybe
 import Protocols
 import Protocols.Wishbone
 
+import Clash.Sized.Vector.ToTuple (VecToTuple (vecToTuple))
 import qualified Protocols.Df as Df
 import qualified Protocols.Wishbone as Wishbone
 
@@ -540,9 +542,34 @@ wbToVec readableData WishboneM2S{..} = (writtenData, wbS2M)
     | otherwise = repeat Nothing
   wbS2M = (emptyWishboneS2M @(Bytes 4)){acknowledge, readData, err}
 
-{- | Wishbone accessible circuit that contains a free running 64 bit counter. We can
-observe this counter to get a sense of time, overflows should be accounted for by
-the master.
+data TimeCmd = Capture | WaitForCmp deriving (Eq, Generic, NFDataX, BitPack)
+
+{- | Wishbone accessible circuit that contains a free running 64 bit counter with stalling
+capabilities.
+
+The word-aligned address layout of the Wishbone interface is as follows:
+
++--------------+-------------------+--------------+---------------+
+| Field number | Field description | Field name   | Offset (in B) |
++==============+===================+==============+===============+
+| 0            | Timer command     | 'timer_cmd'  | 0x00          |
+| 1            | Comparison result | 'cmp_result' | 0x04          |
+| 2            | Scratchpad LSBs   | n/a          | 0x08          |
+| 3            | Scratchpad MSBs   | n/a          | 0x0C          |
+| 4            | Frequency LSBs    | n/a          | 0x10          |
+| 5            | Frequency MSBs    | n/a          | 0x14          |
++--------------+-------------------+--------------+---------------+
+
+The register-level layout of the Wishbone interface is as follows:
+
++--------------+-------------------+--------------+---------------+-------------+---------------+----+
+| Field number | Field description | Field name   | Field type    | Size (in B) | Offset (in B) | RW |
++==============+===================+==============+===============+=============================+====+
+| 0            | Timer command     | 'time_cmd'   | 'TimeCmd'     | 1           | 0x00          | W  |
+| 1            | Comparison result | 'cmp_result' | 'Bool'        | 1           | 0x04          | R  |
+| 2            | Scratchpad        | 'scratchpad' | 'Unsigned 64' | 8           | 0x08          | R  |
+| 4            | Frequency         | 'frequency'  | 'Unsigned 64' | 8           | 0x10          | R  |
++--------------+-------------------+--------------+---------------+-------------+---------------+----+
 -}
 timeWb ::
   forall dom addrW.
@@ -551,18 +578,42 @@ timeWb ::
   , 1 <= DomainPeriod dom
   ) =>
   Circuit (Wishbone dom 'Standard addrW (Bytes 4)) ()
-timeWb = Circuit $ \(wbM2S, _) -> (mealy goMealy (0, 0) wbM2S, ())
+timeWb = Circuit $ \(wbM2S, _) -> (mealy goMealy (False, 0, 0) wbM2S, ())
  where
-  goMealy (frozen, count :: Unsigned 64) wbM2S = ((nextFrozen, succ count), wbS2M)
+  goMealy (reqCmp0, scratch0 :: Unsigned 64, count :: Unsigned 64) wbM2S =
+    ((reqCmp1, scratch1, succ count), wbS2M1)
    where
     freq = natToNum @(DomainToHz dom) :: Unsigned 64
-    nextFrozen = if isJust (head writes) then count else frozen
-    RegisterBank (splitAtI -> (frozenMsbs, frozenLsbs)) = getRegsBe @8 frozen
     RegisterBank (splitAtI -> (freqMsbs, freqLsbs)) = getRegsBe @8 freq
-    (writes, wbS2M) =
-      wbToVec
-        (0 :> fmap pack (frozenLsbs :> frozenMsbs :> freqLsbs :> freqMsbs :> Nil))
-        wbM2S
+
+    readVec :: Vec 6 (BitVector 32)
+    readVec =
+      0 -- Timer command is write-only, provide default 0 on read
+        :> (resize . pack $ runCmp)
+        :> pack scratchLsbs0
+        :> pack scratchMsbs0
+        :> pack freqLsbs
+        :> pack freqMsbs
+        :> Nil
+    (writes, wbS2M0) = wbToVec @4 @_ readVec wbM2S
+    (f0, _f1, f2, f3, _f4, _f5) = vecToTuple writes
+
+    command :: Maybe TimeCmd
+    command = unpack . resize <$> f0
+    cmdWaitForCmp = Just WaitForCmp == command
+    reqCmp1 = if reqCmp0 then not runCmp else cmdWaitForCmp
+
+    RegisterBank (splitAtI -> (scratchMsbs0, scratchLsbs0)) = getRegsBe @8 scratch0
+    scratch1 = case (f2, f3, command) of
+      (Just newLsbs, _, _) -> getDataBe $ RegisterBank (scratchMsbs0 ++ unpack newLsbs)
+      (_, Just newMsbs, _) -> getDataBe $ RegisterBank (unpack newMsbs ++ scratchLsbs0)
+      (_, _, Nothing) -> scratch0
+      (_, _, Just Capture) -> count
+      (_, _, Just WaitForCmp) -> scratch0
+
+    runCmp = count >= scratch0
+    cmpResult = not reqCmp0 || runCmp -- if reqCmp0 then runCmp else True
+    wbS2M1 = wbS2M0{acknowledge = wbS2M0.acknowledge && cmpResult}
 
 {- | Wishbone wrapper for DnaPortE2, adds extra register with wishbone interface
 to access the DNA device identifier. The DNA device identifier is a 96-bit

--- a/firmware-binaries/examples/smoltcp_client/src/main.rs
+++ b/firmware-binaries/examples/smoltcp_client/src/main.rs
@@ -68,7 +68,7 @@ fn main() -> ! {
     set_local(&mut eth_addr);
     let mut config = Config::new(eth_addr.into());
     let mut eth: AxiEthernet<ETH_MTU> = AxiEthernet::new(Medium::Ethernet, axi_rx, axi_tx, None);
-    let now = clock.elapsed().into();
+    let now = clock.now().into();
     let mut iface = Interface::new(config, &mut eth, now);
 
     // Create sockets
@@ -97,12 +97,12 @@ fn main() -> ! {
     let mut stress_test_end = Instant::end_of_time();
     info!(
         "{}, TCP Server send chunks of {} bytes for {}",
-        clock.elapsed(),
+        clock.now(),
         CHUNK_SIZE,
         stress_test_duration
     );
     loop {
-        let elapsed = clock.elapsed().into();
+        let elapsed = clock.now().into();
         iface.poll(elapsed, &mut eth, &mut sockets);
         let dhcp_socket = sockets.get_mut::<dhcpv4::Socket>(dhcp_handle);
         update_dhcp(&mut iface, dhcp_socket);
@@ -112,8 +112,8 @@ fn main() -> ! {
 
         if my_ip.is_none() {
             my_ip = iface.ipv4_addr();
-            info!("{}, IP address: {}", clock.elapsed(), my_ip.unwrap());
-            let now = clock.elapsed();
+            info!("{}, IP address: {}", clock.now(), my_ip.unwrap());
+            let now = clock.now();
             stress_test_end = now + stress_test_duration;
             info!("{}, Stress test will end at {}", now, stress_test_end);
         }
@@ -121,7 +121,7 @@ fn main() -> ! {
         let mut socket = sockets.get_mut::<Socket>(client_handle);
         let cx = iface.context();
         if !socket.is_open() {
-            debug!("{}, Opening socket", clock.elapsed());
+            debug!("{}, Opening socket", clock.now());
             if !socket.is_active() {
                 mac_status = unsafe { MAC_ADDR.read_volatile() };
                 debug!(
@@ -143,7 +143,7 @@ fn main() -> ! {
                 Ok(n) => debug!("Sent {n} bytes"),
                 Err(e) => debug!("Error sending data: {:?}", e),
             }
-            let now = clock.elapsed();
+            let now = clock.now();
             if now > stress_test_end {
                 info!("{}, Stress test complete", now);
                 socket.close();
@@ -151,7 +151,7 @@ fn main() -> ! {
                 uwriteln!(uart, "{:?}", new_mac_status - mac_status).unwrap();
             }
         }
-        match iface.poll_delay(clock.elapsed().into(), &sockets) {
+        match iface.poll_delay(clock.now().into(), &sockets) {
             Some(smoltcp::time::Duration::ZERO) => {}
             Some(delay) => {
                 let smoltcp_delay = Duration::from(delay);

--- a/firmware-binaries/test-cases/time_self_test/src/main.rs
+++ b/firmware-binaries/test-cases/time_self_test/src/main.rs
@@ -21,7 +21,8 @@ fn main() -> ! {
     uwriteln!(uart, "Start time self test").unwrap();
     for (name, result) in test_results {
         match result {
-            Some(s) => uwriteln!(uart, "{}: Some({})", name, s).unwrap(),
+            Some((s, None)) => uwriteln!(uart, "{}: Some({})", name, s).unwrap(),
+            Some((s, Some(fail))) => uwriteln!(uart, "{}: Some({}. {:?})", name, s, fail).unwrap(),
             None => uwriteln!(uart, "{}: None", name).unwrap(),
         };
     }

--- a/firmware-support/bittide-sys/src/time/self_test.rs
+++ b/firmware-support/bittide-sys/src/time/self_test.rs
@@ -1,86 +1,93 @@
 // SPDX-FileCopyrightText: 2024 Google LLC
 //
 // SPDX-License-Identifier: Apache-2.0
-use crate::time::Clock;
-use crate::time::Duration;
-use crate::time::Instant;
+use crate::time::{Clock, Duration, Instant};
+use core::fmt::{self, Debug};
+use ufmt::{uDebug, uwrite};
+
+type TestReturn = Option<(&'static str, Option<FailValue>)>;
+type TestFn = fn(Clock) -> TestReturn;
+
+pub enum FailValue {
+    U64(u64),
+    Duration(Duration),
+    Instant(Instant),
+}
+
+impl Debug for FailValue {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            FailValue::U64(val) => write!(f, "{val:?}"),
+            FailValue::Duration(dur) => write!(f, "{:?}", dur.micros),
+            FailValue::Instant(inst) => write!(f, "{:?}", inst.micros),
+        }
+    }
+}
+
+impl uDebug for FailValue {
+    fn fmt<W>(&self, f: &mut ufmt::Formatter<'_, W>) -> Result<(), W::Error>
+    where
+        W: ufmt::uWrite + ?Sized,
+    {
+        match self {
+            FailValue::U64(val) => uwrite!(f, "{:?}", val),
+            FailValue::Duration(dur) => uwrite!(f, "{:?}", dur.micros as i64),
+            FailValue::Instant(inst) => uwrite!(f, "{:?}", inst.micros),
+        }
+    }
+}
+
+macro_rules! tests {
+    ($($testname:ident),+$(,)?) => {
+        [
+            $(($testname as TestFn, stringify!($testname)),)+
+        ]
+    };
+}
 
 /// Tests for the time module.
 /// It receives a pointer to the timing peripheral and returns a list of tuples containing the
 /// name of the test and an Option<&'static str> indicating if the test passed or an error message.
 #[allow(dead_code)]
-pub fn self_test(
-    clock: Clock,
-) -> impl Iterator<Item = (&'static &'static str, Option<&'static str>)> {
-    // Construct a list of tests with their names.
-    let tests = &[
-        (
-            now_not_null as fn(Clock) -> Option<&'static str>,
-            "now_not_null",
-        ),
-        (
-            freq_not_null as fn(Clock) -> Option<&'static str>,
-            "freq_not_null",
-        ),
-        (wait_1ms as fn(Clock) -> Option<&'static str>, "wait_1ms"),
-        (
-            skip_next_ms as fn(Clock) -> Option<&'static str>,
-            "skip_next_ms",
-        ),
-        (
-            duration_hour_minute as fn(Clock) -> Option<&'static str>,
-            "duration_hour_minute",
-        ),
-        (
-            duration_minute_second as fn(Clock) -> Option<&'static str>,
-            "duration_minute_second",
-        ),
-        (
-            duration_second_millisecond as fn(Clock) -> Option<&'static str>,
-            "duration_second_millisecond",
-        ),
-        (
-            duration_millisecond_microsecond as fn(Clock) -> Option<&'static str>,
-            "duration_millisecond_microsecond",
-        ),
-        (
-            instant_hour_minute as fn(Clock) -> Option<&'static str>,
-            "instant_hour_minute",
-        ),
-        (
-            instant_minute_second as fn(Clock) -> Option<&'static str>,
-            "instant_minute_second",
-        ),
-        (
-            instant_second_millisecond as fn(Clock) -> Option<&'static str>,
-            "instant_second_millisecond",
-        ),
-        (
-            instant_millisecond_microsecond as fn(Clock) -> Option<&'static str>,
-            "instant_millisecond_microsecond",
-        ),
-    ];
+pub fn self_test(clock: Clock) -> impl Iterator<Item = (&'static str, TestReturn)> {
+    let tests = tests!(
+        now_not_null,
+        freq_not_null,
+        skip_next_ms,
+        duration_hour_minute,
+        duration_minute_second,
+        duration_second_millisecond,
+        duration_millisecond_microsecond,
+        instant_hour_minute,
+        instant_minute_second,
+        instant_second_millisecond,
+        instant_millisecond_microsecond,
+    );
     // Run the tests and collect the results.
-    let results = tests.iter().map(move |(f, name)| (name, f(clock.clone())));
-    results
+    tests
+        .into_iter()
+        .map(move |(f, name)| (name, f(clock.clone())))
 }
 
 /// Obtain the value of the counter, check if it's not 0.
-pub fn now_not_null(clock: Clock) -> Option<&'static str> {
-    let frequency = clock.get_frequency();
-    let now = clock.elapsed();
+pub fn now_not_null(mut clock: Clock) -> TestReturn {
+    let frequency = clock.frequency();
+    let now = clock.now();
     if now == Instant::from_cycles(0, frequency) {
-        Some("now_not_null test failed: now is null")
+        Some((
+            "now_not_null test failed: now is null",
+            Some(FailValue::Instant(now)),
+        ))
     } else {
         None
     }
 }
 
 /// Read the frequency value, check if it's not 0.
-pub fn freq_not_null(clock: Clock) -> Option<&'static str> {
-    let frequency: u64 = clock.get_frequency();
+pub fn freq_not_null(clock: Clock) -> TestReturn {
+    let frequency: u64 = clock.frequency();
     if frequency == 0 {
-        Some("freq_not_null test failed: frequency is null")
+        Some(("freq_not_null test failed: frequency is null", None))
     } else {
         None
     }
@@ -88,14 +95,18 @@ pub fn freq_not_null(clock: Clock) -> Option<&'static str> {
 
 /// Read the current time in milliseconds, wait a ms and read again.
 /// The new time should differ less than 100 us from the expected target.
-pub fn wait_1ms(clock: Clock) -> Option<&'static str> {
+pub fn wait_1ms(mut clock: Clock) -> TestReturn {
     let wait_time = Duration::from_millis(1);
-    let time0 = clock.elapsed();
+    let time0 = clock.now();
     clock.wait(wait_time);
-    let time1 = clock.elapsed();
+    let time1 = clock.now();
     let expected = time0 + wait_time;
-    if time1 - expected >= Duration::from_micros(100) {
-        Some("wait_1ms test failed: time difference is too large")
+    let diff = time1 - expected;
+    if diff >= Duration::from_micros(100) {
+        Some((
+            "wait_1ms test failed: time difference is too large",
+            Some(FailValue::Duration(diff)),
+        ))
     } else {
         None
     }
@@ -104,149 +115,213 @@ pub fn wait_1ms(clock: Clock) -> Option<&'static str> {
 /// Read the current time in milliseconds and create a target of the current time in ms + 2.
 /// Wait until we reach the target and obtain the new time. The time should differ no more than
 /// 100 ms from the target.
-pub fn skip_next_ms(clock: Clock) -> Option<&'static str> {
-    let time0 = clock.elapsed();
+pub fn skip_next_ms(mut clock: Clock) -> TestReturn {
+    let time0 = clock.now();
     let target = Instant::from_millis(time0.to_millis() + 2);
     clock.wait_until(target);
-    let time1 = clock.elapsed();
-    if time1 - target >= Duration::from_micros(100) {
-        Some("skip_next_ms test failed: time difference is too large")
+    let time1 = clock.now();
+    let diff = time1 - target;
+    if diff >= Duration::from_micros(100) {
+        Some((
+            "skip_next_ms test failed: time difference is too large",
+            Some(FailValue::Duration(diff)),
+        ))
     } else {
         None
     }
 }
 
 /// Create a Duration of 1 hour and 60 minutes, convert between them and check if they are equal.
-pub fn duration_hour_minute(_: Clock) -> Option<&'static str> {
+pub fn duration_hour_minute(_: Clock) -> TestReturn {
     let duration_hour = Duration::from_hours(1);
     let duration_minute = Duration::from_mins(60);
     let hour_to_minute = duration_hour.to_mins();
     let minute_to_hour = duration_minute.to_hours();
     if duration_hour != duration_minute {
-        Some("duration_hour_minute test failed: durations are not equal")
+        Some((
+            "duration_hour_minute test failed: durations are not equal",
+            None,
+        ))
     } else if hour_to_minute != 60 {
-        Some("duration_hour_minute test failed: hour to minute conversion failed")
+        Some((
+            "duration_hour_minute test failed: hour to minute conversion failed",
+            None,
+        ))
     } else if minute_to_hour != 1 {
-        Some("duration_hour_minute test failed: minute to hour conversion failed")
+        Some((
+            "duration_hour_minute test failed: minute to hour conversion failed",
+            None,
+        ))
     } else {
         None
     }
 }
 
 /// Create a Duration of 1 minute and 60 seconds, convert between them and check if they are equal.
-pub fn duration_minute_second(_: Clock) -> Option<&'static str> {
+pub fn duration_minute_second(_: Clock) -> TestReturn {
     let duration_minute = Duration::from_mins(1);
     let duration_second = Duration::from_secs(60);
     let minute_to_second = duration_minute.to_secs();
     let second_to_minute = duration_second.to_mins();
     if duration_minute != duration_second {
-        Some("duration_minute_second test failed: durations are not equal")
+        Some((
+            "duration_minute_second test failed: durations are not equal",
+            None,
+        ))
     } else if minute_to_second != 60 {
-        Some("duration_minute_second test failed: minute to second conversion failed")
+        Some((
+            "duration_minute_second test failed: minute to second conversion failed",
+            None,
+        ))
     } else if second_to_minute != 1 {
-        Some("duration_minute_second test failed: second to minute conversion failed")
+        Some((
+            "duration_minute_second test failed: second to minute conversion failed",
+            None,
+        ))
     } else {
         None
     }
 }
 
 /// Create a Duration of 1 second and 1000 milliseconds, convert between them and check if they are equal.
-pub fn duration_second_millisecond(_: Clock) -> Option<&'static str> {
+pub fn duration_second_millisecond(_: Clock) -> TestReturn {
     let duration_second = Duration::from_secs(1);
     let duration_millisecond = Duration::from_millis(1000);
     let second_to_millisecond = duration_second.to_millis();
     let millisecond_to_second = duration_millisecond.to_secs();
     if duration_second != duration_millisecond {
-        Some("duration_second_millisecond test failed: durations are not equal")
+        Some((
+            "duration_second_millisecond test failed: durations are not equal",
+            None,
+        ))
     } else if second_to_millisecond != 1000 {
-        Some("duration_second_millisecond test failed: second to millisecond conversion failed")
+        Some((
+            "duration_second_millisecond test failed: second to millisecond conversion failed",
+            None,
+        ))
     } else if millisecond_to_second != 1 {
-        Some("duration_second_millisecond test failed: millisecond to second conversion failed")
+        Some((
+            "duration_second_millisecond test failed: millisecond to second conversion failed",
+            None,
+        ))
     } else {
         None
     }
 }
 
 /// Create a Duration of 1 millisecond and 1000 microseconds, convert between them and check if they are equal.
-pub fn duration_millisecond_microsecond(_: Clock) -> Option<&'static str> {
+pub fn duration_millisecond_microsecond(_: Clock) -> TestReturn {
     let duration_millisecond = Duration::from_millis(1);
     let duration_microsecond = Duration::from_micros(1000);
     let millisecond_to_microsecond = duration_millisecond.to_micros();
     let microsecond_to_millisecond = duration_microsecond.to_millis();
     if duration_millisecond != duration_microsecond {
-        Some("duration_millisecond_microsecond test failed: durations are not equal")
+        Some((
+            "duration_millisecond_microsecond test failed: durations are not equal",
+            None,
+        ))
     } else if millisecond_to_microsecond != 1000 {
-        Some("duration_millisecond_microsecond test failed: millisecond to microsecond conversion failed")
+        Some(("duration_millisecond_microsecond test failed: millisecond to microsecond conversion failed", None))
     } else if microsecond_to_millisecond != 1 {
-        Some("duration_millisecond_microsecond test failed: microsecond to millisecond conversion failed")
+        Some(("duration_millisecond_microsecond test failed: microsecond to millisecond conversion failed", None))
     } else {
         None
     }
 }
 
 /// Create an Instant of 1 hour and 60 minutes, convert between them and check if they are equal.
-pub fn instant_hour_minute(_clock: Clock) -> Option<&'static str> {
+pub fn instant_hour_minute(_clock: Clock) -> TestReturn {
     let instant_hour = Instant::from_hours(1);
     let instant_minute = Instant::from_mins(60);
     let hour_to_minute = instant_hour.to_mins();
     let minute_to_hour = instant_minute.to_hours();
     if instant_hour != instant_minute {
-        Some("instant_hour_minute test failed: instants are not equal")
+        Some((
+            "instant_hour_minute test failed: instants are not equal",
+            None,
+        ))
     } else if hour_to_minute != 60 {
-        Some("instant_hour_minute test failed: hour to minute conversion failed")
+        Some((
+            "instant_hour_minute test failed: hour to minute conversion failed",
+            None,
+        ))
     } else if minute_to_hour != 1 {
-        Some("instant_hour_minute test failed: minute to hour conversion failed")
+        Some((
+            "instant_hour_minute test failed: minute to hour conversion failed",
+            None,
+        ))
     } else {
         None
     }
 }
 
 /// Create an Instant of 1 minute and 60 seconds, convert between them and check if they are equal.
-pub fn instant_minute_second(_clock: Clock) -> Option<&'static str> {
+pub fn instant_minute_second(_clock: Clock) -> TestReturn {
     let instant_minute = Instant::from_mins(1);
     let instant_second = Instant::from_secs(60);
     let minute_to_second = instant_minute.to_secs();
     let second_to_minute = instant_second.to_mins();
     if instant_minute != instant_second {
-        Some("instant_minute_second test failed: instants are not equal")
+        Some((
+            "instant_minute_second test failed: instants are not equal",
+            None,
+        ))
     } else if minute_to_second != 60 {
-        Some("instant_minute_second test failed: minute to second conversion failed")
+        Some((
+            "instant_minute_second test failed: minute to second conversion failed",
+            None,
+        ))
     } else if second_to_minute != 1 {
-        Some("instant_minute_second test failed: second to minute conversion failed")
+        Some((
+            "instant_minute_second test failed: second to minute conversion failed",
+            None,
+        ))
     } else {
         None
     }
 }
 
 /// Create an Instant of 1 second and 1000 milliseconds, convert between them and check if they are equal.
-pub fn instant_second_millisecond(_clock: Clock) -> Option<&'static str> {
+pub fn instant_second_millisecond(_clock: Clock) -> TestReturn {
     let instant_second = Instant::from_secs(1);
     let instant_millisecond = Instant::from_millis(1000);
     let second_to_millisecond = instant_second.to_millis();
     let millisecond_to_second = instant_millisecond.to_secs();
     if instant_second != instant_millisecond {
-        Some("instant_second_millisecond test failed: instants are not equal")
+        Some((
+            "instant_second_millisecond test failed: instants are not equal",
+            None,
+        ))
     } else if second_to_millisecond != 1000 {
-        Some("instant_second_millisecond test failed: second to millisecond conversion failed")
+        Some((
+            "instant_second_millisecond test failed: second to millisecond conversion failed",
+            None,
+        ))
     } else if millisecond_to_second != 1 {
-        Some("instant_second_millisecond test failed: millisecond to second conversion failed")
+        Some((
+            "instant_second_millisecond test failed: millisecond to second conversion failed",
+            None,
+        ))
     } else {
         None
     }
 }
 
 /// Create an Instant of 1 millisecond and 1000 microseconds, convert between them and check if they are equal.
-pub fn instant_millisecond_microsecond(_clock: Clock) -> Option<&'static str> {
+pub fn instant_millisecond_microsecond(_clock: Clock) -> TestReturn {
     let instant_millisecond = Instant::from_millis(1);
     let instant_microsecond = Instant::from_micros(1000);
     let millisecond_to_microsecond = instant_millisecond.to_micros();
     let microsecond_to_millisecond = instant_microsecond.to_millis();
     if instant_millisecond != instant_microsecond {
-        Some("instant_millisecond_microsecond test failed: instants are not equal")
+        Some((
+            "instant_millisecond_microsecond test failed: instants are not equal",
+            None,
+        ))
     } else if millisecond_to_microsecond != 1000 {
-        Some("instant_millisecond_microsecond test failed: millisecond to microsecond conversion failed")
+        Some(("instant_millisecond_microsecond test failed: millisecond to microsecond conversion failed", None))
     } else if microsecond_to_millisecond != 1 {
-        Some("instant_millisecond_microsecond test failed: microsecond to millisecond conversion failed")
+        Some(("instant_millisecond_microsecond test failed: microsecond to millisecond conversion failed", None))
     } else {
         None
     }

--- a/firmware-support/bittide-sys/src/uart/log.rs
+++ b/firmware-support/bittide-sys/src/uart/log.rs
@@ -1,7 +1,10 @@
 // SPDX-FileCopyrightText: 2024 Google LLC
 //
 // SPDX-License-Identifier: Apache-2.0
-use crate::{time, uart};
+use crate::{
+    time::{self, Clock},
+    uart,
+};
 
 // The logger utilizes core::fmt to format the log messages because ufmt formatting is not
 // compatible with (dependencies of) the log crate.
@@ -62,7 +65,8 @@ impl log::Log for UartLogger {
                             write!(l, "{} | ", record.level()).unwrap()
                         }
                         if let (true, Some(clock)) = (&self.print_time, &self.clock) {
-                            let time = clock.elapsed();
+                            let mut clock = Clock::new(clock.as_ptr());
+                            let time = clock.now();
                             write!(l, "{time} | ").unwrap();
                         }
                         if record.level() <= self.display_source {


### PR DESCRIPTION
If the number of transceivers increases too much, it may be worth moving the diff counting addition to hardware instead of keeping it in software. At which point, the control loop could end up being too fast and needing to be limited. With this in mind, this branch introduces a timing fence to the control loop by leveraging the fact that the CPU stalls if a write over the Wishbone bus is not acknowledged. Writes to the address for clock speed changes will now only be acknowledged after the software-configurable number of cycles has passed.