### PR TITLE
Tee Picocom stdout and stderr to files and archive them

### DIFF
--- a/bittide-instances/data/picocom/start.sh
+++ b/bittide-instances/data/picocom/start.sh
@@ -8,4 +8,18 @@
 #
 #    /dev/serial/by-id/usb-FTDI_Dual_RS232-if01-port0
 #
-picocom  --baud 921600 --imap lfcrlf --omap lfcrlf $@
+set -e
+
+# Default stdout to /dev/null
+PICOCOM_STDOUT_LOG="${PICOCOM_STDOUT_LOG:-/dev/null}"
+stdout_dir=$(dirname "${PICOCOM_STDOUT_LOG}")
+mkdir -p "${stdout_dir}"
+
+# Default stderr to /dev/null
+PICOCOM_STDERR_LOG="${PICOCOM_STDERR_LOG:-/dev/null}"
+stderr_dir=$(dirname "${PICOCOM_STDERR_LOG}")
+mkdir -p "${stderr_dir}"
+
+picocom  --baud 921600 --imap lfcrlf --omap lfcrlf $@ \
+  > >(tee "${PICOCOM_STDOUT_LOG}") \
+  2> >(tee "${PICOCOM_STDERR_LOG}" >&2)

--- a/bittide-instances/exe/post-vex-riscv-tcp-test/Main.hs
+++ b/bittide-instances/exe/post-vex-riscv-tcp-test/Main.hs
@@ -79,6 +79,13 @@ case_testTcpClient = do
   (serverSock, _) <- startServer
   withAnnotatedGdbScriptPath gdbScriptPath $ \gdbProgPath -> do
     currentEnv <- getEnvironment
+    projectDir <- findParentContaining "cabal.project"
+    let
+      hitlDir = projectDir </> "_build" </> "hitl"
+      stdoutLog = hitlDir </> "picocom-stdout.log"
+      stderrLog = hitlDir </> "picocom-stderr.log"
+    putStrLn $ "logging stdout to `" <> stdoutLog <> "`"
+    putStrLn $ "logging stderr to `" <> stderrLog <> "`"
     let
       openOcdProc =
         (proc startOpenOcdPath [])
@@ -95,6 +102,9 @@ case_testTcpClient = do
           { std_out = CreatePipe
           , std_in = CreatePipe
           , new_session = True
+          , env =
+              Just
+                (currentEnv <> [("PICOCOM_STDOUT_LOG", stdoutLog), ("PICOCOM_STDERR_LOG", stderrLog)])
           }
 
     putStrLn "Starting OpenOcd..."


### PR DESCRIPTION
CI seems to fail spuriously on timeouts, almost exclusively on the Vex RISC-V TCP test and in invoking Picocom. However, when certain functions time out, their previously read input is discarded, often along with what's left in the buffer being read from. These should instead probably be printed out on the program's stdout so that CI logs show what occurred prior to the timeout.