### PR TITLE
Use `info!` instead of `debug!` in trap handler

### DIFF
--- a/firmware-binaries/examples/smoltcp_client/src/main.rs
+++ b/firmware-binaries/examples/smoltcp_client/src/main.rs
@@ -167,9 +167,9 @@ fn exception_handler(_trap_frame: &riscv_rt::TrapFrame) -> ! {
     let mut uart = unsafe { Uart::new(UART_ADDR) };
     riscv::interrupt::free(|| {
         uwriteln!(uart, "... caught an exception. Looping forever now.\n").unwrap();
-        debug!("mcause: {:?}\n", mcause::read());
-        debug!("mepc: {:?}\n", mepc::read());
-        debug!("mtval: {:?}\n", mtval::read());
+        info!("mcause: {:?}\n", mcause::read());
+        info!("mepc: {:?}\n", mepc::read());
+        info!("mtval: {:?}\n", mtval::read());
     });
     loop {
         continue;


### PR DESCRIPTION
Causes trap info to be written to UART for standard logging levels. AFAIK this is always what we want.