### PR TITLE
Use `info!` instead of `error!`

### DIFF
--- a/firmware-binaries/examples/smoltcp_client/src/main.rs
+++ b/firmware-binaries/examples/smoltcp_client/src/main.rs
@@ -15,7 +15,7 @@ use bittide_sys::smoltcp::{set_local, set_unicast};
 use bittide_sys::time::{Clock, Duration, Instant};
 use bittide_sys::uart::log::LOGGER;
 use bittide_sys::uart::Uart;
-use log::{debug, error, info, LevelFilter};
+use log::{debug, info, LevelFilter};
 
 #[cfg(not(test))]
 use riscv_rt::entry;
@@ -181,7 +181,7 @@ fn panic_handler(info: &core::panic::PanicInfo) -> ! {
     let mut uart = unsafe { Uart::new(UART_ADDR) };
 
     uwriteln!(uart, "Panicked!").unwrap();
-    error!("{}", info);
+    info!("error: {}\n", info);
     uwriteln!(uart, "Looping forever now").unwrap();
     loop {
         continue;


### PR DESCRIPTION
The latter doesn't propagate to the logs?

https://github.com/bittide/bittide-hardware/actions/runs/11817787063/job/32926482076