### PR TITLE
Add extra labels to GHA runners to target a specific machine or runner

### DIFF
--- a/.github/scripts/register_runners.sh
+++ b/.github/scripts/register_runners.sh
@@ -11,7 +11,8 @@
 #
 #    register_runners 8 compute jbg2PSMoQLfqvj0ZeBUW
 #
-# Currently we're labelling runners with either "compute" or "hardware-access".
+# Currently we're labelling runners with either "compute" or "hardware-access". Each
+# runner also has its hostname and a unique name ("hostname-i") as a label.
 # Note that a label "self-hosted" gets applied automatically.
 #
 # With a privileged enough account the token can be found at:
@@ -89,7 +90,7 @@ do
       --replace \
       --url "${URL}" \
       --token "${TOKEN}" \
-      --labels "${LABELS}" \
+      --labels "${LABELS},$(hostname),$(hostname)-$i" \
       --name "${runner_name}"
 
     # TODO:


### PR DESCRIPTION
We have a new second build server which we want to compare to our current build server. This PR adds 2 extra labels to the GitHub Actions runners (`hostname` and `hostname-i`), so a CI job can target a specific machine or runner.