### PR TITLE
Test the GDB programming of all devices

### DIFF
--- a/bittide-instances/data/openocd/sipeed.tcl
+++ b/bittide-instances/data/openocd/sipeed.tcl
@@ -3,10 +3,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Tell OpenOCD to use the ftdi interface
-interface ftdi
+adapter driver ftdi
 
 # Find the device based on the USB vendor/product ID
-ftdi_vid_pid 0x0403 0x6010
+ftdi vid_pid 0x0403 0x6010
 
 set usb_device_loc [env USB_DEVICE]
 
@@ -25,16 +25,16 @@ adapter usb location $usb_device_loc
 #
 # The first 16bit value is the initial IO state. Just make TMS and RST high
 # The second 16bit value is data direction for each pin, 1 = Output
-ftdi_layout_init 0x0028 0x2b
+ftdi layout_init 0x0028 0x2b
 
 # We'll use RST for the system reset, not the JTAG reset. Thus, disable nTRST
 # by setting data and enable mask to 0. If you want to use
 # the RST pin for nTRST instead, switch this and the nSRST line.
-ftdi_layout_signal nTRST -data 0x0 -oe 0x0
+ftdi layout_signal nTRST -data 0x0 -oe 0x0
 
 # RST is on bit 5, so the mask is 0x20. The pin is directly connected, so
 # we don't have an output-enable pin -> set the same mask
-ftdi_layout_signal nSRST -data 0x0020 -oe 0x0020
+ftdi layout_signal nSRST -data 0x0020 -oe 0x0020
 
 # JTAG mode
 adapter speed 6000

--- a/bittide-instances/src/Bittide/Instances/Hitl/VexRiscv.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/VexRiscv.hs
@@ -24,6 +24,7 @@ import VexRiscv
 import Bittide.DoubleBufferedRam
 import Bittide.Hitl
 import Bittide.Instances.Domains (Basic125, Ext125)
+import Bittide.Instances.Hitl.Setup (allHwTargets)
 import Bittide.ProcessingElement
 import Bittide.SharedTypes
 import Bittide.Wishbone
@@ -159,7 +160,7 @@ tests =
     , testCases =
         [ HitlTestCase
             { name = "VexRiscV"
-            , parameters = paramForSingleHwTarget (HwTargetByIndex 7) ()
+            , parameters = paramForHwTargets allHwTargets ()
             , postProcData = ()
             }
         ]

--- a/bittide-instances/src/Project/Programs.hs
+++ b/bittide-instances/src/Project/Programs.hs
@@ -32,7 +32,7 @@ And can be used to wait for specific commands to be executed, or simply for debu
 
 After the action returns the generated file gets deleted automatically.
 -}
-withAnnotatedGdbScriptPath :: FilePath -> (FilePath -> IO ()) -> IO ()
+withAnnotatedGdbScriptPath :: FilePath -> (FilePath -> IO a) -> IO a
 withAnnotatedGdbScriptPath srcPath action = do
   withSystemTempFile "gdb-script" $ \dstPath dstHandle -> do
     withFile srcPath ReadMode $ \srcHandle -> do


### PR DESCRIPTION
The demo rig had a wrongly connected jumper cable, causing the issue @lmbollen decribed in #649 . This has been fixed. 

I rewrote the post-processing function for the `vexRiscvTest` so it runs on all devices. @lmbollen also requested I do that for `vexRiscvTcpTest`, but since we still have some issues with that test on a single device I think it is best to postpone extending it to all devices.