### PR TITLE
Filter NULL bytes in `expectLine`

### DIFF
--- a/bittide-instances/src/Project/Handle.hs
+++ b/bittide-instances/src/Project/Handle.hs
@@ -6,7 +6,7 @@ module Project.Handle where
 
 import Prelude
 
-import Data.List.Extra (trim)
+import Data.List.Extra (trimEnd)
 import System.IO
 
 import Test.Tasty.HUnit
@@ -26,7 +26,7 @@ expectLine = expectLine' ""
   expectLine' s0 h f = do
     line <- hGetLine h
     let
-      trimmed = trim line
+      trimmed = filter (/= '\NUL') (trimEnd line)
       s1 = s0 <> "\n" <> line
       cont = expectLine' s1 h f
     if null trimmed


### PR DESCRIPTION
Picocom sometimes produces NULL bytes. Attempts to debug this behavior have been futile, so this patch simply filters them out. This does remove the ability to send over binary data, but I don't think we want to do that over UART anyway..

Note: this removes a call to `trim`, in favor of `trimEnd`. We don't want to strip start of line whitespace..