### PR TITLE
Use `bracket`-style socket setup

### DIFF
--- a/bittide-instances/src/Bittide/Instances/Hitl/Post/TcpServer.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/Post/TcpServer.hs
@@ -10,12 +10,8 @@ import Prelude
 
 import qualified Network.Simple.TCP as NS
 
-startServer :: IO (NS.Socket, NS.SockAddr)
-startServer = do
-  (serverSock, serverAddr) <- NS.bindSock (NS.Host "0.0.0.0") "1234"
-  putStrLn $ "Listening for connections on " <> show serverAddr
-  NS.listenSock serverSock 2048
-  pure (serverSock, serverAddr)
+withServer :: ((NS.Socket, NS.SockAddr) -> IO a) -> IO a
+withServer = NS.listen NS.HostAny "1234"
 
 waitForClients :: Int -> NS.Socket -> IO [(NS.Socket, NS.SockAddr)]
 waitForClients numberOfClients serverSock = do


### PR DESCRIPTION
This makes sure resources get cleaned up in case of errors. This helps running multiple tests, which is for now mainly motivated for debugging purposes.