### PR TITLE
Remove `firmware-binaries/examples/.cargo/Cargo.toml`

### DIFF
--- a/firmware-binaries/examples/.cargo/config.toml
+++ b/firmware-binaries/examples/.cargo/config.toml
@@ -1,9 +1,0 @@
-# SPDX-FileCopyrightText: 2022 Google LLC
-#
-# SPDX-License-Identifier: CC0-1.0
-
-[build]
-target = "riscv32imc-unknown-none-elf"
-
-[unstable]
-build-std = ["core,panic_abort"]

--- a/firmware-binaries/examples/.cargo/config.toml
+++ b/firmware-binaries/examples/.cargo/config.toml
@@ -7,4 +7,3 @@ target = "riscv32imc-unknown-none-elf"
 
 [unstable]
 build-std = ["core,panic_abort"]
-build-std-features = ["panic_immediate_abort"]


### PR DESCRIPTION
This causes rust code to trap instead of panic, leading to undebuggable errors