### PR TITLE
Run nightly 10 times

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,16 @@ on:
     # GitHub scheduling. See the comment at 'branches-ignore' for more
     # information on our development flow. This job will run in context of the
     # branch 'staging'.
-    - cron:  '0 19 * * *'
+    - cron:  '0  19 * * *'
+    - cron:  '30 19 * * *'
+    - cron:  '0  20 * * *'
+    - cron:  '30 20 * * *'
+    - cron:  '0  21 * * *'
+    - cron:  '30 21 * * *'
+    - cron:  '0  22 * * *'
+    - cron:  '30 22 * * *'
+    - cron:  '0  23 * * *'
+    - cron:  '30 23 * * *'
 
   push:
       branches-ignore:


### PR DESCRIPTION
We think https://github.com/bittide/bittide-hardware/pull/690 fixed our nightly issues. At the very least, we cannot reproduce it locally anymore. However, we've also seen that nightly fails more often than local runs, so we'll run nightly a bunch of times in the coming days to see if we've actually fixed things.