### PR TITLE
Lock elf limits repo to hash

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -348,7 +348,7 @@ jobs:
       - run: cache pull build
 
       - name: Install `elf-limits`
-        run: cargo install --locked --git https://github.com/cuddlefishie/elf-limits
+        run: cargo install --locked --git https://github.com/cuddlefishie/elf-limits --rev 5f2488eac17ea7c203975e1efe1686b1682ce0b4
 
       - name: Checking firmware binary limits
         run: |


### PR DESCRIPTION
Previously updating the other repo could break ours