### PR TITLE
add a VivadoM monad to make writing HITL drivers nicer

### DIFF
--- a/bittide-experiments/src/Bittide/Hitl.hs
+++ b/bittide-experiments/src/Bittide/Hitl.hs
@@ -89,6 +89,7 @@ import System.Exit (ExitCode)
 
 import Vivado (VivadoHandle)
 import Vivado.Tcl (HwTarget)
+import Vivado.VivadoM
 
 {- | Fully qualified name to a function that is the target for Clash
 compilation. E.g. @Bittide.Foo.topEntity@.
@@ -209,7 +210,7 @@ data HitlTestGroup where
     , testCases :: [HitlTestCase HwTargetRef a b]
     -- ^ List of test cases
     , mDriverProc ::
-        Maybe (VivadoHandle -> String -> FilePath -> [(HwTarget, DeviceInfo)] -> IO ExitCode)
+        Maybe (String -> [(HwTarget, DeviceInfo)] -> VivadoM ExitCode)
     -- ^ Optional function driving the test. If provided, this function must:
     --   - Handle any pre-processing necessary to begin the test
     --   - Assert the start probe(s)

--- a/bittide-instances/bittide-instances.cabal
+++ b/bittide-instances/bittide-instances.cabal
@@ -103,6 +103,7 @@ common common-options
     cryptohash-sha256,
     deepseq,
     directory,
+    exceptions,
     extra,
     filepath,
     ghc-typelits-extra,

--- a/bittide-shake/bittide-shake.cabal
+++ b/bittide-shake/bittide-shake.cabal
@@ -31,6 +31,7 @@ common common-options
     directory,
     extra,
     filepath,
+    mtl,
     shake,
     string-interpolate,
     template-haskell,

--- a/vivado-hs/src/Vivado/VivadoM.hs
+++ b/vivado-hs/src/Vivado/VivadoM.hs
@@ -1,0 +1,90 @@
+-- SPDX-FileCopyrightText: 2025 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+{-# LANGUAGE GADTs #-}
+
+-- | Monad for common Vivado commands
+module Vivado.VivadoM (
+  VivadoM,
+  ObjectRef,
+  openHardwareTarget,
+  refreshHwDevice,
+  commitVios,
+  setProp,
+  getProp,
+  setVioValue,
+  getVioValue,
+  updateVio,
+  readVio,
+) where
+
+import Control.Monad (forM, forM_)
+import Control.Monad.Reader
+
+import Vivado.Internal
+import Vivado.Tcl
+
+type ObjectRef = String
+
+type VivadoM a = ReaderT VivadoHandle IO a
+
+openHardwareTarget :: HwTarget -> VivadoM ()
+openHardwareTarget hwT = do
+  v <- ask
+  liftIO $ openHwTarget v hwT
+  refreshHwDevice
+
+refreshHwDevice :: VivadoM ()
+refreshHwDevice = do
+  v <- ask
+  liftIO $ refresh_hw_device v []
+
+commitVios :: VivadoM ()
+commitVios = do
+  v <- ask
+  liftIO $ commit_hw_vio v ["[get_hw_vios]"]
+
+setProp :: ObjectRef -> String -> String -> VivadoM ()
+setProp objRef name val = do
+  v <- ask
+  liftIO $ execCmd_ v "set_property" [name, val, objRef]
+
+getProp :: ObjectRef -> String -> VivadoM String
+getProp objRef name = do
+  v <- ask
+  liftIO $ execCmd v "get_property" [name, objRef]
+
+vioProbeRef :: String -> String
+vioProbeRef name = "[get_hw_probes -of_objects [get_hw_vios] " <> name <> "]"
+
+setVioValue :: String -> String -> String -> VivadoM ()
+setVioValue vioName name val = do
+  let vioRef = vioProbeRef $ "*" <> vioName <> "/" <> name
+  setProp vioRef "OUTPUT_VALUE" val
+
+getVioValue :: String -> String -> VivadoM String
+getVioValue vioName name = do
+  let vioRef = vioProbeRef $ "*" <> vioName <> "/" <> name
+  getProp vioRef "INPUT_VALUE"
+
+updateVio :: String -> [(String, String)] -> VivadoM ()
+updateVio vioName values = do
+  forM_ values $ \(name, value) -> do
+    setVioValue vioName name value
+
+  commitVios
+
+{- | Read values from a VIO, the values will be returned
+in an assoc-list in the same order as the probe name list.
+-}
+readVio ::
+  -- | Name of the VIO
+  String ->
+  -- | Names of the values in the VIO to read
+  [String] ->
+  VivadoM [(String, String)]
+readVio vioName names = do
+  refreshHwDevice
+  forM names $ \name -> do
+    val <- getVioValue vioName name
+    pure (name, val)

--- a/vivado-hs/vivado-hs.cabal
+++ b/vivado-hs/vivado-hs.cabal
@@ -53,6 +53,7 @@ library
   exposed-modules:
     Vivado
     Vivado.Tcl
+    Vivado.VivadoM
 
   other-modules:
     Vivado.Internal
@@ -61,7 +62,9 @@ library
     base,
     containers,
     deepseq,
+    exceptions,
     extra,
+    mtl,
     process,
     string-interpolate,
     temporary,


### PR DESCRIPTION
First implementation of a `VivadoM` monad for common Vivado operations.

This is only geared towards making ""user facing"" drivers nicer to write. This could be expanded later to
- add parallelism primitives
- include enough operations/features to move all the Vivado test infrastructure to this monad?