### PR TITLE
Reduce jtag speed from 6000 KHz to 1000 KHz

### DIFF
--- a/bittide-instances/data/openocd/sipeed.tcl
+++ b/bittide-instances/data/openocd/sipeed.tcl
@@ -36,6 +36,8 @@ ftdi layout_signal nTRST -data 0x0 -oe 0x0
 # we don't have an output-enable pin -> set the same mask
 ftdi layout_signal nSRST -data 0x0020 -oe 0x0020
 
-# JTAG mode
-adapter speed 6000
+# The FT2232C supports sustained data rates up to 5.6 Mbit/s
+# https://ftdichip.com/wp-content/uploads/2020/08/DS_FT2232C.pdf
+# Just to be safe we set it to 1000 kHz
+adapter speed 1000
 transport select jtag


### PR DESCRIPTION
According to the [datasheet](https://ftdichip.com/wp-content/uploads/2020/08/DS_FT2232C.pdf) of the FT2232C chip we are using to drive JTAG, this chip has a maximum sustained data rate of 5.6 Mega bits /s.

I've noticed that on some tests that use JTAG the `riscv-openocd` implementation throws warnings that might be caused by the jtag clock being set too high:
```
Error: OpenOCD only supports Debug Module version 2 (0.13) and 3 (1.0), not 6 (dmstatus=0x430c86). This error might be caused by a JTAG signal issue. Try reducing the JTAG clock speed.
```
This error was thrown by FPGA 1.

In [this](https://github.com/bittide/bittide-hardware/actions/runs/12945577800) run I reduced the jtag speed to 1000KHz and ran the vexriscv test 80 times. Not one of the logs contained the error.

[This](https://github.com/bittide/bittide-hardware/actions/runs/12950190725) pipeline runs the vexriscv test 80 times with the old 6000KHz clock.