### PR TITLE
Move all instances using transceivers to one TX domain (+whole bunch of bug fixes)

### DIFF
--- a/bittide-instances/src/Bittide/Instances/Hitl/LinkConfiguration.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/LinkConfiguration.hs
@@ -179,7 +179,7 @@ transceiversStartAndObserve refClk sysClk rst myIndex rxNs rxPs miso =
         , rxPs
         , txDatas = repeat myIndexTx
         , rxReadys = repeat $ pure True
-        , txReadys = repeat $ pure True
+        , txStarts = repeat $ pure True
         }
 
   -- synchronizes the FPGA's stable index to the individual TX clock

--- a/bittide-instances/src/Bittide/Instances/Hitl/LinkConfiguration.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/LinkConfiguration.hs
@@ -186,9 +186,8 @@ transceiversStartAndObserve refClk sysClk rst myIndex rxNs rxPs miso =
   -- domains of the transceivers
   myIndexTxN =
     fmap (zeroExtend . pack . fromMaybe 0)
-      <$> zipWith
-        (xpmCdcStable sysClk myIndex)
-        transceivers.txClocks
+      <$> map
+        (xpmCdcStable sysClk myIndex transceivers.txClock)
         transceivers.txResets
 
   -- check that all the received data matches with our expectations

--- a/bittide-instances/src/Bittide/Instances/Hitl/LinkConfiguration.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/LinkConfiguration.hs
@@ -177,18 +177,17 @@ transceiversStartAndObserve refClk sysClk rst myIndex rxNs rxPs miso =
         , clockPaths
         , rxNs
         , rxPs
-        , txDatas = myIndexTxN
+        , txDatas = repeat myIndexTx
         , rxReadys = repeat $ pure True
         , txReadys = repeat $ pure True
         }
 
   -- synchronizes the FPGA's stable index to the individual TX clock
   -- domains of the transceivers
-  myIndexTxN =
-    fmap (zeroExtend . pack . fromMaybe 0)
-      <$> map
-        (xpmCdcStable sysClk myIndex transceivers.txClock)
-        transceivers.txResets
+  myIndexTx =
+    fmap
+      (zeroExtend . pack . fromMaybe 0)
+      (xpmCdcStable sysClk myIndex transceivers.txClock transceivers.txReset)
 
   -- check that all the received data matches with our expectations
   success =

--- a/bittide-instances/src/Bittide/Instances/Hitl/SwCcTopologies.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/SwCcTopologies.hs
@@ -299,7 +299,7 @@ topologyTest refClk sysClk IlaControl{syncRst = rst, ..} rxNs rxPs miso cfg prog
         , rxNs
         , rxPs
         , txDatas = txCounters
-        , txReadys = repeat (pure True)
+        , txStarts = repeat (pure True)
         , rxReadys = repeat (pure True)
         }
 

--- a/bittide-instances/src/Bittide/Instances/Hitl/SwCcTopologies.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/SwCcTopologies.hs
@@ -563,18 +563,17 @@ topologyTest refClk sysClk IlaControl{syncRst = rst, ..} rxNs rxPs miso cfg prog
       (repeat transceivers.txClock)
 
   txAllStable = xpmCdcSingle sysClk transceivers.txClock allStable1
-  txResets2 =
-    zipWith
-      orReset
-      transceivers.txResets
-      (repeat $ unsafeFromActiveLow txAllStable)
+  txReset2 =
+    orReset
+      transceivers.txReset
+      (unsafeFromActiveLow txAllStable)
 
   txNotInCCResets :: Vec LinkCount (Signal GthTx Bool)
   txNotInCCResets = go <$> (repeat transceivers.txClock)
    where
     go txClk = unsafeSynchronizer sysClk txClk notInCCReset
 
-  txCounters = zipWith3 txCounter (repeat transceivers.txClock) txResets2 txNotInCCResets
+  txCounters = zipWith3 txCounter (repeat transceivers.txClock) (repeat txReset2) txNotInCCResets
   txCounter txClk txRst notInCCReset' = result
    where
     notInCCReset'' :: Signal GthTx (BitVector 1)
@@ -589,7 +588,7 @@ topologyTest refClk sysClk IlaControl{syncRst = rst, ..} rxNs rxPs miso cfg prog
       go
       (repeat transceivers.txClock)
       transceivers.rxClocks
-      txResets2
+      (repeat txReset2)
       transceivers.rxDatas
    where
     go = resettableXilinxElasticBuffer @FifoSize @_ @_ @(Maybe (BitVector 64))

--- a/bittide-instances/src/Bittide/Instances/Hitl/SwCcTopologies.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/SwCcTopologies.hs
@@ -373,7 +373,7 @@ topologyTest refClk sysClk IlaControl{syncRst = rst, ..} rxNs rxPs miso cfg prog
 
   callistoResult =
     callistoClockControlWithIla @LinkCount @CccBufferSize
-      (head transceivers.txClocks)
+      transceivers.txClock
       sysClk
       clockControlReset
       ccConfig
@@ -560,21 +560,21 @@ topologyTest refClk sysClk IlaControl{syncRst = rst, ..} rxNs rxPs miso cfg prog
       (domainDiffCounterExt sysClk)
       (orReset clockControlReset . unsafeFromActiveLow <$> othersNotInCCResetSync)
       transceivers.rxClocks
-      transceivers.txClocks
+      (repeat transceivers.txClock)
 
-  txAllStables = zipWith (xpmCdcSingle sysClk) transceivers.txClocks (repeat allStable1)
+  txAllStable = xpmCdcSingle sysClk transceivers.txClock allStable1
   txResets2 =
     zipWith
       orReset
       transceivers.txResets
-      (map unsafeFromActiveLow txAllStables)
+      (repeat $ unsafeFromActiveLow txAllStable)
 
   txNotInCCResets :: Vec LinkCount (Signal GthTx Bool)
-  txNotInCCResets = go <$> transceivers.txClocks
+  txNotInCCResets = go <$> (repeat transceivers.txClock)
    where
     go txClk = unsafeSynchronizer sysClk txClk notInCCReset
 
-  txCounters = zipWith3 txCounter transceivers.txClocks txResets2 txNotInCCResets
+  txCounters = zipWith3 txCounter (repeat transceivers.txClock) txResets2 txNotInCCResets
   txCounter txClk txRst notInCCReset' = result
    where
     notInCCReset'' :: Signal GthTx (BitVector 1)
@@ -587,7 +587,7 @@ topologyTest refClk sysClk IlaControl{syncRst = rst, ..} rxNs rxPs miso cfg prog
   rxFifos =
     zipWith4
       go
-      transceivers.txClocks
+      (repeat transceivers.txClock)
       transceivers.rxClocks
       txResets2
       transceivers.rxDatas
@@ -595,30 +595,30 @@ topologyTest refClk sysClk IlaControl{syncRst = rst, ..} rxNs rxPs miso cfg prog
     go = resettableXilinxElasticBuffer @FifoSize @_ @_ @(Maybe (BitVector 64))
 
   (_fillLvls, fifoUnderflowsTx, fifoOverflowsTx, _ebMode, mRxCntrs) = unzip5 rxFifos
-  rxCntrs = zipWith3 go transceivers.txClocks txNotInCCResets mRxCntrs
+  rxCntrs = zipWith go txNotInCCResets mRxCntrs
    where
-    go txClk txRst = regMaybe txClk (unsafeFromActiveLow txRst) enableGen rxCounterStartUgn
+    go txRst = regMaybe transceivers.txClock (unsafeFromActiveLow txRst) enableGen rxCounterStartUgn
 
   fifoOverflowsFree :: Vec LinkCount (Signal Basic125 Overflow)
-  fifoOverflowsFree = zipWith (`xpmCdcSingle` sysClk) transceivers.txClocks fifoOverflowsTx
+  fifoOverflowsFree = map (xpmCdcSingle transceivers.txClock sysClk) fifoOverflowsTx
   fifoUnderflowsFree :: Vec LinkCount (Signal Basic125 Underflow)
-  fifoUnderflowsFree = zipWith (`xpmCdcSingle` sysClk) transceivers.txClocks fifoUnderflowsTx
+  fifoUnderflowsFree = map (xpmCdcSingle transceivers.txClock sysClk) fifoUnderflowsTx
 
   ugns1 :: Vec LinkCount (Signal GthTx (BitVector 64))
   ugns1 = zipWith (-) txCounters rxCntrs
   -- see NOTE [magic start values]
 
   ugns2 :: Vec LinkCount (Signal Basic125 (BitVector 64))
-  ugns2 = zipWith3 go transceivers.txClocks othersNotInCCResetSync ugns1
+  ugns2 = zipWith go othersNotInCCResetSync ugns1
    where
-    go txClk enaSig =
+    go enaSig =
       regEn
         sysClk
         clockControlReset
         enableGen
         rxCounterStartUgn
         enaSig
-        . xpmCdcArraySingle txClk sysClk
+        . xpmCdcArraySingle transceivers.txClock sysClk
 
   ugnsStable :: Vec LinkCount (Signal Basic125 Bool)
   ugnsStable = go <$> ugns2

--- a/bittide-instances/src/Bittide/Instances/Hitl/Transceivers.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/Transceivers.hs
@@ -161,7 +161,7 @@ goTransceiversUpTest fpgaIndex refClk sysClk rst rxNs rxPs miso =
         , rxNs
         , rxPs
         , txDatas = repeat txCounter
-        , txReadys = repeat (pure True)
+        , txReadys = repeat (fold (.&&.) transceivers.txReadys)
         , rxReadys = repeat (pure True)
         }
 

--- a/bittide-instances/src/Bittide/Instances/Hitl/Transceivers.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/Transceivers.hs
@@ -128,7 +128,17 @@ goTransceiversUpTest fpgaIndex refClk sysClk rst rxNs rxPs miso =
   gthAllReset = unsafeFromActiveLow spiDone
 
   txCounter =
-    counter transceivers.txClock (unsafeFromActiveLow (fold (.||.) transceivers.txSamplings))
+    counter
+      transceivers.txClock
+      -- We use a single counter for all transmit channels and we start them all
+      -- at the same time. This way, the other side will always receive 'counterStart'
+      -- as the first value and can verify all samples after that by incrementing
+      -- by one each cycle. Note that it doesn't really matter whether we pick
+      -- (.||.) or (.&&.) here, as all links should start transmitting at the
+      -- same time. I.e., txSamplings should all flip at the same time. Still, we
+      -- picked (.||.) to catch situations where some links start transmitting
+      -- earlier than others.
+      (unsafeFromActiveLow (fold (.||.) transceivers.txSamplings))
 
   expectCounterError =
     zipWith3

--- a/bittide-instances/src/Bittide/Instances/Hitl/Transceivers.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/Transceivers.hs
@@ -161,7 +161,11 @@ goTransceiversUpTest fpgaIndex refClk sysClk rst rxNs rxPs miso =
         , rxNs
         , rxPs
         , txDatas = repeat txCounter
-        , txReadys = repeat (fold (.&&.) transceivers.txReadys)
+        , txReadys =
+            repeat
+              ( register transceivers.txClock noReset enableGen False
+                  $ fold (.&&.) transceivers.txReadys -- TODO figure out proper reset
+              )
         , rxReadys = repeat (pure True)
         }
 

--- a/bittide-instances/src/Bittide/Instances/Hitl/Transceivers.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/Transceivers.hs
@@ -50,7 +50,7 @@ a non-zero start value, as a regression test for a bug where the transceivers
 would not come up if the counters started at zero.
 -}
 counterStart :: BitVector 64
-counterStart = 0xDEAD_BEEF_CA55_E77E
+counterStart = 0xDEAD_BEEF_0000_0000
 
 -- | A counter starting at 'counterStart'
 counter ::

--- a/bittide-instances/src/Bittide/Instances/Hitl/Transceivers.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/Transceivers.hs
@@ -127,7 +127,8 @@ goTransceiversUpTest fpgaIndex refClk sysClk rst rxNs rxPs miso =
   -- Transceiver setup
   gthAllReset = unsafeFromActiveLow spiDone
 
-  txCounter = counter transceivers.txClock transceivers.txReset
+  txCounter =
+    counter transceivers.txClock (unsafeFromActiveLow (fold (.||.) transceivers.txSamplings))
 
   expectCounterError =
     zipWith3

--- a/bittide-instances/src/Bittide/Instances/Hitl/Transceivers.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/Transceivers.hs
@@ -161,7 +161,7 @@ goTransceiversUpTest fpgaIndex refClk sysClk rst rxNs rxPs miso =
         , rxNs
         , rxPs
         , txDatas = repeat txCounter
-        , txReadys =
+        , txStarts =
             repeat
               ( register transceivers.txClock noReset enableGen False
                   $ fold (.&&.) transceivers.txReadys -- TODO figure out proper reset

--- a/bittide-instances/src/Bittide/Instances/Hitl/Transceivers.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/Transceivers.hs
@@ -130,9 +130,8 @@ goTransceiversUpTest fpgaIndex refClk sysClk rst rxNs rxPs miso =
 
   -- Send counters
   counters =
-    zipWith3
-      counter
-      transceivers.txClocks
+    zipWith
+      (counter transceivers.txClock)
       transceivers.txResets
       transceivers.txSamplings
 

--- a/bittide-instances/src/Bittide/Instances/Hitl/Transceivers.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/Transceivers.hs
@@ -144,7 +144,7 @@ goTransceiversUpTest fpgaIndex refClk sysClk rst rxNs rxPs miso =
       transceivers.rxDatas
 
   expectCounterErrorSys =
-    fmap and
+    fmap or
       $ bundle
       $ zipWith (.&&.) transceivers.linkUps
       $ zipWith (`xpmCdcSingle` sysClk) transceivers.rxClocks expectCounterError

--- a/bittide-instances/src/Bittide/Instances/Hitl/Transceivers.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/Transceivers.hs
@@ -57,9 +57,8 @@ counter ::
   (KnownDomain dom) =>
   Clock dom ->
   Reset dom ->
-  Signal dom Bool ->
   Signal dom (BitVector 64)
-counter clk rst ena = let c = register clk rst (toEnable ena) counterStart (c + 1) in c
+counter clk rst = let c = register clk rst enableGen counterStart (c + 1) in c
 
 {- | Expect a counter starting at 'counterStart' and incrementing by one on each
 cycle.
@@ -128,12 +127,7 @@ goTransceiversUpTest fpgaIndex refClk sysClk rst rxNs rxPs miso =
   -- Transceiver setup
   gthAllReset = unsafeFromActiveLow spiDone
 
-  -- Send counters
-  counters =
-    zipWith
-      (counter transceivers.txClock)
-      transceivers.txResets
-      transceivers.txSamplings
+  txCounter = counter transceivers.txClock transceivers.txReset
 
   expectCounterError =
     zipWith3
@@ -165,7 +159,7 @@ goTransceiversUpTest fpgaIndex refClk sysClk rst rxNs rxPs miso =
         , clockPaths
         , rxNs
         , rxPs
-        , txDatas = counters
+        , txDatas = repeat txCounter
         , txReadys = repeat (pure True)
         , rxReadys = repeat (pure True)
         }

--- a/bittide-instances/src/Bittide/Instances/Hitl/Transceivers.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/Transceivers.hs
@@ -143,6 +143,8 @@ goTransceiversUpTest fpgaIndex refClk sysClk rst rxNs rxPs miso =
       $ zipWith (.&&.) transceivers.linkUps
       $ zipWith (`xpmCdcSingle` sysClk) transceivers.rxClocks expectCounterError
 
+  txStart = fold (.&&.) transceivers.txReadys
+
   transceivers =
     transceiverPrbsN
       @GthTx
@@ -161,11 +163,7 @@ goTransceiversUpTest fpgaIndex refClk sysClk rst rxNs rxPs miso =
         , rxNs
         , rxPs
         , txDatas = repeat txCounter
-        , txStarts =
-            repeat
-              ( register transceivers.txClock noReset enableGen False
-                  $ fold (.&&.) transceivers.txReadys -- TODO figure out proper reset
-              )
+        , txStarts = repeat txStart
         , rxReadys = repeat (pure True)
         }
 

--- a/bittide-tools/clockcontrol/plot/Main.hs
+++ b/bittide-tools/clockcontrol/plot/Main.hs
@@ -113,6 +113,8 @@ import System.IO (
   hPutStr,
   hSetBuffering,
   openFile,
+  stderr,
+  stdout,
   withFile,
  )
 import Text.Read (readMaybe)
@@ -674,6 +676,8 @@ plotTest refDom testDir cfg dir globalOutDir = do
         -- Fail if clocks did not start at their set offsets. We purposely fail
         -- after generating the report, because the report generation is very
         -- useful for debugging.
+        hFlush stdout
+        hFlush stderr
         maybe (return ()) die maybeError
       _ -> die "Empty topology"
     _ -> die "Topology is larger than expected"

--- a/bittide/src/Bittide/Transceiver.hs
+++ b/bittide/src/Bittide/Transceiver.hs
@@ -603,14 +603,10 @@ transceiverPrbsWith gthCore opts args@Input{clock, reset} =
       $ WordAlign.alignBytesFromMsbs @8 WordAlign.alignLsbFirst (rxUserData .||. rxLast) rx_data0
 
   (alignedAlignBits, alignedRxData1) =
-    unbundle
-      $ WordAlign.splitMsbs @8 @8
-      <$> alignedRxData0
+    unbundle (WordAlign.splitMsbs @8 @8 <$> alignedRxData0)
 
   (alignedMetaBits, alignedRxData2) =
-    unbundle
-      $ WordAlign.splitMsbs @8 @7
-      <$> alignedRxData1
+    unbundle (WordAlign.splitMsbs @8 @7 <$> alignedRxData1)
 
   prbsErrors = Prbs.checker rxClock rxReset enableGen prbsConfig alignedRxData2
   anyPrbsErrors = prbsErrors ./=. pure 0
@@ -622,14 +618,10 @@ transceiverPrbsWith gthCore opts args@Input{clock, reset} =
   --
   -- TODO: Truncate rxCtrl0 and rxCtrl1 in GTH primitive.
   rxCtrlOrError =
-    fmap (truncateB @_ @8) rxCtrl0
-      ./=. pure 0
-      .||. fmap (truncateB @_ @8) rxCtrl1
-      ./=. pure 0
-      .||. rxCtrl2
-      ./=. pure 0
-      .||. rxCtrl3
-      ./=. pure 0
+    (fmap (truncateB @_ @8) rxCtrl0 ./=. pure 0)
+      .||. (fmap (truncateB @_ @8) rxCtrl1 ./=. pure 0)
+      .||. (rxCtrl2 ./=. pure 0)
+      .||. (rxCtrl3 ./=. pure 0)
 
   prbsOk =
     rxUserData

--- a/bittide/src/Bittide/Transceiver.hs
+++ b/bittide/src/Bittide/Transceiver.hs
@@ -172,7 +172,7 @@ types say otherwise.
 data Outputs n tx rx txS free = Outputs
   { txClock :: Clock tx
   -- ^ Single transmit clock, shared by all links
-  , txResets :: Vec n (Reset tx)
+  , txReset :: Reset tx
   -- ^ See 'Output.txReset'
   , txReadys :: Vec n (Signal tx Bool)
   -- ^ See 'Output.txReady'
@@ -322,7 +322,7 @@ transceiverPrbsN opts inputs@Inputs{clock, reset, refClock} =
   Outputs
     { -- tx
       txClock = txClock
-    , txResets = map (.txReset) outputs
+    , txReset = fold orReset $ map (.txReset) outputs
     , txReadys = map (.txReady) outputs
     , txSamplings = map (.txSampling) outputs
     , -- rx

--- a/bittide/src/Bittide/Transceiver.hs
+++ b/bittide/src/Bittide/Transceiver.hs
@@ -206,7 +206,7 @@ data Output tx rx tx1 rx1 txS free serializedData = Output
   -- ^ Ready to signal to neigbor that next word will be user data. Waiting for
   -- 'Input.txStart' to be asserted before starting to send 'txData'.
   , txSampling :: Signal tx Bool
-  -- ^ Data is sampled from 'Input.txSampling'
+  -- ^ Data is sampled from 'Input.txData'
   , txP :: Signal txS serializedData
   -- ^ Transmit data (and implicitly a clock), positive
   , txN :: Signal txS serializedData
@@ -249,9 +249,9 @@ data Input tx rx tx1 rx1 ref free rxS serializedData = Input
   , rxN :: Signal rxS serializedData
   , rxP :: Signal rxS serializedData
   , txData :: Signal tx (BitVector 64)
-  -- ^ Data to transmit to the neighbor. Is sampled on sample after
-  -- 'Output.txSamplingOnNext' is asserted. Is sampled when
-  -- 'Output.txData' is asserted.
+  -- ^ Data to transmit to the neighbor. Is first sampled one cycle after both
+  -- 'Input.txStart' and 'Output.txReady' are asserted. Is continuously sampled
+  -- afterwards.
   , txStart :: Signal tx Bool
   -- ^ When asserted, signal to neighbor that next word will be user data. This
   -- signal is ignored until 'Output.txReady' is asserted. Can be tied
@@ -271,7 +271,7 @@ data Inputs tx rx ref free rxS n = Inputs
   , refClock :: Clock ref
   -- ^ See 'Input.refClock'
   , channelNames :: Vec n String
-  -- ^ See 'Input.channel'
+  -- ^ See 'Input.channelName'
   , clockPaths :: Vec n String
   -- ^ See 'Input.clockPath'
   , rxNs :: Signal rxS (BitVector n)

--- a/bittide/src/Bittide/Transceiver/ResetManager.hs
+++ b/bittide/src/Bittide/Transceiver/ResetManager.hs
@@ -81,7 +81,8 @@ times if we don't see sensible data coming in. See the individual constructors
 and 'resetManager' for more information.
 -}
 data State dom
-  = -- | Reset everything - transmit and receive side
+  = InReset
+  | -- | Reset everything - transmit and receive side
     StartTx
   | -- | Reset just the receive side
     StartRx
@@ -145,11 +146,12 @@ resetManager config clk rst tx_init_done rx_init_done rx_data_good =
       }
 
   initState :: State dom
-  initState = StartTx
+  initState = InReset
 
   update :: (State dom, Statistics) -> (Bool, Bool, Bool) -> (State dom, Statistics)
   update st (tx_done, rx_done, rx_good) =
     case st of
+      (InReset, stats) -> (StartTx, stats)
       -- Reset everything:
       (StartTx, stats) -> (TxWait minBound, stats)
       -- Wait for transceiver to indicate it is done

--- a/bittide/src/Clash/Cores/Xilinx/GTH/BlackBoxes.hs
+++ b/bittide/src/Clash/Cores/Xilinx/GTH/BlackBoxes.hs
@@ -59,6 +59,16 @@ nConstraints = 8
 nNameArgs :: Int
 nNameArgs = 2
 
+{-
+NOTE [ignoring HWType domains]
+
+The ty1 bascially contains type variables in place of the domains.
+While the ty2 contains concrete types for the domains.
+To properly check this we'd have to do unification over all ports together.
+Instead this function decides to do a quick simple check and just ignore the domains.
+
+Note that signals don't exist in HWType, so their domains can't be checked anyways.
+-}
 checkHwTy :: (Show a) => (a, HWType) -> (b, HWType) -> (a, b)
 checkHwTy (nm, ty1) (e, ty2)
   | eqHwTyModuloDomain ty1 ty2 = (nm, e)
@@ -67,6 +77,7 @@ checkHwTy (nm, ty1) (e, ty2)
 
 eqHwTyModuloDomain :: N.HWType -> N.HWType -> Bool
 eqHwTyModuloDomain x y = case (x, y) of
+  -- see NOTE [ignoring HWType domains]
   (N.Clock _, N.Clock _) -> True
   (N.ClockN _, N.ClockN _) -> True
   (N.Reset _, N.Reset _) -> True

--- a/bittide/tests/Tests/Transceiver.hs
+++ b/bittide/tests/Tests/Transceiver.hs
@@ -164,7 +164,7 @@ gthCoreMock
 
 data Input tx rx = Input
   { dat :: Signal tx (BitVector 64)
-  , txReady :: Signal tx Bool
+  , txStart :: Signal tx Bool
   , rxReady :: Signal rx Bool
   }
 
@@ -229,7 +229,7 @@ dut
           , rxN = delaySeqN baDelay Nothing outputB.txN
           , rxP = error "A: rxP not used in simulation"
           , txData = inputA.dat
-          , txReady = inputA.txReady
+          , txStart = inputA.txStart
           , rxReady = inputA.rxReady
           }
 
@@ -253,7 +253,7 @@ dut
           , rxN = delaySeqN abDelay Nothing outputA.txN
           , rxP = error "B: rxP not used in simulation"
           , txData = inputB.dat
-          , txReady = inputB.txReady
+          , txStart = inputB.txStart
           , rxReady = inputB.rxReady
           }
 
@@ -370,11 +370,11 @@ testNotBothUp500ms outputA outputB =
 
 -- Input that applies no (back)pressure on the link
 noPressureInput :: InputFunc txA txB free
-noPressureInput _ = Input{dat = complement <$> 0, txReady = pure True, rxReady = pure True}
+noPressureInput _ = Input{dat = complement <$> 0, txStart = pure True, rxReady = pure True}
 
--- Input that never sets 'txReady' to 'True'
-noTxReadyInput :: InputFunc txA txB free
-noTxReadyInput i = (noPressureInput i){txReady = pure False}
+-- Input that never sets 'txStart' to 'True'
+noTxStartInput :: InputFunc txA txB free
+noTxStartInput i = (noPressureInput i){txStart = pure False}
 
 -- Input that never sets 'rxReady' to 'True'
 noRxReadyInput :: InputFunc txA txB free
@@ -420,12 +420,12 @@ indicates it's ready to the other.
 -}
 prop_noTxReady :: Property
 prop_noTxReady =
-  dutRandomized @A @A @Free testNeitherUp500ms noPressureInput noTxReadyInput Proxy
+  dutRandomized @A @A @Free testNeitherUp500ms noPressureInput noTxStartInput Proxy
 
 -- | Same as 'prop_noTxReady', but with the transceivers flipped
 prop_noTxReadyFlipped :: Property
 prop_noTxReadyFlipped =
-  dutRandomized @A @A @Free testNeitherUp500ms noTxReadyInput noPressureInput Proxy
+  dutRandomized @A @A @Free testNeitherUp500ms noTxStartInput noPressureInput Proxy
 
 {- | Check whether neither node indicates it's up, when it never transitions to
 sending user data.


### PR DESCRIPTION
In https://github.com/bittide/bittide-hardware/pull/688 we modified the transceiver logic to operate on a single TX domain (but multiple RX domains). To keep the changes contained, we still exported multiple clocks still (though just as a `repeat`). This PR cleans this up and removes all superfluous synchronization. During this process we discovered a number of bugs:

1. Transceiver up test would only fail if _all_ links would fail. This is of course an error: it should fail if _any_ link fails.
2. We had two fields called `txReady` (both on `Input` and `Output`). This caused confusion, that lead to the input's `txReady` to be looped back to the `Output`. This was clearly incorrect: `Output.txReady` should clearly depend on whether a neighbor says it is ready to receive data!

Fixes https://github.com/bittide/bittide-hardware/issues/696

# TODO
- [x] See if we can replicate handhshake failure in simulation test