### PR TITLE
Fix intermittent CC failures

### DIFF
--- a/bittide-instances/src/Bittide/Instances/Hitl/SwCcTopologies.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/SwCcTopologies.hs
@@ -29,6 +29,8 @@ module Bittide.Instances.Hitl.SwCcTopologies (
   swCcTopologyTest,
   swCcOneTopologyTest,
   tests,
+  partsPerToSteps,
+  acceptableNoiseLevel,
 ) where
 
 import Clash.Explicit.Prelude hiding (PeriodToCycles)
@@ -87,6 +89,11 @@ import qualified Bittide.Transceiver as Transceiver
 import qualified Bittide.Transceiver.ResetManager as ResetManager
 import qualified Data.Map.Strict as Map (fromList)
 
+{- $setup
+>>> import Clash.Explicit.Prelude
+>>> import qualified Bittide.Arithmetic.PartsPer as PartsPer
+-}
+
 type AllStablePeriod = Seconds 5
 
 {- | The number of FINCs (if positive) or FDECs (if negative) applied
@@ -128,9 +135,8 @@ offsets, which is why we fix it to a single and common value here.
 -}
 commonStepSizeSelect :: StepSizeSelect
 commonStepSizeSelect =
-  -- Don't forget to update the value of f_step this value in "Callisto.hs" and
-  -- "callisto.rs".
-  PPB_100
+  -- Don't forget to update the value of f_step this value in "callisto.rs".
+  PPB_10
 
 commonStepSizePartsPer :: PartsPer
 commonStepSizePartsPer = case commonStepSizeSelect of
@@ -154,9 +160,16 @@ commonSpiConfig = case commonStepSizeSelect of
 
 {- | Accepted noise between the inital clock control calibration run
 and the last calibration verifiction run.
+
+>>> acceptableNoiseLevel == partsPerToSteps (PartsPer.ppb 1500)
+True
 -}
 acceptableNoiseLevel :: FincFdecCount
-acceptableNoiseLevel = 6
+acceptableNoiseLevel =
+  -- This value corresponds to 1.5ppm. We can't calculate it directly, because
+  -- we need it as a constant and we cannot use TemplateHaskell due to staging
+  -- restrictions. The doctest above ensures that the value remains up to date.
+  150
 
 disabled :: TestConfig
 disabled =

--- a/firmware-support/bittide-sys/src/callisto.rs
+++ b/firmware-support/bittide-sys/src/callisto.rs
@@ -168,7 +168,7 @@ pub fn callisto(cc: &ClockControl, config: &ControlConfig, state: &mut ControlSt
     // match the step size of the clock boards. For all our HITL tests this is set by
     // `HwCcTopologies.commonStepSizeSelect`.
     const K_P: f32 = 2e-8;
-    const FSTEP: f32 = 100e-9;
+    const FSTEP: f32 = 10e-9;
 
     let n_buffers = cc.up_links();
     let measured_sum = cc.data_counts().sum::<i32>();


### PR DESCRIPTION
We were seeing two intermittent failures on CI at night:

* Hourglass timeout
* Calibration validation timeout

The first one we can fix by dropping the step size to 10 PPB (see [1](https://github.com/bittide/bittide-hardware/actions/runs/13177560817/job/36781554055), [2](https://github.com/bittide/bittide-hardware/actions/runs/13177563417/job/36781485320), [3](https://github.com/bittide/bittide-hardware/actions/runs/13177564805/job/36781593233), [4](https://github.com/bittide/bittide-hardware/actions/runs/13177566287/job/36781499292), [5](https://github.com/bittide/bittide-hardware/actions/runs/13177568963/job/36781547577), [6](https://github.com/bittide/bittide-hardware/actions/runs/13177570147/job/36781486552)).

The second one is caused by the validation step not falling within "acceptable noise levels". I've relaxed that to 1.5 PPM now, instead of 0.6 PPM. Though it is still a somewhat arbitrary noise level, it is closer to the [measuring artifacts](https://github.com/bittide/bittide-hardware/issues/611) we can observe. I've also de-hardcoded the noise level (though with a doctest trick..).

# TODO
Wait for:
 - [x] https://github.com/bittide/bittide-hardware/actions/runs/13182602092 success
 - [x] https://github.com/bittide/bittide-hardware/actions/runs/13182608136 success
 - [x] https://github.com/bittide/bittide-hardware/actions/runs/13182609293 success
 - [x] https://github.com/bittide/bittide-hardware/actions/runs/13182610212 success
 - [x] https://github.com/bittide/bittide-hardware/actions/runs/13182611512 success