### PR TITLE
Allow setting of the Vivado logging directory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -570,6 +570,10 @@ jobs:
             target="bitstream"
           fi
 
+          export VIVADO_HS_LOG_DIR="$(git rev-parse --show-toplevel)/_build/hitl/vivado-gensynth/"
+          if [[ ! -d "${VIVADO_HS_LOG_DIR} " ]]; then
+            mkdir -p "${VIVADO_HS_LOG_DIR}"
+          fi
           .github/scripts/with_vivado.sh \
             shake ${{ matrix.target.top }}:"${target}"
 
@@ -645,6 +649,10 @@ jobs:
 
       - name: Run tests on hardware
         run: |
+          export VIVADO_HS_LOG_DIR="$(git rev-parse --show-toplevel)/_build/hitl/vivado-run/"
+          if [[ ! -d "${VIVADO_HS_LOG_DIR} " ]]; then
+            mkdir -p "${VIVADO_HS_LOG_DIR}"
+          fi
           .github/scripts/with_vivado.sh \
             shake ${{ matrix.target.top }}:test
 

--- a/vivado-hs/src/Vivado/Internal.hs
+++ b/vivado-hs/src/Vivado/Internal.hs
@@ -24,7 +24,7 @@ import Data.String.Interpolate (__i)
 import Data.Typeable (Typeable)
 import GHC.Stack (HasCallStack)
 import System.Directory.Extra (removeFile)
-import System.Environment (setEnv)
+import System.Environment (getEnv, setEnv)
 import System.IO (Handle)
 import System.Process
 
@@ -231,9 +231,16 @@ execPrint_ v cmd = do
 -}
 with :: (VivadoHandle -> IO a) -> IO a
 with f = do
-  systemTmpDir <- Temp.getCanonicalTemporaryDirectory
+  systemTmpDirEnv <- getEnv "VIVADO_HS_LOG_DIR"
+  systemTmpDir <-
+    if systemTmpDirEnv == ""
+      then Temp.getCanonicalTemporaryDirectory
+      else pure systemTmpDirEnv
+  putStrLn $ "Using tmpdir: " <> systemTmpDir
   (logPath, logHandle) <- Temp.openTempFile systemTmpDir "vivado-hs.log"
+  putStrLn $ "Using log path: " <> logPath
   (prettyLogPath, prettyLogHandle) <- Temp.openTempFile systemTmpDir "pretty-vivado-hs.log"
+  putStrLn $ "Using pretty log path: " <> prettyLogPath
 
   a <-
     finally


### PR DESCRIPTION
As the title says, but fallback to the old behaviour of using a temporary directory in the case that the environment variable is unset.