### PR TITLE
Add user words to transceiver wires

### DIFF
--- a/bittide-instances/src/Bittide/Instances/Hitl/LinkConfiguration.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/LinkConfiguration.hs
@@ -37,7 +37,6 @@ import Bittide.Hitl
 import Bittide.Instances.Hitl.Setup
 
 import Clash.Annotations.TH (makeTopEntity)
-import Clash.Cores.Xilinx.GTH
 import Clash.Cores.Xilinx.Xpm.Cdc.Handshake.Extra
 import Clash.Cores.Xilinx.Xpm.Cdc.Single
 import Clash.Xilinx.ClockGen
@@ -45,6 +44,7 @@ import Data.Maybe (fromMaybe, isJust)
 
 import qualified Bittide.Transceiver as Transceiver
 import qualified Bittide.Transceiver.ResetManager as ResetManager
+import qualified Clash.Cores.Xilinx.GTH as Gth
 
 {- | Checks whether the received index matches with the corresponding
 entry in 'Bittide.Instances.Hitl.Setup.fpgaSetup' and sychronizes
@@ -115,11 +115,11 @@ transceiversStartAndObserve ::
   "SYSCLK" ::: Clock Basic125 ->
   "RST_LOCAL" ::: Reset Basic125 ->
   "MY_INDEX" ::: Signal Basic125 (Index FpgaCount) ->
-  "GTH_RX_NS" ::: TransceiverWires GthRxS LinkCount ->
-  "GTH_RX_PS" ::: TransceiverWires GthRxS LinkCount ->
+  "GTH_RX_NS" ::: Gth.Wires GthRxS GthRx LinkCount ->
+  "GTH_RX_PS" ::: Gth.Wires GthRxS GthRx LinkCount ->
   "MISO" ::: Signal Basic125 Bit ->
-  ( "GTH_TX_NS" ::: TransceiverWires GthTxS LinkCount
-  , "GTH_TX_PS" ::: TransceiverWires GthTxS LinkCount
+  ( "GTH_TX_NS" ::: Gth.Wires GthTxS GthTx LinkCount
+  , "GTH_TX_PS" ::: Gth.Wires GthTxS GthTx LinkCount
   , "allReady" ::: Signal Basic125 Bool
   , "success" ::: Signal Basic125 Bool
   , "stats" ::: Vec LinkCount (Signal Basic125 ResetManager.Statistics)
@@ -209,11 +209,11 @@ linkConfigurationTest ::
   "SMA_MGT_REFCLK_C" ::: DiffClock Ext200 ->
   "SYSCLK_125" ::: DiffClock Ext125 ->
   "SYNC_IN" ::: Signal Basic125 Bool ->
-  "GTH_RX_NS" ::: TransceiverWires GthRxS LinkCount ->
-  "GTH_RX_PS" ::: TransceiverWires GthRxS LinkCount ->
+  "GTH_RX_NS" ::: Gth.Wires GthRxS GthRx LinkCount ->
+  "GTH_RX_PS" ::: Gth.Wires GthRxS GthRx LinkCount ->
   "MISO" ::: Signal Basic125 Bit ->
-  ( "GTH_TX_NS" ::: TransceiverWires GthTxS LinkCount
-  , "GTH_TX_PS" ::: TransceiverWires GthTxS LinkCount
+  ( "GTH_TX_NS" ::: Gth.Wires GthTxS GthTx LinkCount
+  , "GTH_TX_PS" ::: Gth.Wires GthTxS GthTx LinkCount
   , "SYNC_OUT" ::: Signal Basic125 Bool
   , "spiDone" ::: Signal Basic125 Bool
   , ""
@@ -225,7 +225,7 @@ linkConfigurationTest ::
 linkConfigurationTest refClkDiff sysClkDiff syncIn rxns rxps miso =
   (txns, txps, syncOut, spiDone, spiOut)
  where
-  refClk = ibufds_gte3 refClkDiff :: Clock Ext200
+  refClk = Gth.ibufds_gte3 refClkDiff :: Clock Ext200
   (sysClk, sysRst) = clockWizardDifferential sysClkDiff noReset
 
   -- the test starts with a valid configuration coming in

--- a/bittide-instances/src/Bittide/Instances/Hitl/Setup.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/Setup.hs
@@ -9,7 +9,6 @@ module Bittide.Instances.Hitl.Setup (
   FpgaCount,
   LinkCount,
   FpgaId,
-  TransceiverWires,
 
   -- * Topology
   allHwTargets,
@@ -35,12 +34,6 @@ import Data.Constraint.Nat (leTrans)
 type FpgaCount = 8 :: Nat
 
 type LinkCount = FpgaCount - 1
-
-{- | Data wires from/to transceivers. No logic should be inserted on these
-wires. Should be considered asynchronous to one another - even though their
-domain encodes them as related.
--}
-type TransceiverWires dom n = Signal dom (BitVector n)
 
 channelNames :: Vec LinkCount String
 channelNames =

--- a/bittide-instances/src/Bittide/Instances/Hitl/SwCcTopologies.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/SwCcTopologies.hs
@@ -72,7 +72,6 @@ import Bittide.Instances.Hitl.Setup
 
 import Clash.Annotations.TH (makeTopEntity)
 import Clash.Class.Counter
-import Clash.Cores.Xilinx.GTH
 import Clash.Cores.Xilinx.Ila (Depth (..), IlaConfig (..), ila, ilaConfig)
 import Clash.Cores.Xilinx.VIO
 import Clash.Cores.Xilinx.Xpm (xpmCdcArraySingle)
@@ -87,6 +86,7 @@ import qualified Bittide.ClockControl.StabilityChecker as SI
 import qualified Bittide.Instances.Hitl.Driver.SwCcTopologies as D
 import qualified Bittide.Transceiver as Transceiver
 import qualified Bittide.Transceiver.ResetManager as ResetManager
+import qualified Clash.Cores.Xilinx.GTH as Gth
 import qualified Data.Map.Strict as Map (fromList)
 
 {- $setup
@@ -228,15 +228,15 @@ topologyTest ::
   "SMA_MGT_REFCLK_C" ::: Clock Ext200 ->
   "SYSCLK" ::: Clock Basic125 ->
   "ILA_CTRL" ::: IlaControl Basic125 ->
-  "GTH_RX_NS" ::: TransceiverWires GthRxS LinkCount ->
-  "GTH_RX_PS" ::: TransceiverWires GthRxS LinkCount ->
+  "GTH_RX_NS" ::: Gth.Wires GthRxS GthRx LinkCount ->
+  "GTH_RX_PS" ::: Gth.Wires GthRxS GthRx LinkCount ->
   "MISO" ::: Signal Basic125 Bit ->
   "TEST_CFG" ::: Signal Basic125 TestConfig ->
   "PROG_EN" ::: Reset Basic125 ->
   "CALIBRATED_SHIFT" ::: Signal Basic125 FincFdecCount ->
   "JTAG" ::: Signal Basic125 JtagIn ->
-  ( "GTH_TX_NS" ::: TransceiverWires GthTxS LinkCount
-  , "GTH_TX_PS" ::: TransceiverWires GthTxS LinkCount
+  ( "GTH_TX_NS" ::: Gth.Wires GthTxS GthTx LinkCount
+  , "GTH_TX_PS" ::: Gth.Wires GthTxS GthTx LinkCount
   , "FINC_FDEC" ::: Signal Basic125 (FINC, FDEC)
   , "CALLISTO_RESULT" ::: Signal Basic125 (CallistoResult LinkCount)
   , "CALLISTO_RESET" ::: Reset Basic125
@@ -756,12 +756,12 @@ swCcTopologyTest ::
   "SMA_MGT_REFCLK_C" ::: DiffClock Ext200 ->
   "SYSCLK_125" ::: DiffClock Ext125 ->
   "SYNC_IN" ::: Signal Basic125 Bool ->
-  "GTH_RX_NS" ::: TransceiverWires GthRxS LinkCount ->
-  "GTH_RX_PS" ::: TransceiverWires GthRxS LinkCount ->
+  "GTH_RX_NS" ::: Gth.Wires GthRxS GthRx LinkCount ->
+  "GTH_RX_PS" ::: Gth.Wires GthRxS GthRx LinkCount ->
   "MISO" ::: Signal Basic125 Bit ->
   "JTAG" ::: Signal Basic125 JtagIn ->
-  ( "GTH_TX_NS" ::: TransceiverWires GthTxS LinkCount
-  , "GTH_TX_PS" ::: TransceiverWires GthTxS LinkCount
+  ( "GTH_TX_NS" ::: Gth.Wires GthTxS GthTx LinkCount
+  , "GTH_TX_PS" ::: Gth.Wires GthTxS GthTx LinkCount
   , ""
       ::: ( "FINC" ::: Signal Basic125 Bool
           , "FDEC" ::: Signal Basic125 Bool
@@ -778,7 +778,7 @@ swCcTopologyTest ::
 swCcTopologyTest refClkDiff sysClkDiff syncIn rxns rxps miso jtagIn =
   hwSeqX tleDebugIla (txns, txps, unbundle swFincFdecs, syncOut, spiDone, spiOut, jtagOut)
  where
-  refClk = ibufds_gte3 refClkDiff :: Clock Ext200
+  refClk = Gth.ibufds_gte3 refClkDiff :: Clock Ext200
   (sysClk, sysRst) = clockWizardDifferential sysClkDiff noReset
   ilaControl@IlaControl{..} = ilaPlotSetup IlaPlotSetup{..}
   startTest = isJust <$> testConfig
@@ -954,12 +954,12 @@ swCcOneTopologyTest ::
   "SMA_MGT_REFCLK_C" ::: DiffClock Ext200 ->
   "SYSCLK_125" ::: DiffClock Ext125 ->
   "SYNC_IN" ::: Signal Basic125 Bool ->
-  "GTH_RX_NS" ::: TransceiverWires GthRxS LinkCount ->
-  "GTH_RX_PS" ::: TransceiverWires GthRxS LinkCount ->
+  "GTH_RX_NS" ::: Gth.Wires GthRxS GthRx LinkCount ->
+  "GTH_RX_PS" ::: Gth.Wires GthRxS GthRx LinkCount ->
   "MISO" ::: Signal Basic125 Bit ->
   "JTAG" ::: Signal Basic125 JtagIn ->
-  ( "GTH_TX_NS" ::: TransceiverWires GthTxS LinkCount
-  , "GTH_TX_PS" ::: TransceiverWires GthTxS LinkCount
+  ( "GTH_TX_NS" ::: Gth.Wires GthTxS GthTx LinkCount
+  , "GTH_TX_PS" ::: Gth.Wires GthTxS GthTx LinkCount
   , ""
       ::: ( "FINC" ::: Signal Basic125 Bool
           , "FDEC" ::: Signal Basic125 Bool

--- a/bittide-instances/src/Bittide/Instances/Hitl/Transceivers.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/Transceivers.hs
@@ -35,12 +35,12 @@ import Bittide.Instances.Hitl.Setup
 import Bittide.Transceiver
 
 import Clash.Annotations.TH (makeTopEntity)
-import Clash.Cores.Xilinx.GTH
 import Clash.Cores.Xilinx.Xpm.Cdc.Single (xpmCdcSingle)
 import Clash.Xilinx.ClockGen
 import Data.Maybe (fromMaybe, isJust)
 
 import qualified Bittide.Transceiver.ResetManager as ResetManager
+import qualified Clash.Cores.Xilinx.GTH as Gth
 import qualified Clash.Explicit.Prelude as E
 import qualified Data.List as L
 import qualified Data.Map as Map
@@ -84,11 +84,11 @@ goTransceiversUpTest ::
   "SMA_MGT_REFCLK_C" ::: Clock Ext200 ->
   "SYSCLK" ::: Clock Basic125 ->
   "RST_LOCAL" ::: Reset Basic125 ->
-  "GTH_RX_NS" ::: TransceiverWires GthRxS LinkCount ->
-  "GTH_RX_PS" ::: TransceiverWires GthRxS LinkCount ->
+  "GTH_RX_NS" ::: Gth.Wires GthRxS GthRx LinkCount ->
+  "GTH_RX_PS" ::: Gth.Wires GthRxS GthRx LinkCount ->
   "MISO" ::: Signal Basic125 Bit ->
-  ( "GTH_TX_NS" ::: TransceiverWires GthTxS LinkCount
-  , "GTH_TX_PS" ::: TransceiverWires GthTxS LinkCount
+  ( "GTH_TX_NS" ::: Gth.Wires GthTxS GthTx LinkCount
+  , "GTH_TX_PS" ::: Gth.Wires GthTxS GthTx LinkCount
   , "allUp" ::: Signal Basic125 Bool
   , "anyErrors" ::: Signal Basic125 Bool
   , "stats" ::: Vec LinkCount (Signal Basic125 ResetManager.Statistics)
@@ -182,11 +182,11 @@ transceiversUpTest ::
   "SMA_MGT_REFCLK_C" ::: DiffClock Ext200 ->
   "SYSCLK_125" ::: DiffClock Ext125 ->
   "SYNC_IN" ::: Signal Basic125 Bool ->
-  "GTH_RX_NS" ::: TransceiverWires GthRxS LinkCount ->
-  "GTH_RX_PS" ::: TransceiverWires GthRxS LinkCount ->
+  "GTH_RX_NS" ::: Gth.Wires GthRxS GthRx LinkCount ->
+  "GTH_RX_PS" ::: Gth.Wires GthRxS GthRx LinkCount ->
   "MISO" ::: Signal Basic125 Bit ->
-  ( "GTH_TX_NS" ::: TransceiverWires GthTxS LinkCount
-  , "GTH_TX_PS" ::: TransceiverWires GthTxS LinkCount
+  ( "GTH_TX_NS" ::: Gth.Wires GthTxS GthTx LinkCount
+  , "GTH_TX_PS" ::: Gth.Wires GthTxS GthTx LinkCount
   , "SYNC_OUT" ::: Signal Basic125 Bool
   , "spiDone" ::: Signal Basic125 Bool
   , ""
@@ -198,7 +198,7 @@ transceiversUpTest ::
 transceiversUpTest refClkDiff sysClkDiff syncIn rxns rxps miso =
   (txns, txps, syncOut, spiDone, spiOut)
  where
-  refClk = ibufds_gte3 refClkDiff :: Clock Ext200
+  refClk = Gth.ibufds_gte3 refClkDiff :: Clock Ext200
 
   (sysClk, sysRst) = clockWizardDifferential sysClkDiff noReset
 

--- a/bittide/src/Bittide/Transceiver.hs
+++ b/bittide/src/Bittide/Transceiver.hs
@@ -102,6 +102,7 @@ import Clash.Prelude (withClock)
 import Control.Monad (when)
 import Data.Maybe (fromMaybe, isNothing)
 import Data.Proxy (Proxy (Proxy))
+import GHC.Stack (HasCallStack)
 
 import qualified Bittide.Transceiver.Cdc as Cdc
 import qualified Bittide.Transceiver.Comma as Comma
@@ -178,10 +179,12 @@ data Outputs n tx rx txS free = Outputs
   -- ^ See 'Output.txReady'
   , txSamplings :: Vec n (Signal tx Bool)
   -- ^ See 'Output.txSampling'
-  , txPs :: Gth.Wires txS tx n
+  , txPs :: Gth.Wires txS n
   -- ^ See 'Output.txP'
-  , txNs :: Gth.Wires txS tx n
+  , txNs :: Gth.Wires txS n
   -- ^ See 'Output.txN'
+  , txSims :: Gth.SimWires tx n
+  -- ^ See 'Output.txSim'
   , rxClocks :: Vec n (Clock rx)
   -- ^ See 'Output.rxClock'
   , rxResets :: Vec n (Reset rx)
@@ -207,10 +210,12 @@ data Output tx rx tx1 rx1 txS free = Output
   -- 'Input.txStart' to be asserted before starting to send 'txData'.
   , txSampling :: Signal tx Bool
   -- ^ Data is sampled from 'Input.txData'
-  , txP :: Gth.Wire txS tx
+  , txP :: Gth.Wire txS
   -- ^ Transmit data (and implicitly a clock), positive
-  , txN :: Gth.Wire txS tx
+  , txN :: Gth.Wire txS
   -- ^ Transmit data (and implicitly a clock), negative
+  , txSim :: Gth.SimWire tx
+  -- ^ Simulation only construct. Data for the transmit side. Used for testing.
   , rxOutClock :: Clock rx1
   -- ^ Must be routed through xilinxGthUserClockNetworkRx or equivalent to get usable clocks
   , rxReset :: Reset rx
@@ -246,8 +251,10 @@ data Input tx rx tx1 rx1 ref free rxS = Input
   -- ^ Channel name, example \"X0Y18\"
   , clockPath :: String
   -- ^ Clock path, example \"clk0-2\"
-  , rxN :: Gth.Wire rxS rx
-  , rxP :: Gth.Wire rxS rx
+  , rxSim :: Gth.SimWire rx
+  -- ^ Simulation only construct. Data for the receive side. Used for testing.
+  , rxN :: Gth.Wire rxS
+  , rxP :: Gth.Wire rxS
   , txData :: Signal tx (BitVector 64)
   -- ^ Data to transmit to the neighbor. Is first sampled one cycle after both
   -- 'Input.txStart' and 'Output.txReady' are asserted. Is continuously sampled
@@ -274,10 +281,12 @@ data Inputs tx rx ref free rxS n = Inputs
   -- ^ See 'Input.channelName'
   , clockPaths :: Vec n String
   -- ^ See 'Input.clockPath'
-  , rxNs :: Gth.Wires rxS rx n
+  , rxNs :: Gth.Wires rxS n
   -- ^ See 'Input.rxN'
-  , rxPs :: Gth.Wires rxS rx n
+  , rxPs :: Gth.Wires rxS n
   -- ^ See 'Input.rxP'
+  , rxSims :: Gth.SimWires rx n
+  -- ^ See 'Input.rxSim'
   , txDatas :: Vec n (Signal tx (BitVector 64))
   -- ^ See 'Input.txData'
   , txStarts :: Vec n (Signal tx Bool)
@@ -299,6 +308,16 @@ I choose to sidestep the extra complication and pretend tx1/rx1 and tx/rx are th
 This disables the typechecking safety we'd normally get from clash,
 but vivado should call us out when we make a mistake.
 -}
+
+{- | Clash has a very hard time translating maps with 'SimOnly' constructs,
+making compilation take ~10 times longer. The reasons are not clear to me,
+but replacing entire structures with 'deepErrorX' seems to work around the
+issue.
+-}
+simOnlyHdlWorkaround :: (HasCallStack, NFDataX a) => a -> a
+simOnlyHdlWorkaround a
+  | clashSimulation = a
+  | otherwise = deepErrorX "simOnlyHdlWorkaround: not in simulation"
 
 transceiverPrbsN ::
   forall tx rx ref free txS rxS n m.
@@ -325,13 +344,14 @@ transceiverPrbsN opts inputs@Inputs{clock, reset, refClock} =
     , txReset = fold orReset $ map (.txReset) outputs
     , txReadys = map (.txReady) outputs
     , txSamplings = map (.txSampling) outputs
+    , txSims = simOnlyHdlWorkaround (SimOnly (map (Gth.unSimOnly . (.txSim)) outputs))
     , -- rx
       rxClocks = rxClocks
     , rxResets = map (.rxReset) outputs
     , rxDatas = map (.rxData) outputs
     , -- transceiver
-      txPs = Gth.packWires (map (.txP) outputs)
-    , txNs = Gth.packWires (map (.txN) outputs)
+      txPs = pack <$> bundle (map (.txP) outputs)
+    , txNs = pack <$> bundle (map (.txN) outputs)
     , -- free
       linkUps = map (.linkUp) outputs
     , linkReadys = map (.linkReady) outputs
@@ -353,8 +373,9 @@ transceiverPrbsN opts inputs@Inputs{clock, reset, refClock} =
       -- only use this for debugging.
       <*> inputs.channelNames
       <*> inputs.clockPaths
-      <*> Gth.unpackWires inputs.rxNs
-      <*> Gth.unpackWires inputs.rxPs
+      <*> simOnlyHdlWorkaround (map SimOnly (Gth.unSimOnly inputs.rxSims))
+      <*> unbundle (unpack <$> inputs.rxNs)
+      <*> unbundle (unpack <$> inputs.rxPs)
       <*> inputs.txDatas
       <*> inputs.txStarts
       <*> inputs.rxReadys
@@ -377,12 +398,13 @@ transceiverPrbsN opts inputs@Inputs{clock, reset, refClock} =
   rxClockNws = map (flip (Gth.xilinxGthUserClockNetworkRx @rx @rx) rxUsrClkRst) rxOutClks
   (_rxClk1s, rxClocks, _rxClkActives) = unzip3 rxClockNws
 
-  go (clockTx1, clockTx2, txActive) transceiverIndex channelName clockPath rxN rxP txData txStart rxReady (clockRx1, clockRx2, rxActive) =
+  go (clockTx1, clockTx2, txActive) transceiverIndex channelName clockPath rxSim rxN rxP txData txStart rxReady (clockRx1, clockRx2, rxActive) =
     transceiverPrbs
       opts
       Input
         { channelName
         , clockPath
+        , rxSim
         , rxN
         , rxP
         , txData
@@ -524,6 +546,7 @@ transceiverPrbsWith gthCore opts args@Input{clock, reset} =
       { txSampling = txUserData
       , rxData = mux rxUserData (Just <$> alignedRxData0) (pure Nothing)
       , txReady = withLockRxTx rxReadyNeighborSticky
+      , txSim
       , txN = txN
       , txP = txP
       , txOutClock
@@ -541,7 +564,8 @@ transceiverPrbsWith gthCore opts args@Input{clock, reset} =
 
   linkReady = linkUp .||. withLockRxFree rxReadyNeighborSticky
 
-  ( txN
+  ( txSim
+    , txN
     , txP
     , txOutClock
     , rxOutClock
@@ -558,6 +582,7 @@ transceiverPrbsWith gthCore opts args@Input{clock, reset} =
       gthCore
         args.channelName
         args.clockPath
+        args.rxSim
         args.rxN
         args.rxP
         clock -- gtwiz_reset_clk_freerun_in

--- a/bittide/src/Clash/Cores/Xilinx/GTH/BlackBoxes.hs
+++ b/bittide/src/Clash/Cores/Xilinx/GTH/BlackBoxes.hs
@@ -59,6 +59,9 @@ nConstraints = 8
 nNameArgs :: Int
 nNameArgs = 2
 
+simOnlyArgs :: Int
+simOnlyArgs = 1
+
 {-
 NOTE [ignoring HWType domains]
 
@@ -112,7 +115,7 @@ gthCoreBBTF bbCtx
           , _rxusrclk2_in
           , _gtwiz_userclk_rx_active_in
           ] <-
-      drop (nConstraints + nNameArgs) (DSL.tInputs bbCtx)
+      drop (nConstraints + nNameArgs + simOnlyArgs) (DSL.tInputs bbCtx)
   , [tResult] <- map DSL.ety (DSL.tResults bbCtx)
   , [gthCoreName] <- N.bbQsysIncName bbCtx =
       do

--- a/bittide/src/Clash/Cores/Xilinx/GTH/Internal.hs
+++ b/bittide/src/Clash/Cores/Xilinx/GTH/Internal.hs
@@ -2,7 +2,11 @@
 --
 -- SPDX-License-Identifier: Apache-2.0
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE NoFieldSelectors #-}
 
 module Clash.Cores.Xilinx.GTH.Internal where
 
@@ -28,7 +32,63 @@ import Clash.Cores.Xilinx.Xpm.Cdc.Internal (
 type TX_DATA_WIDTH = 64
 type RX_DATA_WIDTH = 64
 
-type GthCore txUser txUser2 rxUser rxUser2 refclk0 freerun txS rxS serializedData =
+{- | Data wires from/to transceivers. No logic should be inserted on these
+wires. Should be considered asynchronous to one another - even though their
+domain encodes them as related.
+-}
+data Wires (line :: Domain) (logic :: Domain) n = Wires
+  { dats :: "" ::: Signal line (BitVector n)
+  -- ^ Wires routed to the transceivers
+  , datsSimulation :: "" ::: SimOnly (Signal logic (Vec n (BitVector 64)))
+  -- ^ Simulation only construct holding sent data in the domain of the user
+  -- transmit domain.
+  }
+
+-- | Data wire from/to transceivers
+data Wire (line :: Domain) (logic :: Domain) = Wire
+  { dat :: "" ::: Signal line (BitVector 1)
+  -- ^ Wires routed to the transceivers
+  , datSimulation :: "" ::: SimOnly (Signal logic (BitVector 64))
+  -- ^ Simulation only construct holding sent data in the domain of the user
+  -- transmit domain.
+  }
+
+-- | Map over the 'datSimulation' field of a 'Wire'
+mapDatSimulation ::
+  (Signal logic (BitVector 64) -> Signal logic (BitVector 64)) ->
+  Wire line logic ->
+  Wire line logic
+mapDatSimulation f (Wire{dat, datSimulation}) =
+  Wire{dat = dat, datSimulation = f <$> datSimulation}
+
+-- | Pack multiple 'Wire's into a 'Wires'
+packWires ::
+  forall line logic n.
+  (KnownNat n) =>
+  Vec n (Wire line logic) ->
+  Wires line logic n
+packWires ins = Wires{dats, datsSimulation}
+ where
+  dats = fmap pack $ bundle $ map (.dat) ins
+  datsSimulation = bundle <$> mapM (.datSimulation) ins
+
+-- | Unpack a 'Wires' into multiple 'Wire's
+unpackWires ::
+  forall line logic n.
+  (KnownNat n) =>
+  Wires line logic n ->
+  Vec n (Wire line logic)
+unpackWires Wires{dats, datsSimulation} =
+  zipWith
+    Wire
+    (unbundle (fmap unpack dats))
+    (map SimOnly (unbundle (unSimOnly datsSimulation)))
+
+-- | Strip "SimOnly" constructor
+unSimOnly :: SimOnly a -> a
+unSimOnly (SimOnly x) = x
+
+type GthCore txUser txUser2 rxUser rxUser2 refclk0 freerun txS rxS =
   ( KnownDomain txUser
   , KnownDomain txUser2
   , KnownDomain rxUser
@@ -42,8 +102,8 @@ type GthCore txUser txUser2 rxUser rxUser2 refclk0 freerun txS rxS serializedDat
   String ->
   -- | refClkSpec
   String ->
-  "gthrxn_in" ::: Signal rxS serializedData ->
-  "gthrxp_in" ::: Signal rxS serializedData ->
+  "gthrxn_in" ::: Wire rxS rxUser2 ->
+  "gthrxp_in" ::: Wire rxS rxUser2 ->
   "gtwiz_reset_clk_freerun_in" ::: Clock freerun ->
   "gtwiz_reset_all_in" ::: Reset freerun ->
   "gtwiz_reset_rx_datapath_in" ::: Reset freerun ->
@@ -56,8 +116,8 @@ type GthCore txUser txUser2 rxUser rxUser2 refclk0 freerun txS rxS serializedDat
   "rxusrclk_in" ::: Clock rxUser ->
   "rxusrclk2_in" ::: Clock rxUser2 ->
   "gtwiz_userclk_rx_active_in" ::: Signal rxUser2 (BitVector 1) ->
-  ( "gthtxn_out" ::: Signal txS serializedData
-  , "gthtxp_out" ::: Signal txS serializedData
+  ( "gthtxn_out" ::: Wire txS txUser2
+  , "gthtxp_out" ::: Wire txS txUser2
   , "txoutclk_out" ::: Clock txUser
   , "rxoutclk_out" ::: Clock rxUser
   , "gtwiz_userdata_rx_out" ::: Signal rxUser2 (BitVector RX_DATA_WIDTH)
@@ -71,16 +131,16 @@ type GthCore txUser txUser2 rxUser rxUser2 refclk0 freerun txS rxS serializedDat
   , "rxctrl3_out" ::: Signal rxUser2 (BitVector 8)
   )
 
-gthCore :: GthCore txUser txUser2 rxUser rxUser2 refclk0 freerun txS rxS (BitVector 1)
+gthCore :: GthCore txUser txUser2 rxUser rxUser2 refclk0 freerun txS rxS
 gthCore
   !_channel
   !_refClkSpec
-  !_gthrxn_in
+  gthrxn_in
   !_gthrxp_in
   !_gtwiz_reset_clk_freerun_in
   !_gtwiz_reset_all_in
   !_gtwiz_reset_rx_datapath_in
-  !_gtwiz_userdata_tx_in
+  !gtwiz_userdata_tx_in
   !_txctrl2_in
   !_gtrefclk0_in
   !_
@@ -89,19 +149,19 @@ gthCore
   !_
   !_
   !_ =
-    ( undefined
-    , undefined
-    , undefined
-    , undefined
-    , undefined
-    , undefined
-    , undefined
-    , undefined
-    , undefined
-    , undefined
-    , undefined
-    , undefined
-    , undefined
+    ( Wire (pure 0) (SimOnly gtwiz_userdata_tx_in)
+    , Wire (pure 0) (SimOnly gtwiz_userdata_tx_in)
+    , clockGen
+    , clockGen
+    , unSimOnly gthrxn_in.datSimulation
+    , pure 1
+    , pure 1
+    , pure 1
+    , pure 1
+    , pure 0
+    , pure 0
+    , pure 0
+    , pure 0
     )
 {-# OPAQUE gthCore #-}
 {-# ANN gthCore hasBlackBox #-}

--- a/bittide/tests/Tests/Transceiver.hs
+++ b/bittide/tests/Tests/Transceiver.hs
@@ -97,8 +97,9 @@ gthCoreMock
   offset
   _channelName
   _clockPath
-  rxSerial
-  _rxSerial
+  rx
+  _rxSerialN
+  _rxSerialP
   freeClk
   rstAll
   rstRx
@@ -111,8 +112,9 @@ gthCoreMock
   _rx1Clk
   rx2Clk
   _rxActive =
-    ( Gth.Wire (pure 0) (SimOnly txWord)
-    , Gth.Wire (pure 0) (SimOnly txWord)
+    ( SimOnly txWord
+    , pure 0
+    , pure 0
     , txOutClk
     , rxOutClk
     , rxWord
@@ -129,8 +131,7 @@ gthCoreMock
     rxWord =
       withClock rxClk
         $ WordAlign.aligner WordAlign.dealignLsbFirst (pure False) (pure offset)
-        $ Gth.unSimOnly
-        $ rxSerial.datSimulation
+        $ Gth.unSimOnly rx
 
     registerRx = register rxClk rxRstRx enableGen
     registerTx = register txClk txRstAll enableGen
@@ -222,7 +223,8 @@ dut
           , transceiverIndex = 0
           , channelName = "A"
           , clockPath = "clkA"
-          , rxN = Gth.mapDatSimulation (delaySeqN baDelay 0) outputB.txN
+          , rxSim = delaySeqN baDelay 0 <$> outputB.txSim
+          , rxN = error "A: rxN not used in simulation"
           , rxP = error "A: rxP not used in simulation"
           , txData = inputA.dat
           , txStart = inputA.txStart
@@ -246,7 +248,8 @@ dut
           , transceiverIndex = 1
           , channelName = "B"
           , clockPath = "clkB"
-          , rxN = Gth.mapDatSimulation (delaySeqN abDelay 0) outputA.txN
+          , rxSim = delaySeqN abDelay 0 <$> outputA.txSim
+          , rxN = error "B: rxN not used in simulation"
           , rxP = error "B: rxP not used in simulation"
           , txData = inputB.dat
           , txStart = inputB.txStart

--- a/bittide/tests/Tests/Transceiver.hs
+++ b/bittide/tests/Tests/Transceiver.hs
@@ -15,12 +15,10 @@ import Clash.Prelude (withClock)
 import Hedgehog
 
 import Bittide.Arithmetic.Time (PeriodToCycles)
-import Bittide.SharedTypes (Bytes)
 import Clash.Annotations.Primitive (dontTranslate)
 import Clash.Cores.Xilinx.GTH (GthCore)
 import Clash.Hedgehog.Sized.Index (genIndex)
 import Clash.Signal.Internal (Signal ((:-)))
-import Data.Maybe (fromMaybe)
 import Data.Proxy (Proxy (Proxy))
 import Data.Sequence (Seq ((:<|), (:|>)))
 import Test.Tasty (TestTree, adjustOption, testGroup)
@@ -29,6 +27,7 @@ import Test.Tasty.Hedgehog (HedgehogTestLimit (HedgehogTestLimit), testPropertyN
 import qualified Bittide.Transceiver as Transceiver
 import qualified Bittide.Transceiver.ResetManager as ResetManager
 import qualified Bittide.Transceiver.WordAlign as WordAlign
+import qualified Clash.Cores.Xilinx.GTH as Gth
 import qualified Data.List as List
 import qualified Data.Sequence as Seq
 import qualified Hedgehog.Gen as Gen
@@ -89,7 +88,7 @@ gthCoreMock ::
   Natural ->
   -- Offset
   Index 8 ->
-  GthCore tx tx rx rx ref free tx rx (Maybe (BitVector 64))
+  GthCore tx tx rx rx ref free tx rx
 gthCoreMock
   _name
   nRxResetCycles
@@ -112,8 +111,8 @@ gthCoreMock
   _rx1Clk
   rx2Clk
   _rxActive =
-    ( txSerial
-    , txSerial
+    ( Gth.Wire (pure 0) (SimOnly txWord)
+    , Gth.Wire (pure 0) (SimOnly txWord)
     , txOutClk
     , rxOutClk
     , rxWord
@@ -130,11 +129,8 @@ gthCoreMock
     rxWord =
       withClock rxClk
         $ WordAlign.aligner WordAlign.dealignLsbFirst (pure False) (pure offset)
-        $ fromMaybe
-        <$> noise rxClk
-        <*> rxSerial
-
-    txSerial = Just <$> txWord
+        $ Gth.unSimOnly
+        $ rxSerial.datSimulation
 
     registerRx = register rxClk rxRstRx enableGen
     registerTx = register txClk txRstAll enableGen
@@ -169,7 +165,7 @@ data Input tx rx = Input
   }
 
 dut ::
-  forall freeA freeB txA txB ref n.
+  forall freeA freeB txA txB ref.
   ( KnownDomain ref
   , HasSynchronousReset txA
   , HasDefinedInitialValues txA
@@ -185,16 +181,16 @@ dut ::
   -- | Number of word clock cycles delay from B -> A
   Natural ->
   ResetManager.Config ->
-  GthCore txA txA txB txB ref freeA txA txB (Maybe (Bytes n)) ->
-  GthCore txB txB txA txA ref freeB txB txA (Maybe (Bytes n)) ->
+  GthCore txA txA txB txB ref freeA txA txB ->
+  GthCore txB txB txA txA ref freeB txB txA ->
   Clock freeA ->
   Reset freeA ->
   Clock freeB ->
   Reset freeB ->
   Input txA txB ->
   Input txB txA ->
-  ( Transceiver.Output txA txB txA txB txA freeA (Maybe (Bytes n))
-  , Transceiver.Output txB txA txB txA txB freeB (Maybe (Bytes n))
+  ( Transceiver.Output txA txB txA txB txA freeA
+  , Transceiver.Output txB txA txB txA txB freeB
   )
 dut
   abDelay
@@ -226,7 +222,7 @@ dut
           , transceiverIndex = 0
           , channelName = "A"
           , clockPath = "clkA"
-          , rxN = delaySeqN baDelay Nothing outputB.txN
+          , rxN = Gth.mapDatSimulation (delaySeqN baDelay 0) outputB.txN
           , rxP = error "A: rxP not used in simulation"
           , txData = inputA.dat
           , txStart = inputA.txStart
@@ -250,7 +246,7 @@ dut
           , transceiverIndex = 1
           , channelName = "B"
           , clockPath = "clkB"
-          , rxN = delaySeqN abDelay Nothing outputA.txN
+          , rxN = Gth.mapDatSimulation (delaySeqN abDelay 0) outputA.txN
           , rxP = error "B: rxP not used in simulation"
           , txData = inputB.dat
           , txStart = inputB.txStart
@@ -258,12 +254,12 @@ dut
           }
 
 type DutTestFunc txA txB free =
-  Transceiver.Output txA txB txA txB txA free (Maybe (BitVector 64)) ->
-  Transceiver.Output txB txA txB txA txB free (Maybe (BitVector 64)) ->
+  Transceiver.Output txA txB txA txB txA free ->
+  Transceiver.Output txB txA txB txA txB free ->
   PropertyT IO ()
 
 type InputFunc txA txB free =
-  Transceiver.Output txA txB txA txB txA free (Maybe (BitVector 64)) ->
+  Transceiver.Output txA txB txA txB txA free ->
   Input txA txB
 
 dutRandomized ::
@@ -323,7 +319,6 @@ dutRandomized f inputA inputB Proxy = property $ do
         @txA
         @txB
         @RefIsUnused
-        @8
         abDelay
         baDelay
         resetManagerConfig


### PR DESCRIPTION
Allows for accessing data at top entity boundaries. Prepares for a multi-node simulation including transceiver data (not just clock signals).