### PR TITLE
Add synthesis caching to CI

### DIFF
--- a/.github/scripts/cache.py
+++ b/.github/scripts/cache.py
@@ -73,7 +73,7 @@ BUILD_CACHE_PATTERNS = (
 )
 
 BUILD_POST_SYNTH_CACHE_BUST = 1
-BUILD_POST_SYNTH_KEY_PREFIX = f"build-products-post-synth-g{GLOBAL_CACHE_BUST}-l{BUILD_CACHE_BUST}-"
+BUILD_POST_SYNTH_KEY_PREFIX = f"build-products-post-synth-g{GLOBAL_CACHE_BUST}-l{BUILD_POST_SYNTH_CACHE_BUST}-"
 BUILD_POST_SYNTH_CACHE_PATTERNS = (
     f"{PWD}/_build/clash",
     f"{PWD}/_build/vivado",
@@ -121,12 +121,10 @@ def get_key_from_patterns(patterns):
 
 def get_cargo_key():
     return CARGO_KEY_PREFIX + get_key_from_patterns(CARGO_KEY_PATTERNS)
-    # return CARGO_KEY_PREFIX + os.environ["GITHUB_SHA"]
 
 
 def get_cabal_key():
     return CABAL_KEY_PREFIX + get_key_from_patterns(CABAL_KEY_PATTERNS)
-    # return CABAL_KEY_PREFIX + os.environ["GITHUB_SHA"]
 
 
 def get_build_key():

--- a/.github/scripts/cache.py
+++ b/.github/scripts/cache.py
@@ -72,7 +72,7 @@ BUILD_CACHE_PATTERNS = (
     f"{PWD}/dist-newstyle/",
 )
 
-SYNTH_CACHE_BUST = 1
+SYNTH_CACHE_BUST = 2
 SYNTH_KEY_PREFIX = f"synth-g{GLOBAL_CACHE_BUST}-l{SYNTH_CACHE_BUST}-"
 SYNTH_KEY_PATTERNS = (
     f"**/bittide-instances/data/constraints/**/*.xdc",
@@ -85,17 +85,13 @@ SYNTH_KEY_PATTERNS_UNTRACKED = (
 )
 SYNTH_CACHE_PATTERNS = (
     f"{PWD}/_build/vivado",
-    f"{PWD}/_build/.shake.database",
-    f"{PWD}/_build/.shake.lock",
 )
 
-BUILD_POST_SYNTH_CACHE_BUST = 1
+BUILD_POST_SYNTH_CACHE_BUST = 2
 BUILD_POST_SYNTH_KEY_PREFIX = f"build-products-post-synth-g{GLOBAL_CACHE_BUST}-l{BUILD_POST_SYNTH_CACHE_BUST}-"
 BUILD_POST_SYNTH_CACHE_PATTERNS = (
     f"{PWD}/_build/clash",
     f"{PWD}/_build/vivado",
-    f"{PWD}/_build/.shake.database",
-    f"{PWD}/_build/.shake.lock",
 )
 
 def log(msg):

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -557,10 +557,6 @@ jobs:
         run: |
           shake ${{ matrix.target.top }}:hdl
 
-          # Workaround for https://github.com/bittide/bittide-hardware/issues/523
-          mkdir -p _build/vivado
-          touch _build/vivado/workaround-issue-523
-
       - name: Synthesis
         if: ${{ matrix.target.stage != 'hdl' }}
         run: |
@@ -593,6 +589,13 @@ jobs:
           else
             echo "Restored cache, no need to synthesize again"
           fi
+
+      - name: Create non-empty vivado directory
+        if: ${{ matrix.target.stage == 'hdl' }}
+        run: |
+          # Workaround for https://github.com/bittide/bittide-hardware/issues/523
+          mkdir -p _build/vivado
+          touch _build/vivado/workaround-issue-523
 
       - name: cache push build-post-synth
         run: cache push build-post-synth --prefix="${{ matrix.target.top }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -560,7 +560,7 @@ jobs:
       - name: Synthesis
         if: ${{ matrix.target.stage != 'hdl' }}
         run: |
-          cache pull synth --prefix="${{ matrix.target.top }}" --overwrite-ok --missing-ok --write-cache-found
+          cache pull synth --prefix="${{ matrix.target.top }}" --missing-ok --write-cache-found
           if [[ $(cat cache_found) == 0 ]]; then
             target="${{ matrix.target.stage }}"
 
@@ -610,8 +610,6 @@ jobs:
           path: |
             _build/clash
             _build/vivado
-            _build/.shake.database
-            _build/.shake.lock
             !_build/vivado/*/ip
           retention-days: 14
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -553,33 +553,46 @@ jobs:
       - run: cache pull cargo
       - run: cache pull build
 
-      - name: HDL generation and synthesis
-        run : |
-          target="${{ matrix.target.stage }}"
-
-          if [[ "${target}" == "program" ]]; then
-            echo "Illegal Shake target on CI: program"
-            exit 1
-          fi
-
-          # Only the local runner connected to the bittide demonstrator (hoeve)
-          # should perform the jobs which need hardware access. And that runner
-          # should do only that, so we let other 'compute' runners do the
-          # bitstream generation.
-          if [[ "${target}" == "test" ]]; then
-            target="bitstream"
-          fi
-
-          export VIVADO_HS_LOG_DIR="$(git rev-parse --show-toplevel)/_build/hitl/vivado-gensynth/"
-          if [[ ! -d "${VIVADO_HS_LOG_DIR} " ]]; then
-            mkdir -p "${VIVADO_HS_LOG_DIR}"
-          fi
-          .github/scripts/with_vivado.sh \
-            shake ${{ matrix.target.top }}:"${target}"
+      - name: HDL generation
+        run: |
+          shake ${{ matrix.target.top }}:hdl
 
           # Workaround for https://github.com/bittide/bittide-hardware/issues/523
           mkdir -p _build/vivado
           touch _build/vivado/workaround-issue-523
+
+      - name: Synthesis
+        if: ${{ matrix.target.stage != 'hdl' }}
+        run: |
+          cache pull synth --prefix="${{ matrix.target.top }}" --overwrite-ok --missing-ok --write-cache-found
+          if [[ $(cat cache_found) == 0 ]]; then
+            target="${{ matrix.target.stage }}"
+
+            if [[ "${target}" == "program" ]]; then
+              echo "Illegal Shake target on CI: program"
+              exit 1
+            fi
+
+            # Only the local runner connected to the bittide demonstrator (hoeve)
+            # should perform the jobs which need hardware access. And that runner
+            # should do only that, so we let other 'compute' runners do the
+            # bitstream generation.
+            if [[ "${target}" == "test" ]]; then
+              target="bitstream"
+            fi
+
+            export VIVADO_HS_LOG_DIR="$(git rev-parse --show-toplevel)/_build/hitl/vivado-gensynth/"
+            if [[ ! -d "${VIVADO_HS_LOG_DIR} " ]]; then
+              mkdir -p "${VIVADO_HS_LOG_DIR}"
+            fi
+            .github/scripts/with_vivado.sh \
+              shake ${{ matrix.target.top }}:"${target}"
+
+            # Pushing synthesis results to cache
+            cache push synth --prefix="${{ matrix.target.top }}"
+          else
+            echo "Restored cache, no need to synthesize again"
+          fi
 
       - name: cache push build-post-synth
         run: cache push build-post-synth --prefix="${{ matrix.target.top }}"

--- a/vivado-hs/src/Vivado/Internal.hs
+++ b/vivado-hs/src/Vivado/Internal.hs
@@ -24,7 +24,7 @@ import Data.String.Interpolate (__i)
 import Data.Typeable (Typeable)
 import GHC.Stack (HasCallStack)
 import System.Directory.Extra (removeFile)
-import System.Environment (getEnv, setEnv)
+import System.Environment (lookupEnv, setEnv)
 import System.IO (Handle)
 import System.Process
 
@@ -231,11 +231,8 @@ execPrint_ v cmd = do
 -}
 with :: (VivadoHandle -> IO a) -> IO a
 with f = do
-  systemTmpDirEnv <- getEnv "VIVADO_HS_LOG_DIR"
-  systemTmpDir <-
-    if systemTmpDirEnv == ""
-      then Temp.getCanonicalTemporaryDirectory
-      else pure systemTmpDirEnv
+  systemTmpDirEnv <- lookupEnv "VIVADO_HS_LOG_DIR"
+  systemTmpDir <- maybe Temp.getCanonicalTemporaryDirectory pure systemTmpDirEnv
   putStrLn $ "Using tmpdir: " <> systemTmpDir
   (logPath, logHandle) <- Temp.openTempFile systemTmpDir "vivado-hs.log"
   putStrLn $ "Using log path: " <> logPath


### PR DESCRIPTION
After this PR, synthesis is only done if any of the following files change:
- `bittide-instances/data/constraints/**/*.xdc`
- `bittide-shake/**/*`
- `_build/clash/*/*.[sdc,tcl,v]` (excludes `clash-manifest.json`, which includes a pessimistic hash)

Note that the synthsis cache key depends on the Clash output, so we do always have to generate HDL.

## Results
Instance              | HDL gen | Synthesis | Total 1 | Total 2
----------------------|---------|-----------|---------|--------
linkConfigurationTest |  7m 18s |   10m 29s | 18m 59s |  8m 59s
safeDffSynchronizer   |     19s |         - |  1m 28s |  1m  7s
swCcOneTopologyTest   | 4m 40s |   15m 58s | 22m 37s |  6m 33s
transceiversUpTest    | 7m 11s |   10m 26s | 18m 52s |  8m 56s
vexRiscvTcpTest       |     33s |    6m 50s |  8m 17s |  1m 24s
vexRiscvTest          |     22s |    4m 54s |  6m 38s |  1m 55s

Since we only start HITL tests once all synthesis jobs are done, we shave off 10 minutes from the total test duration (on push).

[Test 1](https://github.com/bittide/bittide-hardware/actions/runs/13919132112)
[Test 2](https://github.com/bittide/bittide-hardware/actions/runs/13919698528)


### More tests
I've done more tests with these 2 targets:
boardTestExtended:bitstream
boardTestSimple:synth

**Base run (with boardTestSimple:hdl instead of synth)**
boardTestExtended: synthesized
boardTestSimple:   (set to hdl)
https://github.com/bittide/bittide-hardware/actions/runs/13904110830

**Change boardTestSimple:hdl to boardTestSimple:synth**
boardTestExtended: from cache
boardTestSimple:   synthesized
https://github.com/bittide/bittide-hardware/actions/runs/13904341026

**Change file in bittide-instances irrelevant to both targets**
boardTestExtended: from cache
boardTestSimple:   synthesized
https://github.com/bittide/bittide-hardware/actions/runs/13904494524

**Change boardTestExtended**
boardTestExtended: synthesized
boardTestSimple:   from cache
https://github.com/bittide/bittide-hardware/actions/runs/13904494524

**Undo change to boardTestExtended**
boardTestExtended: from cache
boardTestSimple:   from cache
https://github.com/bittide/bittide-hardware/actions/runs/13918985855
