### PR TITLE
Add less specialised version of OpenOCD function.

### DIFF
--- a/bittide-instances/data/openocd/start.sh
+++ b/bittide-instances/data/openocd/start.sh
@@ -6,17 +6,17 @@ set -e
 
 # Default stdout to /dev/null
 OPENOCD_STDOUT_LOG="${OPENOCD_STDOUT_LOG:-/dev/null}"
-stdout_dir=$(dirname "${OPENOCD_STDOUT_LOG}")
+stdout_dir="$(dirname "${OPENOCD_STDOUT_LOG}")"
 mkdir -p "${stdout_dir}"
-OPENOCD_STDOUT_LOG="$(realpath ${OPENOCD_STDOUT_LOG})"
+OPENOCD_STDOUT_LOG="$(realpath "${OPENOCD_STDOUT_LOG}")"
 
 # Default stderr to /dev/null
 OPENOCD_STDERR_LOG="${OPENOCD_STDERR_LOG:-/dev/null}"
-stderr_dir=$(dirname "${OPENOCD_STDERR_LOG}")
+stderr_dir="$(dirname "${OPENOCD_STDERR_LOG}")"
 mkdir -p "${stderr_dir}"
-OPENOCD_STDERR_LOG="$(realpath ${OPENOCD_STDERR_LOG})"
+OPENOCD_STDERR_LOG="$(realpath "${OPENOCD_STDERR_LOG}")"
 
-cd $(dirname $0)
-exec openocd-vexriscv -f ports.tcl -f sipeed.tcl -f vexriscv_init.tcl $@ \
+cd "$(dirname "$0")"
+exec openocd-vexriscv $@ \
   > >(tee "${OPENOCD_STDOUT_LOG}") \
   2> >(tee "${OPENOCD_STDERR_LOG}" >&2)


### PR DESCRIPTION
The switch demo will require starting OpenOCD with a different set of TCL scripts than all of the other test cases, so this adds in a new function that has no default arguments to the program.