### PR TITLE
Make instr/data ILAs conditional for processing elements.

### DIFF
--- a/bittide-instances/src/Bittide/Instances/Hitl/VexRiscv.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/VexRiscv.hs
@@ -195,6 +195,7 @@ vexRiscvInner jtagIn0 uartRx =
         , prefixD = 0b010
         , iBusTimeout = d0 -- No timeouts on the instruction bus
         , dBusTimeout = d0 -- No timeouts on the data bus
+        , includeIlaWb = False
         }
   peConfigRtl =
     PeConfig
@@ -204,6 +205,7 @@ vexRiscvInner jtagIn0 uartRx =
       , prefixD = 0b010
       , iBusTimeout = d0
       , dBusTimeout = d0
+      , includeIlaWb = True
       }
 
 type IMemWords = DivRU (64 * 1024) 4

--- a/bittide-instances/src/Bittide/Instances/Pnr/Ethernet.hs
+++ b/bittide-instances/src/Bittide/Instances/Pnr/Ethernet.hs
@@ -181,6 +181,7 @@ vexRiscGmii SNat sysClk sysRst rxClk rxRst txClk txRst fwd =
         , prefixD = 0b0001
         , iBusTimeout = d0
         , dBusTimeout = d0
+        , includeIlaWb = False
         }
 
   peConfigRtl =
@@ -191,6 +192,7 @@ vexRiscGmii SNat sysClk sysRst rxClk rxRst txClk txRst fwd =
       , prefixD = 0b0001
       , iBusTimeout = d0
       , dBusTimeout = d0
+      , includeIlaWb = True
       }
 
 type IMemWords = DivRU (256 * 1024) 4

--- a/bittide-instances/src/Bittide/Instances/Pnr/ProcessingElement.hs
+++ b/bittide-instances/src/Bittide/Instances/Pnr/ProcessingElement.hs
@@ -93,6 +93,7 @@ vexRiscUartHello diffClk rst_in ((uartTx, jtagIn), _) =
         , prefixD = 0b01
         , iBusTimeout = d0
         , dBusTimeout = d0
+        , includeIlaWb = False
         }
 
   peConfigRtl =
@@ -103,6 +104,7 @@ vexRiscUartHello diffClk rst_in ((uartTx, jtagIn), _) =
       , prefixD = 0b01
       , iBusTimeout = d0
       , dBusTimeout = d0
+      , includeIlaWb = True
       }
 
 type IMemWords = DivRU (64 * 1024) 4

--- a/bittide-instances/tests/Tests/ClockControlWb.hs
+++ b/bittide-instances/tests/Tests/ClockControlWb.hs
@@ -175,6 +175,7 @@ dut =
         , prefixD = 0b010
         , iBusTimeout = d0
         , dBusTimeout = d0
+        , includeIlaWb = False
         }
 {-# NOINLINE dut #-}
 

--- a/bittide-instances/tests/Wishbone/Axi.hs
+++ b/bittide-instances/tests/Wishbone/Axi.hs
@@ -118,6 +118,7 @@ dut =
         , prefixD = 0b001
         , iBusTimeout = d0 -- No timeouts on the instruction bus
         , dBusTimeout = d0 -- No timeouts on the data bus
+        , includeIlaWb = False
         }
 {-# NOINLINE dut #-}
 

--- a/bittide-instances/tests/Wishbone/CaptureUgn.hs
+++ b/bittide-instances/tests/Wishbone/CaptureUgn.hs
@@ -116,6 +116,7 @@ dut eb localCounter = circuit $ do
         , prefixD = 0b01
         , iBusTimeout = d0 -- No timeouts on the instruction bus
         , dBusTimeout = d0 -- No timeouts on the data bus
+        , includeIlaWb = False
         }
 
 type IMemWords = DivRU (64 * 1024) 4

--- a/bittide-instances/tests/Wishbone/DnaPortE2.hs
+++ b/bittide-instances/tests/Wishbone/DnaPortE2.hs
@@ -82,6 +82,7 @@ dut = circuit $ \_unit -> do
         , prefixD = 0b01
         , iBusTimeout = d0 -- No timeouts on the instruction bus
         , dBusTimeout = d0 -- No timeouts on the data bus
+        , includeIlaWb = False
         }
 {-# NOINLINE dut #-}
 

--- a/bittide-instances/tests/Wishbone/ScatterGather.hs
+++ b/bittide-instances/tests/Wishbone/ScatterGather.hs
@@ -114,6 +114,7 @@ dut scatterConfig gatherConfig = circuit $ do
         , prefixD = 0b001
         , iBusTimeout = d0 -- No timeouts on the instruction bus
         , dBusTimeout = d0 -- No timeouts on the data bus
+        , includeIlaWb = False
         }
 
 type IMemWords = DivRU (64 * 1024) 4

--- a/bittide-instances/tests/Wishbone/SwitchDemoProcessingElement.hs
+++ b/bittide-instances/tests/Wishbone/SwitchDemoProcessingElement.hs
@@ -127,6 +127,7 @@ dut localCounter dnaA dnaB = circuit $ do
         , prefixD = 0b001
         , iBusTimeout = d0 -- No timeouts on the instruction bus
         , dBusTimeout = d0 -- No timeouts on the data bus
+        , includeIlaWb = False
         }
 
 type IMemWords = DivRU (32 * 1024) 4

--- a/bittide-instances/tests/Wishbone/Time.hs
+++ b/bittide-instances/tests/Wishbone/Time.hs
@@ -88,6 +88,7 @@ dut = withClockResetEnable clockGen resetGen enableGen
         , prefixD = 0b01
         , iBusTimeout = d0 -- No timeouts on the instruction bus
         , dBusTimeout = d0 -- No timeouts on the data bus
+        , includeIlaWb = False
         }
 {-# NOINLINE dut #-}
 

--- a/bittide-instances/tests/Wishbone/Watchdog.hs
+++ b/bittide-instances/tests/Wishbone/Watchdog.hs
@@ -99,6 +99,7 @@ dut = withClockResetEnable clockGen resetGen enableGen
         , prefixD = 0b001
         , iBusTimeout = d0 -- No timeouts on the instruction bus
         , dBusTimeout = d0 -- No timeouts on the data bus
+        , includeIlaWb = False
         }
 {-# NOINLINE dut #-}
 

--- a/bittide/src/Bittide/ClockControl/CallistoSw.hs
+++ b/bittide/src/Bittide/ClockControl/CallistoSw.hs
@@ -144,4 +144,5 @@ callistoSwClockControl (SwControlConfig jtagIn reframe mgn fsz) mask ebs =
       , prefixD = 0b010
       , iBusTimeout = d0 -- No timeouts on the instruction bus
       , dBusTimeout = d0 -- No timeouts on the data bus
+      , includeIlaWb = True
       }

--- a/bittide/src/Bittide/Wishbone.hs
+++ b/bittide/src/Bittide/Wishbone.hs
@@ -255,6 +255,34 @@ ilaWb SSymbol stages0 depth0 trigger capture = Circuit $ \(m2s, s2m) ->
    in
     ilaInst `hwSeqX` (s2m, m2s)
 
+{- | Conditionally sequences the 'ilaWb' function based on whether the input 'Bool' is
+'True' or 'False'.
+-}
+maybeIlaWb ::
+  forall name dom addrW a.
+  (HiddenClock dom) =>
+  -- | Whether or not this ILA instance should be real or not. 'True' actually creates
+  -- the ILA, 'False' makes this circuit element a no-op.
+  Bool ->
+  -- | Name of the module of the `ila` wrapper. Naming the internal ILA is
+  -- unreliable when more than one ILA is used with the same arguments, but the
+  -- module name can be set reliably.
+  SSymbol name ->
+  -- | Number of registers to insert at each probe. Supported values: 0-6.
+  -- Corresponds to @C_INPUT_PIPE_STAGES@. Default is @0@.
+  Index 7 ->
+  -- | Number of samples to store. Corresponds to @C_DATA_DEPTH@. Default set
+  -- by 'ilaConfig' equals 'D4096'.
+  Depth ->
+  WbToBool dom 'Standard addrW a ->
+  WbToBool dom 'Standard addrW a ->
+  Circuit
+    (Wishbone dom 'Standard addrW a)
+    (Wishbone dom 'Standard addrW a)
+maybeIlaWb True a b c d e = ilaWb a b c d e
+maybeIlaWb False _ _ _ _ _ = circuit $ \left -> do
+  idC -< left
+
 {- | Given a vector with elements and a mask, promote all values with a corresponding
 'True' to 'Just', others to 'Nothing'.
 


### PR DESCRIPTION
In the switch demo PR I introduce multi-PE systems, some of which that are not in always-on domains. As such, I need the ability to have a PE without the debugging ILAs. This PR creates that capability.