### PR TITLE
Add memory map register primitives

### DIFF
--- a/.github/synthesis/all.json
+++ b/.github/synthesis/all.json
@@ -1,5 +1,6 @@
 [
   {"top": "counterReducedPins",            "stage": "pnr"},
+  {"top": "deviceWithMemMap",              "stage": "pnr"},
   {"top": "elasticBuffer5",                "stage": "pnr"},
   {"top": "gatherUnit1KReducedPins",       "stage": "pnr"},
   {"top": "safeDffSynchronizer",           "stage": "pnr"},

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,10 +237,11 @@ jobs:
           - doctests
 
         package:
-          - bittide-extra
           - bittide
           - bittide-experiments
+          - bittide-extra
           - bittide-instances
+          - clash-protocols-memmap
           - ghc-typelits-extra-lemmas
 
         shell_args:

--- a/bittide-instances/bittide-instances.cabal
+++ b/bittide-instances/bittide-instances.cabal
@@ -167,6 +167,7 @@ library
     Bittide.Instances.Hitl.VexRiscv
     Bittide.Instances.Pnr.Calendar
     Bittide.Instances.Pnr.Counter
+    Bittide.Instances.Pnr.DeviceWithMemMap
     Bittide.Instances.Pnr.ElasticBuffer
     Bittide.Instances.Pnr.Ethernet
     Bittide.Instances.Pnr.ProcessingElement

--- a/bittide-instances/src/Bittide/Instances/Pnr/DeviceWithMemMap.hs
+++ b/bittide-instances/src/Bittide/Instances/Pnr/DeviceWithMemMap.hs
@@ -1,0 +1,75 @@
+-- SPDX-FileCopyrightText: 2025 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# OPTIONS_GHC -fplugin=Protocols.Plugin #-}
+
+module Bittide.Instances.Pnr.DeviceWithMemMap where
+
+import Bittide.SharedTypes (Bytes)
+import Clash.Explicit.Prelude
+import GHC.Stack (HasCallStack)
+import Protocols
+import Protocols.MemoryMap
+import Protocols.MemoryMap.Registers.WishboneStandard
+import Protocols.Wishbone
+
+initFloat :: Float
+initFloat = 3.0
+
+initDouble :: Double
+initDouble = 6.0
+
+initU16 :: Unsigned 16
+initU16 = 12
+
+initBool :: Bool
+initBool = True
+
+initS16 :: Signed 16
+initS16 = 500
+
+initEmpty :: Signed 0
+initEmpty = 0
+
+{- | A simple device example that uses the Wishbone protocol to read and write
+registers. The device has a number of registers with different widths and
+types, including floating point, integer, and boolean values.
+-}
+deviceExample ::
+  forall wordSize aw dom.
+  ( HasCallStack
+  , KnownDomain dom
+  , KnownNat wordSize
+  , KnownNat aw
+  , 1 <= wordSize
+  ) =>
+  Clock dom ->
+  Reset dom ->
+  Circuit
+    (ConstBwd MM, Wishbone dom 'Standard aw (Bytes wordSize))
+    ()
+deviceExample clk rst = circuit $ \(mm, wb) -> do
+  [float, double, u16, bool, empty, s16] <- deviceWbC "example" -< (mm, wb)
+
+  _f <- registerWbC clk rst (registerConfig "f") initFloat -< (float, Fwd noWrite)
+  _d <- registerWbC clk rst (registerConfig "d") initDouble -< (double, Fwd noWrite)
+  _u <- registerWbC clk rst (registerConfig "u") initU16 -< (u16, Fwd noWrite)
+  _b <- registerWbC clk rst (registerConfig "b") initBool -< (bool, Fwd noWrite)
+  -- XXX: Empty register causes warnings in the Clash compiler, see:
+  --      https://github.com/clash-lang/clash-compiler/issues/2956
+  _e <- registerWbC clk rst (registerConfig "e") initEmpty -< (empty, Fwd noWrite)
+  _s <- registerWbC clk rst (registerConfig "s") initS16 -< (s16, Fwd noWrite)
+
+  idC
+ where
+  noWrite = pure Nothing
+
+deviceWithMemMap ::
+  Clock XilinxSystem ->
+  Reset XilinxSystem ->
+  Signal XilinxSystem (WishboneM2S 3 4 (BitVector 32)) ->
+  Signal XilinxSystem (WishboneS2M (BitVector 32))
+deviceWithMemMap clk rst m2s =
+  snd $ fst $ toSignals (deviceExample @4 @3 @XilinxSystem clk rst) (((), m2s), ())

--- a/bittide-shake/exe/Main.hs
+++ b/bittide-shake/exe/Main.hs
@@ -180,6 +180,7 @@ targets =
   map enforceValidTarget $
     [ defTarget $ mkName "Bittide.Instances.Pnr.Calendar.switchCalendar1k"
     , defTarget $ mkName "Bittide.Instances.Pnr.Calendar.switchCalendar1kReducedPins"
+    , defTarget $ mkName "Bittide.Instances.Pnr.DeviceWithMemMap.deviceWithMemMap"
     , defTarget $ mkName "Bittide.Instances.Pnr.Counter.counterReducedPins"
     , defTarget $ mkName "Bittide.Instances.Pnr.ElasticBuffer.elasticBuffer5"
     , defTarget $ mkName "Bittide.Instances.Pnr.ProcessingElement.vexRiscUartHello"

--- a/clash-protocols-memmap/clash-protocols-memmap.cabal
+++ b/clash-protocols-memmap/clash-protocols-memmap.cabal
@@ -87,6 +87,7 @@ library
     Protocols.MemoryMap.Check.Normalized
     Protocols.MemoryMap.FieldType
     Protocols.MemoryMap.Json
+    Protocols.MemoryMap.Registers.WishboneStandard
     Protocols.MemoryMap.TypeCollect
 
   build-depends:
@@ -97,6 +98,8 @@ library
     clash-protocols,
     constraints,
     containers,
+    extra,
+    ghc-typelits-extra-lemmas,
     mtl,
     template-haskell,
 
@@ -135,3 +138,52 @@ executable example
     clash-protocols-memmap,
     containers,
     directory,
+
+test-suite doctests
+  type: exitcode-stdio-1.0
+  default-language: Haskell2010
+  main-is: doctests.hs
+  ghc-options:
+    -Wall
+    -Wcompat
+    -threaded
+
+  hs-source-dirs: tests
+  build-depends:
+    base,
+    clash-protocols-memmap,
+    doctest-parallel >=0.3.0.1 && <0.4,
+    filepath,
+    word8,
+
+test-suite unittests
+  import: common-options
+  hs-source-dirs: tests
+  type: exitcode-stdio-1.0
+  main-is: UnitTests.hs
+  ghc-options:
+    -Wall
+    -Wcompat
+    -threaded
+    -rtsopts
+    -with-rtsopts=-N12
+
+  other-modules:
+    Tests.Protocols.MemoryMap.Registers.WishboneStandard
+
+  build-depends:
+    base,
+    clash-prelude-hedgehog,
+    clash-protocols,
+    clash-protocols-memmap,
+    constraints,
+    deepseq,
+    extra,
+    ghc-typelits-extra-lemmas,
+    hedgehog >=1.0 && <1.5,
+    lifted-async,
+    pretty-show,
+    tasty >=1.5 && <1.7,
+    tasty-hedgehog >=1.2 && <1.5,
+    tasty-hunit,
+    tasty-th,

--- a/clash-protocols-memmap/src/BitPackC.hs
+++ b/clash-protocols-memmap/src/BitPackC.hs
@@ -79,10 +79,10 @@ instance (KnownNat n) => BitPackC (BitVector n) where
 
   packC val = toLittleEndian $ case compareSNat (SNat @n) (SNat @(ByteSizeC (BitVector n) * 8)) of
     SNatLE -> zeroExtend @_ @n @(ByteSizeC (BitVector n) * 8 - n) val
-    SNatGT -> deepErrorX "shouldn't happen"
+    SNatGT -> clashCompileError "BitPackC (BitVector n): packC: shouldn't happen"
   unpackC bits = case compareSNat (SNat @n) (SNat @(ByteSizeC (BitVector n) * 8)) of
     SNatLE -> leToPlus @n @(ByteSizeC (BitVector n) * 8) truncateB (fromLittleEndian bits)
-    SNatGT -> deepErrorX "shouldn't happen"
+    SNatGT -> clashCompileError "BitPackC (BitVector n): unpackC: shouldn't happen"
 
 instance (KnownNat n) => BitPackC (Unsigned n) where
   type ByteSizeC (Unsigned n) = NextPowerOfTwo (SizeInBytes n)
@@ -97,11 +97,11 @@ instance (KnownNat n) => BitPackC (Signed n) where
 
   packC val = toLittleEndian $ case compareSNat (SNat @n) (SNat @(ByteSizeC (Signed n) * 8)) of
     SNatLE -> bitCoerce $ signExtend @_ @n @(ByteSizeC (Signed n) * 8 - n) val
-    SNatGT -> deepErrorX "shouldn't happen"
+    SNatGT -> clashCompileError "BitPackC (Signed n): packC: shouldn't happen"
   unpackC bits = case compareSNat (SNat @n) (SNat @(ByteSizeC (Signed n) * 8)) of
     SNatLE ->
       leToPlus @n @(ByteSizeC (Signed n) * 8) $ bitCoerce (truncateB $ fromLittleEndian bits)
-    SNatGT -> deepErrorX "shouldn't happen"
+    SNatGT -> clashCompileError "BitPackC (Signed n): unpackC: shouldn't happen"
 
 instance (KnownNat n, 1 <= n) => BitPackC (Index n) where
   type ByteSizeC (Index n) = ByteSizeC (BitVector (CLog 2 n))

--- a/clash-protocols-memmap/src/BitPackC.hs
+++ b/clash-protocols-memmap/src/BitPackC.hs
@@ -114,15 +114,15 @@ instance BitPackC Float where
   type ByteSizeC Float = 4
   type AlignmentC Float = 4
 
-  packC = pack
-  unpackC = unpack
+  packC = packC . pack
+  unpackC = unpack . unpackC
 
 instance BitPackC Double where
   type ByteSizeC Double = 8
   type AlignmentC Double = 8
 
-  packC = pack
-  unpackC = unpack
+  packC = packC . pack
+  unpackC = unpack . unpackC
 
 instance BitPackC Bool where
   type ByteSizeC Bool = 1

--- a/clash-protocols-memmap/src/BitPackC.hs
+++ b/clash-protocols-memmap/src/BitPackC.hs
@@ -131,8 +131,7 @@ instance BitPackC Bool where
   packC False = 0
   packC True = 1
 
-  unpackC 0 = False
-  unpackC _ = True
+  unpackC b = 1 == b .&. 1
 
 packCwithAlignPadding ::
   forall align a.

--- a/clash-protocols-memmap/src/Protocols/MemoryMap/Check/Normalized.hs
+++ b/clash-protocols-memmap/src/Protocols/MemoryMap/Check/Normalized.hs
@@ -28,7 +28,7 @@ type DeviceName = String
 
 {- | A tree structure that describes the memory map of a device. Its definitions
 are using non-translatable constructs on purpose: Clash is currently pretty
-bad at propagating contants properly, so designers should only /produce/
+bad at propagating constants properly, so designers should only /produce/
 memory maps, not rely on constant folding to be able to extract addresses
 from them to use in their designs.
 -}

--- a/clash-protocols-memmap/src/Protocols/MemoryMap/Registers/WishboneStandard.hs
+++ b/clash-protocols-memmap/src/Protocols/MemoryMap/Registers/WishboneStandard.hs
@@ -1,0 +1,559 @@
+-- SPDX-FileCopyrightText: 2025 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE NoFieldSelectors #-}
+{-# OPTIONS_GHC -fconstraint-solver-iterations=20 #-}
+{-# OPTIONS_GHC -fplugin=Protocols.Plugin #-}
+
+{- | Utilities for creating Wishbone devices and registers, while also creating
+a memory map.
+-}
+module Protocols.MemoryMap.Registers.WishboneStandard (
+  -- * Main functions
+  deviceWbC,
+  deviceWithOffsetsWbC,
+  registerWbC,
+  registerWithOffsetWbC,
+  registerConfig,
+
+  -- * Supporting types
+  BusActivity (..),
+  DeviceConfig (..),
+  RegisterConfig (..),
+
+  -- * Internals
+  RegisterMeta (..),
+  zeroWidthRegisterMeta,
+  maskWriteData,
+  getBusActivity,
+  replaceWith,
+) where
+
+import Clash.Explicit.Prelude
+import Protocols
+
+import BitPackC (BitPackC (..))
+import Clash.Sized.Internal.BitVector (BitVector (unsafeToNatural))
+import Data.Constraint (Dict (Dict))
+import Data.Constraint.Nat.Lemmas (divWithRemainder)
+import Data.Maybe (catMaybes, fromMaybe)
+import GHC.Stack (HasCallStack, SrcLoc, withFrozenCallStack)
+import Protocols.MemoryMap (
+  Access (ReadOnly, ReadWrite, WriteOnly),
+  ConstBwd,
+  ConstFwd,
+  DeviceDefinition (DeviceDefinition, definitionLoc, deviceName, registers, tags),
+  MM,
+  MemoryMap (MemoryMap, deviceDefs, tree),
+  MemoryMapTree (DeviceInstance),
+  Name (..),
+  NamedLoc,
+  Register (..),
+  locCaller,
+  locHere,
+  locN,
+  regType,
+ )
+import Protocols.MemoryMap.FieldType (ToFieldType)
+import Protocols.Wishbone (
+  Wishbone,
+  WishboneM2S (..),
+  WishboneMode (Standard),
+  WishboneS2M (..),
+  emptyWishboneS2M,
+ )
+
+import qualified Data.List as L
+import qualified Data.Map as Map
+import qualified Protocols.Vec as V
+
+type Bytes n = BitVector (n * 8)
+
+data BusActivity a = BusIdle | BusRead a | BusWrite a
+  deriving (Show, Eq, Functor)
+
+data DeviceConfig = DeviceConfig
+  { name :: String
+  }
+
+type Offset aw = BitVector aw
+
+data RegisterMeta aw = RegisterMeta
+  { name :: SimOnly Name
+  , srcLoc :: SimOnly SrcLoc
+  , register :: SimOnly Register
+  , nWords :: BitVector (aw + 1)
+  }
+
+zeroWidthRegisterMeta :: (KnownNat aw) => RegisterMeta aw
+zeroWidthRegisterMeta =
+  RegisterMeta
+    { name = SimOnly (Name{name = "", description = ""})
+    , srcLoc = SimOnly locHere
+    , register =
+        SimOnly
+          Register
+            { -- XXX: There is no regType for unit, so we make it something else
+              fieldType = regType @(Signed 0)
+            , address = 0x0
+            , access = ReadWrite
+            , tags = []
+            , reset = Nothing
+            }
+    , nWords = 0
+    }
+
+data RegisterConfig = RegisterConfig
+  { name :: String
+  , description :: String
+  , tags :: [String]
+  , access :: Access
+  }
+  deriving (Show)
+
+registerConfig :: String -> RegisterConfig
+registerConfig name =
+  RegisterConfig
+    { name
+    , description = ""
+    , tags = []
+    , access = ReadWrite
+    }
+
+-- These have no business being in this module :)
+replaceWith :: (KnownNat n) => Index n -> (a -> a) -> Vec n a -> Vec n a
+replaceWith i f xs = replace i (f (xs !! i)) xs
+
+{- | Tie a bunch of registers together to form a device. Note that @aw@ must be
+chosen such that it can hold the addresses of all registers, including their
+maximum byte address.
+
+Example usage:
+
+> deviceExample clk rst = circuit $ \(mm, wb) -> do
+>   [reg1, reg2, reg3] <- deviceWbC "example" -< (mm, wb)
+>
+>   _reg1o <- registerWbC clk rst (registerConfig "float") (0.0 :: Float)     -< (reg1, Fwd noWrite)
+>   _reg2o <- registerWbC clk rst (registerConfig "u16")   (0 :: Unsigned 16) -< (reg2, Fwd noWrite)
+>   _reg3o <- registerWbC clk rst (registerConfig "bool")  (False :: Bool)    -< (reg3, Fwd noWrite)
+>
+>   idC
+>  where
+>   noWrite = pure Nothing
+-}
+deviceWbC ::
+  forall n wordSize aw dom.
+  ( HasCallStack
+  , KnownNat n
+  , KnownNat wordSize
+  , KnownNat aw
+  ) =>
+  String ->
+  Circuit
+    ( ConstBwd MM
+    , Wishbone dom 'Standard aw (Bytes wordSize)
+    )
+    ( Vec
+        n
+        ( ConstFwd (Offset aw)
+        , ConstBwd (RegisterMeta aw)
+        , Wishbone dom 'Standard aw (Bytes wordSize)
+        )
+    )
+deviceWbC deviceName = circuit $ \(mm, wb) -> do
+  (offsets0, metas0, wbs) <-
+    V.unzip3 <| withFrozenCallStack deviceWithOffsetsWbC deviceName -< (mm, wb)
+  (offsets1, metas1) <- genOffsets -< (offsets0, metas0)
+  V.zip3 -< (offsets1, metas1, wbs)
+ where
+  genOffsets ::
+    Circuit
+      (Vec n (ConstBwd (Offset aw)), Vec n (ConstBwd (RegisterMeta aw)))
+      (Vec n (ConstFwd (Offset aw)), Vec n (ConstBwd (RegisterMeta aw)))
+  genOffsets = Circuit go
+   where
+    go ::
+      ((Vec n (), Vec n ()), (Vec n (), Vec n (RegisterMeta aw))) ->
+      ((Vec n (BitVector aw), Vec n (RegisterMeta aw)), (Vec n (BitVector aw), Vec n ()))
+    go (_, (_, metas)) = ((offsets, metas), (offsets, repeat ()))
+     where
+      sizes = fmap (.nWords) metas
+      offsets = snd $ mapAccumL (\acc size -> (acc + size, resize acc)) 0 sizes
+
+{- | Like 'deviceWbC', but allows you to set offsets of registers manually. This
+can be important in cases where you'd like gaps between the registers. You can
+either pass in the offsets manually or use 'registerWithOffsetWbC'.
+-}
+deviceWithOffsetsWbC ::
+  forall n wordSize aw dom.
+  (HasCallStack, KnownNat n, KnownNat aw, KnownNat wordSize) =>
+  String ->
+  Circuit
+    ( ConstBwd MM
+    , Wishbone dom 'Standard aw (Bytes wordSize)
+    )
+    ( Vec
+        n
+        ( ConstBwd (Offset aw)
+        , ConstBwd (RegisterMeta aw)
+        , Wishbone dom 'Standard aw (Bytes wordSize)
+        )
+    )
+deviceWithOffsetsWbC deviceName =
+  case divWithRemainder @wordSize @8 @7 of
+    Dict ->
+      Circuit go
+ where
+  -- This behemoth of a type signature because the inferred type signature is
+  -- too general, confusing the type checker.
+  go ::
+    ( ((), Signal dom (WishboneM2S aw wordSize (Bytes wordSize)))
+    , Vec
+        n
+        ( BitVector aw
+        , RegisterMeta aw
+        , Signal dom (WishboneS2M (Bytes wordSize))
+        )
+    ) ->
+    ( ( SimOnly MemoryMap
+      , Signal dom (WishboneS2M (Bytes wordSize))
+      )
+    , Vec
+        n
+        ( ()
+        , ()
+        , Signal dom (WishboneM2S aw wordSize (Bytes wordSize))
+        )
+    )
+  go ((_, wbM2S), unzip3 -> (offsets, metas, wbS2Ms)) =
+    ((SimOnly mm, wbS2M), ((),(),) <$> unbundle wbM2Ss)
+   where
+    unSimOnly :: SimOnly a -> a
+    unSimOnly (SimOnly a) = a
+
+    -- Note that we filter zero-width registers out here
+    metaToRegister :: Offset aw -> RegisterMeta aw -> Maybe (NamedLoc Register)
+    metaToRegister o m
+      | m.nWords == 0 = Nothing
+      | otherwise =
+          Just
+            ( unSimOnly m.name
+            , unSimOnly m.srcLoc
+            , (unSimOnly m.register){address = fromIntegral o}
+            )
+
+    mm =
+      MemoryMap
+        { deviceDefs =
+            Map.singleton deviceName
+              $ DeviceDefinition
+                { deviceName = Name{name = deviceName, description = ""}
+                , registers = catMaybes (L.zipWith metaToRegister (toList offsets) (toList metas))
+                , definitionLoc = locN 0
+                , tags = []
+                }
+        , tree = DeviceInstance (locN 1) deviceName
+        }
+
+    (wbS2M, wbM2Ss) =
+      unbundle
+        $ selectSubordinate
+        <$> activeSubordinate
+        <*> wbM2S
+        <*> bundle wbS2Ms
+
+    activeSubordinate :: Signal dom (Maybe (Index n))
+    activeSubordinate = elemIndex True <$> activeSubordinates
+
+    activeSubordinates :: Signal dom (Vec n Bool)
+    activeSubordinates =
+      fmap
+        (isActiveSubordinate <$> offsets <*> metas <*>)
+        (repeat <$> fmap (.addr) wbM2S)
+
+    isActiveSubordinate ::
+      -- Subordinate offset (constant during compilation)
+      BitVector aw ->
+      -- Subordinate meta data
+      RegisterMeta aw ->
+      -- Current address on the bus
+      BitVector aw ->
+      -- Active?
+      Bool
+    isActiveSubordinate offset RegisterMeta{nWords} addr
+      -- Zero-width registers can never be selected -- they don't have an address
+      | nWords == 0 = False
+      -- Optimization case of single word registers: no need to involve `Ord`
+      | nWords == 1 = offset == addr
+      -- General case: check whether the address is within the range of the register
+      | otherwise = addr >= offset && extend addr < extend offset + nWords
+
+    selectSubordinate ::
+      Maybe (Index n) ->
+      WishboneM2S aw wordSize (Bytes wordSize) ->
+      Vec n (WishboneS2M (Bytes wordSize)) ->
+      ( WishboneS2M (Bytes wordSize)
+      , Vec n (WishboneM2S aw wordSize (Bytes wordSize))
+      )
+    selectSubordinate index m2s s2ms
+      | m2s.strobe && m2s.busCycle =
+          case index of
+            Nothing ->
+              -- Unmapped address requested
+              ( emptyWishboneS2M{err = True}
+              , repeat m2s{busCycle = False}
+              )
+            Just i ->
+              -- Mapped address requested
+              ( s2ms !! i
+              , replaceWith
+                  i
+                  (\m -> m{busCycle = True})
+                  (repeat m2s{busCycle = False})
+              )
+      | otherwise =
+          -- Bus inactive
+          (emptyWishboneS2M, repeat m2s)
+
+{- | Circuit writes always take priority over bus writes. Bus writes rejected with
+an error if access rights are set to 'ReadOnly'. Similarly, bus reads are rejected
+if access rights are set to 'WriteOnly'.
+
+You can tie registers created using this function together with 'deviceWbC'. If
+you're looking to create a device with arbitrary offsets, use
+'registerWithOffsetWbC' instead.
+-}
+registerWbC ::
+  forall a dom wordSize aw.
+  ( HasCallStack
+  , ToFieldType a
+  , BitPackC a
+  , BitPack a
+  , NFDataX a
+  , KnownDomain dom
+  , KnownNat wordSize
+  , KnownNat aw
+  , Show a
+  , 1 <= wordSize
+  ) =>
+  Clock dom ->
+  Reset dom ->
+  -- | Configuration values
+  RegisterConfig ->
+  -- | Reset value
+  a ->
+  Circuit
+    ( ( ConstFwd (Offset aw)
+      , ConstBwd (RegisterMeta aw)
+      , Wishbone dom 'Standard aw (Bytes wordSize)
+      )
+    , CSignal dom (Maybe a)
+    )
+    ( CSignal dom a
+    , CSignal dom (BusActivity a)
+    )
+registerWbC clk rst regConfig resetValue =
+  case SNat @(DivRU (ByteSizeC a) wordSize) of
+    (nWords@SNat :: SNat nWords) ->
+      case d1 `compareSNat` nWords of
+        SNatLE ->
+          case divWithRemainder @wordSize @8 @7 of
+            Dict ->
+              Circuit (go nWords)
+        SNatGT ->
+          Circuit $ \_ ->
+            ( (((), zeroWidthRegisterMeta, pure emptyWishboneS2M), pure ())
+            , (pure resetValue, pure BusIdle)
+            )
+ where
+  -- This behemoth of a type signature because the inferred type signature is
+  -- too general, confusing the type checker.
+  go ::
+    forall nWords.
+    (1 <= nWords) =>
+    SNat nWords ->
+    ( ( (Offset aw, (), Signal dom (WishboneM2S aw wordSize (Bytes wordSize)))
+      , Signal dom (Maybe a)
+      )
+    , (Signal dom (), Signal dom ())
+    ) ->
+    ( ( ((), RegisterMeta aw, Signal dom (WishboneS2M (Bytes wordSize)))
+      , Signal dom ()
+      )
+    , (Signal dom a, Signal dom (BusActivity a))
+    )
+  go SNat (((offset, _, wbM2S), aIn), (_, _)) =
+    ((((), reg, wbS2M), pure ()), (aOut, busActivity))
+   where
+    relativeOffset = goRelativeOffset . addr <$> wbM2S
+
+    -- Construct register meta data. This information is only used for simulation,
+    -- i.e., used to build the register map.
+    reg =
+      RegisterMeta
+        { name = SimOnly $ Name{name = regConfig.name, description = regConfig.description}
+        , srcLoc = SimOnly locCaller
+        , nWords = natToNum @nWords
+        , register =
+            SimOnly
+              $ Register
+                { fieldType = regType @a
+                , address = 0x0 -- Note: will be set by 'deviceWithOffsetsWbC'
+                , access = regConfig.access
+                , tags = regConfig.tags
+                , reset = Just (pack resetValue).unsafeToNatural
+                }
+        }
+
+    -- Construct hardware for register. The bulk of this is handled by 'goReg',
+    -- which acts combinationally on the inputs
+    aOut = regMaybe clk rst enableGen resetValue (liftA2 (<|>) aIn aInFromBus)
+    busActivity = getBusActivity <$> wbS2M <*> aOut <*> aInFromBus
+    (wbS2M, aInFromBus) =
+      unbundle
+        $ goReg regConfig.access
+        <$> relativeOffset
+        <*> wbM2S
+        <*> aOut
+
+    goRelativeOffset :: BitVector aw -> Index nWords
+    goRelativeOffset addr = fromMaybe 0 (elemIndex addrLsbs expectedOffsets)
+     where
+      expectedOffsets = iterateI succ offsetLsbs
+      offsetLsbs = resize offset :: BitVector (BitSize (Index nWords))
+      addrLsbs = resize addr :: BitVector (BitSize (Index nWords))
+
+  goReg ::
+    forall nWords.
+    ( 1 <= nWords
+    , KnownNat nWords
+    ) =>
+    Access ->
+    Index nWords ->
+    WishboneM2S aw wordSize (Bytes wordSize) ->
+    a ->
+    (WishboneS2M (Bytes wordSize), Maybe a)
+  goReg busAccess offset wbM2S aFromReg =
+    ( WishboneS2M
+        { readData
+        , acknowledge
+        , err
+        , retry = False
+        , stall = False
+        }
+    , wbWrite
+    )
+   where
+    managerActive = wbM2S.strobe && wbM2S.busCycle
+    err = managerActive && accessFault
+    acknowledge = managerActive && not err
+
+    -- Note that these "faults" are only considered in context of an active bus
+    readOnlyFault = busAccess == ReadOnly && wbM2S.writeEnable
+    writeOnlyFault = busAccess == WriteOnly && not wbM2S.writeEnable
+    accessFault = readOnlyFault || writeOnlyFault
+
+    readData
+      | not wbM2S.writeEnable
+      , acknowledge =
+          resize (packC aFromReg `shiftR` (fromIntegral offset * natToNum @wordSize * 8))
+      | otherwise = 0
+
+    maskedWriteData =
+      maskWriteData
+        offset
+        wbM2S.busSelect
+        wbM2S.writeData
+        (resize (packC aFromReg) :: Bytes (nWords * wordSize))
+
+    wbWrite
+      | wbM2S.writeEnable
+      , acknowledge =
+          Just (unpackC (resize maskedWriteData))
+      | otherwise = Nothing
+
+{- | Same as 'registerWbC', but also takes an offset. You can tie registers
+created using this function together with 'deviceWithOffsetsWbC'.
+-}
+registerWithOffsetWbC ::
+  forall a dom wordSize aw.
+  ( HasCallStack
+  , ToFieldType a
+  , BitPackC a
+  , BitPack a
+  , NFDataX a
+  , KnownDomain dom
+  , KnownNat wordSize
+  , KnownNat aw
+  , Show a
+  , BitSize a <= 8 * wordSize
+  , 1 <= wordSize
+  ) =>
+  Clock dom ->
+  Reset dom ->
+  -- | Configuration values
+  RegisterConfig ->
+  -- | Offset
+  BitVector aw ->
+  -- | Reset value
+  a ->
+  Circuit
+    ( ( ConstBwd (BitVector aw)
+      , ConstBwd (RegisterMeta aw)
+      , Wishbone dom 'Standard aw (Bytes wordSize)
+      )
+    , CSignal dom (Maybe a)
+    )
+    ( CSignal dom a
+    , CSignal dom (BusActivity a)
+    )
+registerWithOffsetWbC clk rst regConfig offset resetValue =
+  circuit $ \((offsetBwd, meta, wb), maybeA) -> do
+    genOffset -< offsetBwd
+    registerWbC clk rst regConfig resetValue -< ((Fwd offset, meta, wb), maybeA)
+ where
+  genOffset :: Circuit (ConstBwd (BitVector aw)) ()
+  genOffset = Circuit $ \_ -> (offset, ())
+
+maskWriteData ::
+  forall wordSize nWords.
+  (KnownNat wordSize, KnownNat nWords, 1 <= nWords) =>
+  -- | Offset
+  Index nWords ->
+  -- | Mask for data on bus
+  BitVector wordSize ->
+  -- | Data from bus
+  Bytes wordSize ->
+  -- | Data from register
+  Bytes (nWords * wordSize) ->
+  -- | Combined data
+  Bytes (nWords * wordSize)
+maskWriteData offset wordMask busData regData = pack newRegDataBytes
+ where
+  shiftBy :: Int -> Int
+  shiftBy n = fromIntegral offset * natToNum @wordSize * n
+  -- shiftBy n = fromIntegral (maxBound - offset) * natToNum @wordSize * n
+
+  regDataBytes :: Vec (nWords * wordSize) (BitVector 8)
+  regDataBytes = unpack regData
+
+  busDataBytes :: Vec (nWords * wordSize) (BitVector 8)
+  busDataBytes = unpack (resize busData `shiftL` shiftBy 8)
+
+  shiftedMask :: Vec (nWords * wordSize) Bool
+  shiftedMask = unpack (resize wordMask `shiftL` shiftBy 1)
+
+  newRegDataBytes :: Vec (nWords * wordSize) (BitVector 8)
+  newRegDataBytes = mux shiftedMask busDataBytes regDataBytes
+
+{- | 'registerWbC' already checks for illegal write or read operations and does not
+acknowledge them. So there is no need to check for 'ReadOnly' or 'WriteOnly'.
+-}
+getBusActivity :: WishboneS2M bv -> a -> Maybe a -> BusActivity a
+getBusActivity s2m regValue maybeUpdatedRegValue
+  | not s2m.acknowledge = BusIdle
+  | Just v <- maybeUpdatedRegValue = BusWrite v
+  | otherwise = BusRead regValue

--- a/clash-protocols-memmap/tests/Tests/Protocols/MemoryMap/Registers/WishboneStandard.hs
+++ b/clash-protocols-memmap/tests/Tests/Protocols/MemoryMap/Registers/WishboneStandard.hs
@@ -1,0 +1,317 @@
+-- SPDX-FileCopyrightText: 2025 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# OPTIONS_GHC -Wno-ambiguous-fields #-}
+-- It's a test, we'll see it :-)
+{-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
+{-# OPTIONS_GHC -fplugin=Protocols.Plugin #-}
+
+module Tests.Protocols.MemoryMap.Registers.WishboneStandard where
+
+import BitPackC (BitPackC (packC, unpackC))
+import Clash.Explicit.Prelude
+import Clash.Prelude (withClockResetEnable)
+import Control.DeepSeq (force)
+import Data.Bifunctor (second)
+import Data.Tuple.Extra (fst3, thd3)
+import GHC.Stack (HasCallStack)
+import Hedgehog (Gen, Property)
+import Hedgehog.Internal.Property (property)
+import Protocols
+import Protocols.Hedgehog (defExpectOptions)
+import Protocols.MemoryMap
+import Protocols.MemoryMap.Registers.WishboneStandard
+import Protocols.Wishbone
+import Protocols.Wishbone.Standard.Hedgehog (
+  WishboneMasterRequest (..),
+  wishbonePropWithModel,
+ )
+import Test.Tasty
+import Test.Tasty.HUnit (Assertion, testCase, (@?=))
+import Test.Tasty.Hedgehog (testPropertyNamed)
+import Text.Show.Pretty (ppShow)
+
+import qualified Data.Map as Map
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
+import qualified Prelude as P
+
+type Bytes n = BitVector (n * 8)
+
+initFloat :: Float
+initFloat = 3.0
+
+initDouble :: Double
+initDouble = 6.0
+
+initU16 :: Unsigned 16
+initU16 = 12
+
+initBool :: Bool
+initBool = True
+
+initS16 :: Signed 16
+initS16 = 500
+
+initEmpty :: Signed 0
+initEmpty = 0
+
+initU32 :: Unsigned 32
+initU32 = 122222
+
+type AddressWidth = 4
+
+{- | Initial state of 'deviceExample', represented as a map from address to bit
+size and value.
+-}
+initState :: Map.Map (BitVector AddressWidth) (Int, BitVector 32)
+initState =
+  Map.fromList @(BitVector AddressWidth)
+    [ (0, (32, packC initFloat))
+    , (1, (32, truncateB $ packC initDouble))
+    , (2, (32, truncateB $ shiftR (packC initDouble) 32))
+    , (3, (16, extend $ packC initU16))
+    , (4, (1, extend $ packC initBool))
+    , -- Zero width registers take a single address due to BitPackC claiming
+      -- they take a single byte to represent.
+      (5, (0, 0))
+    , -- XXX: Using an "odd" size here (e.g., 21) would require the model to
+      --      account for endianness. Either that, or I'm not really understanding
+      --      why it fails.
+      (6, (16, extend $ packC initS16))
+    , (7, (32, packC initFloat))
+    , (8, (32, packC initFloat))
+    , (9, (32, packC initU32))
+    ]
+
+{- | A simple device example that uses the Wishbone protocol to read and write
+registers. The device has a number of registers with different access rights, widths
+and types, including floating point, integer, and boolean values.
+-}
+deviceExample ::
+  forall wordSize aw dom.
+  ( HasCallStack
+  , KnownDomain dom
+  , KnownNat wordSize
+  , KnownNat aw
+  , 1 <= wordSize
+  ) =>
+  Clock dom ->
+  Reset dom ->
+  Circuit
+    (ConstBwd MM, Wishbone dom 'Standard aw (Bytes wordSize))
+    ()
+deviceExample clk rst = circuit $ \(mm, wb) -> do
+  [float, double, u16, bool, empty, s16, readOnly, writeOnly, prio] <-
+    deviceWbC "example" -< (mm, wb)
+
+  _f <- registerWbC clk rst (registerConfig "f") initFloat -< (float, Fwd noWrite)
+  _d <- registerWbC clk rst (registerConfig "d") initDouble -< (double, Fwd noWrite)
+  _u <- registerWbC clk rst (registerConfig "u") initU16 -< (u16, Fwd noWrite)
+  _b <- registerWbC clk rst (registerConfig "b") initBool -< (bool, Fwd noWrite)
+  _e <- registerWbC clk rst (registerConfig "e") initEmpty -< (empty, Fwd noWrite)
+  _s <- registerWbC clk rst (registerConfig "s") initS16 -< (s16, Fwd noWrite)
+
+  _ro <-
+    registerWbC clk rst (registerConfig "ro"){access = ReadOnly} initFloat
+      -< (readOnly, Fwd noWrite)
+  _wo <-
+    registerWbC clk rst (registerConfig "wo"){access = WriteOnly} initFloat
+      -< (writeOnly, Fwd noWrite)
+
+  (_a, Fwd prioOut) <-
+    registerWbC clk rst (registerConfig "prio") initU32
+      -< (prio, Fwd (overwrite <$> prioOut))
+
+  idC
+ where
+  noWrite = pure Nothing
+
+  overwrite = \case
+    -- On bus writes 'the circuit' increments the written value by 1
+    BusWrite newA -> Just (newA + 1)
+    -- On bus reads, the circuit resets the register to its initial value
+    BusRead _ -> Just initU32
+    BusIdle -> Nothing
+
+genWishboneTransfer ::
+  ( KnownNat aw
+  , KnownNat n
+  ) =>
+  Gen (BitVector aw) ->
+  Gen (BitVector (DivRU n 8)) ->
+  Gen (BitVector n) ->
+  Gen (WishboneMasterRequest aw (BitVector n))
+genWishboneTransfer genAddr genMask genData =
+  Gen.choice
+    [ Read <$> genAddr <*> genMask
+    , Write <$> genAddr <*> genMask <*> genData
+    ]
+
+{- | Test 'deviceExample' (and therefore 'deviceWbC' and 'registerWbC') using
+'wishbonePropWithModel'. This property generates a number of random Wishbone
+transactions and checks that the device behaves as expected.
+
+It currently tests:
+
+  * Read/write transactions on both mapped and unmapped addresses
+  * Read/write transactions with varying byte enable masks
+
+It currently does NOT test:
+
+  * "Oddly" shaped types (e.g. @Signed 21@)
+  * 'deviceWithOffsetsWbC' with gaps between registers
+  * Varying the size of the Wishbone bus
+-}
+prop_wb :: Property
+prop_wb =
+  property
+    $ withClockResetEnable clk rst ena
+    $ wishbonePropWithModel @XilinxSystem defExpectOptions model dut genInputs initState
+ where
+  clk = clockGen
+  rst = resetGen
+  ena = enableGen
+
+  model ::
+    WishboneMasterRequest AddressWidth (BitVector 32) ->
+    WishboneS2M (BitVector 32) ->
+    Map.Map (BitVector AddressWidth) (Int, BitVector 32) ->
+    Either String (Map.Map (BitVector AddressWidth) (Int, BitVector 32))
+  model instr WishboneS2M{err = True} s =
+    -- Errors should only happen when we use an unmapped address (in the future
+    -- we may want to to test other errors too).
+    let
+      errorAddress = case instr of
+        Read a _ -> a
+        Write a _ _ -> a
+
+      isRead (Read _ _) = True
+      isRead _ = False
+
+      isWrite (Write{}) = True
+      isWrite _ = False
+     in
+      case Map.lookup errorAddress s of
+        Nothing ->
+          -- Whenever an error occurs, the state should be unchanged.
+          Right s
+        Just (_, v)
+          | isRead instr && errorAddress == 8 ->
+              -- Expect an error when trying to read from the WriteOnly register on address 8.
+              Right s
+          | isWrite instr && errorAddress == 7 ->
+              -- Expect an error when trying to write to the ReadOnly register on address 7.
+              Right s
+          | otherwise ->
+              Left $ "Error on address: " <> show errorAddress <> ", value: " <> show v
+  model _ WishboneS2M{retry = True} s = Right s
+  model _ WishboneS2M{acknowledge = False} s = Right s
+  model (Read a _) WishboneS2M{readData} s =
+    -- XXX: Note that we IGNORE the byte enable mask when reading. The circuit
+    --      does too.
+    case Map.lookup a s of
+      Nothing -> Left $ "Read from unmapped address: " <> show a
+      Just (_, v)
+        | v == readData && a == 9 -> Right $ Map.insert 9 (32, packC initU32) s
+        | v == readData ->
+            Right s
+        | otherwise ->
+            Left $ "a: " <> show a <> ", v: " <> show v <> ", readData: " <> show readData
+  model (Write a m newDat) _ s
+    | a == 9 =
+        let
+          inc :: BitVector 32 -> BitVector 32
+          inc = packC . (+ (1 :: (Unsigned 32))) . unpackC
+         in
+          Right (Map.adjust (second inc . update) a s)
+    | otherwise =
+        Right (Map.adjust update a s)
+   where
+    update :: (Int, BitVector 32) -> (Int, BitVector 32)
+    update (size, oldDat) = (size, truncatedMergedDat)
+     where
+      truncatedMergedDat = mergedDat .&. (2 P.^ size - 1)
+      mergedDat = maskWriteData @4 @1 0 m newDat oldDat
+
+  genInputs :: Gen [WishboneMasterRequest AddressWidth (Bytes 4)]
+  genInputs = Gen.list (Range.linear 0 300) (genWishboneTransfer genAddr genMask genData)
+
+  genMask :: Gen (BitVector 4)
+  genMask = Gen.integral (Range.linear 0 maxBound)
+
+  genData :: Gen (BitVector 32)
+  genData = Gen.integral (Range.linear 0 maxBound)
+
+  genAddr :: Gen (BitVector AddressWidth)
+  genAddr =
+    -- We do plus one to test unmapped addresses
+    Gen.integral (Range.constant 0 (1 + P.maximum (Map.keys initState)))
+
+  dut :: Circuit (Wishbone XilinxSystem Standard AddressWidth (BitVector 32)) ()
+  dut = unMemmap $ deviceExample @4 @AddressWidth @XilinxSystem clk rst
+
+{- FOURMOLU_DISABLE -}
+case_maskWriteData :: Assertion
+case_maskWriteData = do
+  let
+    stored   = 0x01234567_89abcdef_fedcba98_76543210 :: BitVector 128
+    bus      = 0x_________13579bdf                   :: BitVector 32
+    mask     = 0b_________1_1_0_1                    :: BitVector 4
+    expected = 0x01234567_1357cddf_fedcba98_76543210 :: BitVector 128
+
+  maskWriteData 2 mask bus stored @?= expected
+{- FOURMOLU_ENABLE -}
+
+{- | Test that the memory map can be generated without errors. Test for sensible
+values in the memory map.
+-}
+case_memoryMap :: Assertion
+case_memoryMap = do
+  let
+    unSimOnly (SimOnly x) = x
+    device = deviceExample @4 @AddressWidth @XilinxSystem clockGen noReset
+    memoryMap = unSimOnly (getConstBwdAny device)
+    example = memoryMap.deviceDefs Map.! "example"
+
+    -- Make sure the whole tree renders without errors
+    !_tree = force (ppShow memoryMap)
+
+  example.deviceName.name @?= "example"
+
+  let [regF, regD, regU, regB, regE, regS, regRO, regWO, regPrio] = example.registers
+
+  (fst3 regF).name @?= "f"
+  (fst3 regD).name @?= "d"
+  (fst3 regU).name @?= "u"
+  (fst3 regB).name @?= "b"
+  (fst3 regE).name @?= "e"
+  (fst3 regS).name @?= "s"
+  (fst3 regRO).name @?= "ro"
+  (fst3 regWO).name @?= "wo"
+  (fst3 regPrio).name @?= "prio"
+
+  (thd3 regF).address @?= 0
+  (thd3 regD).address @?= 1
+  (thd3 regU).address @?= 3
+  (thd3 regB).address @?= 4
+  (thd3 regE).address @?= 5
+  (thd3 regS).address @?= 6
+  (thd3 regRO).address @?= 7
+  (thd3 regWO).address @?= 8
+  (thd3 regPrio).address @?= 9
+
+tests :: TestTree
+tests =
+  testGroup
+    "WishboneStandard"
+    [ testCase "case_maskWriteData" case_maskWriteData
+    , testCase "case_memoryMap" case_memoryMap
+    , testPropertyNamed "prop_wb" "prop_wb" prop_wb
+    ]

--- a/clash-protocols-memmap/tests/UnitTests.hs
+++ b/clash-protocols-memmap/tests/UnitTests.hs
@@ -1,0 +1,41 @@
+-- SPDX-FileCopyrightText: 2025 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+
+module Main where
+
+import Prelude
+
+import Test.Tasty
+import Test.Tasty.Hedgehog
+
+import qualified Tests.Protocols.MemoryMap.Registers.WishboneStandard
+
+tests :: TestTree
+tests =
+  testGroup
+    "Unittests"
+    [ Tests.Protocols.MemoryMap.Registers.WishboneStandard.tests
+    ]
+
+{- | Default number of tests is 100, which is too low for our (complicated)
+state machinery.
+-}
+setDefaultHedgehogTestLimit :: HedgehogTestLimit -> HedgehogTestLimit
+setDefaultHedgehogTestLimit (HedgehogTestLimit Nothing) = HedgehogTestLimit (Just 1000)
+setDefaultHedgehogTestLimit opt = opt
+
+{- | Hedgehog seemingly gets stuck in an infinite loop when shrinking - probably
+due to the way our generators depend on each other. We limit the number of
+shrinks to 100.
+-}
+setDefaultHedgehogShrinkLimit :: HedgehogShrinkLimit -> HedgehogShrinkLimit
+setDefaultHedgehogShrinkLimit (HedgehogShrinkLimit Nothing) = HedgehogShrinkLimit (Just 100)
+setDefaultHedgehogShrinkLimit opt = opt
+
+main :: IO ()
+main =
+  defaultMain $
+    adjustOption setDefaultHedgehogTestLimit $
+      adjustOption setDefaultHedgehogShrinkLimit $
+        tests

--- a/clash-protocols-memmap/tests/doctests.hs
+++ b/clash-protocols-memmap/tests/doctests.hs
@@ -1,0 +1,14 @@
+-- SPDX-FileCopyrightText: 2025 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+
+module Main where
+
+import System.Environment (getArgs)
+import Test.DocTest (mainFromCabal)
+
+main :: IO ()
+main = do
+  -- We use Nix to setup tooling, not to provide GHC packages so we need to set --no-nix
+  args <- getArgs
+  mainFromCabal "clash-protocols-memmap" ("--no-nix" : args)


### PR DESCRIPTION
We've agreed that for new Bittide components we should incorporate @hydrolarus's work on memory maps. I want to do that for https://github.com/bittide/bittide-hardware/issues/741, so I've written register primitives that allow me to implement the components needed for that.

QA is @hiddemoll, I'll assign this PR once I'm done.

# TODO (before QA)
- [x] Implement byte enables in tests + `registerWbC`
  - Still ignoring it for reads. Perhaps we should error instead?
- [x] Implement error on access faults

# TODO (QA)
- [x] Test `ReadOnly` and `WriteOnly`
- [x] More? I'm leaving it up to QA.