### PR TITLE
Bump `clash-cores` and `clash-protocols`

### DIFF
--- a/bittide-instances/tests/Tests/ClockControlWb.hs
+++ b/bittide-instances/tests/Tests/ClockControlWb.hs
@@ -16,7 +16,7 @@ import Clash.Explicit.Prelude hiding (PeriodToCycles, many)
 -- external imports
 import Clash.Signal (withClockResetEnable)
 import Data.Char (chr)
-import Data.Maybe (mapMaybe)
+import Data.Maybe (catMaybes, mapMaybe)
 import Data.String.Interpolate
 import Project.FilePath
 import Protocols
@@ -45,7 +45,6 @@ import Bittide.Wishbone
 
 -- qualified imports
 import qualified Data.List as L
-import qualified Protocols.Df as Df
 
 -- | The expected output of the UART
 data SerialResult = SerialResult
@@ -65,7 +64,7 @@ sim :: IO ()
 sim =
   putStr
     $ fmap (chr . fromIntegral)
-    . mapMaybe Df.dataToMaybe
+    $ catMaybes
     $ fst (sampleC def dut)
 
 case_clock_control_wb_self_test :: Assertion
@@ -95,7 +94,7 @@ case_clock_control_wb_self_test = do
       putStrLn "Expected ^"
       assertBool "Expected and actual differ" $ actual == expected
  where
-  uartString = chr . fromIntegral <$> mapMaybe Df.dataToMaybe uartStream
+  uartString = chr . fromIntegral <$> catMaybes uartStream
   (uartStream, ccData) = sampleC def dut
 
 type Margin = SNat 2

--- a/bittide-instances/tests/Wishbone/Axi.hs
+++ b/bittide-instances/tests/Wishbone/Axi.hs
@@ -41,7 +41,6 @@ import Text.Parsec.String
 import VexRiscv (DumpVcd (NoDumpVcd))
 
 -- Qualified
-import qualified Protocols.Df as Df
 import qualified Protocols.DfConv as DfConv
 
 -- {-# ANN module "HLint: Missing NOINLINE pragma" #-}
@@ -50,8 +49,7 @@ sim :: IO ()
 sim =
   putStr
     $ fmap (chr . fromIntegral)
-    . mapMaybe Df.dataToMaybe
-    $ (sampleC def dut)
+    $ catMaybes (sampleC def dut)
 
 {- | Run the axi module self test with processingElement and inspect it's uart output.
 The test returns names of tests and a boolean indicating if the test passed.
@@ -66,7 +64,7 @@ case_axi_stream_rust_self_test =
  where
   assertResult (TestResult name (Just errMsg)) = assertFailure ("Test " <> name <> " failed with error \"" <> errMsg <> "\"")
   assertResult (TestResult _ Nothing) = return ()
-  simResult = chr . fromIntegral <$> mapMaybe Df.dataToMaybe uartStream
+  simResult = chr . fromIntegral <$> catMaybes uartStream
   uartStream = sampleC def dut
 
 {- | A simple instance containing just VexRisc and UART as peripheral.

--- a/bittide-instances/tests/Wishbone/CaptureUgn.hs
+++ b/bittide-instances/tests/Wishbone/CaptureUgn.hs
@@ -33,8 +33,6 @@ import Bittide.ProcessingElement.Util
 import Bittide.SharedTypes
 import Bittide.Wishbone
 
-import qualified Protocols.Df as Df
-
 {- | Test whether we can read the local and remote sequence counters from the captureUgn
 peripheral.
 -}
@@ -62,7 +60,7 @@ case_capture_ugn_self_test =
   clk = clockGen
   rst = resetGen
   ena = enableGen
-  simResult = chr . fromIntegral <$> mapMaybe Df.dataToMaybe uartStream
+  simResult = chr . fromIntegral <$> catMaybes uartStream
   uartStream =
     sampleC def
       $ withClockResetEnable clk rst enableGen

--- a/bittide-instances/tests/Wishbone/DnaPortE2.hs
+++ b/bittide-instances/tests/Wishbone/DnaPortE2.hs
@@ -32,13 +32,11 @@ import Bittide.ProcessingElement.Util
 import Bittide.SharedTypes
 import Bittide.Wishbone
 
-import qualified Protocols.Df as Df
-
 sim :: IO ()
 sim = putStr simResult
 
 simResult :: String
-simResult = chr . fromIntegral <$> mapMaybe Df.dataToMaybe uartStream
+simResult = chr . fromIntegral <$> catMaybes uartStream
  where
   uartStream = sampleC def $ withClockResetEnable clockGen resetGen enableGen $ dut @System
 

--- a/bittide-instances/tests/Wishbone/ScatterGather.hs
+++ b/bittide-instances/tests/Wishbone/ScatterGather.hs
@@ -10,7 +10,7 @@ import Clash.Explicit.Prelude
 import Clash.Prelude (HiddenClockResetEnable, withClockResetEnable)
 
 import Data.Char (chr)
-import Data.Maybe (mapMaybe)
+import Data.Maybe (catMaybes)
 import Project.FilePath
 import Protocols
 import Protocols.Idle
@@ -30,14 +30,13 @@ import Bittide.ScatterGather
 import Bittide.SharedTypes
 import Bittide.Wishbone
 
-import qualified Protocols.Df as Df
 import qualified Prelude as P
 
 sim :: IO ()
 sim = putStr simResult
 
 simResult :: String
-simResult = chr . fromIntegral <$> mapMaybe Df.dataToMaybe uartStream
+simResult = chr . fromIntegral <$> catMaybes uartStream
  where
   uartStream =
     sampleC def{timeoutAfter = 100_000}

--- a/bittide-instances/tests/Wishbone/SwitchDemoProcessingElement.hs
+++ b/bittide-instances/tests/Wishbone/SwitchDemoProcessingElement.hs
@@ -11,7 +11,7 @@ import Clash.Prelude (HiddenClockResetEnable, withClockResetEnable)
 
 import Data.Char (chr)
 import Data.List (isPrefixOf)
-import Data.Maybe (mapMaybe)
+import Data.Maybe (catMaybes)
 import Project.FilePath
 import Protocols
 import Protocols.Idle
@@ -30,8 +30,6 @@ import Bittide.SharedTypes
 import Bittide.SwitchDemoProcessingElement
 import Bittide.Wishbone
 
-import qualified Protocols.Df as Df
-
 takeWhileInclusive :: (a -> Bool) -> [a] -> [a]
 takeWhileInclusive _ [] = []
 takeWhileInclusive p (x : xs) = x : if p x then takeWhileInclusive p xs else []
@@ -42,7 +40,7 @@ sim = putStr simResult
 simResult :: String
 simResult = unlines . takeWhileInclusive (/= "Finished") . lines $ uartString
  where
-  uartString = chr . fromIntegral <$> mapMaybe Df.dataToMaybe uartStream
+  uartString = chr . fromIntegral <$> catMaybes uartStream
   uartStream =
     sampleC def{timeoutAfter = 200_000}
       $ withClockResetEnable clk reset enable

--- a/bittide-instances/tests/Wishbone/Time.hs
+++ b/bittide-instances/tests/Wishbone/Time.hs
@@ -35,14 +35,11 @@ import Text.Parsec
 import Text.Parsec.String
 import VexRiscv (DumpVcd (NoDumpVcd))
 
--- Qualified
-import qualified Protocols.Df as Df
-
 sim :: IO ()
 sim = putStrLn simResult
 
 simResult :: String
-simResult = chr . fromIntegral <$> mapMaybe Df.dataToMaybe uartStream
+simResult = chr . fromIntegral <$> catMaybes uartStream
  where
   uartStream = sampleC def dut
 

--- a/bittide-instances/tests/Wishbone/Watchdog.hs
+++ b/bittide-instances/tests/Wishbone/Watchdog.hs
@@ -34,13 +34,12 @@ import VexRiscv (DumpVcd (NoDumpVcd))
 
 -- Qualified
 import qualified Data.List as L
-import qualified Protocols.Df as Df
 
 sim :: IO ()
 sim = putStrLn simResult
 
 simResult :: String
-simResult = chr . fromIntegral <$> mapMaybe Df.dataToMaybe uartStream
+simResult = chr . fromIntegral <$> catMaybes uartStream
  where
   uartStream = sampleC def dut
 

--- a/bittide/src/Bittide/DoubleBufferedRam.hs
+++ b/bittide/src/Bittide/DoubleBufferedRam.hs
@@ -15,7 +15,6 @@ import Clash.Prelude
 import Data.Constraint
 import Data.Maybe
 import Protocols (Ack (Ack), CSignal, Circuit (Circuit), Df)
-import Protocols.Df (dataToMaybe)
 import Protocols.Wishbone
 
 import Bittide.Extra.Maybe
@@ -520,7 +519,7 @@ registerWbC ::
 registerWbC prio initVal = case cancelMulDiv @nBytes @8 of
   Dict -> Circuit go
    where
-    go ((wbM2S, fmap dataToMaybe -> dfM2S), _) = ((wbS2M, fmap Ack dfS2M), aOut)
+    go ((wbM2S, dfM2S), _) = ((wbS2M, fmap Ack dfS2M), aOut)
      where
       (aOut, wbS2M) = registerWb prio initVal wbM2S dfM2S
       dfS2M

--- a/cabal.project
+++ b/cabal.project
@@ -160,12 +160,12 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/clash-lang/clash-cores.git
-  tag: 25b83a8bc91ebc05c15142f821f8c4de3fb65fdb
+  tag: f710a1cbfaa3ea6d07f4454cf01d069487f3bab2
 
 source-repository-package
   type: git
   location: https://github.com/clash-lang/clash-protocols.git
-  tag: febb041c32fa678e7ddb7d0e976516a5c56b03fc
+  tag: 8b6a7695161c2bada9d1373c6fcaf0da887c787a
   subdir:
     clash-protocols
     clash-protocols-base


### PR DESCRIPTION
Changes are due to `clash-protocols` changing the `Fwd` of `Df` from `Signal dom (Df.Data a)` to `Signal dom (Maybe a)`

TODO:
- [ ] Wait for `clash-cores` dependency bump to get merged and update hash https://github.com/clash-lang/clash-cores/pull/34