### PR TITLE
Fix cache fallout after merging #775

### DIFF
--- a/.github/scripts/cache.py
+++ b/.github/scripts/cache.py
@@ -37,7 +37,7 @@ import string
 import subprocess
 import sys
 
-from typing import List, Sequence
+from typing import List, Iterable
 
 PWD = os.getcwd()
 
@@ -116,7 +116,7 @@ def sha256sum_file(path : str) -> str:
     log(f"{digest} {path}")
     return digest
 
-def sha256sum_files(file_paths : Sequence[str]) -> str:
+def sha256sum_files(file_paths : Iterable[str]) -> str:
     hash = hashlib.sha256()
     for path in sorted(set(file_paths)):
         hash.update(sha256sum_file(path).encode())

--- a/.github/scripts/cache.py
+++ b/.github/scripts/cache.py
@@ -72,8 +72,12 @@ BUILD_CACHE_INCLUDE_PATTERNS = (
     f"{PWD}/_build/",
     f"{PWD}/clash-vexriscv/clash-vexriscv/build_out_dir/",
     f"{PWD}/dist-newstyle/",
+    f"{PWD}/firmware-support/bittide-hal/src/shared/",
+    f"{PWD}/firmware-support/bittide-hal/src/hals/",
 )
-BUILD_CACHE_EXCLUDE_PATTERNS = ()
+BUILD_CACHE_EXCLUDE_PATTERNS = (
+    f"{PWD}/firmware-support/bittide-hal/src/shared/mod.rs",
+)
 
 SYNTH_CACHE_BUST = 2
 SYNTH_KEY_PREFIX = f"synth-g{GLOBAL_CACHE_BUST}-l{SYNTH_CACHE_BUST}-"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,7 +184,6 @@ jobs:
 
       - name: Generate HITL based plots
         run: |
-          ./cargo.sh clean
           ./cargo.sh build --frozen --release
           export BITTIDE_ARTIFACT_ACCESS_TOKEN="${{ secrets.GITHUB_TOKEN }}"
           export RUNREF="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"


### PR DESCRIPTION
After HAL generation we need to archive the following directories on CI:

```
f"{PWD}/firmware-support/bittide-hal/src/shared/",
f"{PWD}/firmware-support/bittide-hal/src/hals/",
```

To keep `cache.py` from crashing, we also need to _exclude_ a file that already exists in the repository:

```
f"{PWD}/firmware-support/bittide-hal/src/shared/mod.rs",
```

To do that I've added exclude pattern support to the script.