### PR TITLE
Account for balanced trees in `:+:`

### DIFF
--- a/bittide-instances/src/Bittide/Instances/Tests/RegisterWbC.hs
+++ b/bittide-instances/src/Bittide/Instances/Tests/RegisterWbC.hs
@@ -9,6 +9,8 @@ module Bittide.Instances.Tests.RegisterWbC (
   memoryMap,
   sim,
   simResult,
+  Abc (..),
+  Xyz (..),
 ) where
 
 import Clash.Prelude
@@ -44,11 +46,13 @@ import Project.FilePath (
   firmwareBinariesDir,
  )
 
+import BitPackC (BitPackC)
 import Data.Char (chr)
 import Data.Maybe (catMaybes)
 import Protocols (Circuit (Circuit), Df, Drivable (sampleC), idC, toSignals)
 import Protocols.Idle (idleSource)
 import Protocols.MemoryMap (ConstBwd, MM, MemoryMap, constBwd, getMMAny)
+import Protocols.MemoryMap.FieldType (ToFieldType)
 import Protocols.MemoryMap.Registers.WishboneStandard (
   deviceWbC,
   registerConfig,
@@ -59,6 +63,12 @@ import System.FilePath ((</>))
 import System.IO.Unsafe (unsafePerformIO)
 import Test.Tasty.HUnit (HasCallStack)
 import VexRiscv (DumpVcd (NoDumpVcd))
+
+data Abc = A | B | C
+  deriving (Generic, NFDataX, ShowX, Show, ToFieldType, BitPackC, BitPack)
+
+data Xyz = H | I | J | K | L | M | N | O | P | Q | R | S | T | U | V | W | X | Y | Z
+  deriving (Generic, NFDataX, ShowX, Show, ToFieldType, BitPackC, BitPack)
 
 -- | Example that exports a bunch of different types.
 manyTypesWb ::
@@ -93,6 +103,8 @@ manyTypesWb = circuit $ \(mm, wb) -> do
     , wbB0
     , wbV0
     , wbV1
+    , wbSum0
+    , wbSum1
     ] <-
     deviceWbC "ManyTypes" -< (mm, wb)
 
@@ -120,6 +132,9 @@ manyTypesWb = circuit $ \(mm, wb) -> do
 
   registerWbC_ hasClock hasReset (registerConfig "v0") initWbV0 -< (wbV0, Fwd noWrite)
   registerWbC_ hasClock hasReset (registerConfig "v1") initWbV1 -< (wbV1, Fwd noWrite)
+
+  registerWbC_ hasClock hasReset (registerConfig "sum0") initSum0 -< (wbSum0, Fwd noWrite)
+  registerWbC_ hasClock hasReset (registerConfig "sum1") initSum1 -< (wbSum1, Fwd noWrite)
 
   idC
  where
@@ -179,6 +194,12 @@ manyTypesWb = circuit $ \(mm, wb) -> do
 
   noWrite :: forall a. Signal dom (Maybe a)
   noWrite = pure Nothing
+
+  initSum0 :: Abc
+  initSum0 = C
+
+  initSum1 :: Xyz
+  initSum1 = S
 
 sim :: IO ()
 sim = putStrLn simResult

--- a/firmware-binaries/test-cases/registerwbc_test/src/main.rs
+++ b/firmware-binaries/test-cases/registerwbc_test/src/main.rs
@@ -78,7 +78,11 @@ fn main() -> ! {
     expect("init.v1[1]", Some(0x16), many_types.v1(1));
     expect("init.v1[2]", Some(3721049880298531338), many_types.v1(2));
 
-    // Test writing values:
+    // // XXX: No uDebug trait for enums, so we can't use expect() here.
+    expect("init.sum0", true, hal::Abc::C == many_types.sum0());
+    expect("init.sum1", true, hal::Xyz::S == many_types.sum1());
+
+    // // Test writing values:
     many_types.set_s0(-16);
     many_types.set_s1(16);
     many_types.set_s2(32);
@@ -106,6 +110,8 @@ fn main() -> ! {
     many_types.set_v1(0, 1600).unwrap();
     many_types.set_v1(1, 3200).unwrap();
     many_types.set_v1(2, 7442099760597062676).unwrap();
+    many_types.set_sum0(hal::Abc::A);
+    many_types.set_sum1(hal::Xyz::Z);
 
     // Test read back values:
     expect("rt.s0", -16, many_types.s0());
@@ -135,6 +141,8 @@ fn main() -> ! {
     expect("rt.v1[0]", Some(1600), many_types.v1(0));
     expect("rt.v1[1]", Some(3200), many_types.v1(1));
     expect("rt.v1[2]", Some(7442099760597062676), many_types.v1(2));
+    expect("rt.sum0", true, hal::Abc::A == many_types.sum0());
+    expect("rt.sum1", true, hal::Xyz::Z == many_types.sum1());
 
     test_ok();
 }


### PR DESCRIPTION
Previous logic would assume that the `L` branch would only contain a single constructor. GHC generally makes balanced trees though, so this is incorrect.

Fixes #792