### PR TITLE
Account for various sum-of-product types in HAL generator

### DIFF
--- a/bittide-instances/src/Bittide/Instances/Tests/RegisterWbC.hs
+++ b/bittide-instances/src/Bittide/Instances/Tests/RegisterWbC.hs
@@ -1,7 +1,10 @@
 -- SPDX-FileCopyrightText: 2025 Google LLC
 --
 -- SPDX-License-Identifier: Apache-2.0
+{-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE NoFieldSelectors #-}
+{-# OPTIONS_GHC -fconstraint-solver-iterations=15 #-}
 {-# OPTIONS_GHC -fplugin=Protocols.Plugin #-}
 
 module Bittide.Instances.Tests.RegisterWbC (
@@ -70,6 +73,15 @@ data Abc = A | B | C
 data Xyz = H | I | J | K | L | M | N | O | P | Q | R | S | T | U | V | W | X | Y | Z
   deriving (Generic, NFDataX, ShowX, Show, ToFieldType, BitPackC, BitPack)
 
+data F = F {f :: Float}
+  deriving (Generic, NFDataX, ShowX, Show, ToFieldType, BitPackC, BitPack)
+
+data SoP
+  = SoP0
+  | SoP1 {u :: Unsigned 32}
+  | SoP2
+  deriving (Generic, NFDataX, ShowX, Show, ToFieldType, BitPackC, BitPack)
+
 -- | Example that exports a bunch of different types.
 manyTypesWb ::
   forall wordSize aw dom.
@@ -105,6 +117,8 @@ manyTypesWb = circuit $ \(mm, wb) -> do
     , wbV1
     , wbSum0
     , wbSum1
+    , wbSop0
+    , wbSop1
     ] <-
     deviceWbC "ManyTypes" -< (mm, wb)
 
@@ -135,6 +149,9 @@ manyTypesWb = circuit $ \(mm, wb) -> do
 
   registerWbC_ hasClock hasReset (registerConfig "sum0") initSum0 -< (wbSum0, Fwd noWrite)
   registerWbC_ hasClock hasReset (registerConfig "sum1") initSum1 -< (wbSum1, Fwd noWrite)
+
+  registerWbC_ hasClock hasReset (registerConfig "sop0") initSop0 -< (wbSop0, Fwd noWrite)
+  registerWbC_ hasClock hasReset (registerConfig "sop1") initSop1 -< (wbSop1, Fwd noWrite)
 
   idC
  where
@@ -200,6 +217,12 @@ manyTypesWb = circuit $ \(mm, wb) -> do
 
   initSum1 :: Xyz
   initSum1 = S
+
+  initSop0 :: F
+  initSop0 = F 3.14
+
+  initSop1 :: SoP
+  initSop1 = SoP1 0xBADC_0FEE
 
 sim :: IO ()
 sim = putStrLn simResult

--- a/firmware-binaries/test-cases/registerwbc_test/src/main.rs
+++ b/firmware-binaries/test-cases/registerwbc_test/src/main.rs
@@ -2,6 +2,7 @@
 #![cfg_attr(not(test), no_main)]
 #![allow(const_item_mutation)]
 #![allow(clippy::empty_loop)]
+#![allow(clippy::approx_constant)]
 // SPDX-FileCopyrightText: 2025 Google LLC
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -82,6 +83,8 @@ fn main() -> ! {
     expect("init.sum0", true, hal::Abc::C == many_types.sum0());
     expect("init.sum1", true, hal::Xyz::S == many_types.sum1());
 
+    expect("init.sop0.f", true, many_types.sop0().f == 3.14);
+
     // // Test writing values:
     many_types.set_s0(-16);
     many_types.set_s1(16);
@@ -112,6 +115,7 @@ fn main() -> ! {
     many_types.set_v1(2, 7442099760597062676).unwrap();
     many_types.set_sum0(hal::Abc::A);
     many_types.set_sum1(hal::Xyz::Z);
+    many_types.set_sop0(hal::F { f: 6.28 });
 
     // Test read back values:
     expect("rt.s0", -16, many_types.s0());
@@ -143,6 +147,7 @@ fn main() -> ! {
     expect("rt.v1[2]", Some(7442099760597062676), many_types.v1(2));
     expect("rt.sum0", true, hal::Abc::A == many_types.sum0());
     expect("rt.sum1", true, hal::Xyz::Z == many_types.sum1());
+    expect("rt.sop0.f", true, many_types.sop0().f == 6.28);
 
     test_ok();
 }

--- a/firmware-support/memmap-generate/src/generators/types.rs
+++ b/firmware-support/memmap-generate/src/generators/types.rs
@@ -111,10 +111,13 @@ impl TypeGenerator {
 
         if let Type::SumOfProducts { variants } = &ty.definition {
             match variants.as_slice() {
+                // Empty type (unit)
                 [] => quote! {
                     #attrs
                     pub struct #name #generics;
                 },
+
+                // Single constructor
                 [var @ VariantDesc {
                     name: var_name,
                     fields,
@@ -175,6 +178,8 @@ impl TypeGenerator {
                         }
                     }
                 },
+
+                // Multiple constructors
                 vars => {
                     let variants = vars
                         .iter()
@@ -254,7 +259,7 @@ impl TypeGenerator {
             quote! {
                 #name {
                     #(#fields)*
-                }
+                },
             }
         }
     }


### PR DESCRIPTION
Works around https://github.com/bittide/bittide-hardware/issues/795, fixes https://github.com/bittide/bittide-hardware/issues/796, but is still bothered by https://github.com/bittide/bittide-hardware/issues/797 -- hence missing tests in `main.rs`.