### PR TITLE
fix generation of generic args for types

### DIFF
--- a/bittide-instances/src/Bittide/Instances/Tests/RegisterWbC.hs
+++ b/bittide-instances/src/Bittide/Instances/Tests/RegisterWbC.hs
@@ -119,6 +119,7 @@ manyTypesWb = circuit $ \(mm, wb) -> do
     , wbSum1
     , wbSop0
     , wbSop1
+    , wbE0
     ] <-
     deviceWbC "ManyTypes" -< (mm, wb)
 
@@ -152,6 +153,8 @@ manyTypesWb = circuit $ \(mm, wb) -> do
 
   registerWbC_ hasClock hasReset (registerConfig "sop0") initSop0 -< (wbSop0, Fwd noWrite)
   registerWbC_ hasClock hasReset (registerConfig "sop1") initSop1 -< (wbSop1, Fwd noWrite)
+
+  registerWbC_ hasClock hasReset (registerConfig "e0") initWbE0 -< (wbE0, Fwd noWrite)
 
   idC
  where
@@ -223,6 +226,9 @@ manyTypesWb = circuit $ \(mm, wb) -> do
 
   initSop1 :: SoP
   initSop1 = SoP1 0xBADC_0FEE
+
+  initWbE0 :: Either (BitVector 8) (BitVector 16)
+  initWbE0 = Left 8
 
 sim :: IO ()
 sim = putStrLn simResult

--- a/firmware-support/memmap-generate/src/generators/mod.rs
+++ b/firmware-support/memmap-generate/src/generators/mod.rs
@@ -29,7 +29,10 @@ pub(crate) fn ident(n: impl AsRef<str>) -> Ident {
 }
 
 pub(crate) fn generic_name(idx: u64) -> Ident {
-    ident(format!("{}", 'A' as u64 + idx))
+    ident(format!(
+        "{}",
+        char::from_u32('A' as u32 + idx as u32).unwrap()
+    ))
 }
 
 pub struct RustWrappers {


### PR DESCRIPTION
fixes #788

Accidentally tried to use a number as a name, easy fix once figured out though.

