### PR TITLE
Rework `BitPackC` to correctly do padding and byte ordering

### DIFF
--- a/bittide-instances/src/Bittide/Instances/Pnr/Ethernet.hs
+++ b/bittide-instances/src/Bittide/Instances/Pnr/Ethernet.hs
@@ -24,13 +24,13 @@ import Protocols.Idle
 import Protocols.MemoryMap as MM
 import VexRiscv
 
+import BitPackC (ByteOrder (BigEndian))
 import Bittide.Axi4
 import Bittide.DoubleBufferedRam
 import Bittide.Ethernet.Mac
 import Bittide.Instances.Domains
 import Bittide.ProcessingElement (PeConfig (..), processingElement)
 import Bittide.ProcessingElement.Util (vecFromElfData, vecFromElfInstr)
-import Bittide.SharedTypes (ByteOrder (BigEndian))
 import Bittide.Wishbone
 
 import Project.FilePath (

--- a/bittide-instances/src/Bittide/Instances/Pnr/ProcessingElement.hs
+++ b/bittide-instances/src/Bittide/Instances/Pnr/ProcessingElement.hs
@@ -9,6 +9,7 @@ module Bittide.Instances.Pnr.ProcessingElement where
 
 import Clash.Prelude
 
+import BitPackC (ByteOrder (BigEndian))
 import Clash.Annotations.TH
 import Clash.Cores.UART (ValidBaud)
 import Clash.Explicit.Prelude (noReset, orReset)
@@ -25,7 +26,6 @@ import Bittide.DoubleBufferedRam
 import Bittide.Instances.Domains
 import Bittide.ProcessingElement
 import Bittide.ProcessingElement.Util
-import Bittide.SharedTypes
 import Bittide.Wishbone
 import Project.FilePath
 

--- a/bittide-instances/tests/Tests/ClockControlWb.hs
+++ b/bittide-instances/tests/Tests/ClockControlWb.hs
@@ -14,6 +14,7 @@ module Tests.ClockControlWb where
 import Clash.Explicit.Prelude hiding (PeriodToCycles, many)
 
 -- external imports
+import BitPackC (ByteOrder (BigEndian))
 import Clash.Signal (withClockResetEnable)
 import Data.Char (chr)
 import Data.Maybe (catMaybes, mapMaybe)
@@ -40,7 +41,6 @@ import Bittide.DoubleBufferedRam
 import Bittide.Instances.Hitl.Setup (LinkCount)
 import Bittide.ProcessingElement
 import Bittide.ProcessingElement.Util
-import Bittide.SharedTypes
 import Bittide.Wishbone
 
 -- qualified imports

--- a/bittide-instances/tests/Wishbone/Axi.hs
+++ b/bittide-instances/tests/Wishbone/Axi.hs
@@ -17,11 +17,11 @@ import Bittide.Axi4
 import Bittide.DoubleBufferedRam
 import Bittide.ProcessingElement
 import Bittide.ProcessingElement.Util
-import Bittide.SharedTypes
 import Bittide.Wishbone
 import Project.FilePath
 
 -- Other
+import BitPackC (ByteOrder (BigEndian))
 import Control.Monad (forM_)
 import Data.Char
 import Data.Maybe

--- a/bittide-instances/tests/Wishbone/CaptureUgn.hs
+++ b/bittide-instances/tests/Wishbone/CaptureUgn.hs
@@ -11,6 +11,7 @@ import Clash.Explicit.Prelude
 import Clash.Prelude (HiddenClockResetEnable, withClockResetEnable)
 import qualified Prelude as P
 
+import BitPackC (ByteOrder (BigEndian))
 import Clash.Signal.Internal
 import Data.Char
 import Data.Maybe
@@ -30,7 +31,6 @@ import Bittide.CaptureUgn
 import Bittide.DoubleBufferedRam
 import Bittide.ProcessingElement
 import Bittide.ProcessingElement.Util
-import Bittide.SharedTypes
 import Bittide.Wishbone
 
 {- | Test whether we can read the local and remote sequence counters from the captureUgn

--- a/bittide-instances/tests/Wishbone/DnaPortE2.hs
+++ b/bittide-instances/tests/Wishbone/DnaPortE2.hs
@@ -11,6 +11,7 @@ import Clash.Explicit.Prelude
 import Clash.Prelude (HiddenClockResetEnable, withClockResetEnable)
 import qualified Prelude as P
 
+import BitPackC (ByteOrder (BigEndian))
 import Clash.Cores.Xilinx.Unisim.DnaPortE2
 import Data.Char
 import Data.Maybe
@@ -29,7 +30,6 @@ import VexRiscv (DumpVcd (NoDumpVcd))
 import Bittide.DoubleBufferedRam
 import Bittide.ProcessingElement
 import Bittide.ProcessingElement.Util
-import Bittide.SharedTypes
 import Bittide.Wishbone
 
 sim :: IO ()

--- a/bittide-instances/tests/Wishbone/ScatterGather.hs
+++ b/bittide-instances/tests/Wishbone/ScatterGather.hs
@@ -9,6 +9,7 @@ module Wishbone.ScatterGather where
 import Clash.Explicit.Prelude
 import Clash.Prelude (HiddenClockResetEnable, withClockResetEnable)
 
+import BitPackC (ByteOrder (BigEndian))
 import Data.Char (chr)
 import Data.Maybe (catMaybes)
 import Project.FilePath
@@ -27,7 +28,6 @@ import Bittide.DoubleBufferedRam
 import Bittide.ProcessingElement
 import Bittide.ProcessingElement.Util
 import Bittide.ScatterGather
-import Bittide.SharedTypes
 import Bittide.Wishbone
 
 import qualified Prelude as P

--- a/bittide-instances/tests/Wishbone/SwitchDemoProcessingElement.hs
+++ b/bittide-instances/tests/Wishbone/SwitchDemoProcessingElement.hs
@@ -9,6 +9,7 @@ module Wishbone.SwitchDemoProcessingElement where
 import Clash.Explicit.Prelude
 import Clash.Prelude (HiddenClockResetEnable, withClockResetEnable)
 
+import BitPackC (ByteOrder (BigEndian))
 import Data.Char (chr)
 import Data.List (isPrefixOf)
 import Data.Maybe (catMaybes)
@@ -26,7 +27,6 @@ import VexRiscv (DumpVcd (NoDumpVcd))
 import Bittide.DoubleBufferedRam
 import Bittide.ProcessingElement
 import Bittide.ProcessingElement.Util
-import Bittide.SharedTypes
 import Bittide.SwitchDemoProcessingElement
 import Bittide.Wishbone
 

--- a/bittide-instances/tests/Wishbone/Time.hs
+++ b/bittide-instances/tests/Wishbone/Time.hs
@@ -15,11 +15,11 @@ import Bittide.DoubleBufferedRam
 import Bittide.Instances.Domains
 import Bittide.ProcessingElement
 import Bittide.ProcessingElement.Util
-import Bittide.SharedTypes
 import Bittide.Wishbone
 import Project.FilePath
 
 -- Other
+import BitPackC (ByteOrder (BigEndian))
 import Control.Monad (forM_)
 import Data.Char
 import Data.Maybe

--- a/bittide-instances/tests/Wishbone/Watchdog.hs
+++ b/bittide-instances/tests/Wishbone/Watchdog.hs
@@ -15,11 +15,11 @@ import Bittide.DoubleBufferedRam
 import Bittide.Instances.Domains
 import Bittide.ProcessingElement
 import Bittide.ProcessingElement.Util
-import Bittide.SharedTypes
 import Bittide.Wishbone
 import Project.FilePath
 
 -- Other
+import BitPackC (ByteOrder (BigEndian))
 import Data.Char
 import Data.Maybe
 import Protocols

--- a/bittide/src/Bittide/Calendar.hs
+++ b/bittide/src/Bittide/Calendar.hs
@@ -144,7 +144,8 @@ calendarMemoryMap name (CalendarConfig maxCalDepth@SNat _ _) =
     -- natToNum @(BitSize calEntry `DivRU` 8)
     natToNum @(maxCalDepth * nBytes)
 
-  deviceDef :: forall maxCalDepth. SNat maxCalDepth -> DeviceDefinition
+  deviceDef ::
+    forall maxCalDepth. (1 <= maxCalDepth) => SNat maxCalDepth -> DeviceDefinition
   deviceDef depth@SNat =
     DeviceDefinition
       { registers =
@@ -153,13 +154,7 @@ calendarMemoryMap name (CalendarConfig maxCalDepth@SNat _ _) =
               , loc = locHere
               , value =
                   Register
-                    { fieldType =
-                        -- ghc-typelits-extra isn't smart enough to figure out
-                        -- the BitPackC constraints for the vector type
-                        -- so we use a simpler, separate, BitPackC instance
-                        regTypeSplit
-                          @(Bytes (maxCalDepth * nBytes))
-                          @(Vec maxCalDepth (Bytes nBytes))
+                    { fieldType = regType @(Vec maxCalDepth (Bytes nBytes))
                     , address = 0
                     , access = ReadWrite
                     , reset = Nothing

--- a/bittide/src/Bittide/ClockControl/Freeze.hs
+++ b/bittide/src/Bittide/ClockControl/Freeze.hs
@@ -1,10 +1,13 @@
 -- SPDX-FileCopyrightText: 2025 Google LLC
 --
 -- SPDX-License-Identifier: Apache-2.0
+{-# LANGUAGE ImplicitParams #-}
+{-# OPTIONS_GHC -fconstraint-solver-iterations=20 #-}
 {-# OPTIONS_GHC -fplugin=Protocols.Plugin #-}
 
 module Bittide.ClockControl.Freeze where
 
+import BitPackC (ByteOrder)
 import Bittide.SharedTypes (Bytes)
 import Clash.Explicit.Prelude
 import GHC.Stack (HasCallStack)
@@ -32,6 +35,8 @@ freeze ::
   , KnownNat n
   , HasCallStack
   , 4 <= aw
+  , ?busByteOrder :: ByteOrder
+  , ?regByteOrder :: ByteOrder
   ) =>
   Clock dom ->
   Reset dom ->

--- a/bittide/src/Bittide/ClockControl/Registers.hs
+++ b/bittide/src/Bittide/ClockControl/Registers.hs
@@ -3,7 +3,7 @@
 -- SPDX-License-Identifier: Apache-2.0
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE UndecidableInstances #-}
-{-# OPTIONS_GHC -fconstraint-solver-iterations=6 #-}
+{-# OPTIONS_GHC -fconstraint-solver-iterations=20 #-}
 
 module Bittide.ClockControl.Registers where
 

--- a/bittide/src/Bittide/DoubleBufferedRam.hs
+++ b/bittide/src/Bittide/DoubleBufferedRam.hs
@@ -6,7 +6,7 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TypeApplications #-}
-{-# OPTIONS_GHC -fconstraint-solver-iterations=7 #-}
+{-# OPTIONS_GHC -fconstraint-solver-iterations=20 #-}
 
 module Bittide.DoubleBufferedRam where
 

--- a/bittide/src/Bittide/Ethernet/Mac.hs
+++ b/bittide/src/Bittide/Ethernet/Mac.hs
@@ -11,7 +11,6 @@ import Clash.Explicit.Prelude hiding ((:<))
 
 import BitPackC
 import Bittide.Extra.Maybe
-import Bittide.SharedTypes
 import Bittide.Wishbone
 import Clash.Annotations.Primitive
 import Clash.Cores.Xilinx.Ethernet.Gmii.Internal

--- a/bittide/src/Bittide/ProcessingElement/Util.hs
+++ b/bittide/src/Bittide/ProcessingElement/Util.hs
@@ -12,6 +12,7 @@ import Bittide.ProcessingElement.DeviceTreeCompiler
 import Bittide.ProcessingElement.ReadElf
 import Bittide.SharedTypes
 
+import BitPackC (ByteOrder (..))
 import Control.Monad (when)
 import Data.Maybe
 import GHC.Stack

--- a/bittide/src/Bittide/ScatterGather.hs
+++ b/bittide/src/Bittide/ScatterGather.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# OPTIONS_GHC -fconstraint-solver-iterations=16 #-}
 
 module Bittide.ScatterGather (
   scatterUnitWb,

--- a/bittide/src/Bittide/SharedTypes.hs
+++ b/bittide/src/Bittide/SharedTypes.hs
@@ -11,10 +11,14 @@
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -fconstraint-solver-iterations=8 #-}
 
-module Bittide.SharedTypes where
+module Bittide.SharedTypes (
+  module Bittide.SharedTypes,
+  Bytes,
+) where
 
 import Clash.Prelude
 
+import BitPackC (ByteOrder (..), Bytes)
 import Data.Constraint
 import Data.Constraint.Nat.Lemmas
 import Data.Type.Equality ((:~:) (Refl))
@@ -44,9 +48,6 @@ resizeM2SAddr WishboneM2S{..} = WishboneM2S{addr = resize addr, ..}
 
 -- | A single byte.
 type Byte = BitVector 8
-
--- | BitVector of _n_ bytes.
-type Bytes n = BitVector (n * 8)
 
 -- | A BitVector that contains one bit per byte in the BitSize of a.
 type ByteEnable a = BitVector (Regs a 8)
@@ -85,9 +86,6 @@ type Pad a bw = (Regs a bw * bw) - BitSize a
 
 -- Amount of bw sized registers required to store a.
 type Regs a bw = DivRU (BitSize a) bw
-
-data ByteOrder = LittleEndian | BigEndian
-  deriving (Eq)
 
 -- | Stores any arbitrary datatype as a vector of registers.
 newtype RegisterBank regSize content (byteOrder :: ByteOrder)

--- a/bittide/src/Bittide/SwitchDemoProcessingElement.hs
+++ b/bittide/src/Bittide/SwitchDemoProcessingElement.hs
@@ -3,6 +3,7 @@
 -- SPDX-License-Identifier: Apache-2.0
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE NumericUnderscores #-}
+{-# OPTIONS_GHC -fconstraint-solver-iterations=20 #-}
 
 module Bittide.SwitchDemoProcessingElement where
 

--- a/bittide/src/Bittide/Sync.hs
+++ b/bittide/src/Bittide/Sync.hs
@@ -1,6 +1,7 @@
 -- SPDX-FileCopyrightText: 2025 Google LLC
 --
 -- SPDX-License-Identifier: Apache-2.0
+{-# LANGUAGE ImplicitParams #-}
 {-# OPTIONS_GHC -fplugin=Protocols.Plugin #-}
 
 {- | Circuits for wall-clock synchronizing Bittide boards.
@@ -40,6 +41,7 @@ module Bittide.Sync where
 import Clash.Explicit.Prelude hiding (PeriodToCycles)
 import Protocols
 
+import BitPackC (ByteOrder)
 import Bittide.Arithmetic.Time (PeriodToCycles)
 import Bittide.SharedTypes (Bytes)
 import Clash.Class.Counter (Counter (countSuccOverflow))
@@ -117,6 +119,8 @@ syncOutGenerateWbC ::
   ( KnownDomain dom
   , HasSynchronousReset dom
   , KnownNat aw
+  , ?busByteOrder :: ByteOrder
+  , ?regByteOrder :: ByteOrder
   ) =>
   Clock dom ->
   Reset dom ->

--- a/cabal.project
+++ b/cabal.project
@@ -109,6 +109,15 @@ package bittide-tools
     -RTS
     -j8
 
+package clash-protocols-memmap
+  ghc-options:
+    +RTS
+    -xp
+    -qn8
+    -A64M
+    -RTS
+    -j8
+
 package clash-vexriscv
   ghc-options:
     +RTS

--- a/clash-protocols-memmap/clash-protocols-memmap.cabal
+++ b/clash-protocols-memmap/clash-protocols-memmap.cabal
@@ -80,6 +80,8 @@ library
   default-language: Haskell2010
   exposed-modules:
     BitPackC
+    BitPackC.Align
+    BitPackC.Padding
     Internal.HdlTest.UartMock
     Protocols.MemoryMap
     Protocols.MemoryMap.Check
@@ -173,6 +175,7 @@ test-suite unittests
 
   other-modules:
     Tests.BitPackC
+    Tests.Padding
     Tests.Protocols.MemoryMap.Registers.WishboneStandard
 
   build-depends:
@@ -182,6 +185,7 @@ test-suite unittests
     clash-protocols-memmap,
     constraints,
     deepseq,
+    extra,
     ghc-typelits-extra-lemmas,
     hedgehog >=1.0 && <1.5,
     lifted-async,

--- a/clash-protocols-memmap/src/BitPackC/Align.hs
+++ b/clash-protocols-memmap/src/BitPackC/Align.hs
@@ -1,0 +1,64 @@
+-- SPDX-FileCopyrightText: 2025 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+{-# OPTIONS_GHC -fconstraint-solver-iterations=20 #-}
+
+module BitPackC.Align where
+
+import Clash.Prelude
+import Data.Type.Bool (type If)
+import GHC.TypeLits.KnownNat (
+  KnownNat2,
+  SNatKn (SNatKn),
+  nameToSymbol,
+  natSing2,
+ )
+
+{- | Align calculates the number of bytes needed to align to a given boundary. It
+is the equivalent of:
+
+> type Padding start boundary = (boundary - (start `Mod` boundary)) `Mod` boundary
+
+I.e., it calculates how many bytes to insert to arrive at a multiple of @boundary@
+starting from position @start@. Note that writing it directly this way would make
+the type checker insert spurious @b <= Mod a b@ constraints everywhere.
+-}
+type family Padding (start :: Nat) (boundary :: Nat) :: Nat where
+  Padding _ 1 = 0
+  Padding 0 _ = 0
+  Padding s b =
+    If
+      ((s `Mod` b) <=? b)
+      ((b - (s `Mod` b)) `Mod` b)
+      -- Can't happen, but if we insert a 'TypeError' GHC trips up..
+      0
+
+{- | Term level implementation of 'Padding', used by the type checkers to insert
+proofs. We need this because the type checker plugins cannot evaluate type families,
+as it cannot access their guts.
+-}
+instance (KnownNat start, KnownNat boundary) => KnownNat2 $(nameToSymbol ''Padding) start boundary where
+  natSing2 = SNatKn $ (b - (s `mod` b)) `mod` b
+   where
+    s = natToNum @start
+    b = natToNum @boundary
+  {-# INLINE natSing2 #-}
+
+type family MultipleOf (a :: Nat) (b :: Nat) where
+  MultipleOf a 0 = TypeError ('Text "MultipleOf: b must be non-zero")
+  MultipleOf a b = DivRU a b * b
+
+{- | Term level implementation of 'MultipleOf', used by the type checkers to insert
+proofs. We need this because the type checker plugins cannot evaluate type families,
+as it cannot access their guts.
+-}
+instance (KnownNat a, KnownNat b) => KnownNat2 $(nameToSymbol ''MultipleOf) a b where
+  natSing2 =
+    case d1 `compareSNat` SNat @b of
+      SNatLE -> SNatKn $ natToNum @(DivRU a b * b)
+      _ -> error "MultipleOf: b must be non-zero"
+  {-# INLINE natSing2 #-}

--- a/clash-protocols-memmap/src/BitPackC/Padding.hs
+++ b/clash-protocols-memmap/src/BitPackC/Padding.hs
@@ -1,0 +1,98 @@
+-- SPDX-FileCopyrightText: 2025 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+{-# LANGUAGE FlexibleContexts #-}
+{-# OPTIONS_GHC -fconstraint-solver-iterations=10 #-}
+
+module BitPackC.Padding (
+  packWordC,
+  maybeUnpackWordC,
+  unpackWordOrErrorC,
+  SizeInWordsC,
+
+  -- * Internal
+  pad,
+  unpad,
+) where
+
+import Clash.Prelude
+
+import BitPackC (
+  BitPackC,
+  ByteOrder,
+  ByteSizeC,
+  Bytes,
+  maybeUnpackC,
+  msbResize,
+  packC,
+  unpackOrErrorC,
+ )
+import Data.Typeable (Typeable)
+
+type SizeInWords wordSize nBytes = nBytes `DivRU` wordSize
+type SizeInWordsC wordSize a = SizeInWords wordSize (ByteSizeC a)
+
+-- | Like 'packC', but pads the input to a multiple of a given word size.
+packWordC ::
+  forall wordSize a.
+  ( BitPackC a
+  , KnownNat wordSize
+  , 1 <= wordSize
+  ) =>
+  ByteOrder ->
+  a ->
+  Vec (SizeInWordsC wordSize a) (Bytes wordSize)
+packWordC endian a = pad (packC endian a)
+
+-- | Like 'maybeUnpackC', but unpads the input from a multiple of a given word size.
+maybeUnpackWordC ::
+  forall wordSize a.
+  ( BitPackC a
+  , KnownNat wordSize
+  , 1 <= wordSize
+  ) =>
+  ByteOrder ->
+  Vec (SizeInWordsC wordSize a) (Bytes wordSize) ->
+  Maybe a
+maybeUnpackWordC endian bytes = maybeUnpackC endian (unpad bytes)
+
+{- | Like 'unpackOrErrorC', but unpads the input from a multiple of a given word
+size.
+-}
+unpackWordOrErrorC ::
+  forall wordSize a.
+  ( BitPackC a
+  , Typeable a
+  , NFDataX a
+  , KnownNat wordSize
+  , 1 <= wordSize
+  ) =>
+  ByteOrder ->
+  Vec (SizeInWordsC wordSize a) (Bytes wordSize) ->
+  a
+unpackWordOrErrorC endian bytes =
+  unpackOrErrorC endian (unpad bytes)
+
+-- | Pack bytes into a bunch of words. Pad with zero-bytes if necessary.
+pad ::
+  forall nBytes wordSize.
+  ( KnownNat nBytes
+  , KnownNat wordSize
+  , 1 <= wordSize
+  ) =>
+  Vec nBytes (Bytes 1) ->
+  Vec (SizeInWords wordSize nBytes) (Bytes wordSize)
+pad = unpack . msbResize . pack
+
+{- | Unpack words into a vector of bytes, in such a way that the padding bytes
+introduced by 'pad' are removed again.
+-}
+unpad ::
+  forall nBytes wordSize.
+  ( KnownNat nBytes
+  , KnownNat wordSize
+  , 1 <= wordSize
+  ) =>
+  Vec (SizeInWords wordSize nBytes) (Bytes wordSize) ->
+  Vec nBytes (Bytes 1)
+unpad = unpack . msbResize . pack

--- a/clash-protocols-memmap/src/Internal/HdlTest/UartMock.hs
+++ b/clash-protocols-memmap/src/Internal/HdlTest/UartMock.hs
@@ -57,22 +57,13 @@ import Protocols.Wishbone (
 
 import qualified Data.Map.Strict as Map
 
+data FakeyTypy a b = FakeyTypy a b
+  deriving (Generic, BitPackC)
+
 data FakeType a b
   = FakeA a
   | FakeB b
-  deriving (Generic)
-
-instance
-  ( BitPackC a
-  , BitPackC b
-  , 1 <= Max (AlignmentC a) (AlignmentC b)
-  , Mod (ByteSizeC a) (AlignmentC b) <= AlignmentC b
-  , Mod (ByteSizeC a) (AlignmentC b) <= ByteSizeC a
-  , Mod 1 (Max (AlignmentC a) (AlignmentC b))
-      <= Max (AlignmentC a) (AlignmentC b)
-  , Mod 1 (Max (AlignmentC a) (AlignmentC b)) <= 1
-  ) =>
-  BitPackC (FakeType a b)
+  deriving (Generic, BitPackC)
 
 instance (ToFieldType a, ToFieldType b) => ToFieldType (FakeType a b) where
   type Generics (FakeType a b) = 2

--- a/clash-protocols-memmap/tests/Tests/BitPackC.hs
+++ b/clash-protocols-memmap/tests/Tests/BitPackC.hs
@@ -2,6 +2,12 @@
 --
 -- SPDX-License-Identifier: Apache-2.0
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
 {-# OPTIONS_GHC -fconstraint-solver-iterations=20 #-}
 
 module Tests.BitPackC where
@@ -10,6 +16,7 @@ import Clash.Explicit.Prelude
 
 import BitPackC
 
+import Control.Monad (forM_)
 import Test.Tasty
 import Test.Tasty.HUnit
 import Test.Tasty.TH
@@ -18,49 +25,59 @@ import qualified Prelude as P
 
 -- Helper for testing the pack/unpack identity
 packUnpackIdentity :: forall a. (Eq a, Show a, BitPackC a) => a -> Assertion
-packUnpackIdentity val = unpackC (packC val) @?= val
+packUnpackIdentity val = do
+  maybeUnpackC LittleEndian (packC LittleEndian val) @?= Just val
+  maybeUnpackC BigEndian (packC BigEndian val) @?= Just val
+
+idx :: (KnownNat n) => Vec n a -> Index n -> a
+idx v i = v !! i
 
 newtype MyInt = MkMyInt (Signed 10)
-  deriving (Show, Eq, Generic, NFDataX, BitPackC)
+  deriving (Show, Eq, Generic, BitPackC, NFDataX)
 
--- data MyUnit = MyUnitPayload ()
---   deriving (Show, Eq, Generic, NFDataX, BitPackC)
+data MyUnit = MyUnitPayload ()
+  deriving (Show, Eq, Generic, BitPackC, NFDataX)
+
+data MySumWithPayload
+  = MySumPayload (BitVector 16)
+  | MySumSecondCase
+  deriving (Show, Eq, Generic, BitPackC, NFDataX)
 
 data MyCustomBool = MyFalse | MyTrue
-  deriving (Show, Eq, Generic, NFDataX, BitPackC, Enum, Bounded)
+  deriving (Show, Eq, Generic, BitPackC, NFDataX, BitPack, Enum, Bounded)
 
 data SmallSum = S1 | S2 | S3
-  deriving (Show, Eq, Generic, NFDataX, BitPackC, Enum, Bounded)
+  deriving (Show, Eq, Generic, BitPackC, NFDataX, Enum, Bounded)
 
 data Point2D = Point2D {pX :: Unsigned 4, pY :: Unsigned 4}
-  deriving (Show, Eq, Generic, NFDataX, BitPackC)
+  deriving (Show, Eq, Generic, BitPackC, NFDataX)
 
 data Pixel = Pixel {rCh :: Unsigned 4, gCh :: Unsigned 5, bCh :: Unsigned 6}
-  deriving (Show, Eq, Generic, NFDataX, BitPackC)
+  deriving (Show, Eq, Generic, BitPackC, NFDataX)
 
 data Choice
   = OptA (Signed 5)
   | OptB Bool
-  deriving (Show, Eq, Generic, NFDataX, BitPackC)
+  deriving (Show, Eq, Generic, BitPackC, NFDataX)
 
 data LargeSum = L0 | L1 | L2 | L3 | L4 | L5 | L6 | L7
-  deriving (Show, Eq, Generic, NFDataX, BitPackC, Enum, Bounded)
+  deriving (Show, Eq, Generic, BitPackC, NFDataX, Enum, Bounded)
 
 data NestedProd = NestedProd {npPoint :: Point2D, npActive :: Bool}
-  deriving (Show, Eq, Generic, NFDataX, BitPackC)
+  deriving (Show, Eq, Generic, BitPackC, NFDataX)
 
 data SoPComplex
   = ConSMixed (Unsigned 3) Bool
   | ConSPixel Pixel
   | ConSLargeSum LargeSum
   | ConSEmpty
-  deriving (Show, Eq, Generic, NFDataX, BitPackC)
+  deriving (Show, Eq, Generic, BitPackC, NFDataX)
 
 data WithVec = WithVec {wvItems :: Vec 3 (Unsigned 2)}
-  deriving (Show, Eq, Generic, NFDataX, BitPackC)
+  deriving (Show, Eq, Generic, BitPackC, NFDataX)
 
 data WithBV = WithBV {bvData :: BitVector 11}
-  deriving (Show, Eq, Generic, NFDataX, BitPackC)
+  deriving (Show, Eq, Generic, BitPackC, NFDataX)
 
 data MultiFieldProduct = MFP
   { fieldBool :: Bool
@@ -68,18 +85,18 @@ data MultiFieldProduct = MFP
   , fieldS5 :: Signed 5
   , fieldIdx8 :: Index 8
   , fieldBV1 :: BitVector 1
-  , -- , fieldUnit :: ()
-    fieldCustomB :: MyCustomBool
+  , fieldUnit :: ()
+  , fieldCustomB :: MyCustomBool
   }
-  deriving (Show, Eq, Generic, NFDataX, BitPackC)
+  deriving (Show, Eq, Generic, BitPackC, NFDataX)
 
 case_myInt :: Assertion
 case_myInt = mapM_ packUnpackIdentity [MkMyInt s | s <- [minBound ..]]
 
--- case_myUnit :: Assertion
--- case_myUnit = do
---   let allValues = [MyUnitPayload ()]
---   mapM_ packUnpackIdentity allValues
+case_myUnit :: Assertion
+case_myUnit = do
+  let allValues = [MyUnitPayload ()]
+  mapM_ packUnpackIdentity allValues
 
 case_myCustomBool :: Assertion
 case_myCustomBool = mapM_ packUnpackIdentity [minBound :: MyCustomBool ..]
@@ -150,6 +167,55 @@ case_soPComplex = do
         <> conSEmpty_values
   mapM_ packUnpackIdentity allValues
 
+case_soPComplexTags :: Assertion
+case_soPComplexTags = do
+  let
+    conSMixed_values =
+      [ ConSMixed u b
+      | u <- [minBound ..]
+      , b <- [False, True]
+      ]
+    pixel_values =
+      [ Pixel r g b
+      | r <- [minBound ..]
+      , g <- [minBound ..]
+      , b <- [minBound ..]
+      ]
+
+    conSPixel_values = P.map ConSPixel pixel_values
+
+    conSLargeSum_values = P.map ConSLargeSum [minBound ..]
+    conSEmpty_values = [ConSEmpty]
+
+  let check_tag expected v = expected @?= (v !! (0 :: Int))
+
+  mapM_ (check_tag 0) (packC BigEndian <$> conSMixed_values)
+  mapM_ (check_tag 1) (packC BigEndian <$> conSPixel_values)
+  mapM_ (check_tag 2) (packC BigEndian <$> conSLargeSum_values)
+  mapM_ (check_tag 3) (packC BigEndian <$> conSEmpty_values)
+
+case_soPComplexPixelOffsets :: Assertion
+case_soPComplexPixelOffsets = do
+  let
+    pixel_values =
+      [ Pixel r g b
+      | r <- [minBound ..]
+      , g <- [minBound ..]
+      , b <- [minBound ..]
+      ]
+    conSPixel_values = P.map ConSPixel pixel_values
+
+  forM_ conSPixel_values $ \sPixel@(ConSPixel pixel) -> do
+    packUnpackIdentity pixel
+    forM_ [BigEndian, LittleEndian] $ \endian -> do
+      let bytes = packC endian sPixel
+      -- tag
+      bytes `idx` 0 @?= 1
+
+      bytes `idx` 1 @?= resize (pack pixel.rCh)
+      bytes `idx` 2 @?= resize (pack pixel.gCh)
+      bytes `idx` 3 @?= resize (pack pixel.bCh)
+
 case_withVec :: Assertion
 case_withVec = do
   let
@@ -162,6 +228,13 @@ case_withVec = do
       ]
   mapM_ packUnpackIdentity allVecValues
 
+  forM_ allVecValues $ \wv@(WithVec vec) -> do
+    forM_ [LittleEndian, BigEndian] $ \endian -> do
+      let bytes = packC endian wv
+      bytes `idx` 0 @?= (resize . pack $ vec `idx` 0)
+      bytes `idx` 1 @?= (resize . pack $ vec `idx` 1)
+      bytes `idx` 2 @?= (resize . pack $ vec `idx` 2)
+
 case_withBV :: Assertion
 case_withBV = do
   let allValues = [WithBV bv | bv <- [minBound ..]]
@@ -170,16 +243,94 @@ case_withBV = do
 case_multiFieldProduct :: Assertion
 case_multiFieldProduct = do
   let allValues =
-        [ MFP b u3 s5 idx bv1 cb
+        [ MFP b u3 s5 idx8 bv1 unit cb
         | b <- [False, True]
         , u3 <- [minBound ..]
         , s5 <- [minBound ..]
-        , idx <- [minBound ..]
+        , idx8 <- [minBound ..]
         , bv1 <- [minBound ..]
-        , -- , unit <- [()]
-        cb <- [minBound ..]
+        , unit <- [()]
+        , cb <- [minBound ..]
         ]
   mapM_ packUnpackIdentity allValues
+
+  forM_ allValues $ \val -> do
+    forM_ [LittleEndian, BigEndian] $ \endian -> do
+      let bytes = packC endian val
+      bytes `idx` 0 @?= (resize . pack $ val.fieldBool)
+      bytes `idx` 1 @?= (resize . pack $ val.fieldU3)
+      bytes `idx` 2 @?= pack (signExtend val.fieldS5)
+      bytes `idx` 3 @?= (resize . pack $ val.fieldIdx8)
+      bytes `idx` 4 @?= (resize . pack $ val.fieldBV1)
+      -- no test for unit! This one isn't packed
+      -- and the offset of fieldCustomB below shows that!
+      bytes `idx` 5 @?= (resize . pack $ val.fieldCustomB)
+
+case_myProductByteOrder :: Assertion
+case_myProductByteOrder = do
+  let val = MySumPayload 0xABCD
+  let bytesLe = packC LittleEndian val
+
+  bytesLe `idx` 0 @?= 0 -- tag
+  bytesLe `idx` 2 @?= 0xCD
+  bytesLe `idx` 3 @?= 0xAB
+
+  let bytesBe = packC BigEndian val
+
+  bytesBe `idx` 0 @?= 0 -- tag
+  bytesBe `idx` 2 @?= 0xAB
+  bytesBe `idx` 3 @?= 0xCD
+
+  let bytesNoPayload = packC LittleEndian MySumSecondCase
+  bytesNoPayload `idx` 0 @?= 1 -- tag
+
+case_eitherB8B16 :: Assertion
+case_eitherB8B16 = do
+  mapM_
+    (packUnpackIdentity @(Either (BitVector 8) (BitVector 16)))
+    ([Left x | x <- [minBound ..]] <> [Right x | x <- [minBound ..]])
+
+case_eitherU8U16 :: Assertion
+case_eitherU8U16 = do
+  mapM_
+    (packUnpackIdentity @(Either (Unsigned 8) (Unsigned 16)))
+    ([Left x | x <- [minBound ..]] <> [Right x | x <- [minBound ..]])
+
+case_eitherS8S16 :: Assertion
+case_eitherS8S16 = do
+  mapM_
+    (packUnpackIdentity @(Either (Signed 8) (Signed 16)))
+    ([Left x | x <- [minBound ..]] <> [Right x | x <- [minBound ..]])
+
+case_eitherI256I65536 :: Assertion
+case_eitherI256I65536 = do
+  mapM_
+    (packUnpackIdentity @(Either (Index 256) (Index 65536)))
+    ([Left x | x <- [minBound ..]] <> [Right x | x <- [minBound ..]])
+
+case_eitherB7B15 :: Assertion
+case_eitherB7B15 = do
+  mapM_
+    (packUnpackIdentity @(Either (BitVector 7) (BitVector 15)))
+    ([Left x | x <- [minBound ..]] <> [Right x | x <- [minBound ..]])
+
+case_eitherU7U15 :: Assertion
+case_eitherU7U15 = do
+  mapM_
+    (packUnpackIdentity @(Either (Unsigned 7) (Unsigned 15)))
+    ([Left x | x <- [minBound ..]] <> [Right x | x <- [minBound ..]])
+
+case_eitherS7S15 :: Assertion
+case_eitherS7S15 = do
+  mapM_
+    (packUnpackIdentity @(Either (Signed 7) (Signed 15)))
+    ([Left x | x <- [minBound ..]] <> [Right x | x <- [minBound ..]])
+
+case_eitherI255I65535 :: Assertion
+case_eitherI255I65535 = do
+  mapM_
+    (packUnpackIdentity @(Either (Index 255) (Index 65535)))
+    ([Left x | x <- [minBound ..]] <> [Right x | x <- [minBound ..]])
 
 tests :: TestTree
 tests = $(testGroupGenerator)

--- a/clash-protocols-memmap/tests/Tests/Padding.hs
+++ b/clash-protocols-memmap/tests/Tests/Padding.hs
@@ -1,0 +1,83 @@
+-- SPDX-FileCopyrightText: 2025 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+{-# LANGUAGE OverloadedStrings #-}
+{-# OPTIONS_GHC -fconstraint-solver-iterations=10 #-}
+
+module Tests.Padding where
+
+import Clash.Prelude hiding (someNatVal, withSomeSNat)
+
+import BitPackC.Padding (pad, unpad)
+import Clash.Hedgehog.Sized.BitVector (genDefinedBitVector)
+import Clash.Hedgehog.Sized.Vector (genVec)
+import Data.Data (Proxy)
+import GHC.TypeNats (someNatVal)
+import Hedgehog (Property, annotateShow, forAll, property, (===))
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.Hedgehog (testPropertyNamed)
+
+import qualified Data.List.Extra as L
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
+
+type Bytes n = BitVector (n * 8)
+
+withSomeSNat :: Natural -> (forall (n :: Nat). SNat n -> r) -> r
+withSomeSNat n f = case someNatVal n of
+  SomeNat (_ :: Proxy n) -> f (SNat @n)
+
+-- | Property: @unpad . pad === id@
+prop_unpadPadId :: Property
+prop_unpadPadId = property $ do
+  nBytesNat <- forAll $ Gen.integral (Range.linear 0 64)
+  wordSizeMinusOne <- forAll $ Gen.integral (Range.linear 0 8)
+
+  withSomeSNat nBytesNat $ \(SNat :: SNat nBytes) ->
+    withSomeSNat wordSizeMinusOne $ \(wsMinusOne :: SNat wordSizeMinusOne) -> do
+      case succSNat wsMinusOne of
+        (SNat :: SNat wordSize) -> do
+          input <- forAll $ genVec @nBytes genDefinedBitVector
+
+          let
+            padded = pad @nBytes @wordSize input
+            unpadded = unpad @nBytes padded
+
+          annotateShow input
+          annotateShow padded
+          annotateShow unpadded
+
+          unpadded === input
+
+-- | Property: @pad . unpad === id@ modulo data inserted by padding.
+prop_padUnpadId :: Property
+prop_padUnpadId = property $ do
+  nBytesNat <- forAll $ Gen.integral (Range.linear 0 64)
+  wordSizeMinusOne <- forAll $ Gen.integral (Range.linear 0 8)
+
+  withSomeSNat nBytesNat $ \(SNat :: SNat nBytes) ->
+    withSomeSNat wordSizeMinusOne $ \(wsMinusOne :: SNat wordSizeMinusOne) -> do
+      case succSNat wsMinusOne of
+        (SNat :: SNat wordSize) -> do
+          input <- forAll $ genVec (genDefinedBitVector @(wordSize * 8))
+
+          let
+            unpadded = unpad @nBytes input
+            padded = pad @nBytes unpadded
+
+          annotateShow (toList input)
+          annotateShow (toList unpadded)
+          annotateShow (toList padded)
+
+          -- XXX: Poor man's way of removing the data with the padding. Ideally
+          --      we would generate all zeros for the padding, but I don't see
+          --      any easy way of doing that.
+          L.dropEnd 1 (toList padded) === L.dropEnd 1 (toList input)
+
+tests :: TestTree
+tests =
+  testGroup
+    "Padding"
+    [ testPropertyNamed "prop_unpadPadId" "prop_unpadPadId" prop_unpadPadId
+    , testPropertyNamed "prop_padUnpadId" "prop_padUnpadId" prop_padUnpadId
+    ]

--- a/clash-protocols-memmap/tests/UnitTests.hs
+++ b/clash-protocols-memmap/tests/UnitTests.hs
@@ -10,6 +10,7 @@ import Test.Tasty
 import Test.Tasty.Hedgehog
 
 import qualified Tests.BitPackC
+import qualified Tests.Padding
 import qualified Tests.Protocols.MemoryMap.Registers.WishboneStandard
 
 tests :: TestTree
@@ -17,6 +18,7 @@ tests =
   testGroup
     "Unittests"
     [ Tests.BitPackC.tests
+    , Tests.Padding.tests
     , Tests.Protocols.MemoryMap.Registers.WishboneStandard.tests
     ]
 

--- a/firmware-binaries/test-cases/registerwbc_test/src/main.rs
+++ b/firmware-binaries/test-cases/registerwbc_test/src/main.rs
@@ -49,6 +49,7 @@ fn main() -> ! {
     expect("init.s1", 8, many_types.s1());
     expect("init.s2", 16, many_types.s2());
     expect("init.s3", 3721049880298531338, many_types.s3());
+    expect("init.s4", -12, many_types.s4());
 
     expect("init.u0", 8, many_types.u0());
     expect("init.u1", 16, many_types.u1());
@@ -82,19 +83,43 @@ fn main() -> ! {
     expect("init.v2[0]", Some([0x8, 0x16]), many_types.v2(0));
     expect("init.v2[1]", Some([0x24, 0x32]), many_types.v2(1));
 
-    // // XXX: No uDebug trait for enums, so we can't use expect() here.
+    // XXX: No uDebug trait for enums, so we can't use expect() here.
     expect("init.sum0", true, hal::Abc::C == many_types.sum0());
     expect("init.sum1", true, hal::Xyz::S == many_types.sum1());
 
     expect("init.sop0.f", true, many_types.sop0().f == 3.14);
+    expect("init.sop0.u", true, many_types.sop0().u == 6.28);
+
+    expect("init.p0.0", 0xBADC, many_types.p0().0);
+    expect("init.p0.1", 0x0F, many_types.p0().1);
+    expect("init.p0.2", 0xEE, many_types.p0().2);
+    expect("init.p1.0", 0xBADC, many_types.p1().0);
+    expect("init.p1.1", 0x0F, many_types.p1().1);
+    expect("init.p1.2", 0xBEAD, many_types.p1().2);
+    expect("init.p2.0", 0xBADC, many_types.p2().0);
+    expect("init.p2.1", 0x0F, many_types.p2().1);
+    expect("init.p3.0.0", 0xBADC, many_types.p3().0 .0);
+    expect("init.p3.0.1", 0x0F, many_types.p3().0 .1);
+    expect("init.p3.1", 0xEE, many_types.p3().1);
 
     expect("init.e0", true, hal::Either::Left(8) == many_types.e0());
+    expect(
+        "init.me0",
+        true,
+        hal::Maybe::Just(hal::Either::Left(8)) == many_types.me0(),
+    );
+    expect(
+        "init.me1",
+        true,
+        hal::Maybe::Just(hal::Either::Left(8)) == many_types.me1(),
+    );
 
-    // // Test writing values:
+    // Test writing values:
     many_types.set_s0(-16);
     many_types.set_s1(16);
     many_types.set_s2(32);
     many_types.set_s3(7442099760597062676);
+    many_types.set_s4(-13);
     many_types.set_u0(16);
     many_types.set_u1(32);
     many_types.set_u2(7442099760597062676);
@@ -122,16 +147,18 @@ fn main() -> ! {
     many_types.set_v2(1, [0x12, 0x34]).unwrap();
     many_types.set_sum0(hal::Abc::A);
     many_types.set_sum1(hal::Xyz::Z);
-    many_types.set_sop0(hal::F { f: 6.28 });
-
-    // TODO writing a Right() value doesn't work yet.
+    many_types.set_sop0(hal::F { f: 1.0, u: 8.0 });
+    many_types.set_x2(hal::X2(8, hal::X3(16, 32, 64)));
     many_types.set_e0(hal::Either::Left(0x12));
+    many_types.set_me0(hal::Maybe::Just(hal::Either::Right(0x12)));
+    many_types.set_me1(hal::Maybe::Just(hal::Either::Right(0x12)));
 
     // Test read back values:
     expect("rt.s0", -16, many_types.s0());
     expect("rt.s1", 16, many_types.s1());
     expect("rt.s2", 32, many_types.s2());
     expect("rt.s3", 7442099760597062676, many_types.s3());
+    expect("rt.s4", -13, many_types.s4());
     expect("rt.u0", 16, many_types.u0());
     expect("rt.u1", 32, many_types.u1());
     expect("rt.u2", 7442099760597062676, many_types.u2());
@@ -159,10 +186,32 @@ fn main() -> ! {
     expect("rt.v2[1]", Some([0x12, 0x34]), many_types.v2(1));
     expect("rt.sum0", true, hal::Abc::A == many_types.sum0());
     expect("rt.sum1", true, hal::Xyz::Z == many_types.sum1());
-    expect("rt.sop0.f", true, many_types.sop0().f == 6.28);
-
-    // TODO writing/reading a Right value doesn't work yet
+    expect("rt.sop0.f", true, many_types.sop0().f == 1.0);
+    expect("rt.sop0.g", true, many_types.sop0().u == 8.0);
+    expect("rt.v2[0]", Some([0xAB, 0xCD]), many_types.v2(0));
+    expect("rt.v2[1]", Some([0x12, 0x34]), many_types.v2(1));
+    expect("rt.sum0", true, hal::Abc::A == many_types.sum0());
+    expect("rt.sum1", true, hal::Xyz::Z == many_types.sum1());
+    expect("rt.x2.0", 8, many_types.x2().0);
+    expect("rt.x2.1.0", 16, many_types.x2().1 .0);
+    expect("rt.x2.1.1", 32, many_types.x2().1 .1);
     expect("rt.e0", true, hal::Either::Left(0x12) == many_types.e0());
+    expect(
+        "rt.me0",
+        true,
+        hal::Maybe::Just(hal::Either::Right(0x12)) == many_types.me0(),
+    );
+    expect(
+        "rt.me1",
+        true,
+        hal::Maybe::Just(hal::Either::Right(0x12)) == many_types.me1(),
+    );
+
+    many_types.set_e0(hal::Either::Right(0x12));
+    expect("rt.e0", true, hal::Either::Right(0x12) == many_types.e0());
+
+    many_types.set_x2(hal::X2(8, hal::X3(16, 32, 64)));
+    expect("rt.x2.1.2", 64, many_types.x2().1 .2);
 
     test_ok();
 }

--- a/firmware-support/memmap-generate/src/generators/types.rs
+++ b/firmware-support/memmap-generate/src/generators/types.rs
@@ -221,9 +221,14 @@ impl TypeGenerator {
                     }
                 }
                 vars => {
+                    let fieldless = vars.iter().all(|desc| desc.fields.is_empty());
                     let n = clog2(&(vars.len() as u64));
                     let repr = ident(format!("u{}", n));
-                    quote! { #[repr(#repr)] }
+                    if fieldless {
+                        quote! { #[repr(#repr)] }
+                    } else {
+                        quote! { #[repr(C, #repr)] }
+                    }
                 }
             }
         } else {


### PR DESCRIPTION
Thanks for being very patient @hydrolarus... I realize that after all the wrong turns we took it would have probably made the diff smaller if I reworked the implementation from `origin/staging` from scratch again, but honestly I'm very much done with this whole ordeal :-).

# How `BitPackC` (from documentation)
![Screenshot from 2025-06-03 18-01-30](https://github.com/user-attachments/assets/d4a8760c-8963-4a16-979e-b4126b18db31)


# TODO
- [x] Rework documentation of `BitPackC`
- [x] ~~Tests for `Align` module (does type family correspond to typelits function?)~~
  - No type level implementation exists anymore
- [X] Explain why we do `Align` the way we do
- [x] Add documentation to `Padding`
- [x] Add documentation to `packC` and `unpackC`
- [X] Explain general design choices
- [X] Explain briefly how C packs words and why `BitPackC` corresponds to this
- [x] Make registers/devices configurable both in bus and internal byte order
  - [x] Use IP to pass this around
- [x] Rework broken test
  - `Tests.Protocols.MemoryMap.Registers.WishboneStandard` heavily relies on wrong padding behavior. Just remove types that introduce padding..?

# Maybe TODO for other PRs
- https://github.com/bittide/bittide-hardware/issues/804
- https://github.com/bittide/bittide-hardware/issues/803
- https://github.com/bittide/bittide-hardware/issues/805
- Make VexRiscV configurable in `busByteOrder` (and make it error on `regByteOrder` == BigEndian?). _Honestly I don't know if we want this, so I'm not even making an issue :upside_down_face:_.