### PR TITLE
Update Clash hash for bugfix for GHC 9.10

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -158,7 +158,7 @@ package vivado-hs
 source-repository-package
   type: git
   location: https://github.com/clash-lang/clash-compiler.git
-  tag: 773ae8d3bc5e0b1241d238d39b651f63c737e16a
+  tag: 39b105aec33733c0a2c3285983b785036655e65e
   subdir:
     clash-prelude
     clash-ghc


### PR DESCRIPTION
Upgrading to GHC 9.10 broke CI. Martijn fixed this on `clash-compiler`.

See: https://github.com/clash-lang/clash-compiler/issues/2966