### PR TITLE
Move switch demo to general purpose processing element

### DIFF
--- a/.github/synthesis/debug.json
+++ b/.github/synthesis/debug.json
@@ -1,0 +1,3 @@
+[
+  {"top": "switchDemoTest", "stage": "test"}
+]

--- a/bittide-extra/src/Protocols/Extra.hs
+++ b/bittide-extra/src/Protocols/Extra.hs
@@ -21,10 +21,18 @@ mapCircuit ::
   Circuit (Vec n a) (Vec n b)
 mapCircuit circ = Circuit go
  where
-  circuitFn :: (Fwd a, Bwd b) -> (Bwd a, Fwd b)
-  Circuit circuitFn = circ
   go :: (Vec n (Fwd a), Vec n (Bwd b)) -> (Vec n (Bwd a), Vec n (Fwd b))
-  go (aFwd, bBwd) = unzip $ circuitFn <$> zip aFwd bBwd
+  go (aFwd, bBwd) = unzip $ toSignals circ <$> zip aFwd bBwd
+
+zipCircuit ::
+  forall a b n.
+  (KnownNat n) =>
+  Vec n (Circuit a b) ->
+  Circuit (Vec n a) (Vec n b)
+zipCircuit circs = Circuit go
+ where
+  go :: (Vec n (Fwd a), Vec n (Bwd b)) -> (Vec n (Bwd a), Vec n (Fwd b))
+  go (fwdA, bwdB) = unzip $ toSignals <$> circs <*> zip fwdA bwdB
 
 -- | Applies the mappings @Fwd a -> Fwd b@ and @Bwd b -> Bwd a@ to the circuit's signals.
 applyC ::

--- a/bittide-instances/data/openocd/vexriscv-3chain.tcl
+++ b/bittide-instances/data/openocd/vexriscv-3chain.tcl
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: 2025 Google LLC
+#
+# SPDX-License-Identifier: Apache-2.0
+set user_gdb_port_a [env DEV_A_GDB]
+if { $user_gdb_port_a == "" } {
+  error "Required environment variable 'DEV_A_GDB' not set."
+}
+
+set user_gdb_port_b [env DEV_B_GDB]
+if { $user_gdb_port_b == "" } {
+  error "Required environment variable 'DEV_B_GDB' not set."
+}
+
+set user_gdb_port_c [env DEV_C_GDB]
+if { $user_gdb_port_c == "" } {
+  error "Required environment variable 'DEV_C_GDB' not set."
+}
+
+set user_tcl_port [env TCL_PORT]
+if { $user_tcl_port == "" } {
+  error "Required environment variable 'TCL_PORT' not set."
+}
+
+set user_tel_port [env TEL_PORT]
+if { $user_tel_port == "" } {
+  error "Required environment variable 'TEL_PORT' not set."
+}
+
+set git_top_level [string trim [exec git rev-parse --show-toplevel]]
+
+set _ENDIAN little
+set _TAP_TYPE 1234
+
+bindto 0.0.0.0
+
+if { [info exists CPUTAPID] } {
+  set _CPUTAPID $CPUTAPID
+} else {
+  set _CPUTAPID 0x10001fff
+}
+
+set _CHIPNAME vexrisc_ocd
+
+jtag newtap $_CHIPNAME chain0 -expected-id $_CPUTAPID -irlen 4 -ircapture 0x1
+target create $_CHIPNAME.cpu0 vexriscv -endian $_ENDIAN -chain-position $_CHIPNAME.chain0 -gdb-port $user_gdb_port_a
+vexriscv readWaitCycles 10
+vexriscv cpuConfigFile [file join $git_top_level clash-vexriscv clash-vexriscv example-cpu ExampleCpu.yaml]
+
+jtag newtap $_CHIPNAME chain1 -expected-id $_CPUTAPID -irlen 4 -ircapture 0x1
+target create $_CHIPNAME.cpu1 vexriscv -endian $_ENDIAN -chain-position $_CHIPNAME.chain1 -gdb-port $user_gdb_port_b
+vexriscv readWaitCycles 10
+vexriscv cpuConfigFile [file join $git_top_level clash-vexriscv clash-vexriscv example-cpu ExampleCpu.yaml]
+
+jtag newtap $_CHIPNAME chain2 -expected-id $_CPUTAPID -irlen 4 -ircapture 0x1
+target create $_CHIPNAME.cpu2 vexriscv -endian $_ENDIAN -chain-position $_CHIPNAME.chain2 -gdb-port $user_gdb_port_c
+vexriscv readWaitCycles 10
+vexriscv cpuConfigFile [file join $git_top_level clash-vexriscv clash-vexriscv example-cpu ExampleCpu.yaml]
+
+tcl_port $user_tcl_port
+telnet_port $user_tel_port
+
+poll_period 50
+
+init
+
+echo "Halting processor"
+
+halt
+
+sleep 1000

--- a/bittide-instances/src/Bittide/Instances/Hitl/Driver/SwitchDemo.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/Driver/SwitchDemo.hs
@@ -8,7 +8,10 @@
 
 module Bittide.Instances.Hitl.Driver.SwitchDemo (
   OcdInitData (..),
+  ccWhoAmID,
   driver,
+  muWhoAmID,
+  whoAmIPrefix,
 ) where
 
 import Clash.Prelude
@@ -19,6 +22,7 @@ import Bittide.Instances.Hitl.Setup (FpgaCount, fpgaSetup)
 import Bittide.Instances.Hitl.Utils.Driver
 import Bittide.Instances.Hitl.Utils.Program
 
+import Clash.Sized.Extra (extendLsb0s)
 import Control.Concurrent (threadDelay)
 import Control.Monad (forM, forM_, when, zipWithM)
 import Control.Monad.IO.Class
@@ -56,6 +60,13 @@ data OcdInitData = OcdInitData
 data TestStatus = TestRunning | TestDone Bool | TestTimeout deriving (Eq)
 
 type StartDelay = 5 -- seconds
+
+whoAmIPrefix :: forall n m. (KnownNat n, KnownNat m, n ~ m + 3) => Unsigned n
+whoAmIPrefix = extendLsb0s @3 @m (0b111 :: Unsigned 3)
+ccWhoAmID :: BitVector 32
+ccWhoAmID = $(makeWhoAmIDTH "swcc")
+muWhoAmID :: BitVector 32
+muWhoAmID = $(makeWhoAmIDTH "mgmt")
 
 driver ::
   (HasCallStack) =>

--- a/bittide-instances/src/Bittide/Instances/Hitl/VexRiscv.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/VexRiscv.hs
@@ -185,6 +185,8 @@ vexRiscvTestC =
       , iBusTimeout = d0
       , dBusTimeout = d0
       , includeIlaWb = True
+      , whoAmIPrefix = 0b011
+      , whoAmID = 0x3075_7063
       }
 
 type IMemWords = DivRU (64 * 1024) 4

--- a/bittide-instances/src/Bittide/Instances/MemoryMaps.hs
+++ b/bittide-instances/src/Bittide/Instances/MemoryMaps.hs
@@ -37,6 +37,7 @@ $( do
     let memoryMaps =
           [ ("SwitchDemoCc", SwitchDemo.memoryMapCc)
           , ("SwitchDemoMu", SwitchDemo.memoryMapMu)
+          , ("SwitchDemoGppe", SwitchDemo.memoryMapGppe)
           , ("Ethernet", vexRiscvEthernetMM)
           , ("Freeze", freezeMM)
           , ("ProcessingElement", vexRiscvUartHelloMM)

--- a/bittide-instances/src/Bittide/Instances/Pnr/Ethernet.hs
+++ b/bittide-instances/src/Bittide/Instances/Pnr/Ethernet.hs
@@ -186,6 +186,8 @@ vexRiscGmiiC SNat sysClk sysRst rxClk rxRst txClk txRst =
         , iBusTimeout = d0
         , dBusTimeout = d0
         , includeIlaWb = False
+        , whoAmID = 0x6363_7773
+        , whoAmIPrefix = 0b1110
         }
 
   peConfigRtl =
@@ -197,6 +199,8 @@ vexRiscGmiiC SNat sysClk sysRst rxClk rxRst txClk txRst =
       , iBusTimeout = d0
       , dBusTimeout = d0
       , includeIlaWb = True
+      , whoAmID = 0x6363_7773
+      , whoAmIPrefix = 0b1110
       }
 
 type IMemWords = DivRU (280 * 1024) 4

--- a/bittide-instances/src/Bittide/Instances/Pnr/ProcessingElement.hs
+++ b/bittide-instances/src/Bittide/Instances/Pnr/ProcessingElement.hs
@@ -51,9 +51,9 @@ vexRiscvUartHelloC baudSnat = circuit $ \(mm, (uartRx, jtag)) -> do
     processingElement @dom NoDumpVcd peConfig -< (mm, jtag)
   (uartTx, _uartStatus) <-
     uartInterfaceWb d16 d16 (uartDf baudSnat) -< (mmUart, (uartBus, uartRx))
-  constBwd 0b10 -< prefixUart
+  constBwd 0b100 -< prefixUart
   _localCounter <- timeWb -< (mmTime, timeBus)
-  constBwd 0b11 -< prefixTime
+  constBwd 0b110 -< prefixTime
   idC -< uartTx
  where
   peConfig
@@ -84,12 +84,14 @@ vexRiscvUartHelloC baudSnat = circuit $ \(mm, (uartRx, jtag)) -> do
   peConfigRtl =
     PeConfig
       { initI = Undefined @IMemWords
-      , prefixI = 0b00
+      , prefixI = 0b000
       , initD = Undefined @DMemWords
-      , prefixD = 0b01
+      , prefixD = 0b010
       , iBusTimeout = d0
       , dBusTimeout = d0
       , includeIlaWb = True
+      , whoAmID = 0x6363_7773
+      , whoAmIPrefix = 0b111
       }
 
 {- | A simple instance containing just VexRisc and UART as peripheral.

--- a/bittide-instances/src/Bittide/Instances/Tests/RegisterWbC.hs
+++ b/bittide-instances/src/Bittide/Instances/Tests/RegisterWbC.hs
@@ -24,7 +24,9 @@ import Bittide.ProcessingElement (
     initD,
     initI,
     prefixD,
-    prefixI
+    prefixI,
+    whoAmID,
+    whoAmIPrefix
   ),
   processingElement,
  )
@@ -352,9 +354,9 @@ dut =
         [(prefixUart, (mmUart, uartBus)), (prefixManyTypes, manyTypes)] <-
           processingElement dumpVcd peConfig -< (mm, jtag)
         (uartTx, _uartStatus) <- uartInterfaceWb d2 d2 uartSim -< (mmUart, (uartBus, uartRx))
-        constBwd 0b00 -< prefixUart
+        constBwd 0b000 -< prefixUart
         manyTypesWb -< manyTypes
-        constBwd 0b11 -< prefixManyTypes
+        constBwd 0b110 -< prefixManyTypes
         idC -< uartTx
  where
   dumpVcd =
@@ -374,16 +376,18 @@ dut =
               $ Vec
               $ unsafePerformIO
               $ vecFromElfInstr BigEndian elfPath
-        , prefixI = 0b10
+        , prefixI = 0b100
         , initD =
             Reloadable @DMemWords
               $ Vec
               $ unsafePerformIO
               $ vecFromElfData BigEndian elfPath
-        , prefixD = 0b01
+        , prefixD = 0b010
         , iBusTimeout = d0 -- No timeouts on the instruction bus
         , dBusTimeout = d0 -- No timeouts on the data bus
         , includeIlaWb = False
+        , whoAmID = 0x6363_7773
+        , whoAmIPrefix = 0b111
         }
 {-# NOINLINE dut #-}
 

--- a/bittide-instances/tests/Tests/ClockControlWb.hs
+++ b/bittide-instances/tests/Tests/ClockControlWb.hs
@@ -174,6 +174,8 @@ dut =
         , iBusTimeout = d0
         , dBusTimeout = d0
         , includeIlaWb = False
+        , whoAmIPrefix = 0b111
+        , whoAmID = 0x3075_7063
         }
 {-# NOINLINE dut #-}
 

--- a/bittide-instances/tests/Wishbone/Axi.hs
+++ b/bittide-instances/tests/Wishbone/Axi.hs
@@ -114,6 +114,8 @@ dut =
         , iBusTimeout = d0 -- No timeouts on the instruction bus
         , dBusTimeout = d0 -- No timeouts on the data bus
         , includeIlaWb = False
+        , whoAmIPrefix = 0b111
+        , whoAmID = 0x3075_7063
         }
 {-# NOINLINE dut #-}
 

--- a/bittide-instances/tests/Wishbone/CaptureUgn.hs
+++ b/bittide-instances/tests/Wishbone/CaptureUgn.hs
@@ -94,9 +94,9 @@ dut eb localCounter = circuit $ do
     processingElement @dom NoDumpVcd peConfig -< (mm, jtagIdle)
   (uartTx, _uartStatus) <- uartInterfaceWb d2 d2 uartSim -< (mmUart, (uartBus, uartRx))
   mm <- ignoreMM
-  constBwd 0b10 -< prefixUart
+  constBwd 0b100 -< prefixUart
   _bittideData <- captureUgn localCounter eb -< (mmUgn, ugnBus)
-  constBwd 0b11 -< prefixUgn
+  constBwd 0b110 -< prefixUgn
   idC -< uartTx
  where
   peConfig = unsafePerformIO $ do
@@ -106,12 +106,14 @@ dut eb localCounter = circuit $ do
     pure
       PeConfig
         { initI = Reloadable (Vec iMem)
-        , prefixI = 0b00
+        , prefixI = 0b000
         , initD = Reloadable (Vec dMem)
-        , prefixD = 0b01
+        , prefixD = 0b010
         , iBusTimeout = d0 -- No timeouts on the instruction bus
         , dBusTimeout = d0 -- No timeouts on the data bus
         , includeIlaWb = False
+        , whoAmIPrefix = 0b111
+        , whoAmID = 0x3075_7063
         }
 
 type IMemWords = DivRU (64 * 1024) 4

--- a/bittide-instances/tests/Wishbone/DnaPortE2.hs
+++ b/bittide-instances/tests/Wishbone/DnaPortE2.hs
@@ -63,9 +63,9 @@ dut = circuit $ \_unit -> do
     processingElement @dom NoDumpVcd peConfig -< (mm, jtag)
   (uartTx, _uartStatus) <- uartInterfaceWb d2 d2 uartSim -< (mmUart, (uartBus, uartRx))
   mm <- ignoreMM
-  constBwd 0b10 -< prefixUart
+  constBwd 0b100 -< prefixUart
   _dna <- readDnaPortE2Wb simDna2 -< dnaBus
-  constBwd 0b11 -< prefixDna
+  constBwd 0b110 -< prefixDna
   idC -< uartTx
  where
   peConfig = unsafePerformIO $ do
@@ -75,12 +75,14 @@ dut = circuit $ \_unit -> do
     pure
       PeConfig
         { initI = Reloadable (Vec iMem)
-        , prefixI = 0b00
+        , prefixI = 0b000
         , initD = Reloadable (Vec dMem)
-        , prefixD = 0b01
+        , prefixD = 0b010
         , iBusTimeout = d0 -- No timeouts on the instruction bus
         , dBusTimeout = d0 -- No timeouts on the data bus
         , includeIlaWb = False
+        , whoAmIPrefix = 0b111
+        , whoAmID = 0x3075_7063
         }
 {-# NOINLINE dut #-}
 

--- a/bittide-instances/tests/Wishbone/ScatterGather.hs
+++ b/bittide-instances/tests/Wishbone/ScatterGather.hs
@@ -116,6 +116,8 @@ dut scatterConfig gatherConfig = circuit $ do
         , iBusTimeout = d0 -- No timeouts on the instruction bus
         , dBusTimeout = d0 -- No timeouts on the data bus
         , includeIlaWb = False
+        , whoAmIPrefix = 0b111
+        , whoAmID = 0x3075_7063
         }
 
 type IMemWords = DivRU (64 * 1024) 4

--- a/bittide-instances/tests/Wishbone/SwitchDemoProcessingElement.hs
+++ b/bittide-instances/tests/Wishbone/SwitchDemoProcessingElement.hs
@@ -124,6 +124,8 @@ dut dnaA dnaB = circuit $ do
         , iBusTimeout = d0 -- No timeouts on the instruction bus
         , dBusTimeout = d0 -- No timeouts on the data bus
         , includeIlaWb = False
+        , whoAmIPrefix = 0b111
+        , whoAmID = 0x3075_7063
         }
 
 type IMemWords = DivRU (72 * 1024) 4

--- a/bittide-instances/tests/Wishbone/Time.hs
+++ b/bittide-instances/tests/Wishbone/Time.hs
@@ -66,9 +66,9 @@ dut = withClockResetEnable clockGen resetGen enableGen
       processingElement NoDumpVcd peConfig -< (mm, jtag)
     mm <- ignoreMM
     (uartTx, _uartStatus) <- uartInterfaceWb d2 d2 uartSim -< (mmUart, (uartBus, uartRx))
-    constBwd 0b10 -< prefixUart
+    constBwd 0b100 -< prefixUart
     _localCounter <- timeWb -< (mmTime, timeBus)
-    constBwd 0b11 -< prefixTime
+    constBwd 0b110 -< prefixTime
     idC -< uartTx
  where
   peConfig = unsafePerformIO $ do
@@ -78,12 +78,14 @@ dut = withClockResetEnable clockGen resetGen enableGen
     pure
       PeConfig
         { initI = Reloadable (Vec iMem)
-        , prefixI = 0b00
+        , prefixI = 0b000
         , initD = Reloadable (Vec dMem)
-        , prefixD = 0b01
+        , prefixD = 0b010
         , iBusTimeout = d0 -- No timeouts on the instruction bus
         , dBusTimeout = d0 -- No timeouts on the data bus
         , includeIlaWb = False
+        , whoAmIPrefix = 0b111
+        , whoAmID = 0x3075_7063
         }
 {-# NOINLINE dut #-}
 

--- a/bittide-instances/tests/Wishbone/Watchdog.hs
+++ b/bittide-instances/tests/Wishbone/Watchdog.hs
@@ -99,6 +99,8 @@ dut = withClockResetEnable clockGen resetGen enableGen
         , iBusTimeout = d0 -- No timeouts on the instruction bus
         , dBusTimeout = d0 -- No timeouts on the data bus
         , includeIlaWb = False
+        , whoAmIPrefix = 0b111
+        , whoAmID = 0x3075_7063
         }
 {-# NOINLINE dut #-}
 

--- a/bittide/src/Bittide/Calendar.hs
+++ b/bittide/src/Bittide/Calendar.hs
@@ -84,12 +84,13 @@ data CalendarConfig nBytes addrW a where
     , ShowX a
     , 2 <= maxCalDepth
     ) =>
-    -- | Maximum amount of entries that can be held per calendar.
-    SNat maxCalDepth ->
-    -- | Initial contents of the active calendar.
-    Calendar bootstrapActive a repetitionBits ->
-    -- | Initial contents of the inactive calendar.
-    Calendar bootstrapShadow a repetitionBits ->
+    { maxCalDepth :: SNat maxCalDepth
+    -- ^ Maximum amount of entries that can be held per calendar.
+    , activeCalendar :: Calendar bootstrapActive a repetitionBits
+    -- ^ Initial contents of the active calendar.
+    , inactiveCalendar :: Calendar bootstrapShadow a repetitionBits
+    -- ^ Initial contents of the inactive calendar.
+    } ->
     CalendarConfig nBytes addrW a
 
 -- | Standalone deriving is required because 'CalendarConfig' contains existential type variables.

--- a/bittide/src/Bittide/ClockControl/CallistoSw.hs
+++ b/bittide/src/Bittide/ClockControl/CallistoSw.hs
@@ -34,7 +34,7 @@ import Bittide.ClockControl.DebugRegister (
  )
 import Bittide.ClockControl.Registers (ClockControlData (..), clockControlWb)
 import Bittide.DoubleBufferedRam (InitialContent (Undefined))
-import Bittide.ProcessingElement (PeConfig (..), processingElement)
+import Bittide.ProcessingElement (PeConfig (..), processingElement, PeInternalBusses)
 import Bittide.SharedTypes
 import Bittide.Wishbone (timeWb)
 import Protocols.MemoryMap
@@ -156,9 +156,11 @@ callistoSwClockControl (ccConfig@SwControlConfig{framesize}) mask ebs =
       , iBusTimeout = d0 -- No timeouts on the instruction bus
       , dBusTimeout = d0 -- No timeouts on the data bus
       , includeIlaWb = True
+      , whoAmID = 0x6363_7773
+      , whoAmIPrefix = 0b111
       }
 
-type SwcccInternalBusses = 5
+type SwcccInternalBusses = PeInternalBusses + 3
 type SwcccRemBusWidth n = 30 - CLog 2 (n + SwcccInternalBusses)
 
 -- The additional 'otherWb' type parameter is necessary since this type helps expose

--- a/bittide/src/Bittide/ClockControl/CallistoSw.hs
+++ b/bittide/src/Bittide/ClockControl/CallistoSw.hs
@@ -34,7 +34,7 @@ import Bittide.ClockControl.DebugRegister (
  )
 import Bittide.ClockControl.Registers (ClockControlData (..), clockControlWb)
 import Bittide.DoubleBufferedRam (InitialContent (Undefined))
-import Bittide.ProcessingElement (PeConfig (..), processingElement, PeInternalBusses)
+import Bittide.ProcessingElement (PeConfig (..), PeInternalBusses, processingElement)
 import Bittide.SharedTypes
 import Bittide.Wishbone (timeWb)
 import Protocols.MemoryMap

--- a/bittide/src/Bittide/Node.hs
+++ b/bittide/src/Bittide/Node.hs
@@ -1,6 +1,11 @@
 -- SPDX-FileCopyrightText: 2022 Google LLC
 --
 -- SPDX-License-Identifier: Apache-2.0
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE ImplicitParams #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# OPTIONS_GHC -fconstraint-solver-iterations=6 #-}
 
 {-# OPTIONS -fplugin=Protocols.Plugin #-}
 -- {-# OPTIONS -fplugin-opt=Protocols.Plugin:debug #-}
@@ -9,166 +14,137 @@ module Bittide.Node where
 
 import Clash.Prelude
 
+import BitPackC (ByteOrder)
 import GHC.Stack (HasCallStack)
 import Protocols
 import Protocols.Extra
 import Protocols.Idle
-import Protocols.MemoryMap (ConstBwd, MM, MemoryMap, constBwd)
+import Protocols.MemoryMap (ConstBwd, MM, constBwd)
 import Protocols.Wishbone
 import VexRiscv
 
 import Bittide.Calendar
+import Bittide.CaptureUgn (captureUgn)
+import Bittide.Jtag
 import Bittide.ProcessingElement
 import Bittide.ScatterGather
 import Bittide.SharedTypes
 import Bittide.Switch
+import Bittide.Wishbone (timeWb)
 
 {- | Each 'gppe' results in 2 busses for the 'managementUnit', namely:
 * The 'calendar' for the 'scatterUnitWB'.
 * The 'calendar' for the 'gatherUnitWB'.
 -}
-type BussesPerGppe = 2
+type BussesPerGppe = GppeBusses - GppeBussesNotExposed
 
 -- | Configuration of a 'node'.
-data NodeConfig externalLinks gppes where
+data NodeConfig linkCount gppes where
   NodeConfig ::
-    ( KnownNat nmuBusses
-    , nmuBusses ~ ((BussesPerGppe * gppes) + 1 + NmuInternalBusses)
-    , KnownNat nmuRemBusWidth
-    , nmuRemBusWidth ~ (30 - CLog 2 nmuBusses)
-    , CLog 2 nmuBusses <= 30
+    forall linkCount gppes.
+    ( KnownNat linkCount
+    , KnownNat gppes
+    , NmuPrefixWidth linkCount gppes <= 30
     ) =>
-    -- | Configuration for the 'node's 'managementUnit'.
-    ManagementConfig ((BussesPerGppe * gppes) + 1) ->
-    -- | Configuratoin for the 'node's 'switch'.
-    CalendarConfig 4 nmuRemBusWidth (CalendarEntry (externalLinks + gppes + 1)) ->
-    -- | Configuration for all the node's 'gppe's.
-    Vec gppes (GppeConfig nmuRemBusWidth) ->
-    -- | prefixes for the calendar wishbone interfaces of all GPPEs
-    Vec gppes (Vec 2 (Unsigned (CLog 2 nmuBusses))) ->
-    NodeConfig externalLinks gppes
+    { managementConfig :: ManagementConfig linkCount gppes
+    -- ^ Configuration for the 'node's 'managementUnit'.
+    , calendarConfig ::
+        CalendarConfig 4 (NmuRemBusWidth linkCount gppes) (CalendarEntry (linkCount + gppes + 1))
+    -- ^ Configuratoin for the 'node's 'switch'.
+    , gppeConfigs :: Vec gppes (GppeConfig (NmuRemBusWidth linkCount gppes))
+    -- ^ Configuration for all the node's 'gppe's.
+    } ->
+    NodeConfig linkCount gppes
 
 -- | A 'node' consists of a 'switch', 'managementUnit' and @0..n@ 'gppe's.
 node ::
-  forall dom extLinks gppes.
-  (HiddenClockResetEnable dom, KnownNat extLinks, KnownNat gppes) =>
-  NodeConfig extLinks gppes ->
+  forall dom linkCount gppes.
+  ( HiddenClockResetEnable dom
+  , 1 <= DomainPeriod dom
+  , ?busByteOrder :: ByteOrder
+  , ?regByteOrder :: ByteOrder
+  ) =>
+  NodeConfig linkCount gppes ->
   Circuit
-    (ConstBwd MM, Vec gppes (ConstBwd MM), Vec extLinks (CSignal dom (BitVector 64)))
-    (Vec extLinks (CSignal dom (BitVector 64)))
-node (NodeConfig nmuConfig switchConfig gppeConfigs prefixes) = circuit $ \(mmNmu, mms, linksIn) -> do
-  (switchOut, _cal) <- switchC switchConfig -< (mmSwWb, (switchIn, swWb))
-  switchIn <- appendC3 -< ([nmuLinkOut], pesToSwitch, linksIn)
-  ([Fwd nmuLinkIn], switchToPes, linksOut) <- split3CI -< switchOut
-  (nmuLinkOut, nmuWbs0) <- managementUnitC nmuConfig nmuLinkIn -< mmNmu
-  ([(preSw, (mmSwWb, swWb))], nmuWbs1) <- splitAtCI -< nmuWbs0
-  peWbs <- unconcatC d2 -< nmuWbs1
-
-  constBwd 0b0 -< preSw
-
-  pesToSwitch <- nodeGppes gppeConfigs prefixes -< (mms, switchToPes, peWbs)
-  idC -< linksOut
-
-nodeGppes ::
-  forall gppes dom nmuBusses nmuRemBusWidth.
-  (KnownNat gppes, HiddenClockResetEnable dom, KnownNat nmuBusses, KnownNat nmuRemBusWidth) =>
-  Vec gppes (GppeConfig nmuRemBusWidth) ->
-  Vec gppes (Vec 2 (Unsigned (CLog 2 nmuBusses))) ->
-  Circuit
-    ( Vec gppes (ConstBwd MM)
+    ( ConstBwd MM
+    , Vec gppes (ConstBwd MM)
+    , Jtag dom
+    , Vec linkCount (CSignal dom (Maybe (BitVector 64)))
+    )
+    ( Vec linkCount (CSignal dom (BitVector 64))
+    , CSignal dom (Unsigned 64)
+    , (ConstBwd MM, NmuWishbone dom linkCount gppes)
     , Vec gppes (CSignal dom (BitVector 64))
-    , Vec
-        gppes
-        ( Vec
-            2
-            ( ConstBwd (Unsigned (CLog 2 nmuBusses))
-            , ( ConstBwd MM
-              , Wishbone dom Standard nmuRemBusWidth (BitVector 32)
-              )
-            )
-        )
+    , Vec gppes (CSignal dom (BitVector 64))
+    , CSignal dom (Vec (linkCount + gppes + 1) (Index (linkCount + gppes + 2)))
     )
-    (Vec gppes (CSignal dom (BitVector 64)))
-nodeGppes configs prefixes = Circuit go
+node (NodeConfig muConfig switchConfig gppeConfigs) =
+  circuit $ \(muMM, gppeMMs, jtag, Fwd rxs) -> do
+    [muJtag, gppesJtagTap] <- jtagChain -< jtag
+    gppesJtag <- jtagChain -< gppesJtagTap
+
+    ( nmuLinkOut
+      , Fwd localCounter
+      , (switchMM, switchWb)
+      , externalMMWb
+      , captureUgnsMMWb
+      , scatterCalsMMWb
+      , gatherCalsMMWb
+      ) <-
+      managementUnitC muConfig -< (muMM, nmuLinkIn, muJtag)
+
+    ugnRxs <- zipCircuit (captureUgn localCounter <$> rxs) -< captureUgnsMMWb
+
+    Fwd peLinksOut <-
+      zipCircuit (gppeC <$> gppeConfigs)
+        <| zipC5
+        -< (gppeMMs, Fwd switchToGppes, scatterCalsMMWb, gatherCalsMMWb, gppesJtag)
+
+    switchIn <- appendC3 -< ([nmuLinkOut], Fwd peLinksOut, ugnRxs)
+    (switchOut, cal) <-
+      switchC @_ @_ @_ @_ @64 switchConfig -< (switchMM, (switchIn, switchWb))
+    ([nmuLinkIn], Fwd switchToGppes, linksOut) <- split3CI -< switchOut
+
+    idC -< (linksOut, Fwd localCounter, externalMMWb, Fwd switchToGppes, Fwd peLinksOut, cal)
  where
-  go ::
-    ( ( Vec gppes ()
-      , Vec gppes (Signal dom (BitVector 64))
-      , Vec gppes (Vec 2 ((), ((), Signal dom (WishboneM2S nmuRemBusWidth 4 (BitVector 32)))))
-      )
-    , Vec gppes (Signal dom ())
-    ) ->
-    ( ( Vec gppes (SimOnly MemoryMap)
-      , Vec gppes (Signal dom ())
-      , Vec
-          gppes
-          ( Vec
-              2
-              ( Unsigned (CLog 2 nmuBusses)
-              , (SimOnly MemoryMap, Signal dom (WishboneS2M (BitVector 32)))
-              )
-          )
-      )
-    , Vec gppes (Signal dom (BitVector 64))
-    )
-  go ((_, linksIn, map (snd . snd <$>) -> m2ss), _) = ((mms, repeat (pure ()), interfaces), linksOut)
-   where
-    (unzip3 -> (mms, interfaces, linksOut)) = singleGppe <$> configs <*> linksIn <*> prefixes <*> m2ss
+  zipC5 ::
+    forall a b c d e n.
+    (KnownNat n) =>
+    Circuit (Vec n a, Vec n b, Vec n c, Vec n d, Vec n e) (Vec n (a, b, c, d, e))
+  zipC5 = applyC (\(a, b, c, d, e) -> zip5 a b c d e) unzip5
 
-  singleGppe ::
-    GppeConfig nmuRemBusWidth ->
-    Signal dom (BitVector 64) ->
-    Vec 2 (Unsigned (CLog 2 nmuBusses)) ->
-    Vec 2 (Signal dom (WishboneM2S nmuRemBusWidth 4 (BitVector 32))) ->
-    ( SimOnly MemoryMap
-    , Vec
-        2
-        ( Unsigned (CLog 2 nmuBusses)
-        , (SimOnly MemoryMap, Signal dom (WishboneS2M (BitVector 32)))
-        )
-    , Signal dom (BitVector 64)
-    )
-  singleGppe config linkIn prefixes' m2ss = (mm, zip prefixes' interfacesOut, linkOut)
-   where
-    ((mm, interfacesOut), linkOut) = toSignals (gppeC config linkIn) (((), ((),) <$> m2ss), pure ())
+{- Type-level number of GPPE internal busses.
 
-type NmuInternalBusses = 6
-type NmuRemBusWidth nodeBusses = 30 - CLog 2 (nodeBusses + NmuInternalBusses)
-
-{- | Configuration for the 'managementUnit' and its 'Bittide.Link'.
-The management unit contains the 4 wishbone busses that each pe has
-and also the management busses for itself and all other pe's in this node.
-Furthermore it also has access to the 'calendar' for the 'switch'.
+Internal busses:
+  * Instruction bus (not exposed to MU)
+  * Data bus (not exposed to MU)
+  * 'whoAmIWb' (not exposed to MU)
+  * Scatter unit
+  * Gather unit
 -}
-data ManagementConfig nodeBusses where
-  ManagementConfig ::
-    (KnownNat nodeBusses) =>
-    ScatterConfig 4 (NmuRemBusWidth nodeBusses) ->
-    Unsigned (CLog 2 (nodeBusses + NmuInternalBusses)) ->
-    Unsigned (CLog 2 (nodeBusses + NmuInternalBusses)) ->
-    GatherConfig 4 (NmuRemBusWidth nodeBusses) ->
-    Unsigned (CLog 2 (nodeBusses + NmuInternalBusses)) ->
-    Unsigned (CLog 2 (nodeBusses + NmuInternalBusses)) ->
-    PeConfig (nodeBusses + NmuInternalBusses) ->
-    DumpVcd ->
-    ManagementConfig nodeBusses
+type GppeBusses = 2 + PeInternalBusses
+type GppeBussesNotExposed = PeInternalBusses
+type GppeBusWidth = 30 - CLog 2 GppeBusses
 
 {- | Configuration for a general purpose processing element together with its link to the
 switch.
 -}
 data GppeConfig nmuRemBusWidth where
   GppeConfig ::
-    ScatterConfig 4 nmuRemBusWidth ->
-    -- | Interconnect prefix for the scatter engine
-    Unsigned 2 ->
-    GatherConfig 4 nmuRemBusWidth ->
-    -- | Interconnect prefix for the gather engine
-    Unsigned 2 ->
-    -- | Configuration for a 'gppe's 'processingElement', which statically
+    { scatterConfig :: ScatterConfig 4 nmuRemBusWidth
+    -- ^ Configuration for the scatter engine
+    , scatterPrefix :: Unsigned (CLog 2 GppeBusses)
+    -- ^ Interconnect prefix for the scatter engine
+    , gatherConfig :: GatherConfig 4 nmuRemBusWidth
+    -- ^ Configuration for the gather engine
+    , gatherPrefix :: Unsigned (CLog 2 GppeBusses)
+    -- ^ Interconnect prefix for the gather engine
+    , peConfig :: PeConfig GppeBusses
+    -- ^ Configuration for a 'gppe's 'processingElement', which statically
     -- has four external busses connected to the instruction memory, data memory
     -- , 'scatterUnitWb' and 'gatherUnitWb'.
-    PeConfig 4 ->
-    DumpVcd ->
+    , dumpVcd :: DumpVcd
+    } ->
     GppeConfig nmuRemBusWidth
 
 {-# NOINLINE gppeC #-}
@@ -181,29 +157,108 @@ The order of Wishbone busses is as follows:
 ('scatterUnitWb' :> 'gatherUnitWb' :> Nil).
 -}
 gppeC ::
-  (HasCallStack, KnownNat nmuRemBusWidth, HiddenClockResetEnable dom) =>
+  ( HasCallStack
+  , KnownNat nmuRemBusWidth
+  , HiddenClockResetEnable dom
+  , ?busByteOrder :: ByteOrder
+  , ?regByteOrder :: ByteOrder
+  ) =>
   -- | Configures all local parameters
   GppeConfig nmuRemBusWidth ->
-  -- |
-  -- ( Incoming 'Bittide.Link'
-  -- , Incoming @Vector@ of master busses
-  -- )
-  Signal dom (BitVector 64) ->
   Circuit
-    ( ConstBwd MM
-    , Vec 2 (ConstBwd MM, Wishbone dom 'Standard nmuRemBusWidth (Bytes 4))
+    ( -- \| GPPE memory map
+      ConstBwd MM
+    , -- \| Incoming link from switch
+      CSignal dom (BitVector 64)
+    , -- \| Scatter unit calendar memory map and Wishbone bus
+      (ConstBwd MM, Wishbone dom 'Standard nmuRemBusWidth (Bytes 4))
+    , -- \| Gather unit calendar memory map and Wishbone bus
+      (ConstBwd MM, Wishbone dom 'Standard nmuRemBusWidth (Bytes 4))
+    , -- \| JTAG connection
+      Jtag dom
     )
     (CSignal dom (BitVector 64))
-gppeC (GppeConfig scatterConfig prefixS gatherConfig prefixG peConfig dumpVcd) linkIn = circuit $ \(mm, nmuWbs) -> do
-  [(mmSCal, wbScatCal), (mmGCal, wbGathCal)] <- idC -< nmuWbs
-  jtag <- idleSource
-  [(preS, (mmS, wbScat)), (preG, (mmG, wbGu))] <-
-    processingElement dumpVcd peConfig -< (mm, jtag)
-  constBwd prefixS -< preS
-  constBwd prefixG -< preG
-  scatterUnitWbC scatterConfig linkIn -< ((mmS, wbScat), (mmSCal, wbScatCal))
-  linkOut <- gatherUnitWbC gatherConfig -< ((mmG, wbGu), (mmGCal, wbGathCal))
-  idC -< linkOut
+gppeC (GppeConfig{..}) =
+  circuit $ \(mm, Fwd linkIn, (scatterCalMM, scatterCalWb), (gatherCalMM, gatherCalWb), jtag) -> do
+    [ (scatterPfx, (scatterMM, scatterWb))
+      , (gatherPfx, (gatherMM, gatherWb))
+      ] <-
+      processingElement dumpVcd peConfig -< (mm, jtag)
+    constBwd scatterPrefix -< scatterPfx
+    constBwd gatherPrefix -< gatherPfx
+    scatterUnitWbC scatterConfig linkIn
+      -< ((scatterMM, scatterWb), (scatterCalMM, scatterCalWb))
+    linkOut <-
+      gatherUnitWbC gatherConfig -< ((gatherMM, gatherWb), (gatherCalMM, gatherCalWb))
+    idC -< linkOut
+
+{- Type-level number of node management unit internal busses
+
+Internal busses:
+  * Instruction bus
+  * Data bus
+  * 'whoAmIC'
+  * Scatter unit
+  * Scatter calendar
+  * Gather unit
+  * Gather calendar
+  * Switch
+  * 'timeWb'
+  * External link
+  * 'linkCount' number of 'captureUgn' components
+  * 'gppes' number of Scatter calendars
+  * 'gppes' number of Gather calendars
+-}
+type NmuBusses linkCount gppes = PeInternalBusses + 7 + linkCount + 2 * gppes
+type NmuPrefixWidth linkCount gppes = CLog 2 (NmuBusses linkCount gppes)
+type NmuRemBusWidth linkCount gppes = 30 - NmuPrefixWidth linkCount gppes
+type NmuWishbone dom linkCount gppes =
+  Wishbone dom 'Standard (NmuRemBusWidth linkCount gppes) (Bytes 4)
+
+{- | Configuration for the 'managementUnit' and its 'Bittide.Link'.
+The management unit contains the 4 wishbone busses that each pe has
+and also the management busses for itself and all other pe's in this node.
+Furthermore it also has access to the 'calendar' for the 'switch'.
+-}
+data ManagementConfig linkCount gppes where
+  ManagementConfig ::
+    ( KnownNat gppes
+    , KnownNat linkCount
+    , NmuPrefixWidth linkCount gppes <= 30
+    ) =>
+    { scatterConfig :: ScatterConfig 4 (NmuRemBusWidth linkCount gppes)
+    -- ^ Configuration for the management unit scatter unit
+    , scatterCalPrefix :: Unsigned (NmuPrefixWidth linkCount gppes)
+    -- ^ Memory map prefix for the scatter unit calendar
+    , scatterPrefix :: Unsigned (NmuPrefixWidth linkCount gppes)
+    -- ^ Memory map prefix for the scatter unit
+    , gatherConfig :: GatherConfig 4 (NmuRemBusWidth linkCount gppes)
+    -- ^ Configuration for the management unit gather unit
+    , gatherCalPrefix :: Unsigned (NmuPrefixWidth linkCount gppes)
+    -- ^ Memory map prefix for the gather unit calendar
+    , gatherPrefix :: Unsigned (NmuPrefixWidth linkCount gppes)
+    -- ^ Memory map prefix for the gather unit
+    , timerPrefix :: Unsigned (NmuPrefixWidth linkCount gppes)
+    -- ^ Memory map prefix for the timer component
+    , switchPrefix :: Unsigned (NmuPrefixWidth linkCount gppes)
+    -- ^ Memory map prefix for the switch.
+    , externalPrefix :: Unsigned (NmuPrefixWidth linkCount gppes)
+    -- ^ Memory map prefix for an external Wishbone connection
+    , captureUgnPrefixes ::
+        Vec linkCount (Unsigned (NmuPrefixWidth linkCount gppes))
+    -- ^ Memory map prefixes for all of the 'captureUgn' components
+    , peScatterGatherPrefixes ::
+        Vec
+          gppes
+          ( Unsigned (NmuPrefixWidth linkCount gppes)
+          , Unsigned (NmuPrefixWidth linkCount gppes)
+          )
+    , peConfig :: PeConfig (NmuBusses linkCount gppes)
+    -- ^ Processing element configuration
+    , dumpVcd :: DumpVcd
+    -- ^ VCD dump configuration
+    } ->
+    ManagementConfig linkCount gppes
 
 {- | A special purpose 'processingElement' that manages a Bittide Node. It contains
 a 'processingElement', 'linkToPe' and 'peToLink' which create the interface for the
@@ -212,52 +267,85 @@ Bittide Link. It takes a 'ManagementConfig', incoming link and a vector of incom
 'WishboneM2S' signals.
 -}
 managementUnitC ::
-  forall dom nodeBusses.
+  forall dom linkCount gppes.
   ( HiddenClockResetEnable dom
-  , CLog 2 (nodeBusses + NmuInternalBusses) <= 30
+  , 1 <= DomainPeriod dom
+  , ?busByteOrder :: ByteOrder
+  , ?regByteOrder :: ByteOrder
   ) =>
-  -- |
-  -- ( Configures all local parameters
-  -- , Incoming 'Bittide.Link'
-  -- , Incoming @Vector@ of master busses
-  -- )
-  ManagementConfig nodeBusses ->
-  Signal dom (BitVector 64) ->
+  ManagementConfig linkCount gppes ->
   Circuit
-    (ConstBwd MM)
-    ( CSignal dom (BitVector 64)
-    , Vec
-        nodeBusses
-        ( ConstBwd (Unsigned (CLog 2 (nodeBusses + NmuInternalBusses)))
-        , (ConstBwd MM, Wishbone dom 'Standard (NmuRemBusWidth nodeBusses) (Bytes 4))
-        )
+    (ConstBwd MM, CSignal dom (BitVector 64), Jtag dom)
+    ( -- \| Node management unit link output
+      CSignal dom (BitVector 64)
+    , -- \| Node management unit local counter
+      CSignal dom (Unsigned 64)
+    , -- \| Switch memory map and Wishbone bus
+      (ConstBwd MM, NmuWishbone dom linkCount gppes)
+    , -- \| External connection memory map and Wishbone bus
+      (ConstBwd MM, NmuWishbone dom linkCount gppes)
+    , -- \| 'captureUgn's memory maps and Wishbone busses
+      Vec
+        linkCount
+        (ConstBwd MM, NmuWishbone dom linkCount gppes)
+    , -- \| GPPE scatter unit memory maps and Wishbone busses
+      Vec
+        gppes
+        (ConstBwd MM, NmuWishbone dom linkCount gppes)
+    , -- \| GPPE gather unit memory maps and Wishbone busses
+      Vec
+        gppes
+        (ConstBwd MM, NmuWishbone dom linkCount gppes)
     )
 managementUnitC
   ( ManagementConfig
-      scatterConfig
-      prefixSCal
-      prefixS
-      gatherConfig
-      prefixGCal
-      prefixG
-      peConfig
-      dumpVcd
-    )
-  linkIn = circuit $ \mm -> do
-    jtag <- idleSource
+      { peScatterGatherPrefixes = unzip -> (peScatterPrefixes, peGatherPrefixes)
+      , ..
+      }
+    ) = circuit $ \(mm, Fwd linkIn, jtag) -> do
     peWbs <- processingElement dumpVcd peConfig -< (mm, jtag)
-    ( [ (preSCal, wbScatCal)
-        , (preS, (mmScat, wbScat))
-        , (preGCal, wbGathCal)
-        , (preG, wbGu)
+    ( [ (myScatterPfx, (myScatterMM, myScatterWb))
+        , (myScatterCalPfx, myScatterCalMMWb)
+        , (myGatherPfx, myGatherMMWb)
+        , (myGatherCalPfx, myGatherCalMMWb)
+        , (switchPfx, switchMMWb)
+        , (timePfx, timeMMWb)
+        , (externalPfx, externalMMWb)
         ]
-      , nmuWbs
+      , myWbRest
       ) <-
       splitAtCI -< peWbs
-    constBwd prefixSCal -< preSCal
-    constBwd prefixS -< preS
-    constBwd prefixGCal -< preGCal
-    constBwd prefixG -< preG
-    linkOut <- gatherUnitWbC gatherConfig -< (wbGu, wbGathCal)
-    scatterUnitWbC scatterConfig linkIn -< ((mmScat, wbScat), wbScatCal)
-    idC -< (linkOut, nmuWbs)
+
+    constBwd scatterPrefix -< myScatterPfx
+    constBwd scatterCalPrefix -< myScatterCalPfx
+    constBwd gatherPrefix -< myGatherPfx
+    constBwd gatherCalPrefix -< myGatherCalPfx
+    constBwd switchPrefix -< switchPfx
+    constBwd timerPrefix -< timePfx
+    constBwd externalPrefix -< externalPfx
+
+    localCounter <- timeWb -< timeMMWb
+
+    scatterUnitWbC scatterConfig linkIn -< ((myScatterMM, myScatterWb), myScatterCalMMWb)
+    linkOut <- gatherUnitWbC gatherConfig -< (myGatherMMWb, myGatherCalMMWb)
+
+    (captureUgnPfxMMWbs, scatterPfxMMWbs, gatherPfxMMWbs) <- split3CI -< myWbRest
+
+    (captureUgnPfxs, captureUgnMMWbs) <- unzipC -< captureUgnPfxMMWbs
+    idleSink <| zipCircuit (constBwd <$> captureUgnPrefixes) -< captureUgnPfxs
+
+    (scatterPfxs, scatterMMWbs) <- unzipC -< scatterPfxMMWbs
+    idleSink <| zipCircuit (constBwd <$> peScatterPrefixes) -< scatterPfxs
+
+    (gatherPfxs, gatherMMWbs) <- unzipC -< gatherPfxMMWbs
+    idleSink <| zipCircuit (constBwd <$> peGatherPrefixes) -< gatherPfxs
+
+    idC
+      -< ( linkOut
+         , localCounter
+         , switchMMWb
+         , externalMMWb
+         , captureUgnMMWbs
+         , scatterMMWbs
+         , gatherMMWbs
+         )

--- a/bittide/src/Bittide/ProcessingElement.hs
+++ b/bittide/src/Bittide/ProcessingElement.hs
@@ -38,7 +38,7 @@ data PeConfig nBusses where
     , KnownNat depthD
     , 1 <= depthD
     , KnownNat nBusses
-    , 2 <= nBusses
+    , PeInternalBusses <= nBusses
     , CLog 2 nBusses <= 30
     ) =>
     { prefixI :: Unsigned (CLog 2 nBusses)
@@ -62,18 +62,20 @@ data PeConfig nBusses where
     } ->
     PeConfig nBusses
 
+type PeInternalBusses = 2
+
 {- | VexRiscV based RV32IMC core together with instruction memory, data memory and
 'singleMasterInterconnect'.
 -}
 processingElement ::
   forall dom nBusses.
-  (HiddenClockResetEnable dom, KnownNat nBusses, 2 <= nBusses) =>
+  (HiddenClockResetEnable dom, KnownNat nBusses, PeInternalBusses <= nBusses) =>
   DumpVcd ->
   PeConfig nBusses ->
   Circuit
     (MM.ConstBwd MM.MM, Jtag dom)
     ( Vec
-        (nBusses - 2)
+        (nBusses - PeInternalBusses)
         ( MM.ConstBwd (Unsigned (CLog 2 nBusses))
         , (MM.ConstBwd MM.MM, Wishbone dom 'Standard (MappedBusAddrWidth 30 nBusses) (Bytes 4))
         )

--- a/bittide/src/Bittide/ScatterGather.hs
+++ b/bittide/src/Bittide/ScatterGather.hs
@@ -1,6 +1,10 @@
 -- SPDX-FileCopyrightText: 2022 Google LLC
 --
 -- SPDX-License-Identifier: Apache-2.0
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RecordWildCards #-}
 
 module Bittide.ScatterGather (
@@ -35,8 +39,9 @@ higher level APIs.
 data ScatterConfig nBytes addrW where
   ScatterConfig ::
     (KnownNat memDepth, 1 <= memDepth) =>
-    SNat memDepth ->
-    (CalendarConfig nBytes addrW (Index memDepth)) ->
+    { memDepth :: SNat memDepth
+    , calendarConfig :: CalendarConfig nBytes addrW (Index memDepth)
+    } ->
     ScatterConfig nBytes addrW
 
 {- | Existential type to explicitly differentiate between a configuration for
@@ -46,8 +51,9 @@ higher level APIs.
 data GatherConfig nBytes addrW where
   GatherConfig ::
     (KnownNat memDepth, 1 <= memDepth) =>
-    SNat memDepth ->
-    (CalendarConfig nBytes addrW (Index memDepth)) ->
+    { memDepth :: SNat memDepth
+    , calendarConfig :: CalendarConfig nBytes addrW (Index memDepth)
+    } ->
     GatherConfig nBytes addrW
 
 {- | Double buffered memory component that can be written to by a Bittide link. The write
@@ -310,7 +316,8 @@ scatterUnitWb (ScatterConfig _memDepth calConfig) wbInCal linkIn wbInSu =
 
 gatherUnitWbC ::
   forall dom awGu nBytesCal awCal.
-  ( HiddenClockResetEnable dom
+  ( HasCallStack
+  , HiddenClockResetEnable dom
   , KnownNat awGu
   , KnownNat nBytesCal
   , 1 <= nBytesCal
@@ -392,7 +399,7 @@ gatherUnitWbC conf@(GatherConfig memDepthSnat calConfig) = case (cancelMulDiv @n
             ]
         , deviceName =
             Name
-              { name = "ScatterUnit"
+              { name = "GatherUnit"
               , description = ""
               }
         , definitionLoc = locHere

--- a/bittide/src/Clash/Sized/Extra.hs
+++ b/bittide/src/Clash/Sized/Extra.hs
@@ -6,6 +6,9 @@ module Clash.Sized.Extra where
 
 import Clash.Prelude
 
+import Data.Constraint.Nat.Extra (Dict (..))
+import Data.Constraint.Nat.Lemmas (nLe0Eq0)
+
 {- $setup
 >>> import Clash.Prelude
 -}
@@ -31,3 +34,22 @@ concatUnsigneds ::
   Unsigned (a + b)
 concatUnsigneds a b =
   shiftL (extend a) (natToNum @b) .|. extend b
+
+extendLsb0s ::
+  forall m n a b.
+  ( KnownNat m
+  , KnownNat n
+  , BitPack a
+  , BitSize a ~ m
+  , BitPack b
+  , BitSize b ~ m + n
+  ) =>
+  a ->
+  b
+extendLsb0s a =
+  unpack $ case SNat @n `compareSNat` d0 of
+    SNatLE -> case nLe0Eq0 @n of Dict -> packedA
+    SNatGT -> packedA ++# 0
+ where
+  packedA :: BitVector (BitSize a)
+  packedA = pack a


### PR DESCRIPTION
I am once again PRing a big diff. This time with fun additions!

- All processing elements now have a non-optional identifier component. This can be ignored, but it is intended to be used as a way to guarantee that you're looking at the correct CPU in a JTAG chain.
- Some helper functions for creating these identifiers and search strings for GDB output have been added
- A number of GADTs were updated to use record syntax. I didn't like not having it be explicit what things were.
- Significant rewrite of `Node.hs`. Should be a lot simpler to work with now.
- Added a utility function for prefixes. This is primarily intended to be used for the prefix of the identifier component, where it's expected to have a minimum address width that may need to get widened with 0s to fit other processing elements' prefix widths. Usage looks like
```hs
whoAmIPfx :: forall n. (KnownNat n) => Unsigned (3 + n)
whoAmIPfx = extendLsb0s @3 @n 0b111
-- This prefix can now be used in arbitrary locations expecting
-- a prefix with a width of 3 bits or more.
```
- Added a binary for the switch demo GPPE (WIP)