### PR TITLE
Skip `haskell-tests` with non-empty debug.json

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,13 +221,43 @@ jobs:
           path: plot-sources
           retention-days: 14
 
+  should-run-haskell-tests:
+    name: Decide whether to run Haskell tests
+    runs-on: [self-hosted, compute]
+    defaults:
+      run:
+        shell: git-nix-shell {0}
+    container:
+      image: ghcr.io/clash-lang/nixos-bittide-hardware:2025-06-10
+      options: --memory=11g
+    outputs:
+      run_tests: ${{ steps.check.outputs.run_tests }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: check
+        name: Check for non-empty debug.json
+        run: |
+          if [[ -f .github/synthesis/debug.json ]]; then
+            if [[ $(jq 'length' .github/synthesis/debug.json) -gt 0 ]]; then
+              echo "Found non-empty debug.json, will skip Haskell tests."
+              echo "run_tests=false" >> "$GITHUB_OUTPUT"
+            else
+              echo "Found empty debug.json, will run Haskell tests."
+              echo "run_tests=true" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            echo "No debug.json found, will run Haskell tests."
+            echo "run_tests=true" >> "$GITHUB_OUTPUT"
+          fi
+
   haskell-tests:
     name: HT # Short name because the GitHub UI truncates "long" names..
     runs-on: [self-hosted, compute]
     defaults:
       run:
         shell: git-nix-shell {0} ${{ matrix.shell_args }}
-    needs: [build]
+    needs: [build, should-run-haskell-tests]
+    if: ${{ needs.should-run-haskell-tests.outputs.run_tests == 'true' }}
 
     container:
       image: ghcr.io/clash-lang/nixos-bittide-hardware:2025-06-10
@@ -650,6 +680,7 @@ jobs:
         license-check,
         lint,
         rust-lints,
+        should-run-haskell-tests,
       ]
     runs-on: ubuntu-22.04
     steps:


### PR DESCRIPTION
Sometimes I want to run many HITL jobs to bisect an issue. Because we trigger 16 Haskell test jobs per commit, this clogs up CI. This commit skips the Haskell tests if `debug.json` is present and at least one HITL test runs.

# Runs
- [x] no `debug.json`: https://github.com/bittide/bittide-hardware/actions/runs/16002248710
- [x] non-empty `debug.json`: https://github.com/bittide/bittide-hardware/actions/runs/16002257180
- [x] empty `debug.json`: https://github.com/bittide/bittide-hardware/actions/runs/16002260869