### PR TITLE
Fixes for missing `HasCallStack` and incorrect device name in gather unit

### DIFF
--- a/bittide/src/Bittide/ScatterGather.hs
+++ b/bittide/src/Bittide/ScatterGather.hs
@@ -310,7 +310,8 @@ scatterUnitWb (ScatterConfig _memDepth calConfig) wbInCal linkIn wbInSu =
 
 gatherUnitWbC ::
   forall dom awGu nBytesCal awCal.
-  ( HiddenClockResetEnable dom
+  ( HasCallStack
+  , HiddenClockResetEnable dom
   , KnownNat awGu
   , KnownNat nBytesCal
   , 1 <= nBytesCal
@@ -392,7 +393,7 @@ gatherUnitWbC conf@(GatherConfig memDepthSnat calConfig) = case (cancelMulDiv @n
             ]
         , deviceName =
             Name
-              { name = "ScatterUnit"
+              { name = "GatherUnit"
               , description = ""
               }
         , definitionLoc = locHere


### PR DESCRIPTION
Small things, but they come up in some other PRs and I figure it's worth doing this independent of those.