### PR TITLE
Cache Clash on CI

### DIFF
--- a/.github/scripts/cache.py
+++ b/.github/scripts/cache.py
@@ -129,13 +129,14 @@ def sha256sum_files(file_paths : Iterable[str]) -> str:
 
 
 def get_git_files_from_patterns(patterns):
-    filesytem_files = itertools.chain.from_iterable(
+    filesytem_files = get_files_from_patterns(patterns)
+    git_files = get_all_git_files()
+    return (p for p in filesytem_files if p in git_files)
+
+def get_files_from_patterns(patterns):
+    return itertools.chain.from_iterable(
         glob.glob(pattern, recursive=True) for pattern in patterns
     )
-
-    git_files = get_all_git_files()
-    return [p for p in filesytem_files if p in git_files]
-
 
 def get_key_from_patterns(patterns):
     return sha256sum_files(get_git_files_from_patterns(patterns))
@@ -154,14 +155,10 @@ def get_build_key():
 
 
 def get_synth_key():
-    """
-    Files in the _build directory are not tracked by git. Therefore we have
-    to get the list of files in separate steps.
-    """
+    # Files in the _build directory are not tracked by git. Therefore we have
+    # to get the list of files in separate steps.
     tracked_files = get_git_files_from_patterns(SYNTH_KEY_PATTERNS)
-    untracked_files = itertools.chain.from_iterable(
-        glob.glob(pattern, recursive=True) for pattern in SYNTH_KEY_PATTERNS_UNTRACKED
-    )
+    untracked_files = get_files_from_patterns(SYNTH_KEY_PATTERNS_UNTRACKED)
     return SYNTH_KEY_PREFIX + sha256sum_files(itertools.chain(tracked_files, untracked_files))
 
 

--- a/.github/scripts/cache.py
+++ b/.github/scripts/cache.py
@@ -52,7 +52,7 @@ CLEAR_AFTER_DAYS=7
 CLEAR_AFTER=f"{CLEAR_AFTER_DAYS}d00h00m00s"
 TOUCH_AFTER=datetime.timedelta(days=1)
 
-GLOBAL_CACHE_BUST = 8
+GLOBAL_CACHE_BUST = 9
 
 CARGO_CACHE_BUST = 2
 CARGO_KEY_PREFIX = f"cargo-g{GLOBAL_CACHE_BUST}-l{CARGO_CACHE_BUST}-"
@@ -63,7 +63,10 @@ CARGO_CACHE_EXCLUDE_PATTERNS = ()
 CABAL_CACHE_BUST = 2
 CABAL_KEY_PREFIX = f"cabal-g{GLOBAL_CACHE_BUST}-l{CABAL_CACHE_BUST}-"
 CABAL_KEY_PATTERNS = ("**/cabal.project", "**/cabal.project.freeze")
-CABAL_CACHE_INCLUDE_PATTERNS = ("~/.cabal-nix",)
+CABAL_CACHE_INCLUDE_PATTERNS = (
+    "~/.cabal-nix",
+    f"{PWD}/dist-newstyle/src",
+)
 CABAL_CACHE_EXCLUDE_PATTERNS = ()
 
 BUILD_CACHE_BUST = 2
@@ -77,6 +80,7 @@ BUILD_CACHE_INCLUDE_PATTERNS = (
 )
 BUILD_CACHE_EXCLUDE_PATTERNS = (
     f"{PWD}/firmware-support/bittide-hal/src/shared/mod.rs",
+    f"{PWD}/dist-newstyle/src",
 )
 
 SYNTH_CACHE_BUST = 2

--- a/.github/scripts/cache.py
+++ b/.github/scripts/cache.py
@@ -4,8 +4,8 @@ Strict caching script, that uploads to a hardcoded S3 server. Users should set
 an environment variable 'S3_PASSWORD'.
 
 Usage:
-  cache push (cabal|cargo|build|synth|build-post-synth) [--prefix=<prefix>] [--empty-pattern-ok] [--write-cache-found] [--overwrite-ok]
-  cache pull (cabal|cargo|build|synth|build-post-synth) [--prefix=<prefix>] [--missing-ok] [--overwrite-ok] [--write-cache-found]
+  cache push (cabal|cargo|build|clash|synth|build-post-synth) [--prefix=<prefix>] [--empty-pattern-ok] [--write-cache-found] [--overwrite-ok]
+  cache pull (cabal|cargo|build|clash|synth|build-post-synth) [--prefix=<prefix>] [--missing-ok] [--overwrite-ok] [--write-cache-found]
   cache clean
   cache -h | --help
   cache --version
@@ -52,7 +52,7 @@ CLEAR_AFTER_DAYS=7
 CLEAR_AFTER=f"{CLEAR_AFTER_DAYS}d00h00m00s"
 TOUCH_AFTER=datetime.timedelta(days=1)
 
-GLOBAL_CACHE_BUST = 9
+GLOBAL_CACHE_BUST = 11
 
 CARGO_CACHE_BUST = 2
 CARGO_KEY_PREFIX = f"cargo-g{GLOBAL_CACHE_BUST}-l{CARGO_CACHE_BUST}-"
@@ -82,6 +82,19 @@ BUILD_CACHE_EXCLUDE_PATTERNS = (
     f"{PWD}/firmware-support/bittide-hal/src/shared/mod.rs",
     f"{PWD}/dist-newstyle/src",
 )
+
+CLASH_CACHE_BUST = 0
+CLASH_KEY_PREFIX = f"clash-g{GLOBAL_CACHE_BUST}-l{CLASH_CACHE_BUST}-"
+CLASH_KEY_PATTERNS = CABAL_KEY_PATTERNS + (
+    "**/*.cabal",
+    "**/*.hs",
+    "**/*.hs-boot",
+    "**/*.csv",
+)
+CLASH_CACHE_INCLUDE_PATTERNS = (
+    f"{PWD}/_build/clash",
+)
+CLASH_CACHE_EXCLUDE_PATTERNS = ()
 
 SYNTH_CACHE_BUST = 2
 SYNTH_KEY_PREFIX = f"synth-g{GLOBAL_CACHE_BUST}-l{SYNTH_CACHE_BUST}-"
@@ -157,6 +170,11 @@ def get_cabal_key():
 def get_build_key():
     return BUILD_KEY_PREFIX + os.environ["GITHUB_SHA"]
 
+def get_clash_key():
+    exclude = "bittide-instances/src/Bittide/Instances/Hitl/Driver/"
+    files = get_git_files_from_patterns(CLASH_KEY_PATTERNS)
+    files = (f for f in files if not f.startswith(exclude))
+    return CLASH_KEY_PREFIX + sha256sum_files(files)
 
 def get_synth_key():
     # Files in the _build directory are not tracked by git. Therefore we have
@@ -379,6 +397,10 @@ def main(opts):
         key = get_build_key()
         include_patterns = BUILD_CACHE_INCLUDE_PATTERNS
         exclude_patterns = BUILD_CACHE_EXCLUDE_PATTERNS
+    elif opts["clash"]:
+        key = get_clash_key()
+        include_patterns = CLASH_CACHE_INCLUDE_PATTERNS
+        exclude_patterns = CLASH_CACHE_EXCLUDE_PATTERNS
     elif opts["synth"]:
         key = get_synth_key()
         include_patterns = SYNTH_CACHE_INCLUDE_PATTERNS

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -539,8 +539,8 @@ jobs:
         run: |
           shake ${{ matrix.target.top }}:hdl
 
-      - name: Synthesis
-        if: ${{ matrix.target.stage != 'hdl' }}
+      - name: Determine whether synthesis should run
+        id: check_synthesis_status
         run: |
           target="${{ matrix.target.stage }}"
 
@@ -548,6 +548,23 @@ jobs:
             echo "Illegal Shake target on CI: program"
             exit 1
           fi
+
+          if [[ "${target}" == "hdl" ]]; then
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          cache pull synth --prefix="${{ matrix.target.top }}-${target}" --missing-ok --write-cache-found
+          if [[ $(cat cache_found) == 0 ]]; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Synthesis
+        if: ${{ steps.check_synthesis_status.outputs.should_run == 'true'  }}
+        run: |
+          target="${{ matrix.target.stage }}"
 
           # Only the local runner connected to the bittide demonstrator (hoeve)
           # should perform the jobs which need hardware access. And that runner
@@ -557,21 +574,15 @@ jobs:
             target="bitstream"
           fi
 
-          cache pull synth --prefix="${{ matrix.target.top }}-${target}" --missing-ok --write-cache-found
-          if [[ $(cat cache_found) == 0 ]]; then
-
-            export VIVADO_HS_LOG_DIR="$(git rev-parse --show-toplevel)/_build/hitl/vivado-gensynth/"
-            if [[ ! -d "${VIVADO_HS_LOG_DIR} " ]]; then
-              mkdir -p "${VIVADO_HS_LOG_DIR}"
-            fi
-            .github/scripts/with_vivado.sh \
-              shake ${{ matrix.target.top }}:"${target}"
-
-            # Pushing synthesis results to cache
-            cache push synth --prefix="${{ matrix.target.top }}-${target}"
-          else
-            echo "Restored cache, no need to synthesize again"
+          export VIVADO_HS_LOG_DIR="$(git rev-parse --show-toplevel)/_build/hitl/vivado-gensynth/"
+          if [[ ! -d "${VIVADO_HS_LOG_DIR} " ]]; then
+            mkdir -p "${VIVADO_HS_LOG_DIR}"
           fi
+          .github/scripts/with_vivado.sh \
+            shake ${{ matrix.target.top }}:"${target}"
+
+          # Pushing synthesis results to cache
+          cache push synth --prefix="${{ matrix.target.top }}-${target}"
 
       - name: Create non-empty vivado directory
         if: ${{ matrix.target.stage == 'hdl' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -531,18 +531,42 @@ jobs:
         run: |
           .github/scripts/set_ci_flags.sh
 
-      - run: cache pull cabal
-      - run: cache pull cargo
-      - run: cache pull build
+      - name: Determine whether HDL generation should run
+        id: check_hdl_gen_status
+        run: |
+          cache pull clash --prefix="${{ matrix.target.top }}" --missing-ok --write-cache-found
+
+          if [[ $(cat cache_found) == 0 ]]; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Pull caches (if HDL generation should run)
+        if: ${{ steps.check_hdl_gen_status.outputs.should_run == 'true'  }}
+        run: |
+          cache pull cabal
+          cache pull cargo
+          cache pull build
 
       - name: HDL generation
+        if: ${{ steps.check_hdl_gen_status.outputs.should_run == 'true'  }}
         run: |
           shake ${{ matrix.target.top }}:hdl
+          cache push clash --prefix="${{ matrix.target.top }}"
 
       - name: Determine whether synthesis should run
         id: check_synthesis_status
         run: |
           target="${{ matrix.target.stage }}"
+
+          # Only the local runner connected to the bittide demonstrator (hoeve)
+          # should perform the jobs which need hardware access. And that runner
+          # should do only that, so we let other 'compute' runners do the
+          # bitstream generation.
+          if [[ "${target}" == "test" ]]; then
+            target="bitstream"
+          fi
 
           if [[ "${target}" == "program" ]]; then
             echo "Illegal Shake target on CI: program"
@@ -560,6 +584,13 @@ jobs:
           else
             echo "should_run=false" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Pull caches (if synthesis should run and caches not already pulled)
+        if: ${{ steps.check_synthesis_status.outputs.should_run == 'true' && !(steps.check_hdl_gen_status.outputs.should_run == 'true')  }}
+        run: |
+          cache pull cabal
+          cache pull cargo
+          cache pull build
 
       - name: Synthesis
         if: ${{ steps.check_synthesis_status.outputs.should_run == 'true'  }}


### PR DESCRIPTION
I had to wait a bunch just in order to test new SW, so I figured I'd add Clash caching to CI.

- Run with empty cache: https://github.com/bittide/bittide-hardware/actions/runs/16289797786/attempts/1
  - Job only generating HDL: https://github.com/bittide/bittide-hardware/actions/runs/16289797786/job/45997009841
  - Job generating HDL and synthesis: https://github.com/bittide/bittide-hardware/actions/runs/16289797786/job/45997009829
  - Job generating HDL and synthesis, but getting cancelled before synthesis finishes: https://github.com/bittide/bittide-hardware/actions/runs/16289797786/job/45997009828
  - Rerun of cancelled job: https://github.com/bittide/bittide-hardware/actions/runs/16289797786/job/45997681652
- Run with fully primed caches: https://github.com/bittide/bittide-hardware/actions/runs/16289797786

It's slightly hacky, but I guess that's the state until we go full Nix.