### PR TITLE
Use `freeze` in demo switch

### DIFF
--- a/bittide-instances/data/constraints/switchDemoTest.xdc
+++ b/bittide-instances/data/constraints/switchDemoTest.xdc
@@ -35,3 +35,7 @@ set_property -dict {IOSTANDARD LVCMOS12 PACKAGE_PIN AF25} [get_ports {FDEC}]
 set_property -dict {IOSTANDARD LVCMOS12 PACKAGE_PIN AE21} [get_ports {CSB}]
 set_property -dict {IOSTANDARD LVCMOS12 PACKAGE_PIN AM17} [get_ports {MISO}]
 
+# USER SMA GPIO_P
+set_property -dict {IOSTANDARD LVCMOS18 PACKAGE_PIN H27} [get_ports {SYNC_IN}]
+# USER_SMA_GPIO_N (connected on node 0 to SYNC_IN of all nodes)
+set_property -dict {IOSTANDARD LVCMOS18 PACKAGE_PIN G27} [get_ports {SYNC_OUT}]

--- a/bittide-instances/src/Bittide/Instances/Pnr/Freeze.hs
+++ b/bittide-instances/src/Bittide/Instances/Pnr/Freeze.hs
@@ -38,7 +38,7 @@ freezeExample clk rst =
 
       idC
  where
-  counter0 = Freeze.counter @(Unsigned 32) clk rst enableGen 0
+  counter0 = Freeze.counter clk rst enableGen 0
   counter1 = Freeze.counter @(Unsigned 32) clk rst enableGen 1
   counter2 = Freeze.counter @(Unsigned 32) clk rst enableGen 2
 
@@ -46,13 +46,13 @@ freezeExample clk rst =
   -- propagate a constant to the register's reset value.
   ebCounters =
     bundle
-      $ Freeze.counter @(Signed 32) clk rst enableGen 3
-      :> Freeze.counter @(Signed 32) clk rst enableGen 4
-      :> Freeze.counter @(Signed 32) clk rst enableGen 5
-      :> Freeze.counter @(Signed 32) clk rst enableGen 6
-      :> Freeze.counter @(Signed 32) clk rst enableGen 7
-      :> Freeze.counter @(Signed 32) clk rst enableGen 8
-      :> Freeze.counter @(Signed 32) clk rst enableGen 9
+      $ Freeze.counter @(Signed 25) clk rst enableGen 3
+      :> Freeze.counter @(Signed 25) clk rst enableGen 4
+      :> Freeze.counter @(Signed 25) clk rst enableGen 5
+      :> Freeze.counter @(Signed 25) clk rst enableGen 6
+      :> Freeze.counter @(Signed 25) clk rst enableGen 7
+      :> Freeze.counter @(Signed 25) clk rst enableGen 8
+      :> Freeze.counter @(Signed 25) clk rst enableGen 9
       :> Nil
 
 freezeMM :: MemoryMap

--- a/bittide-instances/src/Bittide/Instances/Pnr/Freeze.hs
+++ b/bittide-instances/src/Bittide/Instances/Pnr/Freeze.hs
@@ -34,7 +34,7 @@ freezeExample clk rst =
    in
     circuit $ \(mm, wb) -> do
       Freeze.freeze clk rst
-        -< (mm, wb, Fwd ebCounters, Fwd counter0, Fwd counter1, Fwd counter2)
+        -< ((mm, wb), Fwd ebCounters, Fwd counter0, Fwd counter1, Fwd counter2)
 
       idC
  where

--- a/bittide/src/Bittide/ClockControl/Freeze.hs
+++ b/bittide/src/Bittide/ClockControl/Freeze.hs
@@ -38,8 +38,9 @@ freeze ::
   Clock dom ->
   Reset dom ->
   Circuit
-    ( ConstBwd MM
-    , Wishbone dom 'Standard aw (Bytes 4)
+    ( ( ConstBwd MM
+      , Wishbone dom 'Standard aw (Bytes 4)
+      )
     , "elastic_buffer_counters" ::: CSignal dom (Vec 7 (Signed 32))
     , "local_clock_counter" ::: CSignal dom (Unsigned n)
     , "sync_in_counter" ::: CSignal dom (Unsigned 32)
@@ -47,7 +48,7 @@ freeze ::
     )
     ()
 freeze clk rst =
-  circuit $ \(mm, wb, ebCounters, localCounter, syncPulseCounter, lastPulseCounter) -> do
+  circuit $ \((mm, wb), ebCounters, localCounter, syncPulseCounter, lastPulseCounter) -> do
     -- Create a bunch of register wishbone interfaces. We don't really care about
     -- ordering, so we just append a number to the end of a generic name.
     [wb0, wb1, wb2, wb3, wb4, wb5] <-

--- a/bittide/src/Bittide/ClockControl/Freeze.hs
+++ b/bittide/src/Bittide/ClockControl/Freeze.hs
@@ -26,10 +26,11 @@ control measurements. This makes sure the clock control algorithm works on
 measurements that are taken at the same clock cycle.
 -}
 freeze ::
-  forall aw n dom.
+  forall aw nLinks ebCounterWidth dom.
   ( KnownDomain dom
   , KnownNat aw
-  , KnownNat n
+  , KnownNat ebCounterWidth
+  , KnownNat nLinks
   , HasCallStack
   , 4 <= aw
   , ?busByteOrder :: ByteOrder
@@ -41,8 +42,8 @@ freeze ::
     ( ( ConstBwd MM
       , Wishbone dom 'Standard aw (Bytes 4)
       )
-    , "elastic_buffer_counters" ::: CSignal dom (Vec 7 (Signed 32))
-    , "local_clock_counter" ::: CSignal dom (Unsigned n)
+    , "elastic_buffer_counters" ::: CSignal dom (Vec nLinks (Signed ebCounterWidth))
+    , "local_clock_counter" ::: CSignal dom (Unsigned 64)
     , "sync_in_counter" ::: CSignal dom (Unsigned 32)
     , "cycles_since_sync_in" ::: CSignal dom (Unsigned 32)
     )

--- a/bittide/src/Bittide/ClockControl/Registers.hs
+++ b/bittide/src/Bittide/ClockControl/Registers.hs
@@ -119,9 +119,9 @@ clockControlWb margin frameSize linkMask (bundle -> counters) = circuit $ \(mm, 
  where
   noWrite = pure Nothing
 
-  wbNumLinksConfig = (registerConfig "num_links"){access = ReadOnly}
+  wbNumLinksConfig = (registerConfig "n_links"){access = ReadOnly}
   wbLinkMaskConfig = (registerConfig "link_mask"){access = ReadOnly}
-  wbUpLinksConfig = (registerConfig "up_links"){access = ReadOnly}
+  wbUpLinksConfig = (registerConfig "n_up_links"){access = ReadOnly}
   wbChangeSpeedConfig = (registerConfig "change_speed"){access = WriteOnly}
   wbLinksStableConfig = (registerConfig "links_stable"){access = ReadOnly}
   wbLinksSettledConfig = (registerConfig "links_settled"){access = ReadOnly}

--- a/bittide/src/Bittide/Sync.hs
+++ b/bittide/src/Bittide/Sync.hs
@@ -129,7 +129,7 @@ syncOutGenerateWbC ::
     (ConstBwd MM, Wishbone dom 'Standard aw (Bytes 4))
     (CSignal dom Bit)
 syncOutGenerateWbC clk rst = circuit $ \(mm, wb) -> do
-  [activeWb] <- deviceWbC (show 'syncOutGenerateWbC) -< (mm, wb)
+  [activeWb] <- deviceWbC "SyncOutGenerator" -< (mm, wb)
   (Fwd active, _activity) <- registerWbC clk rst config False -< (activeWb, Fwd noWrite)
   syncOut <- syncOutGeneratorC clk (rst `orReset` unsafeFromActiveLow active)
   idC -< syncOut

--- a/bittide/tests/Tests/ClockControl/Freeze.hs
+++ b/bittide/tests/Tests/ClockControl/Freeze.hs
@@ -109,13 +109,13 @@ prop_wb = property $ do
    where
     readDataU = unpackOrErrorC endian (unpack readData)
   model (Read a _) WishboneS2M{readData} s@ModelState{lastSeen = Nothing}
-    | a < 2 = Right s
+    | a < 3 = Right s
     | otherwise =
         -- Record the value of the register that is being read. This can predict the
         -- value of all other registers (until a freeze is requested).
         Right s{lastSeen = Just (unpackOrErrorC endian (unpack readData) - fromIntegral a)}
   model (Read a _) WishboneS2M{readData} s@ModelState{lastSeen = Just l}
-    | a < 2 = Right s
+    | a < 3 = Right s
     | readDataU - fromIntegral a == l = Right s
     | otherwise =
         Left $ "Read value mismatch: expected " <> show l <> ", got " <> show readDataU
@@ -168,7 +168,7 @@ prop_wb = property $ do
   localCounter = counter clk rst ena 0
   syncPulseCounter = counter clk rst ena 1
   lastPulseCounter = counter clk rst ena 2
-  ebCounters = bundle $ counter clk rst ena <$> iterateI (+ 1) 3
+  ebCounters = bundle $ counter clk rst ena <$> iterateI (+ 1) (3 :: Signed 32)
 
   dut :: Circuit (Wishbone XilinxSystem Standard AddressWidth (BitVector 32)) ()
   dut = unMemmap dutMm

--- a/bittide/tests/Tests/ClockControl/Freeze.hs
+++ b/bittide/tests/Tests/ClockControl/Freeze.hs
@@ -154,8 +154,7 @@ prop_wb = property $ do
      in
       circuit $ \(mm, wb) -> do
         freeze @4 @32 clk rst
-          -< ( mm
-             , wb
+          -< ( (mm, wb)
              , Fwd ebCounters
              , Fwd localCounter
              , Fwd syncPulseCounter

--- a/firmware-binaries/clock-control-swcctopologies/src/main.rs
+++ b/firmware-binaries/clock-control-swcctopologies/src/main.rs
@@ -37,7 +37,7 @@ fn main() -> ! {
     );
 
     loop {
-        callisto::callisto(&cc, &config, &mut state);
+        callisto::callisto(&cc, cc.data_counts_volatile_iter(), &config, &mut state);
         cc.set_change_speed(state.b_k);
     }
 }

--- a/firmware-binaries/clock-control/src/main.rs
+++ b/firmware-binaries/clock-control/src/main.rs
@@ -26,6 +26,7 @@ fn main() -> ! {
     let dbgreg = INSTANCES.debug_register;
     let timer = INSTANCES.timer;
     let mut uart = INSTANCES.uart;
+    let freeze = INSTANCES.freeze;
 
     uwriteln!(uart, "Starting clock control..").unwrap();
 
@@ -47,7 +48,8 @@ fn main() -> ! {
     let mut next_update = timer.now() + interval;
 
     loop {
-        callisto::callisto(&cc, &config, &mut state);
+        freeze.set_freeze(true);
+        callisto::callisto(&cc, freeze.eb_counters_volatile_iter(), &config, &mut state);
         cc.set_change_speed(state.b_k);
         timer.wait_until(next_update);
         next_update += interval;

--- a/firmware-binaries/test-cases/clock-control-wb/src/main.rs
+++ b/firmware-binaries/test-cases/clock-control-wb/src/main.rs
@@ -44,9 +44,9 @@ fn main() -> ! {
     let cc = unsafe { ClockControl::new(0xC000_0000 as *mut u8) };
     let dbg = unsafe { DebugRegister::new(0xA000_0000 as *mut u8) };
 
-    writeln!(uart, "nLinks: {}", cc.num_links()).unwrap();
+    writeln!(uart, "nLinks: {}", cc.n_links()).unwrap();
     writeln!(uart, "linkMask: {}", cc.link_mask()).unwrap();
-    writeln!(uart, "linkMaskPopcnt: {}", cc.up_links()).unwrap();
+    writeln!(uart, "linkMaskPopcnt: {}", cc.n_up_links()).unwrap();
     writeln!(
         uart,
         "reframingEnabled: {}",
@@ -84,7 +84,7 @@ fn main() -> ! {
     writeln!(uart, "]").unwrap();
 
     // Mark end of transmission - should hopefully be unique enough?
-    for _ in 0..cc.up_links() {
+    for _ in 0..cc.n_up_links() {
         cc.set_change_speed(SpeedChange::NoChange);
     }
 

--- a/firmware-support/bittide-sys/src/callisto.rs
+++ b/firmware-support/bittide-sys/src/callisto.rs
@@ -117,7 +117,14 @@ fn is_active_link(link_mask: u8, n_buffers: u8, i: usize) -> bool {
 
 /// Clock correction strategy based on:
 /// [https://github.com/bittide/Callisto.jl](https://github.com/bittide/Callisto.jl)
-pub fn callisto(cc: &ClockControl, config: &ControlConfig, state: &mut ControlSt) {
+pub fn callisto<I>(
+    cc: &ClockControl,
+    eb_counters_iter: I,
+    config: &ControlConfig,
+    state: &mut ControlSt,
+) where
+    I: Iterator<Item = i32>,
+{
     // see clock control algorithm simulation here:
     //
     // https://github.com/bittide/Callisto.jl/blob/e47139fca128995e2e64b2be935ad588f6d4f9fb/demo/pulsecontrol.jl#L24
@@ -133,8 +140,7 @@ pub fn callisto(cc: &ClockControl, config: &ControlConfig, state: &mut ControlSt
     let link_mask = cc.link_mask();
 
     // Sum the data counts for all active links
-    let measured_sum: i32 = cc
-        .data_counts_volatile_iter()
+    let measured_sum: i32 = eb_counters_iter
         .enumerate()
         .map(|(i, v)| {
             if is_active_link(link_mask, n_links, i) {

--- a/firmware-support/bittide-sys/src/callisto.rs
+++ b/firmware-support/bittide-sys/src/callisto.rs
@@ -108,6 +108,13 @@ fn speed_change_to_sign(speed_change: SpeedChange) -> i32 {
     }
 }
 
+/// Determining whether a link is active is a bit tricky, because the link mask's
+/// bit indices are inverted compared to the indices of the links. This makes
+/// sense from a Clash lens (as BitPack "reverses" bits).
+fn is_active_link(link_mask: u8, n_buffers: u8, i: usize) -> bool {
+    link_mask & (1 << ((n_buffers - 1) as usize - i)) != 0
+}
+
 /// Clock correction strategy based on:
 /// [https://github.com/bittide/Callisto.jl](https://github.com/bittide/Callisto.jl)
 pub fn callisto(cc: &ClockControl, config: &ControlConfig, state: &mut ControlSt) {
@@ -121,11 +128,24 @@ pub fn callisto(cc: &ClockControl, config: &ControlConfig, state: &mut ControlSt
     const K_P: f32 = 2e-8;
     const FSTEP: f32 = 10e-9;
 
-    let n_buffers = cc.up_links();
+    let n_links = cc.n_links();
+    let n_up_links = cc.n_up_links();
+    let link_mask = cc.link_mask();
 
-    let measured_sum: i32 = cc.data_counts_volatile_iter().sum();
+    // Sum the data counts for all active links
+    let measured_sum: i32 = cc
+        .data_counts_volatile_iter()
+        .enumerate()
+        .map(|(i, v)| {
+            if is_active_link(link_mask, n_links, i) {
+                v
+            } else {
+                0
+            }
+        })
+        .sum();
 
-    let r_k = (measured_sum - n_buffers as i32 * config.target_count as i32) as f32;
+    let r_k = (measured_sum - n_up_links as i32 * config.target_count as i32) as f32;
     let c_des = K_P * r_k + state.steady_state_target;
 
     state.z_k += speed_change_to_sign(state.b_k);


### PR DESCRIPTION
This makes sure that all buffer occupancies are captured at the exact
same time, instead of "when the CPU gets to it". `Freeze` doesn't know
about active links, hence the software needs to more defensive in which
buffers it reads out and which it doesn't.

Note that we don't switch over `swcctopologies` -- the idea being that
that instance will get entirely replaced by software based sample
capturing.

This is part of #742.