### PR TITLE
Mark `Bittide.Ethernet.Mac.ethMac1GFifoBb` as `OPAQUE`

### DIFF
--- a/bittide/src/Bittide/Ethernet/Mac.hs
+++ b/bittide/src/Bittide/Ethernet/Mac.hs
@@ -432,7 +432,7 @@ ethMac1GFifoBb SNat SNat !_ !_ !_ !_ !_ !_ !_ !_ !_ !_ !_ !_ !_ !_ !_ !_ !_ !_ =
  where
   err :: forall dom a. (NFDataX a) => Signal dom a
   err = pure $ deepErrorX "simulation model not implemented"
-{-# NOINLINE ethMac1GFifoBb #-}
+{-# OPAQUE ethMac1GFifoBb #-}
 {-# ANN ethMac1GFifoBb hasBlackBox #-}
 {-# ANN
   ethMac1GFifoBb


### PR DESCRIPTION
Prevents Clash warnings

Fixes #878