### PR TITLE
Add `repld`: load all packages into a REPL at once

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -84,7 +84,15 @@ allow-newer:
 --
 --   ghcid -c cabal repl bittide bittide:unittests
 --
--- Finally, note that it is not limited to units from the same Cabal file:
+-- Note that it is not limited to units from the same Cabal file:
 --
 --   cabal repl bittide bittide:unittests bittide-instances bittide-instance:unittests
+--
+-- Finally, we maintain a script that loads _all_ development packages:
+--
+--   repld
+--
+-- This is also usable in combination with ghcid:
+--
+--   ghcid -c repld
 multi-repl: True

--- a/nix/bin/repld
+++ b/nix/bin/repld
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+cabal repl \
+  bittide-experiments bittide-experiments:unittests \
+  bittide-extra bittide-extra:unittests \
+  bittide-instances bittide-instances:unittests \
+  bittide-shake \
+  bittide-tools \
+  bittide bittide:unittests \
+  clash-bitpackc clash-bitpackc:unittests \
+  clash-protocols-memmap clash-protocols-memmap:unittests \
+  ghc-typelits-extra-lemmas ghc-typelits-extra-lemmas:unittests \
+  vivado-hs vivado-hs:unittests


### PR DESCRIPTION
Example usage:

```
$ ghcid -c repld
[  1 of 228] Compiling Bittide.Arithmetic.Time ( /home/martijn/code/bittide-hardware/bittide/src/Bittide/Arithmetic/Time.hs, interpreted )[bittide-0.1-inplace]
[  2 of 228] Compiling Bittide.Arithmetic.PartsPer ( /home/martijn/code/bittide-hardware/bittide/src/Bittide/Arithmetic/PartsPer.hs, interpreted )[bittide-0.1-inplace]
[  3 of 228] Compiling Bittide.ClockControl.StabilityChecker ( /home/martijn/code/bittide-hardware/bittide/src/Bittide/ClockControl/StabilityChecker.hs, interpreted )[bittide-0.1-inplace]
[..]
[205 of 228] Compiling Main             ( /home/martijn/code/bittide-hardware/bittide-instances/tests/unittests.hs, interpreted )[bittide-instances-0.1-inplace-unittests]
Ok, 205 modules loaded.
All good (205 modules, at 11:38:03)
```