### PR TITLE
Disallow merging PRs with `do-not-merge` label

### DIFF
--- a/.github/workflows/do-not-merge.yml
+++ b/.github/workflows/do-not-merge.yml
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: 2025 Google LLC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: 'Check Pull Request labels for merge block'
+
+on:
+  pull_request:
+    types:
+      - opened
+      - labeled
+      - unlabeled
+
+jobs:
+  do-not-merge:
+    if: contains(github.event.pull_request.labels.*.name, 'do-not-merge')
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - run: exit 1


### PR DESCRIPTION
This can be useful when setting up merge chains where you want one PR to merge to `main` before another. Applying the `do-not-merge` prevents easy mistakes.