### PR TITLE
Add `synchronize` to `do-not-merge` check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,30 @@ jobs:
     - name: REUSE Compliance Check
       uses: fsfe/reuse-action@v1
 
+  check-pr-labels:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check for 'do-not-merge' label
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH_NAME: ${{ github.ref_name }}
+        run: |
+          PR_LABELS=$(gh pr list --head "${BRANCH_NAME}" --state open --json labels)
+          echo "Found labels for PR on branch '$BRANCH_NAME':"
+          echo ${PR_LABELS}
+
+          DO_NOT_MERGE=$(echo ${PR_LABELS} | jq '.[0].labels | map(.name) | any(. == "do-not-merge")')
+
+          if [ $DO_NOT_MERGE = "true" ]; then
+            echo "Error: The label 'do-not-merge' is present on the associated PR."
+            exit 1
+          else
+            echo "The 'do-not-merge' label is not present. Proceeding."
+            exit 0
+          fi
+
   lint:
     name: Basic linting
     runs-on: [self-hosted, compute]
@@ -719,6 +743,7 @@ jobs:
     needs: [
         bittide-instances-publish-artifacts,
         cachix,
+        check-pr-labels,
         firmware-limit-checks,
         firmware-support-tests,
         generate-control-reports,

--- a/.github/workflows/do-not-merge.yml
+++ b/.github/workflows/do-not-merge.yml
@@ -13,8 +13,15 @@ on:
 
 jobs:
   do-not-merge:
-    if: contains(github.event.pull_request.labels.*.name, 'do-not-merge')
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
-      - run: exit 1
+      - name: Fail if 'do-not-merge' label is present
+        run: |
+          HAS_LABEL="${{ contains(github.event.pull_request.labels.*.name, 'do-not-merge') }}"
+
+          echo "HAS_LABEL: ${HAS_LABEL}.."
+          if [ "${HAS_LABEL}" == "true" ]; then
+            exit 1
+          else
+            exit 0
+          fi


### PR DESCRIPTION
Otherwise check doesn't re-run on (force) pushes

Fall out from https://github.com/bittide/bittide-hardware/pull/917