### PR TITLE
Greatly simplify `froccTopologyType` & friends

### DIFF
--- a/bittide-experiments/src/Bittide/Simulate/Config.hs
+++ b/bittide-experiments/src/Bittide/Simulate/Config.hs
@@ -18,7 +18,6 @@ import Data.Aeson (FromJSON (..), ToJSON (..), encode)
 import Data.Default (Default (..))
 import GHC.Generics (Generic)
 import Language.Dot.Pretty (render)
-import Numeric.Natural (Natural)
 import System.Directory (createDirectoryIfMissing)
 import System.FilePath ((</>))
 
@@ -34,7 +33,7 @@ simTopologyFileName = "topology.gv"
 
 -- | Collection of all clock control configuration parameters.
 data CcConf = CcConf
-  { ccTopologyType :: TopologyType Natural
+  { ccTopologyType :: TopologyType
   -- ^ The topology type of the network to be simulated. Have a
   -- look at 'Bittide.Topology' for more insights on the supported
   -- topology types and their corresponding topologies.

--- a/bittide-experiments/src/Bittide/Simulate/Config.hs
+++ b/bittide-experiments/src/Bittide/Simulate/Config.hs
@@ -12,15 +12,17 @@ module Bittide.Simulate.Config (
 ) where
 
 import Bittide.Arithmetic.PartsPer (PartsPer)
-import Bittide.Topology (STop (..), TopologyType (..), toDot)
+import Bittide.Topology (STopology (..), TopologyType (..), toDot)
 
 import Data.Aeson (FromJSON (..), ToJSON (..), encode)
-import qualified Data.ByteString.Lazy as BS (writeFile)
 import Data.Default (Default (..))
 import GHC.Generics (Generic)
 import Language.Dot.Pretty (render)
+import Numeric.Natural (Natural)
 import System.Directory (createDirectoryIfMissing)
 import System.FilePath ((</>))
+
+import qualified Data.ByteString.Lazy as BS (writeFile)
 
 -- | Default name of the clock control JSON configuration file.
 simJsonConfigFileName :: String
@@ -32,7 +34,7 @@ simTopologyFileName = "topology.gv"
 
 -- | Collection of all clock control configuration parameters.
 data CcConf = CcConf
-  { ccTopologyType :: TopologyType IO Integer
+  { ccTopologyType :: TopologyType Natural
   -- ^ The topology type of the network to be simulated. Have a
   -- look at 'Bittide.Topology' for more insights on the supported
   -- topology types and their corresponding topologies.
@@ -76,8 +78,8 @@ instance Default CcConf where
 {- | Saves a topology and a corresponding simulation configuration to
 respective files in 'outDir'.
 -}
-saveCcConfig :: STop -> CcConf -> IO ()
-saveCcConfig (STop t) cfg@CcConf{..} = do
+saveCcConfig :: STopology -> CcConf -> IO ()
+saveCcConfig (STopology t) cfg@CcConf{..} = do
   createDirectoryIfMissing True outDir
   let topologyFile = outDir </> simTopologyFileName
   writeFile topologyFile $ (<> "\n") $ render $ toDot t

--- a/bittide-experiments/src/Bittide/Topology.hs
+++ b/bittide-experiments/src/Bittide/Topology.hs
@@ -1,6 +1,7 @@
 -- SPDX-FileCopyrightText: 2022 Google LLC
 --
 -- SPDX-License-Identifier: Apache-2.0
+{-# LANGUAGE ImpredicativeTypes #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -16,7 +17,7 @@ module Bittide.Topology (
     topologyType,
     hasEdge
   ),
-  STop (..),
+  STopology (..),
   TreeSize,
 
   -- * Special Topologies
@@ -54,9 +55,8 @@ import Clash.Prelude (
   SomeNat (..),
   d0,
   d1,
-  natToInteger,
+  natToNum,
   snatProxy,
-  snatToInteger,
   snatToNum,
   someNatVal,
   type Div,
@@ -80,18 +80,17 @@ import Data.List (groupBy, sort)
 import Data.Maybe (catMaybes, mapMaybe)
 import Data.Proxy (Proxy (..))
 import Data.Tuple (swap)
+import GHC.Num.Natural (Natural)
+import GHC.TypeLits.KnownNat (KnownNat2 (..), SNatKn (..), nameToSymbol)
+import GHC.TypeNats (natVal)
+import Language.Dot.Graph (GraphType (..), Name (..), Statement (..), Subgraph (..))
+import Language.Dot.Parser (parse)
 import System.Random (randomIO, randomRIO)
 
 import qualified Data.Array as A (accumArray, array, listArray, (!))
 import qualified Data.Map.Strict as M (fromList, (!))
 import qualified Data.Set as S (fromList, toList)
-
-import GHC.Num.Natural (Natural)
-import GHC.TypeLits.KnownNat (KnownNat2 (..), SNatKn (..), nameToSymbol)
-import GHC.TypeNats (natVal)
-
-import Language.Dot.Graph (GraphType (..), Name (..), Statement (..), Subgraph (..))
-import Language.Dot.Parser (parse)
+import qualified GHC.TypeNats as Nats
 
 -- | Special topologies may have names given as a string.
 type TopologyName = String
@@ -102,17 +101,17 @@ bound, a name and a 'TopologyType'.
 data Topology (n :: Nat) = Topology
   { topologyName :: TopologyName
   , topologyGraph :: Graph
-  , topologyType :: TopologyType IO Integer
+  , topologyType :: TopologyType Natural
   , hasEdge :: Index n -> Index n -> Bool
   }
 
 -- | Existentially quantified version hiding the type level bound.
-data STop = forall n. (KnownNat n) => STop (Topology n)
+data STopology = forall n. (KnownNat n) => STopology (Topology n)
 
 -- | Smart constructor of 'Topology'.
 fromGraph :: forall n. (KnownNat n) => TopologyName -> Graph -> Topology n
 fromGraph name graph =
-  Topology name graph (Random $ natToInteger @n) $
+  Topology name graph (Random $ natToNum @n) $
     curry $
       (A.!) $
         A.accumArray (const id) False bounds $
@@ -122,32 +121,27 @@ fromGraph name graph =
   edgeIndices = map (bimap fromIntegral fromIntegral) $ edges graph
 
 {- | Disambiguates between a selection of known topologies, topologies
-that are loaded from DOT files, and random topologies. The first
-type parameter @m@ indicates a context, that may be required to
-generate an instance of the given topology type. If no specific
-context is required @m@ is left unspecified. The second type
-parameter @n@ indicates an integral type, in which the topology may
-be parameterized.
+that are loaded from DOT files, and random topologies.
 -}
-data TopologyType m n where
-  Diamond :: TopologyType m n
-  Pendulum :: n -> n -> TopologyType m n
-  Line :: n -> TopologyType m n
-  HyperCube :: n -> TopologyType m n
-  Grid :: n -> n -> TopologyType m n
-  Torus2D :: n -> n -> TopologyType m n
-  Torus3D :: n -> n -> n -> TopologyType m n
-  Tree :: n -> n -> TopologyType m n
-  Star :: n -> TopologyType m n
-  Cycle :: n -> TopologyType m n
-  Complete :: n -> TopologyType m n
-  Dumbbell :: n -> n -> n -> TopologyType m n
-  Hourglass :: n -> TopologyType m n
-  Beads :: n -> n -> n -> TopologyType m n
-  DotFile :: FilePath -> TopologyType IO n
-  Random :: n -> TopologyType IO n
+data TopologyType n where
+  Diamond :: TopologyType n
+  Pendulum :: n -> n -> TopologyType n
+  Line :: n -> TopologyType n
+  HyperCube :: n -> TopologyType n
+  Grid :: n -> n -> TopologyType n
+  Torus2D :: n -> n -> TopologyType n
+  Torus3D :: n -> n -> n -> TopologyType n
+  Tree :: n -> n -> TopologyType n
+  Star :: n -> TopologyType n
+  Cycle :: n -> TopologyType n
+  Complete :: n -> TopologyType n
+  Dumbbell :: n -> n -> n -> TopologyType n
+  Hourglass :: n -> TopologyType n
+  Beads :: n -> n -> n -> TopologyType n
+  DotFile :: FilePath -> TopologyType n
+  Random :: n -> TopologyType n
 
-instance Show (TopologyType m a) where
+instance Show (TopologyType a) where
   show = \case
     Diamond{} -> (.topologyName) diamond
     Pendulum{} -> (.topologyName) $ pendulum d0 d0
@@ -167,7 +161,7 @@ instance Show (TopologyType m a) where
     Random{} -> "random"
 
 -- Unfortunately, we cannot derive 'Eq' and 'Ord' for GADTs.
-instance (Eq a) => Eq (TopologyType m a) where
+instance (Eq a) => Eq (TopologyType a) where
   x == y = case (x, y) of
     (Diamond, Diamond) -> True
     (Pendulum n m, Pendulum n' m') -> n == n' && m == m'
@@ -186,7 +180,7 @@ instance (Eq a) => Eq (TopologyType m a) where
     (DotFile p, DotFile p') -> p == p'
     _ -> False
 
-instance (Ord a) => Ord (TopologyType m a) where
+instance (Ord a) => Ord (TopologyType a) where
   compare x y = case (x, y) of
     (Diamond, Diamond) -> EQ
     (Pendulum n m, Pendulum n' m') -> compare (n, m) (n', m')
@@ -224,7 +218,7 @@ instance (Ord a) => Ord (TopologyType m a) where
       DotFile{} -> 14
       Random{} -> 15
 
-instance (ToJSON a) => ToJSON (TopologyType m a) where
+instance (ToJSON a) => ToJSON (TopologyType a) where
   toJSON t = object $ case t of
     Diamond -> [gt]
     DotFile f -> [gt, "filepath" .= f]
@@ -245,7 +239,7 @@ instance (ToJSON a) => ToJSON (TopologyType m a) where
    where
     gt = "graph" .= show t
 
-instance (FromJSON a) => FromJSON (TopologyType IO a) where
+instance (FromJSON a) => FromJSON (TopologyType a) where
   parseJSON v = case v of
     Object o ->
       o .: "graph" >>= \(name :: String) -> case name of
@@ -262,103 +256,80 @@ instance (FromJSON a) => FromJSON (TopologyType IO a) where
         "tree" -> Tree <$> o .: "depth" <*> o .: "childs"
         "grid" -> Grid <$> o .: "rows" <*> o .: "cols"
         "torus2d" -> Torus2D <$> o .: "rows" <*> o .: "cols"
-        "torus3d" ->
-          Torus3D
-            <$> o
-              .: "rows"
-            <*> o
-              .: "cols"
-            <*> o
-              .: "planes"
-        "dumbbell" ->
-          Dumbbell
-            <$> o
-              .: "width"
-            <*> o
-              .: "left"
-            <*> o
-              .: "right"
-        "beads" ->
-          Beads
-            <$> o
-              .: "count"
-            <*> o
-              .: "distance"
-            <*> o
-              .: "weight"
+        "torus3d" -> Torus3D <$> (o .: "rows") <*> (o .: "cols") <*> (o .: "planes")
+        "dumbbell" -> Dumbbell <$> (o .: "width") <*> (o .: "left") <*> (o .: "right")
+        "beads" -> Beads <$> (o .: "count") <*> (o .: "distance") <*> (o .: "weight")
         _ -> tmm
     _ -> tmm
    where
     tmm = typeMismatch "Topology" v
 
-newtype FUN a = FUN (forall n. SNat n -> a)
+data SomeSNat where
+  SomeSNat :: (KnownNat n) => SNat n -> SomeSNat
 
 -- | Generates some topology of the given topology type, if possible.
 froccTopologyType ::
-  (Integral n, Applicative m) =>
-  TopologyType m n ->
-  m (Either String STop)
-froccTopologyType tt = case tt of
-  Diamond -> ret $ Just $ STop diamond
-  Pendulum n m ->
-    let pendulum# :: FUN (FUN STop)
-        pendulum# = FUN (\l@SNat -> FUN (\w@SNat -> STop $ pendulum l w))
-     in ret $ pendulum# <#> n <!> m
-  Line n -> ret $ FUN (\sn@SNat -> STop $ line sn) <#> n
-  HyperCube n -> ret $ FUN (\sn@SNat -> STop $ hypercube sn) <#> n
+  TopologyType Natural ->
+  IO (Either String STopology)
+froccTopologyType = \case
+  Diamond -> ret diamond
+  Pendulum l w ->
+    case (naturalToSomeSNat l, naturalToSomeSNat w) of
+      (SomeSNat sL, SomeSNat sW) ->
+        ret (pendulum sL sW)
+  Line n ->
+    case naturalToSomeSNat n of
+      SomeSNat sN -> ret (line sN)
+  HyperCube n ->
+    case naturalToSomeSNat n of
+      SomeSNat sN -> ret (hypercube sN)
   Grid rows cols ->
-    let grid# :: FUN (FUN STop)
-        grid# = FUN (\n@SNat -> FUN (\m@SNat -> STop $ grid n m))
-     in ret $ grid# <#> rows <!> cols
+    case (naturalToSomeSNat rows, naturalToSomeSNat cols) of
+      (SomeSNat sRows, SomeSNat sCols) -> ret (grid sRows sCols)
   Torus2D rows cols ->
-    let torus2d# :: FUN (FUN STop)
-        torus2d# = FUN (\r@SNat -> FUN (\c@SNat -> STop $ torus2d r c))
-     in ret $ torus2d# <#> rows <!> cols
+    case (naturalToSomeSNat rows, naturalToSomeSNat cols) of
+      (SomeSNat sRows, SomeSNat sCols) -> ret (torus2d sRows sCols)
   Torus3D rows cols planes ->
-    let torus3d# :: FUN (FUN (FUN STop))
-        torus3d# = FUN (\r@SNat -> FUN (\c@SNat -> FUN (\p@SNat -> STop $ torus3d r c p)))
-     in ret $ torus3d# <#> rows <!> cols <!> planes
+    case (naturalToSomeSNat rows, naturalToSomeSNat cols, naturalToSomeSNat planes) of
+      (SomeSNat sRows, SomeSNat sCols, SomeSNat sPlanes) ->
+        ret (torus3d sRows sCols sPlanes)
   Tree depth childs ->
-    let tree# :: FUN (FUN STop)
-        tree# = FUN (\n@SNat -> FUN (\m@SNat -> STop $ tree n m))
-     in ret $ tree# <#> depth <!> childs
-  Star n -> ret $ FUN (\sn@SNat -> STop $ star sn) <#> n
-  Cycle n -> ret $ FUN (\sn@SNat -> STop $ cyclic sn) <#> n
-  Complete n -> ret $ FUN (\sn@SNat -> STop $ complete sn) <#> n
-  Dumbbell n m k ->
-    let dumbbell# :: FUN (FUN (FUN STop))
-        dumbbell# = FUN (\w@SNat -> FUN (\l@SNat -> FUN (\r@SNat -> STop $ dumbbell w l r)))
-     in ret $ dumbbell# <#> n <!> m <!> k
-  Hourglass n -> ret $ FUN (\sn@SNat -> STop $ hourglass sn) <#> n
-  Beads n m k ->
-    let beads# :: FUN (FUN (FUN STop))
-        beads# = FUN (\c@SNat -> FUN (\d@SNat -> FUN (\w@SNat -> STop $ beads c d w)))
-     in ret $ beads# <#> n <!> m <!> k
+    case (naturalToSomeSNat depth, naturalToSomeSNat childs) of
+      (SomeSNat sDepth, SomeSNat sChilds) -> ret (tree sDepth sChilds)
+  Star n ->
+    case naturalToSomeSNat n of
+      SomeSNat sN -> ret (star sN)
+  Cycle n ->
+    case naturalToSomeSNat n of
+      SomeSNat sN -> ret (cyclic sN)
+  Complete n ->
+    case naturalToSomeSNat n of
+      SomeSNat sN -> ret (complete sN)
+  Dumbbell w l r ->
+    case (naturalToSomeSNat w, naturalToSomeSNat l, naturalToSomeSNat r) of
+      (SomeSNat sW, SomeSNat sL, SomeSNat sR) -> ret (dumbbell sW sL sR)
+  Hourglass n ->
+    case naturalToSomeSNat n of
+      SomeSNat sN -> ret (hourglass sN)
+  Beads c d w ->
+    case (naturalToSomeSNat c, naturalToSomeSNat d, naturalToSomeSNat w) of
+      (SomeSNat sC, SomeSNat sD, SomeSNat sW) -> ret (beads sC sD sW)
   Random n ->
-    either (return . Left) (Right <$>) $
-      maybeToEither $
-        FUN (\sn@SNat -> STop <$> randomTopology sn)
-          <#> n
-  DotFile f ->
-    readFile f
-      >>= return
-        . first (("Invalid DOT file - " <> f <> "\n") <>)
-        . fromDot
+    case naturalToSomeSNat n of
+      SomeSNat sN -> do
+        topology <- randomTopology sN
+        ret topology
+  DotFile f -> do
+    contents <- readFile f
+    pure $ first (("Invalid DOT file - " <> f <> "\n") <>) $ fromDot $ contents
  where
-  ret = pure . maybeToEither
-  maybeToEither = maybe (Left "cannot construct SNat arguments") Right
+  ret :: forall (n :: Nat). (KnownNat n) => Topology n -> IO (Either String STopology)
+  ret = pure . pure . STopology
 
-  infixl 8 <!>
-  (<!>) :: (Integral i) => Maybe (FUN a) -> i -> Maybe a
-  msnf <!> n = do
-    snf <- msnf
-    SomeNat p <- someNatVal $ toInteger n
-    case snf of
-      FUN f -> pure (f (snatProxy p))
-
-  infixl 8 <#>
-  (<#>) :: (Integral i) => FUN a -> i -> Maybe a
-  (<#>) f i = Just f <!> i
+  naturalToSomeSNat :: Natural -> SomeSNat
+  naturalToSomeSNat n =
+    case Nats.someNatVal n of
+      Nats.SomeNat sn -> SomeSNat (snatProxy sn)
 
 -- | Given a list of edges, turn it into a directed graph.
 fromEdgeList :: forall a. (Ord a) => [(a, a)] -> Graph
@@ -382,7 +353,7 @@ pendulum :: SNat l -> SNat w -> Topology (l + w)
 pendulum sl sw =
   (dumbbell sl d0 sw)
     { topologyName = "pendulum"
-    , topologyType = Pendulum (snatToInteger sl) $ snatToInteger sw
+    , topologyType = Pendulum (snatToNum sl) (snatToNum sw)
     }
 
 {- | @n@ nodes in a line, connected to their neighbors.
@@ -395,14 +366,14 @@ line :: SNat n -> Topology n
 line sn =
   (dumbbell sn d0 d0)
     { topologyName = "line"
-    , topologyType = Line $ snatToInteger sn
+    , topologyType = Line $ snatToNum sn
     }
 
 -- | @n@-dimensional hypercube
 hypercube :: SNat n -> Topology (2 ^ n)
 hypercube sn@SNat =
   (fromGraph "hypercube" $ fromEdgeList es)
-    { topologyType = HyperCube $ snatToInteger sn
+    { topologyType = HyperCube $ snatToNum sn
     }
  where
   n = snatToNum sn
@@ -430,9 +401,9 @@ torus3d sna@SNat snb@SNat snc@SNat =
     { topologyType = Torus3D a b c
     }
  where
-  a = snatToInteger sna
-  b = snatToInteger snb
-  c = snatToInteger snc
+  a = snatToNum sna
+  b = snatToNum snb
+  c = snatToNum snc
   pairs = [(l, m, n) | l <- [0 .. (a - 1)], m <- [0 .. (b - 1)], n <- [0 .. (c - 1)]]
   neighborsOf (l, m, n) =
     [ ((l - 1) `mod` a, m, n)
@@ -451,8 +422,8 @@ torus2d snRows@SNat snCols@SNat =
     { topologyType = Torus2D rows cols
     }
  where
-  rows = snatToInteger snRows
-  cols = snatToInteger snCols
+  rows = snatToNum snRows
+  cols = snatToNum snCols
   pairs = [(m, n) | m <- [0 .. (rows - 1)], n <- [0 .. (cols - 1)]]
   neighborsOf (m, n) =
     [ ((m - 1) `mod` rows, n)
@@ -469,8 +440,8 @@ grid snRows@SNat snCols@SNat =
     { topologyType = Grid rows cols
     }
  where
-  rows = snatToInteger snRows
-  cols = snatToInteger snCols
+  rows = snatToNum snRows
+  cols = snatToNum snCols
   pairs = [(m, n) | m <- [1 .. rows], n <- [1 .. cols]]
   mkEdges (m, n) =
     [ (a, b)
@@ -515,8 +486,8 @@ tree snDepth@SNat snChilds@SNat =
     { topologyType = Tree depth c
     }
  where
-  depth = snatToInteger snDepth
-  c = snatToInteger snChilds
+  depth = snatToNum snDepth
+  c = snatToNum snChilds
   -- \| At depth @d_i@, child node @i@ is connected to the @(i-1) `div` c + 1@st
   -- node at depth @d_i - 1@
   pairs = [(d_i, i, (i - 1) `div` c + 1) | d_i <- [0 .. depth], i <- [1 .. (c ^ d_i)]]
@@ -530,7 +501,7 @@ star :: SNat childs -> Topology (TreeSize 1 childs)
 star sn =
   (tree SNat sn)
     { topologyName = "star"
-    , topologyType = Star $ snatToInteger sn
+    , topologyType = Star $ snatToNum sn
     }
 
 {- | [Cyclic graph](https://mathworld.wolfram.com/CycleGraph.html) with @n@
@@ -540,7 +511,7 @@ cyclic :: SNat n -> Topology n
 cyclic sn =
   (beads sn d0 d1)
     { topologyName = "cycle"
-    , topologyType = Cycle $ snatToInteger sn
+    , topologyType = Cycle $ snatToNum sn
     }
 
 {- | [Complete graph](https://mathworld.wolfram.com/CompleteGraph.html) with @n@
@@ -550,7 +521,7 @@ complete :: SNat n -> Topology n
 complete sn =
   (beads d1 d0 sn)
     { topologyName = "complete"
-    , topologyType = Complete $ snatToInteger sn
+    , topologyType = Complete $ snatToNum sn
     }
 
 {- | An dumbbell shaped graph consisting of two independent complete
@@ -561,7 +532,7 @@ dumbbell :: SNat w -> SNat l -> SNat r -> Topology (w + l + r)
 dumbbell sw@SNat sl@SNat sr@SNat =
   t{topologyType = Dumbbell (sn2i sw) (sn2i sl) (sn2i sr)}
  where
-  sn2i = snatToInteger
+  sn2i = snatToNum
   w = snatToNum sw
   l = snatToNum sl
   r = snatToNum sr
@@ -593,7 +564,7 @@ hourglass :: SNat n -> Topology (n + n)
 hourglass sn =
   (dumbbell d0 sn sn)
     { topologyName = "hourglass"
-    , topologyType = Hourglass $ snatToInteger sn
+    , topologyType = Hourglass $ snatToNum sn
     }
 
 {- | A beads shaped graph consisting of two @c@ independend complete
@@ -607,7 +578,7 @@ beads sc@SNat sd@SNat sw@SNat =
     { topologyType = Beads (sn2i sc) (sn2i sd) (sn2i sw)
     }
  where
-  sn2i = snatToInteger
+  sn2i = snatToNum
   c = snatToNum sc :: Int
   d = snatToNum sd :: Int
   w = snatToNum sw :: Int
@@ -713,7 +684,7 @@ fromDot ::
   -- | the string holding the graphviz dot content
   String ->
   -- | either an error, if given an unusable input, or the extracted topology
-  Either String STop
+  Either String STopology
 fromDot cnt = do
   (strict, gType, maybe "" fromDotName -> name, statements) <- parse cnt
 
@@ -749,7 +720,7 @@ fromDot cnt = do
   case someNatVal $ toInteger n of
     Nothing -> Left "cannot construct SNat arguments"
     Just (SomeNat (_ :: Proxy n)) ->
-      return $ STop $ fromGraph @n name graph
+      return $ STopology $ fromGraph @n name graph
  where
   fromStatement :: Statement -> Either String (Maybe [Name])
   fromStatement = \case

--- a/bittide-instances/src/Bittide/Instances/Hitl/SwCcTopologies.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/SwCcTopologies.hs
@@ -60,7 +60,17 @@ import Bittide.Instances.Hitl.IlaPlot (
 import Bittide.Instances.Hitl.Setup (FpgaCount, LinkCount)
 import Bittide.SharedTypes (withBittideByteOrder)
 import Bittide.Simulate.Config (CcConf (..))
-import Bittide.Topology
+import Bittide.Topology (
+  Topology (topologyName, topologyType),
+  TopologyType (Complete),
+  complete,
+  cyclic,
+  diamond,
+  hourglass,
+  line,
+  star,
+  torus2d,
+ )
 import Bittide.Transceiver (transceiverPrbsN)
 
 import Clash.Annotations.TH (makeTopEntity)

--- a/bittide-instances/src/Bittide/Instances/Hitl/SwCcTopologies.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/SwCcTopologies.hs
@@ -1061,7 +1061,7 @@ tests = [testGroup True, testGroup False]
                     })
       , postProcData =
           defSimCfg
-            { ccTopologyType = Complete $ natToInteger @FpgaCount
+            { ccTopologyType = Complete $ natToNum @FpgaCount
             , clockOffsets = Nothing
             , startupDelays = toList $ repeat @FpgaCount 0
             }

--- a/bittide-tools/clockcontrol/plot/Main.hs
+++ b/bittide-tools/clockcontrol/plot/Main.hs
@@ -569,9 +569,9 @@ plotTest refDom testDir cfg dir globalOutDir = do
           . length
           . filter knownId
         >>= \case
-          SomeNat n -> return $ STop $ complete $ snatProxy n
+          SomeNat n -> return $ STopology $ complete $ snatProxy n
 
-  STop (t :: Topology topologySize) <-
+  STopology (t :: Topology topologySize) <-
     case cfg.ccTopologyType of
       Random{} -> topFromDirs
       DotFile f -> readFile f >>= either die return . fromDot


### PR DESCRIPTION
I had a hard time figuring out what was happening with the newtypes, custom infix operators, and polymorphic contexts. Current code is slightly more repetitive in some cases, but obvious (?).