### PR TITLE
Make helper functions for the implicit byte ordering arguments

### DIFF
--- a/bittide/src/Bittide/SharedTypes.hs
+++ b/bittide/src/Bittide/SharedTypes.hs
@@ -190,11 +190,33 @@ forceReset force = unsafeFromActiveHigh (unsafeToActiveHigh hasReset .||. force)
 divRU :: (Integral a) => a -> a -> a
 divRU b a = (b + a - 1) `div` a
 
-withBittideByteOrder ::
-  ((?busByteOrder :: ByteOrder, ?regByteOrder :: ByteOrder) => r) -> r
-withBittideByteOrder f =
+{- | Makes the implicit byte ordering parameters explicit, similar to
+'withClockResetEnable'. Argument ordering is bus byte order followed by register
+byte order.
+-}
+withByteOrderings ::
+  ByteOrder ->
+  ByteOrder ->
+  ((?busByteOrder :: ByteOrder, ?regByteOrder :: ByteOrder) => r) ->
+  r
+withByteOrderings busByteOrder regByteOrder f =
   let
-    ?busByteOrder = BigEndian
-    ?regByteOrder = LittleEndian
+    ?busByteOrder = busByteOrder
+    ?regByteOrder = regByteOrder
    in
     f
+
+-- | Use the byte ordering for Bittide systems: big-endian bus, little-endian registers.
+withBittideByteOrder ::
+  ((?busByteOrder :: ByteOrder, ?regByteOrder :: ByteOrder) => r) -> r
+withBittideByteOrder = withByteOrderings BigEndian LittleEndian
+
+-- | Use big-endian ordering for both busses and registers.
+withBigEndian ::
+  ((?busByteOrder :: ByteOrder, ?regByteOrder :: ByteOrder) => r) -> r
+withBigEndian = withByteOrderings BigEndian BigEndian
+
+-- | Use little-endian ordering for both busses and registers.
+withLittleEndian ::
+  ((?busByteOrder :: ByteOrder, ?regByteOrder :: ByteOrder) => r) -> r
+withLittleEndian = withByteOrderings LittleEndian LittleEndian

--- a/bittide/tests/Tests/ClockControl/Freeze.hs
+++ b/bittide/tests/Tests/ClockControl/Freeze.hs
@@ -6,7 +6,7 @@
 module Tests.ClockControl.Freeze where
 
 import Bittide.ClockControl.Freeze (counter, freeze)
-import Bittide.SharedTypes (Bytes)
+import Bittide.SharedTypes (Bytes, withByteOrderings)
 import Clash.Class.BitPackC (ByteOrder (BigEndian), unpackOrErrorC)
 import Clash.Explicit.Prelude
 import Clash.Prelude (withClockResetEnable)
@@ -144,19 +144,14 @@ prop_wb = property $ do
 
   dutMm ::
     Circuit (ConstBwd MM, Wishbone XilinxSystem Standard AddressWidth (BitVector 32)) ()
-  dutMm =
-    let
-      ?regByteOrder = endian
-      ?busByteOrder = endian
-     in
-      circuit $ \(mm, wb) -> do
-        freeze @4 @32 clk rst
-          -< ( (mm, wb)
-             , Fwd ebCounters
-             , Fwd localCounter
-             , Fwd syncPulseCounter
-             , Fwd lastPulseCounter
-             )
+  dutMm = withByteOrderings endian endian $ circuit $ \(mm, wb) -> do
+    freeze @4 @32 clk rst
+      -< ( (mm, wb)
+         , Fwd ebCounters
+         , Fwd localCounter
+         , Fwd syncPulseCounter
+         , Fwd lastPulseCounter
+         )
 
   -- Input registers that are spaced one apart. This allows us to predict the
   -- value of all counters, by just reading one. Note that this only works if


### PR DESCRIPTION
I know that some upcoming and in-progress PRs use a lot of `let ... in ...` to handle the new implicit parameters for byte ordering that we have. As such, I've provided some helper functions to deal with these and adapted existing code to use them. 