### PR TITLE
Use "clock active" as TX domain reset

### DIFF
--- a/bittide/src/Bittide/Transceiver.hs
+++ b/bittide/src/Bittide/Transceiver.hs
@@ -351,7 +351,7 @@ transceiverPrbsN opts inputs@Inputs{clock, reset, refClock} =
   Outputs
     { -- tx
       txClock = txClock
-    , txReset = unsafeFromActiveLow (head outputs).handshakeDoneTx
+    , txReset = unsafeFromActiveLow (unpack <$> txClkActives)
     , txReadys = map (.txReady) outputs
     , txSamplings = map (.txSampling) outputs
     , handshakesDoneTx = map (.handshakeDoneTx) outputs
@@ -404,7 +404,7 @@ transceiverPrbsN opts inputs@Inputs{clock, reset, refClock} =
   txOutClk = (head outputs).txOutClock
   -- see [NOTE: duplicate tx/rx domain]
   txClockNw = Gth.xilinxGthUserClockNetworkTx @tx @tx txOutClk txUsrClkRst
-  (_txClk1s, txClock, _txClkActives) = txClockNw
+  (_txClk1s, txClock, txClkActives) = txClockNw
 
   rxOutClks = map (.rxOutClock) outputs
   -- see [NOTE: duplicate tx/rx domain]


### PR DESCRIPTION
We currently mark the TX domain as stable only after the first link has negotiated its handshake, the idea being that after this the PLLs won't be reset anymore. This shouldn't be that way: the Bittide domain _should_ be able to be perfectly usable independent of what the transceivers are doing. This made me wonder: are the PLLs reset at all by the Xilinx IP? This doesn't seem to be the case, as the block generating the clock signal has its PLL reset signals connected to ground:

<img width="522" height="359" alt="Screenshot from 2025-08-07 13-13-10" src="https://github.com/user-attachments/assets/0b6e3c9c-eda6-48c0-92ee-2280b257d61a" />
<img width="522" height="224" alt="Screenshot from 2025-08-07 13-14-27" src="https://github.com/user-attachments/assets/dd96973c-27b2-4862-a3ef-922cdca650fe" />
<img width="446" height="228" alt="Screenshot from 2025-08-07 13-15-16" src="https://github.com/user-attachments/assets/c182a453-471f-46de-ad40-8db7d44ad0fb" />

I'll pick this up later, marking as "Draft" for now.