### PR TITLE
Add `Gdb.Commands.Write` and use it in `SwitchDemo` driver

### DIFF
--- a/bittide-instances/src/Bittide/Instances/Hitl/Driver/SwitchDemo.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/Driver/SwitchDemo.hs
@@ -243,14 +243,14 @@ initPicocom hitlDir (_hwTarget, deviceInfo) targetIndex = do
 ccGdbCheck :: Gdb -> VivadoM ExitCode
 ccGdbCheck gdb = do
   let whoAmIBase = ccBaseAddress @Integer "WhoAmI"
-  bytes <- liftIO (Gdb.readBytes @4 gdb whoAmIBase)
+  bytes <- Gdb.readBytes @4 gdb whoAmIBase
   let bytesAsInts = L.map fromIntegral $ V.toList $ bytes
   pure $ if bytesAsInts == L.map ord "swcc" then ExitSuccess else ExitFailure 1
 
 muGdbCheck :: Gdb -> VivadoM ExitCode
 muGdbCheck gdb = do
   let whoAmIBase = muBaseAddress @Integer "WhoAmI"
-  bytes <- liftIO (Gdb.readBytes @4 gdb whoAmIBase)
+  bytes <- Gdb.readBytes @4 gdb whoAmIBase
   let bytesAsInts = L.map fromIntegral $ V.toList $ bytes
   pure $ if bytesAsInts == L.map ord "mgmt" then ExitSuccess else ExitFailure 1
 
@@ -286,7 +286,7 @@ driver testName targets = do
         readUgnMmio addr = Gdb.readLe gdb addr
 
       liftIO $ putStrLn $ "Getting UGNs for device " <> d.deviceId
-      liftIO $ mapM readUgnMmio muCaptureUgnAddresses
+      mapM readUgnMmio muCaptureUgnAddresses
 
     muReadPeBuffer :: (HasCallStack) => (HwTarget, DeviceInfo) -> Gdb -> IO ()
     muReadPeBuffer (_, d) gdb = do

--- a/bittide-instances/src/Bittide/Instances/Hitl/Driver/SwitchDemo.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/Driver/SwitchDemo.hs
@@ -17,12 +17,12 @@ import Bittide.Instances.Hitl.Setup (FpgaCount, fpgaSetup)
 import Bittide.Instances.Hitl.SwitchDemo (memoryMapCc, memoryMapMu)
 import Bittide.Instances.Hitl.Utils.Driver
 import Bittide.Instances.Hitl.Utils.Program
+import Bittide.Wishbone (TimeCmd (Capture))
 import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async (forConcurrently_, mapConcurrently_)
 import Control.Concurrent.Async.Extra (zipWithConcurrently, zipWithConcurrently3_)
 import Control.Monad (forM, forM_, when)
 import Control.Monad.IO.Class
-import Data.Bifunctor (Bifunctor (bimap))
 import Data.Char (ord)
 import Data.Maybe (fromJust, fromMaybe)
 import Data.String.Interpolate (i)
@@ -278,8 +278,7 @@ driver testName targets = do
   let
     hitlDir = projectDir </> "_build/hitl" </> testName
 
-    muGetUgns ::
-      (HwTarget, DeviceInfo) -> Gdb -> IO [(Unsigned 64, Unsigned 64)]
+    muGetUgns :: (HwTarget, DeviceInfo) -> Gdb -> IO [(Unsigned 64, Unsigned 64)]
     muGetUgns (_, d) gdb = do
       let
         readUgnMmio :: Integer -> IO (Unsigned 64, Unsigned 64)
@@ -302,8 +301,7 @@ driver testName targets = do
     muGetCurrentTime (_, d) gdb = do
       putStrLn $ "Getting current time from device " <> d.deviceId
       let timerBase = muBaseAddress @Integer "Timer"
-      -- Write capture command to `timeWb` component
-      Gdb.runCommand gdb [i|set {char[4]}(#{showHex32 timerBase}) = 0x0|]
+      Gdb.writeLe gdb timerBase Capture
       Gdb.readLe gdb (timerBase + 0x8)
 
     muWriteCfg ::
@@ -312,30 +310,16 @@ driver testName targets = do
       Gdb ->
       Calc.CyclePeConfig (Unsigned 64) (Index 9) ->
       VivadoM ()
-    muWriteCfg target@(_, d) gdb (bimap pack fromIntegral -> cfg) = do
-      let
-        start = muBaseAddress "SwitchDemoPE"
-
-        write64 :: Unsigned 32 -> BitVector 64 -> [String]
-        write64 address value =
-          [ [i|set {char[4]}(#{showHex32 address}) = #{showHex32 valueLsb}|]
-          , [i|set {char[4]}(#{showHex32 (address + 4)}) = #{showHex32 valueMsb}|]
-          ]
-         where
-          (valueMsb :: BitVector 32, valueLsb :: BitVector 32) = bitCoerce value
+    muWriteCfg target@(_, d) gdb cfg = do
+      let start = muBaseAddress "SwitchDemoPE"
 
       liftIO $ do
         muReadPeBuffer target gdb
         putStrLn $ "Writing config to device " <> d.deviceId
-        Gdb.runCommands
-          gdb
-          ( L.concat
-              [ write64 (start + 0x00) cfg.startReadAt
-              , write64 (start + 0x08) cfg.readForN
-              , write64 (start + 0x10) cfg.startWriteAt
-              , write64 (start + 0x18) cfg.writeForN
-              ]
-          )
+        Gdb.writeLe @(Unsigned 64) gdb (start + 0x00) cfg.startReadAt
+        Gdb.writeLe @(Unsigned 64) gdb (start + 0x08) (numConvert cfg.readForN)
+        Gdb.writeLe @(Unsigned 64) gdb (start + 0x10) cfg.startWriteAt
+        Gdb.writeLe @(Unsigned 64) gdb (start + 0x18) (numConvert cfg.writeForN)
 
     finalCheck ::
       (HasCallStack) =>

--- a/gdb-hs/gdb-hs.cabal
+++ b/gdb-hs/gdb-hs.cabal
@@ -99,6 +99,7 @@ library
     Gdb
     Gdb.Commands.Basic
     Gdb.Commands.Read
+    Gdb.Commands.Write
     Gdb.Internal
 
   hs-source-dirs: src
@@ -124,6 +125,7 @@ test-suite unittests
   other-modules:
     Tests.Common
     Tests.Gdb.Commands.Read
+    Tests.Gdb.Commands.Write
     Tests.Gdb.Internal
 
   main-is: unittests.hs

--- a/gdb-hs/src/Gdb.hs
+++ b/gdb-hs/src/Gdb.hs
@@ -18,8 +18,10 @@ module Gdb (
   -- * Wrappers around common commands
   module Gdb.Commands.Basic,
   module Gdb.Commands.Read,
+  module Gdb.Commands.Write,
 ) where
 
 import Gdb.Commands.Basic
 import Gdb.Commands.Read
+import Gdb.Commands.Write
 import Gdb.Internal

--- a/gdb-hs/src/Gdb/Commands/Write.hs
+++ b/gdb-hs/src/Gdb/Commands/Write.hs
@@ -1,0 +1,81 @@
+-- SPDX-FileCopyrightText: 2025 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+
+module Gdb.Commands.Write (
+  writeBytes,
+  write,
+  writeLe,
+  writeBe,
+) where
+
+import Clash.Prelude hiding (read)
+
+import Clash.Class.BitPackC (
+  BitPackC,
+  ByteOrder (BigEndian, LittleEndian),
+  Bytes,
+  packC,
+ )
+import Control.Monad.Catch (MonadMask)
+import Control.Monad.IO.Class (MonadIO)
+import Data.String.Interpolate (i)
+import Data.Typeable (Typeable)
+import GHC.Stack (HasCallStack)
+import Gdb.Internal (Gdb, runCommand, withLanguage)
+import Numeric (showHex)
+
+import qualified Clash.Sized.Vector as Vec
+import qualified Data.List as L
+
+-- | Write a vector of bytes to a given address in GDB
+writeBytes ::
+  forall n m.
+  (HasCallStack, MonadIO m, MonadMask m, KnownNat n) =>
+  Gdb ->
+  Integer ->
+  Vec n (Bytes 1) ->
+  m ()
+writeBytes gdb address bytes = do
+  -- The syntax expected by GDB is language dependent. We sometimes run commands
+  -- in a C context and sometimes in a Rust context, so we set the language to
+  -- a known one and use that to write the bytes.
+  withLanguage gdb "c" $ do
+    runCommand gdb [i|set {unsigned char[#{natToInteger @n}]}(#{addressHex}) = {#{bytesHex}}|]
+ where
+  toHex s = "0x" <> showHex s ""
+  bytesHex = L.intercalate ", " (toHex . toInteger <$> Vec.toList bytes)
+  addressHex = "0x" <> showHex address ""
+
+{- | Write an arbitrary type to the GDB process at the given address. The type
+must be laid out in memory according to C FFI rules. E.g., in Rust types must
+be annotated with @#[repr(C)]@.
+-}
+write ::
+  (HasCallStack, BitPackC a, Typeable a, NFDataX a, MonadIO m, MonadMask m) =>
+  ByteOrder ->
+  Gdb ->
+  Integer ->
+  a ->
+  m ()
+write byteOrder gdb address value = do
+  let bytes = packC byteOrder value
+  writeBytes gdb address bytes
+
+-- | Like 'write', but uses little-endian byte order
+writeLe ::
+  (HasCallStack, BitPackC a, Typeable a, NFDataX a, MonadIO m, MonadMask m) =>
+  Gdb ->
+  Integer ->
+  a ->
+  m ()
+writeLe = write LittleEndian
+
+-- | Like 'write', but uses big-endian byte order
+writeBe ::
+  (HasCallStack, BitPackC a, Typeable a, NFDataX a, MonadIO m, MonadMask m) =>
+  Gdb ->
+  Integer ->
+  a ->
+  m ()
+writeBe = write BigEndian

--- a/gdb-hs/src/Gdb/Internal.hs
+++ b/gdb-hs/src/Gdb/Internal.hs
@@ -45,17 +45,17 @@ it will throw an exception. If both the main action and cleanup thrown an
 exception, the main action's exception will be thrown.
 -}
 withGdb :: (MonadIO m, MonadMask m, HasCallStack) => (Gdb -> m a) -> m a
-withGdb = preferMainBracket (liftIO start) (liftIO . stop)
+withGdb = preferMainBracket start stop
 
 -- | Like 'withGdb', but spawns multiple processes
 withGdbs :: (MonadIO m, MonadMask m, HasCallStack) => Int -> ([Gdb] -> m a) -> m a
-withGdbs n = brackets (L.replicate n (liftIO start)) (liftIO . stop)
+withGdbs n = brackets (L.replicate n start) stop
 
 {- | Start a GDB process and pipe its stdin/stdout/stderr. Note that it is always
 preferable to use one of 'withGdb' / 'withGdbs'.
 -}
-start :: (HasCallStack) => IO Gdb
-start = do
+start :: (HasCallStack, MonadIO m) => m Gdb
+start = liftIO $ do
   (gdbStdin, gdbStdout, gdbStderr, gdbPh) <-
     createProcess $
       (proc "gdb" [])
@@ -82,8 +82,8 @@ start = do
 doesn't within 15 seconds, an exception is thrown. Note that this means the
 process might still be running.
 -}
-stop :: (HasCallStack) => Gdb -> IO ()
-stop gdb = do
+stop :: (HasCallStack, MonadIO m) => Gdb -> m ()
+stop gdb = liftIO $ do
   -- TODO: If GDB doesn't quit after asking nicely, kill it with force.
   cleanupProcess (Just gdb.stdin, Just gdb.stdout, Just gdb.stderr, gdb.process)
   exitCode <- tryWithTimeout "Stop GDB" 10_000_000 (waitForProcess gdb.process)
@@ -104,8 +104,8 @@ Note that this function assumes only a single command is sent to GDB. If
 multiple commands are sent, the output will contain REPL prompts such as
 @(gdb)@.
 -}
-readCommandRaw :: (HasCallStack) => Gdb -> String -> IO String
-readCommandRaw gdb cmd = do
+readCommandRaw :: (HasCallStack, MonadIO m) => Gdb -> String -> m String
+readCommandRaw gdb cmd = liftIO $ do
   hPutStrLn gdb.stdin [i|echo \\n> #{cmd}\\n|]
   hPutStrLn gdb.stdin [i|echo #{magic}|]
   hPutStrLn gdb.stdin (L.trimEnd cmd)
@@ -123,7 +123,7 @@ is stripped of trailing whitespace (see 'Data.Char.isSpace'). Any leading and
 trailing empty lines are removed. See 'readCommandRaw' if you need access to
 the raw output.
 -}
-readCommand :: (HasCallStack) => Gdb -> String -> IO [String]
+readCommand :: (HasCallStack, MonadIO m) => Gdb -> String -> m [String]
 readCommand gdb cmd = do
   output <- readCommandRaw gdb cmd
   pure
@@ -134,7 +134,7 @@ readCommand gdb cmd = do
     $ output
 
 -- | Execute a command in GDB and read its output. Errors if there is output.
-readCommand0 :: (HasCallStack) => Gdb -> String -> IO ()
+readCommand0 :: (HasCallStack, MonadIO m) => Gdb -> String -> m ()
 readCommand0 gdb cmd = do
   result <- readCommand gdb cmd
   case result of
@@ -144,7 +144,7 @@ readCommand0 gdb cmd = do
 {- | Read a single line of output from GDB after executing a command. Errors if
 the output is not exactly one line.
 -}
-readCommand1 :: (HasCallStack) => Gdb -> String -> IO String
+readCommand1 :: (HasCallStack, MonadIO m) => Gdb -> String -> m String
 readCommand1 gdb cmd = do
   result <- readCommand gdb cmd
   case result of
@@ -153,9 +153,9 @@ readCommand1 gdb cmd = do
     ls -> error [i|Command '#{cmd}' returned multiple lines, expected one: #{ls}|]
 
 -- | Like 'readCommand', but ignore output
-runCommand :: (HasCallStack) => Gdb -> String -> IO ()
+runCommand :: (HasCallStack, MonadIO m) => Gdb -> String -> m ()
 runCommand gdb cmd = void (readCommandRaw gdb cmd)
 
 -- | Like 'runCommand', but takes a list of commands and runs them sequentially.
-runCommands :: (HasCallStack) => Gdb -> [String] -> IO ()
+runCommands :: (HasCallStack, MonadIO m) => Gdb -> [String] -> m ()
 runCommands gdb commands = mapM_ (runCommand gdb) commands

--- a/gdb-hs/src/Gdb/Internal.hs
+++ b/gdb-hs/src/Gdb/Internal.hs
@@ -7,8 +7,8 @@ module Gdb.Internal where
 
 import Prelude
 
-import Control.Monad (void)
-import Control.Monad.Catch (MonadMask)
+import Control.Monad (unless, void)
+import Control.Monad.Catch (MonadMask, finally)
 import Control.Monad.IO.Class (MonadIO (liftIO))
 import Data.Maybe (fromJust)
 import Data.String.Interpolate (i)
@@ -159,3 +159,44 @@ runCommand gdb cmd = void (readCommandRaw gdb cmd)
 -- | Like 'runCommand', but takes a list of commands and runs them sequentially.
 runCommands :: (HasCallStack, MonadIO m) => Gdb -> [String] -> m ()
 runCommands gdb commands = mapM_ (runCommand gdb) commands
+
+{- | Parse the output of 'show language' to extract the current language.
+
+>>> parseShowLanguage "The current source language is \"c\"."
+Just "c"
+>>> parseShowLanguage "The current source language is \"auto; currently c\"."
+Just "auto"
+-}
+parseShowLanguage :: String -> Maybe String
+parseShowLanguage s0 = do
+  s1 <- L.stripPrefix [i|The current source language is "|] s0
+  s2 <- L.stripSuffix [i|".|] s1
+  Just (if L.isPrefixOf "auto; currently " s2 then "auto" else s2)
+
+-- | Detect the language of the current GDB session
+getLanguage :: (HasCallStack, MonadIO m) => Gdb -> m String
+getLanguage gdb = do
+  output <- readCommand1 gdb "show language"
+  case parseShowLanguage output of
+    Nothing -> error [i|Could not parse GDB language output: #{output}|]
+    Just lang -> return lang
+
+-- | Set the language of the current GDB session
+setLanguage :: (HasCallStack, MonadIO m) => Gdb -> String -> m ()
+setLanguage gdb lang = runCommand gdb [i|set language #{lang}|]
+
+{- | Run an action in a specific language context. This will set the language
+for the duration of the action, and restore it afterwards. This can be useful
+for running language-specific commands, without having to implement it for every
+language.
+-}
+withLanguage :: (HasCallStack, MonadIO m, MonadMask m) => Gdb -> String -> m a -> m a
+withLanguage gdb lang action = do
+  restoreLang <- getLanguage gdb
+
+  unless (restoreLang == lang) $
+    setLanguage gdb lang
+
+  finally action $
+    unless (restoreLang == lang) $
+      setLanguage gdb restoreLang

--- a/gdb-hs/tests/Tests/Common.hs
+++ b/gdb-hs/tests/Tests/Common.hs
@@ -9,6 +9,7 @@ import Prelude
 import Data.List.Extra (trim)
 import Data.String.Interpolate (i)
 import System.Exit (ExitCode (ExitFailure, ExitSuccess))
+import System.FilePath ((</>))
 import System.Process (
   CreateProcess (cwd),
   proc,
@@ -16,9 +17,6 @@ import System.Process (
   readProcess,
  )
 import Test.Tasty.HUnit (assertFailure)
-
-getGitRoot :: IO FilePath
-getGitRoot = trim <$> readProcess "git" ["rev-parse", "--show-toplevel"] ""
 
 run :: FilePath -> [String] -> Maybe FilePath -> IO ()
 run cmd0 args cwd = do
@@ -41,3 +39,16 @@ run cmd0 args cwd = do
 
         #{stdErr}
     |]
+
+getGitRoot :: IO FilePath
+getGitRoot = trim <$> readProcess "git" ["rev-parse", "--show-toplevel"] ""
+
+getDataRoot :: IO FilePath
+getDataRoot = do
+  gitRoot <- getGitRoot
+  pure $ gitRoot </> "gdb-hs" </> "tests" </> "data"
+
+getBinaryPath :: String -> IO FilePath
+getBinaryPath name = do
+  dataRoot <- getDataRoot
+  pure $ dataRoot </> name </> "target" </> "x86_64-unknown-linux-gnu" </> "debug" </> name

--- a/gdb-hs/tests/Tests/Gdb/Commands/Read.hs
+++ b/gdb-hs/tests/Tests/Gdb/Commands/Read.hs
@@ -13,12 +13,10 @@ import Prelude
 
 import Clash.Class.BitPackC (BitPackC)
 import GHC.Generics (Generic)
-import System.FilePath ((</>))
-import System.IO.Unsafe (unsafePerformIO)
 import Test.Tasty
 import Test.Tasty.HUnit
 import Test.Tasty.TH (testGroupGenerator)
-import Tests.Common (getGitRoot, run)
+import Tests.Common (getBinaryPath)
 
 import qualified Gdb
 
@@ -34,7 +32,7 @@ data WeirdAlignment = WeirdAlignment
 case_simple_adt :: Assertion
 case_simple_adt = do
   Gdb.withGdb $ \gdb -> do
-    Gdb.setFile gdb binaryPath
+    Gdb.setFile gdb =<< getBinaryPath "simple_adt"
     Gdb.runCommand gdb "break main.rs:22"
     Gdb.runCommand gdb "break main.rs:28"
     Gdb.runCommand gdb "run"
@@ -48,8 +46,6 @@ case_simple_adt = do
     actual2 <- Gdb.readLe gdb address
     assertEqual "WeirdAlignment2" actual2 expected2
  where
-  binaryPath = simpleAdtRoot </> "target" </> "x86_64-unknown-linux-gnu" </> "debug" </> "simple_adt"
-
   expected1 =
     WeirdAlignment
       { a = 0x12
@@ -69,20 +65,4 @@ case_simple_adt = do
       }
 
 tests :: TestTree
-tests =
-  sequentialTestGroup
-    "Tests.Gdb.Commands.Read"
-    AllSucceed
-    [ testGroup
-        "Build Rust crates"
-        [ testCase "simple_adt" (run "cargo" ["build"] (Just simpleAdtRoot))
-        ]
-    , $(testGroupGenerator)
-    ]
- where
-
-simpleAdtRoot :: FilePath
-simpleAdtRoot = dataRoot </> "simple_adt"
-
-dataRoot :: FilePath
-dataRoot = unsafePerformIO getGitRoot </> "gdb-hs" </> "tests" </> "data"
+tests = $(testGroupGenerator)

--- a/gdb-hs/tests/Tests/Gdb/Commands/Write.hs
+++ b/gdb-hs/tests/Tests/Gdb/Commands/Write.hs
@@ -1,0 +1,42 @@
+-- SPDX-FileCopyrightText: 2025 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+
+module Tests.Gdb.Commands.Write where
+
+import Prelude
+
+import Test.Tasty
+import Test.Tasty.HUnit
+import Test.Tasty.TH (testGroupGenerator)
+import Tests.Common (getBinaryPath)
+import Tests.Gdb.Commands.Read (WeirdAlignment (WeirdAlignment, a, b, c, d, e))
+
+import qualified Gdb
+
+case_simple_adt :: Assertion
+case_simple_adt = do
+  Gdb.withGdb $ \gdb -> do
+    Gdb.setFile gdb =<< getBinaryPath "simple_adt"
+    Gdb.runCommand gdb "break main.rs:28"
+    Gdb.runCommand gdb "run"
+
+    address <- (read @Integer . last . words) <$> Gdb.readCommand1 gdb "print &x"
+
+    Gdb.writeLe gdb address set
+    printResult <- Gdb.readCommand gdb "continue"
+    case printResult of
+      ["Continuing.", "Done: 25 abcdef01 1234 abcdef0123456789 ea", _exit] -> pure ()
+      _ -> assertFailure $ "Unexpected output: " <> show printResult
+ where
+  set =
+    WeirdAlignment
+      { a = 0x25
+      , b = 0xABCDEF01
+      , c = 0x01234
+      , d = 0xABCDEF0123456789
+      , e = 0xEA
+      }
+
+tests :: TestTree
+tests = $(testGroupGenerator)

--- a/gdb-hs/tests/unittests.hs
+++ b/gdb-hs/tests/unittests.hs
@@ -7,15 +7,35 @@ module Main where
 import Test.Tasty
 import Prelude
 
+import System.FilePath ((</>))
+import Test.Tasty.HUnit (testCase)
+import Tests.Common (getDataRoot, run)
+
 import qualified Tests.Gdb.Commands.Read
+import qualified Tests.Gdb.Commands.Write
 import qualified Tests.Gdb.Internal
+
+buildTestCase :: String -> TestTree
+buildTestCase name = do
+  testCase name $ do
+    dataRoot <- getDataRoot
+    run "cargo" ["build"] (Just (dataRoot </> name))
 
 tests :: TestTree
 tests =
-  testGroup
-    "Unittests"
-    [ Tests.Gdb.Commands.Read.tests
-    , Tests.Gdb.Internal.tests
+  sequentialTestGroup
+    "."
+    AllSucceed
+    [ testGroup
+        "Build test programs"
+        [ buildTestCase "simple_adt"
+        ]
+    , testGroup
+        "Tests"
+        [ Tests.Gdb.Commands.Read.tests
+        , Tests.Gdb.Commands.Write.tests
+        , Tests.Gdb.Internal.tests
+        ]
     ]
 
 main :: IO ()


### PR DESCRIPTION
As a result, we can replace:

```haskell
Gdb.runCommand gdb [i|set {char[4]}(#{showHex32 timerBase}) = 0x0|]
```

With a much less error prone:

```haskell
Gdb.writeLe gdb timerBase Capture
```