### PR TITLE
`check_cabal_log.sh`: Explicit status check

### DIFF
--- a/.github/scripts/check_cabal_log.sh
+++ b/.github/scripts/check_cabal_log.sh
@@ -7,7 +7,7 @@ set -xou pipefail
 grep -v '^Warning: The package list for .* is .* old\.$' "$1" \
     | grep -E -B 10 '^Warning:'
 
-if [[ $? == 0 ]]; then
+if [[ ${PIPESTATUS[1]} == 0 ]]; then
     echo "Cabal produced warnings. See ^"
     exit 1;
 fi


### PR DESCRIPTION
The original code worked correctly, but in a rather convoluted way. By checking just the exit code of the second command in the pipe, it is easier to see it is correct.