### PR TITLE
Generalize pre-commit excludes and add more hooks

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,7 +8,7 @@
     "**/*.hi-boot": true,
     "**/dist-newstyle": true,
     "**/.stack-work": true,
-    "**/.ghc.environment.*": true,
+    "**/.ghc.environment.*": true
   },
   "files.insertFinalNewline": true,
   "files.trimFinalNewlines": true,

--- a/nix/git-hooks.nix
+++ b/nix/git-hooks.nix
@@ -16,6 +16,9 @@
     trim-trailing-whitespace.enable = true;
     end-of-file-fixer.enable = true;
     check-added-large-files.enable = true;
+    check-yaml.enable = true;
+    check-toml.enable = true;
+    check-json.enable = true;
 
     # Enable a formatter for Haskell
     cabal-gild.enable = true;


### PR DESCRIPTION
Accidentally committed a faulty `ci.yml` and found out there are hooks to check your configuration files.

No more finding out your syntax is wrong on CI! :) 

Also I discovered `lib.mapAttrs` and used it to generalize excluded patterns for the hooks.