### PR TITLE
Add `mdbook` to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -724,7 +724,7 @@ jobs:
     container:
       image: ghcr.io/clash-lang/nixos-bittide-hardware:2025-08-05
       options: --memory=11g
-    if: github.ref == 'refs/heads/main' || github.event_name == 'pull_request'
+    # if: github.ref == 'refs/heads/main' || github.event_name == 'pull_request'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -745,7 +745,7 @@ jobs:
           path: _build/book
 
       - name: Deploy to GitHub Pages
-        if: github.ref == 'refs/heads/main'
+        # if: github.ref == 'refs/heads/main'
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ concurrency:
  cancel-in-progress: true
 
 jobs:
+
   cachix:
     name: Populate Cachix cache
     runs-on: [self-hosted, compute]
@@ -714,6 +715,44 @@ jobs:
             _build/hitl/*
           retention-days: 14
 
+  mdbook:
+    name: Build and Publish mdBook
+    runs-on: [self-hosted, compute]
+    defaults:
+      run:
+        shell: git-nix-shell {0} --ignore-environment
+    container:
+      image: ghcr.io/clash-lang/nixos-bittide-hardware:2025-08-05
+      options: --memory=11g
+    if: github.ref == 'refs/heads/main' || github.event_name == 'pull_request'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set CI flags
+        run: |
+          .github/scripts/set_ci_flags.sh
+
+      - name: Build mdBook
+        run: |
+          cd docs
+          mdbook build
+
+      - name: Upload book artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: mdbook
+          path: _build/book
+
+      - name: Deploy to GitHub Pages
+        if: github.ref == 'refs/heads/main'
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: _build/book
+          publish_branch: gh-pages
+
+
   all:
     name: All jobs finished
     if: ${{ !cancelled() }}
@@ -727,6 +766,7 @@ jobs:
         license-check,
         lint,
         rust-lints,
+        mdbook,
       ]
     runs-on: ubuntu-22.04
     steps:

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,18 @@
+<!--
+SPDX-FileCopyrightText: 2025 Google LLC
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Working with mdBook
+To build the documentation, run the following command in a nix shell in this directory:
+
+```bash
+mdbook build
+```
+
+While working on the documentation you can use the following command to start a live reloading server:
+
+```bash
+mdbook serve
+```

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -1,0 +1,12 @@
+<!--
+SPDX-FileCopyrightText: 2025 Google LLC
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Summary
+
+- [Introduction](sections/introduction.md)
+- [Hardware-in-the-Loop (HITL) Platform](sections/hitl-platform.md)
+- [Example Bittide System](sections/example-system.md)
+- [Experiments](sections/experiments.md)

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: 2025 Google LLC
+#
+# SPDX-License-Identifier: CC0-1.0
+
+[book]
+title = "Developing on a Bittide system"
+author = ["QBayLogic B.V."]
+src = "."
+
+language = "en"
+
+[build]
+build-dir = "../_build/book"

--- a/docs/sections/example-system.md
+++ b/docs/sections/example-system.md
@@ -1,0 +1,56 @@
+<!--
+SPDX-FileCopyrightText: 2025 Google LLC
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Example Bittide System
+
+This document describes a concrete example of a Bittide design that can be programmed on the FPGAs of the HITL platform. It showcases the internal architecture and configuration of the system.
+
+## Architecture
+**Requires diagram**
+
+### Domain related
+Components:
+- Transceivers
+- Domain difference counters
+- Clock control (CC)
+- SPI programmer for clock generator
+- Elastic buffers
+- UGN capture
+
+### Node related
+Components:
+- Switch (Crossbar + calendar)
+- Management unit (MNU)
+- 1x General purpose processing element (GPPE)
+
+### Management unit
+Components:
+- RISCV core
+- Scatter unit
+- Gather unit
+- UART (For debugging)
+
+The management unit has access to, and is responsible for all calendars in the node.
+
+Calendars:
+- Switch calendar
+- Management unit scatter calendar
+- Management unit gather calendar
+- GPPE scatter unit
+- GPPE gather unit
+
+## Debugging related
+- UART arbiter
+- JTAG interconnect
+- Integrated logic analyzers
+- SYNC_IN / SYNC_OUT
+
+# Example System
+
+Below is a diagram generated from the first page of `bittide_concepts.drawio`:
+
+TODO: Insert diagram
+<!-- ![Bittide System](diagrams/bittide_concepts_0.svg) -->

--- a/docs/sections/experiments.md
+++ b/docs/sections/experiments.md
@@ -1,0 +1,29 @@
+<!--
+SPDX-FileCopyrightText: 2025 Google LLC
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Experiments
+This chapter describes the existing infrastructure to support the creation and execution of experiments on the example Bittide system.
+
+## Required components
+- **Example design**: Contains all bittide related FPGA logic.
+- **Programs**: The binary files that will be loaded into the CPUs that exist in the example design.
+- **Driver**: Runs on the host PC and communicates with the testbench.
+- **Testbench**: Contains the example design and other necessary logic such as ILA's.
+
+## Relevant infrastructure
+Names which tools are relevant and where they live
+
+## Execution
+Describes how tests are executed as part of a CI/CD pipeline.
+
+## Writing programs
+Describes how to write new programs for the management unit, general purpose processing element or clock control.
+
+## Writing a driver
+Describes how to write a driver for the experiment.
+
+## Adding your experiment to CI/CD
+Describes how to add your experiment to the CI/CD pipeline.

--- a/docs/sections/hitl-platform.md
+++ b/docs/sections/hitl-platform.md
@@ -1,0 +1,22 @@
+<!--
+SPDX-FileCopyrightText: 2025 Google LLC
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Hardware-in-the-Loop (HITL) Platform
+
+This chapter describes the specific hardware setup used to realize a Bittide system in our lab environment. The HITL platform is designed to implement the principles of Bittide using real hardware components for experimentation, development, and validation for topologies up to 8 nodes.
+
+## Platform Overview
+**Requires diagram**
+
+The HITL platform consists of the following main components:
+
+- **Host Computer**: Executes experiments on the Bittide system.
+- **FPGA Boards**: Implement clock control, Bittide routing, and compute fabric.
+- **Clock Adjustment Boards**: Provide single controllable clock source for an FPGA.
+- **High-Speed Interconnects**: Serial links (such as SFP+ or QSFP) connect the FPGAs for low-latency, high-bandwidth communication.
+- **JTAG/UART dongles**: Provide JTAG and UART interface for each FPGA to the host computer.
+- **Ethernet connections**: Each FPGA has an ethernet connection from a dedicated RJ45 port to the host computer.
+- **SYNC_IN / SYNC_OUT**: Ring connection through all FPGAs to get a sense of global time. This is used for starting / stopping experiments and mapping measurement data from all FPGAs to a single time line. This is **not** part of the Bittide architecture itself.

--- a/docs/sections/introduction.md
+++ b/docs/sections/introduction.md
@@ -1,0 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2025 Google LLC
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Introduction
+
+Welcome to the Bittide documentation book. This book serves as design and reference documentation for Bittide and the experimentation framework. Our goal is to provide the necessary information to develop and deploy experiments on Bittide-based systems.

--- a/flake.nix
+++ b/flake.nix
@@ -94,6 +94,9 @@
 
             # UART communication
             pkgs.picocom
+
+            # mdbook dependencies
+            pkgs.mdbook
           ];
 
           shellHook = ''

--- a/nix/bin/book
+++ b/nix/bin/book
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+cd "$(git rev-parse --show-toplevel)"
+cd docs
+mdbook serve -o


### PR DESCRIPTION
We now have a basic mdbook in the docs directory. We'd like to build it on CI and publish it to GH pages such that other people can easily access it.

This work-in-progress branch implements that.