### PR TITLE
Add `wbToDf`, a component to drive a `Df` stream over `Wishbone`

### DIFF
--- a/bittide-instances/bittide-instances.cabal
+++ b/bittide-instances/bittide-instances.cabal
@@ -211,6 +211,7 @@ library
     Bittide.Instances.Tests.RegisterWb
     Bittide.Instances.Tests.ScatterGather
     Bittide.Instances.Tests.SwitchCalendar
+    Bittide.Instances.Tests.WbToDf
     Paths.Bittide.Instances
 
   other-modules:
@@ -238,6 +239,7 @@ library
     clock,
     constraints,
     containers,
+    deepseq,
     directory,
     exceptions,
     extra,
@@ -286,6 +288,7 @@ test-suite unittests
   main-is: unittests.hs
   ghc-options: -threaded
   other-modules:
+    Df.WbToDf
     Tests.ClockControlWb
     Wishbone.Axi
     Wishbone.CaptureUgn

--- a/bittide-instances/src/Bittide/Instances/MemoryMaps.hs
+++ b/bittide-instances/src/Bittide/Instances/MemoryMaps.hs
@@ -26,6 +26,7 @@ import qualified Bittide.Instances.Hitl.SwCcTopologies as SwCcTopologies
 import qualified Bittide.Instances.Tests.RegisterWb as RegisterWb
 import qualified Bittide.Instances.Tests.ScatterGather as ScatterGather
 import qualified Bittide.Instances.Tests.SwitchCalendar as SwitchCalendar
+import qualified Bittide.Instances.Tests.WbToDf as WbToDf
 import qualified Data.ByteString.Lazy as BS
 import qualified Protocols.MemoryMap.Json as Json
 
@@ -45,6 +46,7 @@ $( do
           , ("SwitchC", SwitchCalendar.memoryMap)
           , ("SwitchDemoMu", SwitchDemo.memoryMapMu)
           , ("SwitchDemoCc", SwitchDemo.memoryMapCc)
+          , ("WbToDfTest", WbToDf.dutMM)
           , ("VexRiscv", vexRiscvTestMM)
           ]
 

--- a/bittide-instances/src/Bittide/Instances/Tests/WbToDf.hs
+++ b/bittide-instances/src/Bittide/Instances/Tests/WbToDf.hs
@@ -1,0 +1,107 @@
+-- SPDX-FileCopyrightText: 2025 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+module Bittide.Instances.Tests.WbToDf where
+
+import Clash.Explicit.Prelude
+import Clash.Prelude (withClockResetEnable)
+
+import Bittide.Df
+import Bittide.DoubleBufferedRam
+import Bittide.ProcessingElement
+import Bittide.ProcessingElement.Util
+import Bittide.SharedTypes (withBittideByteOrder)
+import Bittide.Wishbone
+import Clash.Class.BitPackC
+import Control.DeepSeq (NFData)
+import GHC.Stack (HasCallStack)
+import Project.FilePath
+import Protocols
+import Protocols.Idle
+import Protocols.MemoryMap
+import Protocols.MemoryMap.FieldType (ToFieldType (..))
+import Protocols.MemoryMap.Registers.WishboneStandard
+import System.Environment (lookupEnv)
+import System.FilePath
+import System.IO.Unsafe (unsafePerformIO)
+import VexRiscv (DumpVcd (..))
+
+data SomeAdt
+  = ConA
+  | ConB (Unsigned 40)
+  | ConC (BitVector 16) (BitVector 20)
+  | ConD (Vec 3 (BitVector 8))
+  deriving (Generic, NFDataX, ShowX, Show, ToFieldType, BitPackC, BitPack, Eq, NFData)
+
+testValue :: Vec 4 SomeAdt
+testValue =
+  ConA
+    :> ConB 0xDEADABBABAAB1234
+    :> ConC 0xDEAD 0xBEEF
+    :> ConD (0xA :> 0xB :> 0xC :> Nil)
+    :> Nil
+
+-- | Strip "SimOnly" constructor
+unSimOnly :: SimOnly a -> a
+unSimOnly (SimOnly x) = x
+
+dutMM :: (HasCallStack) => Protocols.MemoryMap.MemoryMap
+dutMM = unSimOnly $ fst (toSignals dut (deepErrorX "memoryMap"))
+
+{- | A simulation-only instance containing VexRisc with UART, a register to hold
+a vector of input values and a wbToDf component to send out values over `Df`.
+The processor runs the `wb_to_df_test` program which copies values from the
+register to the `Df` output and also sends some debug messages over UART.
+-}
+dut ::
+  (HasCallStack) =>
+  Circuit (ConstBwd MM) (Df System SomeAdt, Df System (BitVector 8))
+dut = withBittideByteOrder $ withClockResetEnable clockGen (resetGenN d2) enableGen $ circuit $ \mm -> do
+  (uartRx, jtagIdle) <- idleSource
+  [srcBus, dfBus, uartBus] <-
+    processingElement @_ dumpVcd peConfig -< (mm, jtagIdle)
+  (uartTx, _uartStatus) <- uartInterfaceWb d16 d2 uartBytes -< (uartBus, uartRx)
+
+  [refWb] <- deviceWb "WbToDfReference" -< srcBus
+  registerWbI_ refCfg testValue -< (refWb, Fwd (pure Nothing))
+
+  df <- wbToDf "WbToDfTest" -< dfBus
+  idC -< (df, uartTx)
+ where
+  refCfg =
+    (registerConfig "value")
+      { description = "Reference memory for WbToDfTest"
+      , access = ReadOnly
+      }
+
+  dumpVcd =
+    unsafePerformIO $ do
+      mVal <- lookupEnv "WBTODF_DUMP_VCD"
+      case mVal of
+        Just s -> pure (DumpVcd s)
+        _ -> pure NoDumpVcd
+
+  peConfig = unsafePerformIO $ do
+    root <- findParentContaining "cabal.project"
+    let
+      elfDir = root </> firmwareBinariesDir "riscv32imc" Release
+      elfPath = elfDir </> "wb_to_df_test"
+    pure
+      PeConfig
+        { initI =
+            NonReloadable @IMemWords
+              $ Vec
+              $ unsafePerformIO
+              $ vecFromElfInstr BigEndian elfPath
+        , initD =
+            NonReloadable @DMemWords
+              $ Vec
+              $ unsafePerformIO
+              $ vecFromElfData BigEndian elfPath
+        , iBusTimeout = d0 -- No timeouts on the instruction bus
+        , dBusTimeout = d0 -- No timeouts on the data bus
+        , includeIlaWb = False
+        }
+
+type IMemWords = DivRU (64 * 1024) 4
+type DMemWords = DivRU (32 * 1024) 4

--- a/bittide-instances/tests/Df/WbToDf.hs
+++ b/bittide-instances/tests/Df/WbToDf.hs
@@ -1,0 +1,40 @@
+-- SPDX-FileCopyrightText: 2025 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+module Df.WbToDf where
+
+import Bittide.Instances.Tests.WbToDf
+import Clash.Explicit.Prelude
+import Data.Char
+import Hedgehog
+import Protocols
+import Protocols.Hedgehog
+import Protocols.Idle
+import Protocols.MemoryMap
+import Test.Tasty
+import Test.Tasty.Hedgehog
+import Test.Tasty.TH
+
+-- | Test whether the wbToDf component correctly converts wishbone writes to Df stream transactions
+prop_wb_to_df_test :: Property
+prop_wb_to_df_test = propWithModel eOpts (pure []) model impl prop
+ where
+  -- We can not make a `Test` instance for `()`, so we use `Df System ()` as placeholder
+  impl :: Circuit (Df System ()) (Df System SomeAdt, Df System (BitVector 8))
+  impl = idleSink |> ignoreMM |> dut
+
+  eOpts =
+    defExpectOptions
+      { eoSampleMax = 1_000_000
+      , eoStopAfterEmpty = Just 1_000 -- Increase when using UART
+      , eoStallsMax = 1000
+      , eoConsecutiveStalls = 10
+      }
+
+  model _ = (toList testValue, [])
+  prop (expected, _) (actual, uart) = do
+    footnote $ "Log: " <> fmap (chr . fromIntegral) uart
+    actual === expected
+
+tests :: TestTree
+tests = $(testGroupGenerator)

--- a/bittide-instances/tests/unittests.hs
+++ b/bittide-instances/tests/unittests.hs
@@ -15,6 +15,7 @@ import Test.Tasty
 import Test.Tasty.HUnit (assertFailure, testCase)
 import "extra" Data.List.Extra (trim)
 
+import qualified Df.WbToDf as WbToDf
 import qualified Tests.ClockControlWb as ClockControlWb
 import qualified Wishbone.Axi as Axi
 import qualified Wishbone.CaptureUgn as CaptureUgn
@@ -73,6 +74,7 @@ tests =
         , RegisterWb.tests
         , Watchdog.tests
         , Wishbone.SwitchCalendar.tests
+        , WbToDf.tests
         ]
     ]
  where

--- a/bittide/src/Bittide/Df.hs
+++ b/bittide/src/Bittide/Df.hs
@@ -2,17 +2,26 @@
 --
 -- SPDX-License-Identifier: Apache-2.0
 
-module Bittide.Df (asciiDebugMux) where
+module Bittide.Df (asciiDebugMux, wbToDf) where
 
 import Clash.Prelude
 import Protocols
 
 import Bittide.PacketStream (timeout)
-import Bittide.SharedTypes (Byte)
+import Bittide.SharedTypes (Byte, Bytes)
+import Clash.Class.BitPackC (BitPackC, ByteOrder)
+import Data.Bifunctor
 import Data.Char (ord)
 import Data.Coerce (coerce)
 import Data.Functor ((<&>))
+import GHC.Stack (HasCallStack)
 import Protocols.Df (CollectMode (Skip))
+import Protocols.MemoryMap.FieldType (ToFieldType)
+import Protocols.MemoryMap.Registers.WishboneStandard (
+  BusActivity,
+  registerWb,
+  registerWbDf,
+ )
 import Protocols.PacketStream (
   PacketStream,
   PacketStreamM2S (..),
@@ -22,6 +31,10 @@ import Protocols.PacketStream (
 import Protocols.PacketStream.Base (truncateAbortedPackets)
 import Protocols.PacketStream.Routing (packetArbiterC)
 import Protocols.Vec (vecCircuits)
+import Protocols.Wishbone
+
+import qualified Protocols.MemoryMap as MM
+import qualified Protocols.MemoryMap.Registers.WishboneStandard as MM
 
 {- | Muxes multiple 'Df' streams of bytes into a single 'Df' stream of bytes,
 interleaving the streams from the different sources on newline characters. As
@@ -126,3 +139,59 @@ unsafeBytesFromPacketStream f =
       | Just PacketStreamM2S{_abort = True} <- m2s = (coerce True, Nothing)
       | Just PacketStreamM2S{_last = Just 0} <- m2s = (coerce True, Nothing)
       | otherwise = (coerce ack, fmap (pack . (._data)) m2s)
+
+{- | Component to create a `Df` stream from a wishbone interface. This component
+features two registers, one to accumulate the data and one to create the `Df` transaction.
+-}
+wbToDf ::
+  forall dom a addrW nBytes.
+  ( HiddenClockResetEnable dom
+  , KnownNat nBytes
+  , 1 <= nBytes
+  , KnownNat addrW
+  , Show a
+  , ShowX a
+  , ToFieldType a
+  , NFDataX a
+  , BitPack a
+  , BitPackC a
+  , ?busByteOrder :: ByteOrder
+  , ?regByteOrder :: ByteOrder
+  , HasCallStack
+  ) =>
+  String ->
+  Circuit
+    (MM.ConstBwd MM.MM, Wishbone dom 'Standard addrW (Bytes nBytes))
+    (Df dom a)
+wbToDf name = circuit $ \(mm, wb) -> do
+  [wbData, wbCommit] <- MM.deviceWb name -< (mm, wb)
+
+  (dat, _0) <- registerWb hasClock hasReset cfgData (unpack 0) -< (wbData, Fwd noWrite)
+  (_1, df) <- registerWbDf hasClock hasReset cfgCommit () -< (wbCommit, Fwd noWrite)
+
+  replaceDfData -< (dat, df)
+ where
+  noWrite = pure Nothing
+
+  -- Given a Df stream and a raw signal, replace the contents of the Df with the
+  -- contents of the raw signal. Usage of this function is only valid as long as
+  -- the raw signal stays stable whenever the Df stream is active. In our case
+  -- this is true, as the circuit doesn't write to either register and the wishbone
+  -- bus can only do one access at a time.
+  replaceDfData :: Circuit (CSignal dom a, Df dom (BusActivity ())) (Df dom a)
+  replaceDfData = Circuit (first unbundle . unbundle . fmap go . bundle . first bundle)
+   where
+    go :: ((a, Maybe (BusActivity ())), Ack) -> (((), Ack), Maybe a)
+    go ((a, busActivity), ack) = (((), ack), fmap (const a) busActivity)
+
+  cfgData =
+    (MM.registerConfig "data")
+      { MM.access = MM.WriteOnly
+      , MM.description = "Data register for " <> name
+      }
+
+  cfgCommit =
+    (MM.registerConfig "commit")
+      { MM.access = MM.WriteOnly
+      , MM.description = "Commit register for " <> name
+      }

--- a/firmware-binaries/Cargo.lock
+++ b/firmware-binaries/Cargo.lock
@@ -747,3 +747,14 @@ dependencies = [
  "riscv-rt",
  "ufmt",
 ]
+
+[[package]]
+name = "wb_to_df_test"
+version = "0.1.0"
+dependencies = [
+ "bittide-hal",
+ "bittide-sys",
+ "memmap-generate",
+ "riscv-rt",
+ "ufmt",
+]

--- a/firmware-binaries/Cargo.toml
+++ b/firmware-binaries/Cargo.toml
@@ -21,6 +21,7 @@ members = [
   "test-cases/capture_ugn_test",
   "test-cases/clock-control-wb",
   "test-cases/dna_port_e2_test",
+  "test-cases/wb_to_df_test",
   "test-cases/scatter_gather_test",
   "test-cases/switch_demo_pe_test",
   "test-cases/switch_calendar_test",

--- a/firmware-binaries/clock-control/src/main.rs
+++ b/firmware-binaries/clock-control/src/main.rs
@@ -7,13 +7,13 @@
 
 use core::panic::PanicInfo;
 
-use bittide_hal::freeze::Tuple0;
 use bittide_hal::manual_additions::timer::Duration;
 use bittide_hal::manual_additions::timer::Instant;
 use bittide_hal::manual_additions::timer::WaitResult;
 use bittide_hal::shared::devices::DomainDiffCounters;
 use bittide_hal::shared::devices::Timer;
 use bittide_hal::shared::devices::Uart;
+use bittide_hal::shared::types::Tuple0;
 use bittide_hal::switch_demo_cc::DeviceInstances;
 use bittide_sys::sample_store::SampleStore;
 use bittide_sys::stability_detector::StabilityDetector;

--- a/firmware-binaries/test-cases/wb_to_df_test/Cargo.toml
+++ b/firmware-binaries/test-cases/wb_to_df_test/Cargo.toml
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: 2024 Google LLC
+#
+# SPDX-License-Identifier: CC0-1.0
+
+[package]
+name = "wb_to_df_test"
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0"
+authors = ["Google LLC"]
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+riscv-rt = "0.11.0"
+bittide-sys = { path = "../../../firmware-support/bittide-sys" }
+bittide-hal = { path = "../../../firmware-support/bittide-hal" }
+ufmt = "0.2.0"
+
+[build-dependencies]
+memmap-generate = { path = "../../../firmware-support/memmap-generate" }

--- a/firmware-binaries/test-cases/wb_to_df_test/build.rs
+++ b/firmware-binaries/test-cases/wb_to_df_test/build.rs
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: 2022 Google LLC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use memmap_generate::memory_x_from_memmap;
+
+fn memmap_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../")
+        .join("_build")
+        .join("memory_maps")
+}
+
+/// Put the linker script somewhere the linker can find it.
+fn main() {
+    let memory_x = memory_x_from_memmap(
+        memmap_dir().join("WbToDfTest.json"),
+        "DataMemory",
+        "InstructionMemory",
+    );
+
+    let out_dir = env::var("OUT_DIR").expect("No out dir");
+    let dest_path = Path::new(&out_dir).join("memory.x");
+    fs::write(dest_path, memory_x).expect("Could not write file");
+
+    if env::var("CARGO_CFG_TARGET_ARCH").unwrap() == "riscv32" {
+        println!("cargo:rustc-link-arg=-Tmemory.x");
+        println!("cargo:rustc-link-arg=-Tlink.x"); // linker script from riscv-rt
+    }
+    println!("cargo:rustc-link-search={out_dir}");
+
+    println!("cargo:rerun-if-changed=build.rs");
+}

--- a/firmware-binaries/test-cases/wb_to_df_test/src/main.rs
+++ b/firmware-binaries/test-cases/wb_to_df_test/src/main.rs
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2024 Google LLC
+//
+// SPDX-License-Identifier: Apache-2.0
+#![no_std]
+#![cfg_attr(not(test), no_main)]
+
+use bittide_hal::shared::types::Tuple0;
+use bittide_hal::wb_to_df_test::DeviceInstances;
+#[cfg(not(test))]
+use riscv_rt::entry;
+// use ufmt::{uwrite, uwriteln}; // Uncomment for debugging
+
+const INSTANCES: DeviceInstances = unsafe { DeviceInstances::new() };
+
+#[cfg_attr(not(test), entry)]
+fn main() -> ! {
+    // Initialize peripherals.
+    // let mut uart = INSTANCES.uart;
+    // uwriteln!(uart, "Starting WbToDfTest").unwrap();
+    let source: bittide_hal::freeze::WbToDfReference = INSTANCES.wb_to_df_reference;
+    let destination = INSTANCES.wb_to_df_test;
+    for i in source.value_volatile_iter() {
+        // uwrite!(uart, "Writing {:?}", i).unwrap();
+        destination.set_data(i);
+        // uwriteln!(uart, ".").unwrap();
+        destination.set_commit(Tuple0);
+    }
+
+    loop {
+        continue;
+    }
+}
+
+#[panic_handler]
+fn panic_handler(_info: &core::panic::PanicInfo) -> ! {
+    loop {
+        continue;
+    }
+}


### PR DESCRIPTION
A re-usable component that features two registers. One for accumulating data of type `a` and one to initiate a transaction consisting of the accumulated data to the `Df` stream.

TODO:
- [ ] Consider moving to `clash-protocols-memmap`