### PR TITLE
Bump clash to prevent causing `Synth 8-9873`

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -43,7 +43,7 @@ jobs: $ncpus
 source-repository-package
   type: git
   location: https://github.com/clash-lang/clash-compiler.git
-  tag: 229f243605f5ac88fc4e65076acec650ce1164df
+  tag: 386c9606b18a8363bbb5f6907c9e692b34129840
   subdir:
     clash-prelude
     clash-ghc


### PR DESCRIPTION
New clash contains fix for deduplicating included files.
Previously multiple instances of `VexRiscv` would cause the verilog to be copied multiple files. This has been fixed in https://github.com/clash-lang/clash-compiler/pull/3009 . 