### PR TITLE
Overwrite artifact of HITL data upon rerun

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -712,6 +712,7 @@ jobs:
           path: |
             _build/vivado/*/ila-data
             _build/hitl/*
+          overwrite: true
           retention-days: 14
 
   all:


### PR DESCRIPTION
Previously CI would always use the ILA data from the first run for clock report generation. This would cause this job to error if the hardware setup changes after a failed HITL test, even when the HITL test would pass on the second run. This sometimes happens when the external clock boards don't work and we have to power cycle them.

Note that this also changes how we can debug with ILA data from HITL tests. A new link to the artifact will be generated on each rerun of the job, but the old link will stop working. So if you want to run your HITL test multiple times, you should download the artifact before rerunning the job.