### PR TITLE
Rewrite of `Node.hs` functions+types, add JTAG to MU+GPPE, add UART to GPPE

### DIFF
--- a/bittide/src/Bittide/Node.hs
+++ b/bittide/src/Bittide/Node.hs
@@ -1,6 +1,7 @@
 -- SPDX-FileCopyrightText: 2022 Google LLC
 --
 -- SPDX-License-Identifier: Apache-2.0
+{-# OPTIONS_GHC -fconstraint-solver-iterations=6 #-}
 
 {-# OPTIONS -fplugin=Protocols.Plugin #-}
 -- {-# OPTIONS -fplugin-opt=Protocols.Plugin:debug #-}
@@ -10,100 +11,156 @@ module Bittide.Node where
 import Clash.Prelude
 
 import Clash.Class.BitPackC (ByteOrder)
+import Clash.Cores.Xilinx.Unisim.DnaPortE2 (simDna2)
 import GHC.Stack (HasCallStack)
 import Protocols
 import Protocols.Extra
-import Protocols.Idle
-import Protocols.MemoryMap (ConstBwd, MM)
+import Protocols.MemoryMap (
+  ConstBwd,
+  MM,
+  MemoryMap (..),
+  MemoryMapTree (WithName),
+  locCaller,
+ )
 import Protocols.Vec (vecCircuits)
 import Protocols.Wishbone
 import VexRiscv
 
 import Bittide.Calendar
+import Bittide.CaptureUgn (captureUgn)
+import Bittide.Jtag
+import Bittide.MetaPeConfig (metaPeConfig)
 import Bittide.ProcessingElement
 import Bittide.ScatterGather
 import Bittide.SharedTypes
 import Bittide.Switch
+import Bittide.Wishbone (readDnaPortE2Wb, timeWb, uartBytes, uartInterfaceWb)
 
 {- | Each 'gppe' results in 2 busses for the 'managementUnit', namely:
 * The 'calendar' for the 'scatterUnitWB'.
 * The 'calendar' for the 'gatherUnitWB'.
 -}
-type BussesPerGppe = 2
+type BussesPerGppe = GppeBusses - GppeBussesNotExposed
 
 -- | Configuration of a 'node'.
-data NodeConfig externalLinks gppes where
+data NodeConfig linkCount gppes metaPeBufferWidth where
   NodeConfig ::
-    ( KnownNat nmuBusses
-    , nmuBusses ~ ((BussesPerGppe * gppes) + 1 + NmuInternalBusses)
-    , KnownNat nmuRemBusWidth
-    , nmuRemBusWidth ~ RemainingBusWidth nmuBusses
-    , nmuRemBusWidth <= 30
+    forall linkCount gppes metaPeBufferWidth.
+    ( KnownNat linkCount
+    , KnownNat gppes
+    , NmuPrefixWidth linkCount gppes <= 30
     ) =>
-    -- | Configuration for the 'node's 'managementUnit'.
-    ManagementConfig ((BussesPerGppe * gppes) + 1) ->
-    -- | Configuratoin for the 'node's 'switch'.
-    CalendarConfig nmuRemBusWidth (CalendarEntry (externalLinks + gppes + 1)) ->
-    -- | Configuration for all the node's 'gppe's.
-    Vec gppes (GppeConfig nmuRemBusWidth) ->
-    NodeConfig externalLinks gppes
+    { managementConfig :: ManagementConfig linkCount gppes
+    -- ^ Configuration for the 'node's 'managementUnit'.
+    , calendarConfig ::
+        CalendarConfig (NmuRemBusWidth linkCount gppes) (CalendarEntry (linkCount + gppes + 1))
+    -- ^ Configuration for the 'node's 'switch'.
+    , gppeConfigs :: Vec gppes (GppeConfig (NmuRemBusWidth linkCount gppes) metaPeBufferWidth)
+    -- ^ Configuration for all the node's 'gppe's.
+    } ->
+    NodeConfig linkCount gppes metaPeBufferWidth
 
 -- | A 'node' consists of a 'switch', 'managementUnit' and @0..n@ 'gppe's.
 node ::
-  forall dom extLinks gppes.
+  forall dom linkCount gppes metaPeBufferWidth.
   ( HiddenClockResetEnable dom
-  , KnownNat extLinks
-  , KnownNat gppes
+  , 1 <= DomainPeriod dom
   , ?busByteOrder :: ByteOrder
   , ?regByteOrder :: ByteOrder
-  , PrefixWidth ((BussesPerGppe * gppes) + 1 + NmuInternalBusses) <= 30
   ) =>
-  NodeConfig extLinks gppes ->
+  NodeConfig linkCount gppes metaPeBufferWidth ->
   Circuit
-    (ConstBwd MM, Vec gppes (ConstBwd MM), Vec extLinks (CSignal dom (BitVector 64)))
-    (Vec extLinks (CSignal dom (BitVector 64)))
-node (NodeConfig nmuConfig switchConfig gppeConfigs) =
-  circuit $ \(mmNmu, mms, linksIn) -> do
-    (switchOut, _cal) <- switchC switchConfig -< (mmSwWb, (switchIn, swWb))
-    switchIn <- appendC3 -< ([nmuLinkOut], pesToSwitch, linksIn)
-    ([Fwd nmuLinkIn], Fwd switchToPes, linksOut) <- split3CI -< switchOut
-    (nmuLinkOut, nmuWbs0) <- managementUnitC nmuConfig nmuLinkIn -< mmNmu
-    ([(mmSwWb, swWb)], nmuWbs1) <- splitAtCI -< nmuWbs0
-    peWbs <- unconcatC d2 -< nmuWbs1
+    ( ConstBwd MM
+    , Vec gppes (ConstBwd MM)
+    , Jtag dom
+    , Vec linkCount (CSignal dom (Maybe (BitVector 64)))
+    )
+    ( Vec linkCount (CSignal dom (BitVector 64))
+    , CSignal dom (Unsigned 64)
+    , (ConstBwd MM, NmuWishbone dom linkCount gppes)
+    , Vec gppes (CSignal dom (BitVector 64))
+    , Vec gppes (CSignal dom (BitVector 64))
+    , Vec gppes (Df dom Byte)
+    , CSignal dom (Vec (linkCount + gppes + 1) (Index (linkCount + gppes + 2)))
+    )
+node (NodeConfig muConfig switchConfig gppeConfigs) =
+  circuit $ \(muMM, gppeMMs, jtag, Fwd rxs) -> do
+    [muJtag, gppesJtagTap] <- jtagChain -< jtag
+    gppesJtag <- jtagChain -< gppesJtagTap
 
-    pesToSwitch <- vecCircuits (gppeC <$> gppeConfigs <*> switchToPes) <| zipC -< (mms, peWbs)
-    idC -< linksOut
+    ( nmuLinkOut
+      , Fwd localCounter
+      , (switchMM, switchWb)
+      , externalMMWb
+      , captureUgnsMMWb
+      , scatterCalsMMWb
+      , gatherCalsMMWb
+      ) <-
+      managementUnitC muConfig -< (muMM, nmuLinkIn, muJtag)
 
-type NmuInternalBusses = 6
-type NmuRemBusWidth nodeBusses = RemainingBusWidth (nodeBusses + NmuInternalBusses)
+    ugnRxs <- vecCircuits (captureUgn localCounter <$> rxs) -< captureUgnsMMWb
 
-{- | Configuration for the 'managementUnit' and its 'Bittide.Link'.
-The management unit contains the 4 wishbone busses that each pe has
-and also the management busses for itself and all other pe's in this node.
-Furthermore it also has access to the 'calendar' for the 'switch'.
+    (Fwd peLinksOut, peUartsOut) <-
+      unzipC
+        <| vecCircuits (zipWith gppeC gppeConfigs (fromIntegral <$> indicesI))
+        <| zipC5
+        -< (gppeMMs, Fwd switchToGppes, scatterCalsMMWb, gatherCalsMMWb, gppesJtag)
+
+    switchIn <- appendC3 -< ([nmuLinkOut], Fwd peLinksOut, ugnRxs)
+    (switchOut, cal) <-
+      switchC @_ @_ @_ @_ @64 switchConfig -< (switchMM, (switchIn, switchWb))
+    ([nmuLinkIn], Fwd switchToGppes, linksOut) <- split3CI -< switchOut
+
+    idC
+      -< ( linksOut
+         , Fwd localCounter
+         , externalMMWb
+         , Fwd switchToGppes
+         , Fwd peLinksOut
+         , peUartsOut
+         , cal
+         )
+ where
+  zipC5 ::
+    forall a b c d e n.
+    (KnownNat n) =>
+    Circuit (Vec n a, Vec n b, Vec n c, Vec n d, Vec n e) (Vec n (a, b, c, d, e))
+  zipC5 = applyC (\(a, b, c, d, e) -> zip5 a b c d e) unzip5
+
+{- Type-level number of GPPE internal busses.
+
+Internal busses:
+  * Instruction bus (not exposed to MU, PE internal)
+  * Data bus (not exposed to MU, PE internal)
+  * 'whoAmIWb' (not exposed to MU, PE internal)
+  * 'metaPeConfig' (not exposed to MU)
+  * Scatter unit
+  * Gather unit
+  * UART (not exposed to MU)
 -}
-data ManagementConfig nodeBusses where
-  ManagementConfig ::
-    (KnownNat nodeBusses) =>
-    ScatterConfig 4 (NmuRemBusWidth nodeBusses) ->
-    GatherConfig 4 (NmuRemBusWidth nodeBusses) ->
-    PeConfig (nodeBusses + NmuInternalBusses) ->
-    DumpVcd ->
-    ManagementConfig nodeBusses
+type GppeBussesNotExposed = PeInternalBusses + 3
+type GppeBusses = GppeBussesNotExposed + 2
+type GppeBusWidth = 30 - CLog 2 GppeBusses
 
 {- | Configuration for a general purpose processing element together with its link to the
 switch.
 -}
-data GppeConfig nmuRemBusWidth where
+data GppeConfig nmuRemBusWidth metaPeBufferWidth where
   GppeConfig ::
-    ScatterConfig 4 nmuRemBusWidth ->
-    GatherConfig 4 nmuRemBusWidth ->
-    -- | Configuration for a 'gppe's 'processingElement', which statically
+    forall nmuRemBusWidth metaPeBufferWidth.
+    (KnownNat metaPeBufferWidth, 1 <= metaPeBufferWidth) =>
+    { scatterConfig :: ScatterConfig 4 nmuRemBusWidth
+    -- ^ Configuration for the scatter engine
+    , gatherConfig :: GatherConfig 4 nmuRemBusWidth
+    -- ^ Configuration for the gather engine
+    , peConfig :: PeConfig GppeBusses
+    -- ^ Configuration for a 'gppe's 'processingElement', which statically
     -- has four external busses connected to the instruction memory, data memory
     -- , 'scatterUnitWb' and 'gatherUnitWb'.
-    PeConfig 4 ->
-    DumpVcd ->
-    GppeConfig nmuRemBusWidth
+    , dumpVcd :: DumpVcd
+    , metaPeConfigBufferWidth :: SNat metaPeBufferWidth
+    } ->
+    GppeConfig nmuRemBusWidth metaPeBufferWidth
 
 {-# NOINLINE gppeC #-}
 
@@ -115,6 +172,7 @@ The order of Wishbone busses is as follows:
 ('scatterUnitWb' :> 'gatherUnitWb' :> Nil).
 -}
 gppeC ::
+  forall dom nmuRemBusWidth metaPeBufferWidth.
   ( HasCallStack
   , KnownNat nmuRemBusWidth
   , HiddenClockResetEnable dom
@@ -122,24 +180,86 @@ gppeC ::
   , ?regByteOrder :: ByteOrder
   ) =>
   -- | Configures all local parameters
-  GppeConfig nmuRemBusWidth ->
-  -- |
-  -- ( Incoming 'Bittide.Link'
-  -- , Incoming @Vector@ of master busses
-  -- )
-  Signal dom (BitVector 64) ->
+  GppeConfig nmuRemBusWidth metaPeBufferWidth ->
+  -- | Index number of this GPPE
+  Integer ->
   Circuit
-    ( ConstBwd MM
-    , Vec 2 (ConstBwd MM, Wishbone dom 'Standard nmuRemBusWidth (Bytes 4))
+    ( -- \| GPPE memory map
+      ConstBwd MM
+    , -- \| Incoming link from switch
+      CSignal dom (BitVector 64)
+    , -- \| Scatter unit calendar memory map and Wishbone bus
+      (ConstBwd MM, Wishbone dom 'Standard nmuRemBusWidth (Bytes 4))
+    , -- \| Gather unit calendar memory map and Wishbone bus
+      (ConstBwd MM, Wishbone dom 'Standard nmuRemBusWidth (Bytes 4))
+    , -- \| JTAG connection
+      Jtag dom
     )
-    (CSignal dom (BitVector 64))
-gppeC (GppeConfig scatterConfig gatherConfig peConfig dumpVcd) linkIn = circuit $ \(mm, nmuWbs) -> do
-  [(mmSCal, wbScatCal), (mmGCal, wbGathCal)] <- idC -< nmuWbs
-  jtag <- idleSource
-  [(mmS, wbScat), (mmG, wbGu)] <- processingElement dumpVcd peConfig -< (mm, jtag)
-  scatterUnitWbC scatterConfig linkIn -< ((mmS, wbScat), (mmSCal, wbScatCal))
-  linkOut <- gatherUnitWbC gatherConfig -< ((mmG, wbGu), (mmGCal, wbGathCal))
-  idC -< linkOut
+    (CSignal dom (BitVector 64), Df dom Byte)
+gppeC cfg@GppeConfig{} (show -> idx) =
+  circuit $ \(mm, Fwd linkIn, (scatterCalMM, scatterCalWb), (gatherCalMM, gatherCalWb), jtag) -> do
+    [dnaBus, (scatterMM, scatterWb), (gatherMM, gatherWb), metaPeBus, uartBus] <-
+      processingElement cfg.dumpVcd cfg.peConfig -< (mm, jtag)
+    _dna <- readDnaPortE2Wb simDna2 -< dnaBus
+    metaPeConfig cfg.metaPeConfigBufferWidth -< metaPeBus
+    withNamesSG
+      ("ScatterUnitPe" <> idx)
+      ("ScatterCalPe" <> idx)
+      (scatterUnitWbC cfg.scatterConfig linkIn)
+      -< ((scatterMM, scatterWb), (scatterCalMM, scatterCalWb))
+    linkOut <-
+      withNamesSG
+        ("GatherUnitPe" <> idx)
+        ("GatherCalPe" <> idx)
+        (gatherUnitWbC cfg.gatherConfig)
+        -< ((gatherMM, gatherWb), (gatherCalMM, gatherCalWb))
+    (gppeUartBytes, _uartStatus) <-
+      uartInterfaceWb d16 d16 uartBytes -< (uartBus, Fwd (pure Nothing))
+    idC -< (linkOut, gppeUartBytes)
+
+{- Type-level number of node management unit internal busses
+
+Internal busses:
+  * Instruction bus
+  * Data bus
+  * Scatter unit
+  * Scatter calendar
+  * Gather unit
+  * Gather calendar
+  * Switch
+  * 'timeWb'
+  * External link
+  * 'linkCount' number of 'captureUgn' components
+  * 'gppes' number of Scatter calendars
+  * 'gppes' number of Gather calendars
+-}
+type NmuBusses linkCount gppes = PeInternalBusses + 7 + linkCount + 2 * gppes
+type NmuPrefixWidth linkCount gppes = CLog 2 (NmuBusses linkCount gppes + 1)
+type NmuRemBusWidth linkCount gppes = 30 - NmuPrefixWidth linkCount gppes
+type NmuWishbone dom linkCount gppes =
+  Wishbone dom 'Standard (NmuRemBusWidth linkCount gppes) (Bytes 4)
+
+{- | Configuration for the 'managementUnit' and its 'Bittide.Link'.
+The management unit contains the 4 wishbone busses that each pe has
+and also the management busses for itself and all other pe's in this node.
+Furthermore it also has access to the 'calendar' for the 'switch'.
+-}
+data ManagementConfig linkCount gppes where
+  ManagementConfig ::
+    ( KnownNat gppes
+    , KnownNat linkCount
+    , NmuPrefixWidth linkCount gppes <= 30
+    ) =>
+    { scatterConfig :: ScatterConfig 4 (NmuRemBusWidth linkCount gppes)
+    -- ^ Configuration for the management unit scatter unit
+    , gatherConfig :: GatherConfig 4 (NmuRemBusWidth linkCount gppes)
+    -- ^ Configuration for the management unit gather unit
+    , peConfig :: PeConfig (NmuBusses linkCount gppes)
+    -- ^ Processing element configuration
+    , dumpVcd :: DumpVcd
+    -- ^ VCD dump configuration
+    } ->
+    ManagementConfig linkCount gppes
 
 {- | A special purpose 'processingElement' that manages a Bittide Node. It contains
 a 'processingElement', 'linkToPe' and 'peToLink' which create the interface for the
@@ -148,44 +268,82 @@ Bittide Link. It takes a 'ManagementConfig', incoming link and a vector of incom
 'WishboneM2S' signals.
 -}
 managementUnitC ::
-  forall dom nodeBusses.
+  forall dom linkCount gppes.
   ( HiddenClockResetEnable dom
+  , 1 <= DomainPeriod dom
   , ?busByteOrder :: ByteOrder
   , ?regByteOrder :: ByteOrder
-  , PrefixWidth (nodeBusses + NmuInternalBusses) <= 30
   ) =>
-  -- |
-  -- ( Configures all local parameters
-  -- , Incoming 'Bittide.Link'
-  -- , Incoming @Vector@ of master busses
-  -- )
-  ManagementConfig nodeBusses ->
-  Signal dom (BitVector 64) ->
+  ManagementConfig linkCount gppes ->
   Circuit
-    (ConstBwd MM)
-    ( CSignal dom (BitVector 64)
-    , Vec
-        nodeBusses
-        (ConstBwd MM, Wishbone dom 'Standard (NmuRemBusWidth nodeBusses) (Bytes 4))
+    (ConstBwd MM, CSignal dom (BitVector 64), Jtag dom)
+    ( -- \| Node management unit link output
+      CSignal dom (BitVector 64)
+    , -- \| Node management unit local counter
+      CSignal dom (Unsigned 64)
+    , -- \| Switch memory map and Wishbone bus
+      (ConstBwd MM, NmuWishbone dom linkCount gppes)
+    , -- \| External connection memory map and Wishbone bus
+      (ConstBwd MM, NmuWishbone dom linkCount gppes)
+    , -- \| 'captureUgn's memory maps and Wishbone busses
+      Vec
+        linkCount
+        (ConstBwd MM, NmuWishbone dom linkCount gppes)
+    , -- \| GPPE scatter unit memory maps and Wishbone busses
+      Vec
+        gppes
+        (ConstBwd MM, NmuWishbone dom linkCount gppes)
+    , -- \| GPPE gather unit memory maps and Wishbone busses
+      Vec
+        gppes
+        (ConstBwd MM, NmuWishbone dom linkCount gppes)
     )
-managementUnitC
-  ( ManagementConfig
-      scatterConfig
-      gatherConfig
-      peConfig
-      dumpVcd
-    )
-  linkIn = circuit $ \mm -> do
-    jtag <- idleSource
+managementUnitC (ManagementConfig{scatterConfig, gatherConfig, peConfig, dumpVcd}) =
+  circuit $ \(mm, Fwd linkIn, jtag) -> do
     peWbs <- processingElement dumpVcd peConfig -< (mm, jtag)
-    ( [ wbScatCal
-        , wbScat
-        , wbGathCal
-        , wbGu
+    ( [ (myScatterMM, myScatterWb)
+        , myScatterCalMMWb
+        , myGatherMMWb
+        , myGatherCalMMWb
+        , switchMMWb
+        , timeMMWb
+        , externalMMWb
         ]
-      , nmuWbs
+      , myWbRest
       ) <-
       splitAtCI -< peWbs
-    linkOut <- gatherUnitWbC gatherConfig -< (wbGu, wbGathCal)
-    scatterUnitWbC scatterConfig linkIn -< (wbScat, wbScatCal)
-    idC -< (linkOut, nmuWbs)
+
+    localCounter <- timeWb -< timeMMWb
+
+    withNamesSG "ScatterUnitMu" "ScatterCalMu" (scatterUnitWbC scatterConfig linkIn)
+      -< ((myScatterMM, myScatterWb), myScatterCalMMWb)
+    linkOut <-
+      withNamesSG "GatherUnitMu" "GatherCalMu" (gatherUnitWbC gatherConfig)
+        -< (myGatherMMWb, myGatherCalMMWb)
+
+    (captureUgnMMWbs, scatterMMWbs, gatherMMWbs) <- split3CI -< myWbRest
+
+    idC
+      -< ( linkOut
+         , localCounter
+         , switchMMWb
+         , externalMMWb
+         , captureUgnMMWbs
+         , scatterMMWbs
+         , gatherMMWbs
+         )
+
+withNamesSG ::
+  forall a b c.
+  (HasCallStack) =>
+  String ->
+  String ->
+  Circuit ((ConstBwd MM, a), (ConstBwd MM, b)) c ->
+  Circuit ((ConstBwd MM, a), (ConstBwd MM, b)) c
+withNamesSG nameA nameB (Circuit f) = Circuit go
+ where
+  go ((((), fwdA), ((), fwdB)), bwdC) = (((SimOnly mmA', bwdA), (SimOnly mmB', bwdB)), fwdC)
+   where
+    (((SimOnly mmA, bwdA), (SimOnly mmB, bwdB)), fwdC) = f ((((), fwdA), ((), fwdB)), bwdC)
+    mmA' = mmA{tree = WithName locCaller nameA mmA.tree}
+    mmB' = mmB{tree = WithName locCaller nameB mmB.tree}

--- a/bittide/src/Bittide/ProcessingElement.hs
+++ b/bittide/src/Bittide/ProcessingElement.hs
@@ -67,6 +67,8 @@ data PeConfig nBusses where
 type PrefixWidth nBusses = CLog 2 (nBusses + 1)
 type RemainingBusWidth nBusses = 30 - PrefixWidth nBusses
 
+type PeInternalBusses = 2
+
 {- | VexRiscV based RV32IMC core together with instruction memory, data memory and
 'singleMasterInterconnect'.
 -}
@@ -77,7 +79,7 @@ processingElement ::
   , ?busByteOrder :: ByteOrder
   , ?regByteOrder :: ByteOrder
   , KnownNat nBusses
-  , 2 <= nBusses
+  , PeInternalBusses <= nBusses
   , KnownNat pfxWidth
   , pfxWidth <= 30
   , pfxWidth ~ PrefixWidth nBusses
@@ -87,7 +89,7 @@ processingElement ::
   Circuit
     (MM.ConstBwd MM.MM, Jtag dom)
     ( Vec
-        (nBusses - 2)
+        (nBusses - PeInternalBusses)
         (MM.ConstBwd MM.MM, Wishbone dom 'Standard (RemainingBusWidth nBusses) (Bytes 4))
     )
 processingElement dumpVcd PeConfig{initI, initD, iBusTimeout, dBusTimeout, includeIlaWb} = circuit $ \(mm, jtagIn) -> do


### PR DESCRIPTION
In specific, here's a rough list of the changes I made:
- All config types converted from plain GADT to a record GADT
- Nodes now handle capturing UGNs, so they now need the elastic buffer outputs as inputs. This adds another type parameter to the config type (`linkCount`).
- Added UART output to the GPPE function.
- Added JTAG I/O to both the MU and GPPE functions.
- Added function to call `withName` on the scatter/gather engine functions, since those are unsuited to using `withName` as is.
- Added type alias to processing element file for the number of internal Wishbone busses to avoid having an extra magic constant in a number of places.