### PR TITLE
Add `Df` versions of `registerWbC`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -44,6 +44,7 @@
   "cSpell.words": [
     "bitstream",
     "bittide",
+    "combinationally",
     "deassert",
     "deasserted",
     "dflipflop",

--- a/bittide-instances/bittide-instances.cabal
+++ b/bittide-instances/bittide-instances.cabal
@@ -208,7 +208,7 @@ library
     Bittide.Instances.Pnr.Si539xSpi
     Bittide.Instances.Pnr.Switch
     Bittide.Instances.Pnr.Synchronizer
-    Bittide.Instances.Tests.RegisterWbC
+    Bittide.Instances.Tests.RegisterWb
     Bittide.Instances.Tests.ScatterGather
     Bittide.Instances.Tests.SwitchCalendar
     Paths.Bittide.Instances
@@ -290,7 +290,7 @@ test-suite unittests
     Wishbone.Axi
     Wishbone.CaptureUgn
     Wishbone.DnaPortE2
-    Wishbone.RegisterWbC
+    Wishbone.RegisterWb
     Wishbone.ScatterGather
     Wishbone.SwitchCalendar
     Wishbone.SwitchDemoProcessingElement

--- a/bittide-instances/src/Bittide/Instances/Hitl/VexRiscv.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/VexRiscv.hs
@@ -23,9 +23,9 @@ import Protocols.MemoryMap (Access (WriteOnly), ConstBwd, MM, getMMAny)
 import Protocols.MemoryMap.FieldType
 import Protocols.MemoryMap.Registers.WishboneStandard (
   RegisterConfig (access, description),
-  deviceWbC,
+  deviceWb,
   registerConfig,
-  registerWbC,
+  registerWb,
  )
 import Protocols.Wishbone
 import System.Environment (lookupEnv)
@@ -101,9 +101,9 @@ statusRegister ::
     (ConstBwd MM, Wishbone dom 'Standard aw (Bytes 4))
     (CSignal dom TestStatus)
 statusRegister = circuit $ \(mm, wb) -> do
-  [statusWb] <- deviceWbC "StatusRegister" -< (mm, wb)
+  [statusWb] <- deviceWb "StatusRegister" -< (mm, wb)
   (statusOut, _a) <-
-    registerWbC hasClock hasReset statusConf Running -< (statusWb, Fwd (pure Nothing))
+    registerWb hasClock hasReset statusConf Running -< (statusWb, Fwd (pure Nothing))
   idC -< statusOut
  where
   statusConf =

--- a/bittide-instances/src/Bittide/Instances/MemoryMaps.hs
+++ b/bittide-instances/src/Bittide/Instances/MemoryMaps.hs
@@ -23,7 +23,7 @@ import System.FilePath
 
 import qualified Bittide.Instances.Hitl.Dut.SwitchDemo as SwitchDemo
 import qualified Bittide.Instances.Hitl.SwCcTopologies as SwCcTopologies
-import qualified Bittide.Instances.Tests.RegisterWbC as RegisterWbC
+import qualified Bittide.Instances.Tests.RegisterWb as RegisterWb
 import qualified Bittide.Instances.Tests.ScatterGather as ScatterGather
 import qualified Bittide.Instances.Tests.SwitchCalendar as SwitchCalendar
 import qualified Data.ByteString.Lazy as BS
@@ -39,7 +39,7 @@ $( do
           [ ("Ethernet", vexRiscvEthernetMM)
           , ("Freeze", freezeMM)
           , ("ProcessingElement", vexRiscvUartHelloMM)
-          , ("RegisterWbC", RegisterWbC.memoryMap)
+          , ("RegisterWb", RegisterWb.memoryMap)
           , ("ScatterGather", ScatterGather.dutMM)
           , ("SwCcTopologies", SwCcTopologies.memoryMap)
           , ("SwitchC", SwitchCalendar.memoryMap)

--- a/bittide-instances/src/Bittide/Instances/Tests/RegisterWb.hs
+++ b/bittide-instances/src/Bittide/Instances/Tests/RegisterWb.hs
@@ -196,7 +196,7 @@ manyTypesWb = circuit $ \(mm, wb) -> do
   (_unit, Fwd unitActivity) <-
     registerWb hasClock hasReset (registerConfig "unit") initUnit -< (wbUnit, Fwd noWrite)
 
-  let unitWritten = orNothing <$> (unitActivity .== BusWrite ()) <*> pure True
+  let unitWritten = orNothing <$> (unitActivity .== Just (BusWrite ())) <*> pure True
 
   registerWb_ hasClock hasReset (registerConfig "unitW") initUnitW
     -< (wbUnitW, Fwd unitWritten)

--- a/bittide-instances/src/Bittide/Instances/Tests/RegisterWb.hs
+++ b/bittide-instances/src/Bittide/Instances/Tests/RegisterWb.hs
@@ -2,7 +2,7 @@
 --
 -- SPDX-License-Identifier: Apache-2.0
 
-module Bittide.Instances.Tests.RegisterWbC where
+module Bittide.Instances.Tests.RegisterWb where
 
 import Clash.Prelude
 
@@ -38,10 +38,10 @@ import Protocols.MemoryMap (ConstBwd, MM, MemoryMap, getMMAny)
 import Protocols.MemoryMap.FieldType (ToFieldType)
 import Protocols.MemoryMap.Registers.WishboneStandard (
   BusActivity (..),
-  deviceWbC,
+  deviceWb,
   registerConfig,
-  registerWbC,
-  registerWbC_,
+  registerWb,
+  registerWb_,
  )
 import Protocols.Wishbone (Wishbone, WishboneMode (Standard))
 import System.Environment (lookupEnv)
@@ -164,68 +164,68 @@ manyTypesWb = circuit $ \(mm, wb) -> do
     , wbI20
     , wbMI12
     ] <-
-    deviceWbC "ManyTypes" -< (mm, wb)
+    deviceWb "ManyTypes" -< (mm, wb)
 
-  registerWbC_ hasClock hasReset (registerConfig "s0") initWbS0 -< (wbS0, Fwd noWrite)
-  registerWbC_ hasClock hasReset (registerConfig "s1") initWbS1 -< (wbS1, Fwd noWrite)
-  registerWbC_ hasClock hasReset (registerConfig "s2") initWbS2 -< (wbS2, Fwd noWrite)
-  registerWbC_ hasClock hasReset (registerConfig "s3") initWbS3 -< (wbS3, Fwd noWrite)
-  registerWbC_ hasClock hasReset (registerConfig "s4") initWbS4 -< (wbS4, Fwd noWrite)
+  registerWb_ hasClock hasReset (registerConfig "s0") initWbS0 -< (wbS0, Fwd noWrite)
+  registerWb_ hasClock hasReset (registerConfig "s1") initWbS1 -< (wbS1, Fwd noWrite)
+  registerWb_ hasClock hasReset (registerConfig "s2") initWbS2 -< (wbS2, Fwd noWrite)
+  registerWb_ hasClock hasReset (registerConfig "s3") initWbS3 -< (wbS3, Fwd noWrite)
+  registerWb_ hasClock hasReset (registerConfig "s4") initWbS4 -< (wbS4, Fwd noWrite)
 
-  registerWbC_ hasClock hasReset (registerConfig "u0") initWbU0 -< (wbU0, Fwd noWrite)
-  registerWbC_ hasClock hasReset (registerConfig "u1") initWbU1 -< (wbU1, Fwd noWrite)
-  registerWbC_ hasClock hasReset (registerConfig "u2") initWbU2 -< (wbU2, Fwd noWrite)
-  registerWbC_ hasClock hasReset (registerConfig "u3") initWbU3 -< (wbU3, Fwd noWrite)
+  registerWb_ hasClock hasReset (registerConfig "u0") initWbU0 -< (wbU0, Fwd noWrite)
+  registerWb_ hasClock hasReset (registerConfig "u1") initWbU1 -< (wbU1, Fwd noWrite)
+  registerWb_ hasClock hasReset (registerConfig "u2") initWbU2 -< (wbU2, Fwd noWrite)
+  registerWb_ hasClock hasReset (registerConfig "u3") initWbU3 -< (wbU3, Fwd noWrite)
 
-  registerWbC_ hasClock hasReset (registerConfig "bv0") initWbBv0 -< (wbBv0, Fwd noWrite)
-  registerWbC_ hasClock hasReset (registerConfig "bv1") initWbBv1 -< (wbBv1, Fwd noWrite)
-  registerWbC_ hasClock hasReset (registerConfig "bv2") initWbBv2 -< (wbBv2, Fwd noWrite)
+  registerWb_ hasClock hasReset (registerConfig "bv0") initWbBv0 -< (wbBv0, Fwd noWrite)
+  registerWb_ hasClock hasReset (registerConfig "bv1") initWbBv1 -< (wbBv1, Fwd noWrite)
+  registerWb_ hasClock hasReset (registerConfig "bv2") initWbBv2 -< (wbBv2, Fwd noWrite)
 
-  registerWbC_ hasClock hasReset (registerConfig "f0") initWbF0 -< (wbF0, Fwd noWrite)
-  registerWbC_ hasClock hasReset (registerConfig "f1") initWbF1 -< (wbF1, Fwd noWrite)
+  registerWb_ hasClock hasReset (registerConfig "f0") initWbF0 -< (wbF0, Fwd noWrite)
+  registerWb_ hasClock hasReset (registerConfig "f1") initWbF1 -< (wbF1, Fwd noWrite)
 
-  registerWbC_ hasClock hasReset (registerConfig "d0") initWbD0 -< (wbD0, Fwd noWrite)
-  registerWbC_ hasClock hasReset (registerConfig "d1") initWbD1 -< (wbD1, Fwd noWrite)
+  registerWb_ hasClock hasReset (registerConfig "d0") initWbD0 -< (wbD0, Fwd noWrite)
+  registerWb_ hasClock hasReset (registerConfig "d1") initWbD1 -< (wbD1, Fwd noWrite)
 
-  registerWbC_ hasClock hasReset (registerConfig "b0") initWbB0 -< (wbB0, Fwd noWrite)
+  registerWb_ hasClock hasReset (registerConfig "b0") initWbB0 -< (wbB0, Fwd noWrite)
 
-  registerWbC_ hasClock hasReset (registerConfig "v0") initWbV0 -< (wbV0, Fwd noWrite)
-  registerWbC_ hasClock hasReset (registerConfig "v1") initWbV1 -< (wbV1, Fwd noWrite)
-  registerWbC_ hasClock hasReset (registerConfig "v2") initWbV2 -< (wbV2, Fwd noWrite)
+  registerWb_ hasClock hasReset (registerConfig "v0") initWbV0 -< (wbV0, Fwd noWrite)
+  registerWb_ hasClock hasReset (registerConfig "v1") initWbV1 -< (wbV1, Fwd noWrite)
+  registerWb_ hasClock hasReset (registerConfig "v2") initWbV2 -< (wbV2, Fwd noWrite)
 
   (_unit, Fwd unitActivity) <-
-    registerWbC hasClock hasReset (registerConfig "unit") initUnit -< (wbUnit, Fwd noWrite)
+    registerWb hasClock hasReset (registerConfig "unit") initUnit -< (wbUnit, Fwd noWrite)
 
   let unitWritten = orNothing <$> (unitActivity .== BusWrite ()) <*> pure True
 
-  registerWbC_ hasClock hasReset (registerConfig "unitW") initUnitW
+  registerWb_ hasClock hasReset (registerConfig "unitW") initUnitW
     -< (wbUnitW, Fwd unitWritten)
-  registerWbC_ hasClock hasReset (registerConfig "zs") initZS -< (wbZS, Fwd noWrite)
+  registerWb_ hasClock hasReset (registerConfig "zs") initZS -< (wbZS, Fwd noWrite)
 
-  registerWbC_ hasClock hasReset (registerConfig "sum0") initSum0 -< (wbSum0, Fwd noWrite)
-  registerWbC_ hasClock hasReset (registerConfig "sum1") initSum1 -< (wbSum1, Fwd noWrite)
+  registerWb_ hasClock hasReset (registerConfig "sum0") initSum0 -< (wbSum0, Fwd noWrite)
+  registerWb_ hasClock hasReset (registerConfig "sum1") initSum1 -< (wbSum1, Fwd noWrite)
 
-  registerWbC_ hasClock hasReset (registerConfig "sop0") initSop0 -< (wbSop0, Fwd noWrite)
-  registerWbC_ hasClock hasReset (registerConfig "sop1") initSop1 -< (wbSop1, Fwd noWrite)
+  registerWb_ hasClock hasReset (registerConfig "sop0") initSop0 -< (wbSop0, Fwd noWrite)
+  registerWb_ hasClock hasReset (registerConfig "sop1") initSop1 -< (wbSop1, Fwd noWrite)
 
-  registerWbC_ hasClock hasReset (registerConfig "e0") initWbE0 -< (wbE0, Fwd noWrite)
+  registerWb_ hasClock hasReset (registerConfig "e0") initWbE0 -< (wbE0, Fwd noWrite)
 
-  registerWbC_ hasClock hasReset (registerConfig "oi") initOI0 -< (wbOI0, Fwd noWrite)
+  registerWb_ hasClock hasReset (registerConfig "oi") initOI0 -< (wbOI0, Fwd noWrite)
 
-  registerWbC_ hasClock hasReset (registerConfig "x2") initWbX2 -< (wbX2, Fwd noWrite)
+  registerWb_ hasClock hasReset (registerConfig "x2") initWbX2 -< (wbX2, Fwd noWrite)
 
-  registerWbC_ hasClock hasReset (registerConfig "me0") initWbMe0 -< (wbMe0, Fwd noWrite)
-  registerWbC_ hasClock hasReset (registerConfig "me1") initWbMe1 -< (wbMe1, Fwd noWrite)
+  registerWb_ hasClock hasReset (registerConfig "me0") initWbMe0 -< (wbMe0, Fwd noWrite)
+  registerWb_ hasClock hasReset (registerConfig "me1") initWbMe1 -< (wbMe1, Fwd noWrite)
 
-  registerWbC_ hasClock hasReset (registerConfig "p0") initP0 -< (wbP0, Fwd noWrite)
-  registerWbC_ hasClock hasReset (registerConfig "p1") initP1 -< (wbP1, Fwd noWrite)
-  registerWbC_ hasClock hasReset (registerConfig "p2") initP2 -< (wbP2, Fwd noWrite)
-  registerWbC_ hasClock hasReset (registerConfig "p3") initP3 -< (wbP3, Fwd noWrite)
+  registerWb_ hasClock hasReset (registerConfig "p0") initP0 -< (wbP0, Fwd noWrite)
+  registerWb_ hasClock hasReset (registerConfig "p1") initP1 -< (wbP1, Fwd noWrite)
+  registerWb_ hasClock hasReset (registerConfig "p2") initP2 -< (wbP2, Fwd noWrite)
+  registerWb_ hasClock hasReset (registerConfig "p3") initP3 -< (wbP3, Fwd noWrite)
 
-  registerWbC_ hasClock hasReset (registerConfig "t0") initT0 -< (wbT0, Fwd noWrite)
+  registerWb_ hasClock hasReset (registerConfig "t0") initT0 -< (wbT0, Fwd noWrite)
 
-  registerWbC_ hasClock hasReset (registerConfig "i20") initI20 -< (wbI20, Fwd noWrite)
-  registerWbC_ hasClock hasReset (registerConfig "mi12") initMI12 -< (wbMI12, Fwd noWrite)
+  registerWb_ hasClock hasReset (registerConfig "i20") initI20 -< (wbI20, Fwd noWrite)
+  registerWb_ hasClock hasReset (registerConfig "mi12") initMI12 -< (wbMI12, Fwd noWrite)
 
   idC
  where
@@ -386,7 +386,7 @@ dut =
 
   peConfig = unsafePerformIO $ do
     root <- findParentContaining "cabal.project"
-    let elfPath = root </> firmwareBinariesDir "riscv32imc" Release </> "registerwbc_test"
+    let elfPath = root </> firmwareBinariesDir "riscv32imc" Release </> "registerwb_test"
     pure
       PeConfig
         { initI =

--- a/bittide-instances/tests/Wishbone/RegisterWb.hs
+++ b/bittide-instances/tests/Wishbone/RegisterWb.hs
@@ -2,7 +2,7 @@
 --
 -- SPDX-License-Identifier: Apache-2.0
 
-module Wishbone.RegisterWbC where
+module Wishbone.RegisterWb where
 
 import Clash.Prelude
 
@@ -10,7 +10,7 @@ import Test.Tasty (TestTree)
 import Test.Tasty.HUnit (Assertion, assertFailure, testCase)
 import Test.Tasty.TH (testGroupGenerator)
 
-import Bittide.Instances.Tests.RegisterWbC (simResult)
+import Bittide.Instances.Tests.RegisterWb (simResult)
 
 import qualified Text.Parsec as P
 import qualified Text.Parsec.String as P

--- a/bittide-instances/tests/unittests.hs
+++ b/bittide-instances/tests/unittests.hs
@@ -19,7 +19,7 @@ import qualified Tests.ClockControlWb as ClockControlWb
 import qualified Wishbone.Axi as Axi
 import qualified Wishbone.CaptureUgn as CaptureUgn
 import qualified Wishbone.DnaPortE2 as DnaPortE2
-import qualified Wishbone.RegisterWbC as RegisterWbC
+import qualified Wishbone.RegisterWb as RegisterWb
 import qualified Wishbone.ScatterGather as ScatterGather
 import qualified Wishbone.SwitchCalendar as Wishbone.SwitchCalendar
 import qualified Wishbone.SwitchDemoProcessingElement as SwitchDemoProcessingElement
@@ -70,7 +70,7 @@ tests =
         , ScatterGather.tests
         , SwitchDemoProcessingElement.tests
         , Time.tests
-        , RegisterWbC.tests
+        , RegisterWb.tests
         , Watchdog.tests
         , Wishbone.SwitchCalendar.tests
         ]

--- a/bittide/src/Bittide/Calendar.hs
+++ b/bittide/src/Bittide/Calendar.hs
@@ -38,7 +38,6 @@ import Protocols
 import Protocols.MemoryMap
 import Protocols.MemoryMap.FieldType (FieldType, ToFieldType (..), Var)
 import Protocols.MemoryMap.Registers.WishboneStandard (
-  BusActivity (..),
   RegisterConfig (access, description),
   busActivityWrite,
   deviceWb,
@@ -384,7 +383,7 @@ mkCalendarC
           <$> newShadowDepth
           <*> newShadowEntry
           <*> readAddr
-          <*> (swapActive ./=. pure BusIdle)
+          <*> (swapActive ./= Nothing)
     idC -< Fwd (calOut.activeEntry.veEntry, calOut.lastCycle, metacycleCount)
    where
     noWrite = pure Nothing

--- a/bittide/src/Bittide/Calendar.hs
+++ b/bittide/src/Bittide/Calendar.hs
@@ -41,10 +41,10 @@ import Protocols.MemoryMap.Registers.WishboneStandard (
   BusActivity (..),
   RegisterConfig (access, description),
   busActivityWrite,
-  deviceWbC,
+  deviceWb,
   registerConfig,
-  registerWbCI,
-  registerWbCI_,
+  registerWbI,
+  registerWbI_,
  )
 import Protocols.Wishbone
 
@@ -359,16 +359,16 @@ mkCalendarC
       bsShadow
     ) = circuit $ \(mm, wb) -> do
 {- FOURMOLU_DISABLE -}
-    [wb0, wb1, wb2, wb3, wb4, wb5, wb6, (wb7Offset, wb7Meta, wb7Bus)] <- deviceWbC (compName <> "_calendar") -< (mm, wb)
-    Fwd (writeEntry, _) <- registerWbCI writeEntryCfg (unpack 0) -< (wb4, Fwd noWrite)
-    Fwd (_, writeActive) <- registerWbCI writeAddrCfg (0 :: Index calDepth) -< (wb1, Fwd noWrite)
-    Fwd (readAddr, _) <- registerWbCI readAddrCfg (0 :: Index calDepth) -< (wb2, Fwd noWrite)
-    registerWbCI_ readEntryCfg (unpack 0) -< (wb3, Fwd readEntry)
-    Fwd (_, shadowDepthActive) <- registerWbCI shadowDepthCfg 0 -< (wb0, Fwd shadowDepthWrite)
-    Fwd (_, swapActive) <- registerWbCI swapActiveCfg False -< (wb5, Fwd noWrite)
-    Fwd (metacycleCount, _) <- registerWbCI metacycleCountCfg (0 :: Unsigned 32) -< (wb6, Fwd nextMetacycleCount)
+    [wb0, wb1, wb2, wb3, wb4, wb5, wb6, (wb7Offset, wb7Meta, wb7Bus)] <- deviceWb (compName <> "_calendar") -< (mm, wb)
+    Fwd (writeEntry, _) <- registerWbI writeEntryCfg (unpack 0) -< (wb4, Fwd noWrite)
+    Fwd (_, writeActive) <- registerWbI writeAddrCfg (0 :: Index calDepth) -< (wb1, Fwd noWrite)
+    Fwd (readAddr, _) <- registerWbI readAddrCfg (0 :: Index calDepth) -< (wb2, Fwd noWrite)
+    registerWbI_ readEntryCfg (unpack 0) -< (wb3, Fwd readEntry)
+    Fwd (_, shadowDepthActive) <- registerWbI shadowDepthCfg 0 -< (wb0, Fwd shadowDepthWrite)
+    Fwd (_, swapActive) <- registerWbI swapActiveCfg False -< (wb5, Fwd noWrite)
+    Fwd (metacycleCount, _) <- registerWbI metacycleCountCfg (0 :: Unsigned 32) -< (wb6, Fwd nextMetacycleCount)
     wbEom <- andAck calOut.lastCycle -< wb7Bus
-    registerWbCI_ endOfMetacycleCfg False -< ((wb7Offset, wb7Meta, wbEom), Fwd noWrite)
+    registerWbI_ endOfMetacycleCfg False -< ((wb7Offset, wb7Meta, wbEom), Fwd noWrite)
     {- FOURMOLU_ ENABLE -}
     let
       nextMetacycleCount = orNothing <$> calOut.lastCycle <*> (metacycleCount + 1)

--- a/bittide/src/Bittide/CaptureUgn.hs
+++ b/bittide/src/Bittide/CaptureUgn.hs
@@ -14,9 +14,9 @@ import Protocols
 import Protocols.MemoryMap (Access (ReadOnly), ConstBwd, MM)
 import Protocols.MemoryMap.Registers.WishboneStandard (
   RegisterConfig (access),
-  deviceWbC,
+  deviceWb,
   registerConfig,
-  registerWbCI_,
+  registerWbI_,
  )
 import Protocols.Wishbone (Wishbone, WishboneMode (Standard))
 
@@ -55,16 +55,16 @@ captureUgn ::
     (ConstBwd MM, Wishbone dom 'Standard addrW (Bytes 4))
     (CSignal dom (BitVector 64))
 captureUgn localCounter linkIn = circuit $ \bus -> do
-  [wbLocalCounter, wbRemoteCounter, wbHasCaptured] <- deviceWbC "CaptureUgn" -< bus
+  [wbLocalCounter, wbRemoteCounter, wbHasCaptured] <- deviceWb "CaptureUgn" -< bus
 
   let trigger = C.isRising False (isJust <$> linkIn)
   capturedLocalCounter <- shutter trigger -< Fwd localCounter
   capturedRemoteCounter <- shutter trigger -< Fwd (fromMaybe 0 <$> linkIn)
   capturedHasCaptured <- shutter trigger -< Fwd (isJust <$> linkIn)
 
-  registerWbCI_ localCounterConfig 0 -< (wbLocalCounter, capturedLocalCounter)
-  registerWbCI_ remoteCounterConfig 0 -< (wbRemoteCounter, capturedRemoteCounter)
-  registerWbCI_ hasCapturedConfig False -< (wbHasCaptured, capturedHasCaptured)
+  registerWbI_ localCounterConfig 0 -< (wbLocalCounter, capturedLocalCounter)
+  registerWbI_ remoteCounterConfig 0 -< (wbRemoteCounter, capturedRemoteCounter)
+  registerWbI_ hasCapturedConfig False -< (wbHasCaptured, capturedHasCaptured)
 
   idC -< Fwd (fromJust <$> linkIn)
  where

--- a/bittide/src/Bittide/ClockControl/Freeze.hs
+++ b/bittide/src/Bittide/ClockControl/Freeze.hs
@@ -14,10 +14,10 @@ import Protocols.MemoryMap (Access (ReadOnly, WriteOnly), ConstBwd, MM)
 import Protocols.MemoryMap.Registers.WishboneStandard (
   BusActivity (BusWrite),
   RegisterConfig (access, description),
-  deviceWbC,
+  deviceWb,
   registerConfig,
-  registerWbC,
-  registerWbC_,
+  registerWb,
+  registerWb_,
  )
 import Protocols.Wishbone
 
@@ -52,7 +52,7 @@ freeze clk rst =
     -- Create a bunch of register wishbone interfaces. We don't really care about
     -- ordering, so we just append a number to the end of a generic name.
     [wb0, wb1, wb2, wb3, wb4, wb5] <-
-      deviceWbC "Freeze" -< (mm, wb)
+      deviceWb "Freeze" -< (mm, wb)
 
     -- Only writeable register in this device: can be used by the wishbone manager
     -- to freeze all the incoming signals.
@@ -61,26 +61,26 @@ freeze clk rst =
     --       don't expect this to cause any problems as we don't critically rely
     --       on the counter being exact (i.e., reading one less just means we
     --       drop one measurement at the end of a clock control experiment). Still,
-    --       it would be nice for 'registerWbC' to support this.
-    (_a0, Fwd freezeActivity) <- registerWbC clk rst freezeConfig () -< (wb0, Fwd noWrite)
+    --       it would be nice for 'registerWb' to support this.
+    (_a0, Fwd freezeActivity) <- registerWb clk rst freezeConfig () -< (wb0, Fwd noWrite)
     let shut = freezeActivity .==. pure (BusWrite ())
 
     -- Read-only register that counts how many times the user requested a freeze
     let freezeCounterWrite = Just <$> counter @(Unsigned 32) clk rst (toEnable shut) 0
-    registerWbC_ clk rst freezeCounterConfig 0 -< (wb1, Fwd freezeCounterWrite)
+    registerWb_ clk rst freezeCounterConfig 0 -< (wb1, Fwd freezeCounterWrite)
 
     -- Counters that are frozen when the user requests a freeze.
     localClockWrite <- shutter shut -< localCounter
-    registerWbC_ clk rst localClockConfig 0 -< (wb2, localClockWrite)
+    registerWb_ clk rst localClockConfig 0 -< (wb2, localClockWrite)
 
     syncPulseCounterWrite <- shutter shut -< syncPulseCounter
-    registerWbC_ clk rst syncCounterConfig 0 -< (wb3, syncPulseCounterWrite)
+    registerWb_ clk rst syncCounterConfig 0 -< (wb3, syncPulseCounterWrite)
 
     lastPulseWrite <- shutter shut -< lastPulseCounter
-    registerWbC_ clk rst lastSyncPulseConfig 0 -< (wb4, lastPulseWrite)
+    registerWb_ clk rst lastSyncPulseConfig 0 -< (wb4, lastPulseWrite)
 
     ebcWrite <- shutter shut -< ebCounters
-    registerWbC_ clk rst ebCountersConfig (repeat 0) -< (wb5, ebcWrite)
+    registerWb_ clk rst ebCountersConfig (repeat 0) -< (wb5, ebcWrite)
 
     idC
  where

--- a/bittide/src/Bittide/ClockControl/Freeze.hs
+++ b/bittide/src/Bittide/ClockControl/Freeze.hs
@@ -63,7 +63,7 @@ freeze clk rst =
     --       drop one measurement at the end of a clock control experiment). Still,
     --       it would be nice for 'registerWb' to support this.
     (_a0, Fwd freezeActivity) <- registerWb clk rst freezeConfig () -< (wb0, Fwd noWrite)
-    let shut = freezeActivity .==. pure (BusWrite ())
+    let shut = freezeActivity .== Just (BusWrite ())
 
     -- Read-only register that counts how many times the user requested a freeze
     let freezeCounterWrite = Just <$> counter @(Unsigned 32) clk rst (toEnable shut) 0

--- a/bittide/src/Bittide/ClockControl/Registers.hs
+++ b/bittide/src/Bittide/ClockControl/Registers.hs
@@ -137,7 +137,7 @@ clockControlWb linkMask linksOk (bundle -> counters) = circuit $ \(mm, wb) -> do
     dataCountsSeenReset =
       unsafeOrReset
         hasReset
-        (unsafeFromActiveHigh (clearDataCountsSeen .== BusWrite True))
+        (unsafeFromActiveHigh (clearDataCountsSeen .== Just (BusWrite True)))
 
     minDataCountsSeen1 :: Signal dom (Vec nLinks (RelDataCount m))
     minDataCountsSeen1 = zipWith min <$> minDataCountsSeen0 <*> maskedCounters
@@ -187,6 +187,6 @@ clockControlWb linkMask linksOk (bundle -> counters) = circuit $ \(mm, wb) -> do
   maskedCounters :: Signal dom (Vec nLinks (RelDataCount m))
   maskedCounters = applyMask 0 linkMask counters
 
-  busActivityToMaybeSpeedChange :: BusActivity SpeedChange -> Maybe SpeedChange
-  busActivityToMaybeSpeedChange (BusWrite change) = Just change
+  busActivityToMaybeSpeedChange :: Maybe (BusActivity SpeedChange) -> Maybe SpeedChange
+  busActivityToMaybeSpeedChange (Just (BusWrite change)) = Just change
   busActivityToMaybeSpeedChange _ = Nothing

--- a/bittide/src/Bittide/Counter.hs
+++ b/bittide/src/Bittide/Counter.hs
@@ -20,10 +20,10 @@ import GHC.Stack (HasCallStack)
 import Protocols.MemoryMap (Access (ReadOnly), ConstBwd, MM)
 import Protocols.MemoryMap.Registers.WishboneStandard (
   RegisterConfig (access, description),
-  deviceWbC,
+  deviceWb,
   registerConfig,
-  registerWbC,
-  registerWbC_,
+  registerWb,
+  registerWb_,
  )
 import Protocols.Wishbone (Wishbone, WishboneMode (Standard))
 
@@ -125,12 +125,12 @@ domainDiffCountersWbC ::
     (ConstBwd MM, Wishbone dst 'Standard addrW (Bytes 4))
     (CSignal dst (Vec n (Signed 32, Active)))
 domainDiffCountersWbC srcClocks srcResets clk rst = circuit $ \bus -> do
-  [enableWb, countersWb, activesWb] <- deviceWbC "DomainDiffCounters" -< bus
+  [enableWb, countersWb, activesWb] <- deviceWb "DomainDiffCounters" -< bus
 
   (Fwd enables, _a) <-
-    registerWbC clk rst enableConfig (repeat False) -< (enableWb, Fwd noWrite)
-  registerWbC_ clk rst countersConfig (repeat 0) -< (countersWb, Fwd countersWrite)
-  registerWbC_ clk rst activeConfig (repeat False) -< (activesWb, Fwd countersActiveWrite)
+    registerWb clk rst enableConfig (repeat False) -< (enableWb, Fwd noWrite)
+  registerWb_ clk rst countersConfig (repeat 0) -< (countersWb, Fwd countersWrite)
+  registerWb_ clk rst activeConfig (repeat False) -< (activesWb, Fwd countersActiveWrite)
 
   let
     resets = unsafeFromActiveLow <$> unbundle enables

--- a/bittide/src/Bittide/MetaPeConfig.hs
+++ b/bittide/src/Bittide/MetaPeConfig.hs
@@ -14,9 +14,9 @@ import Protocols
 import Protocols.MemoryMap (Access (..), ConstBwd, MM)
 import Protocols.MemoryMap.Registers.WishboneStandard (
   RegisterConfig (access, description),
-  deviceWbC,
+  deviceWb,
   registerConfig,
-  registerWbCI_,
+  registerWbI_,
  )
 import Protocols.Wishbone
 
@@ -38,16 +38,16 @@ metaPeConfig ::
     )
     ()
 metaPeConfig SNat = circuit $ \(mm, wb) -> do
-  [wMC, wO, wN, rMC, rO, rN, buffer] <- deviceWbC "MetaPeConfig" -< (mm, wb)
+  [wMC, wO, wN, rMC, rO, rN, buffer] <- deviceWb "MetaPeConfig" -< (mm, wb)
 
-  registerWbCI_ wMcConfig (0 :: Unsigned 32) -< (wMC, Fwd noWrite)
-  registerWbCI_ wOConfig (0 :: Unsigned 32) -< (wO, Fwd noWrite)
-  registerWbCI_ wNConfig (0 :: Unsigned 32) -< (wN, Fwd noWrite)
-  registerWbCI_ rMcConfig (0 :: Unsigned 32) -< (rMC, Fwd noWrite)
-  registerWbCI_ rOConfig (0 :: Unsigned 32) -< (rO, Fwd noWrite)
-  registerWbCI_ rNConfig (0 :: Unsigned 32) -< (rN, Fwd noWrite)
+  registerWbI_ wMcConfig (0 :: Unsigned 32) -< (wMC, Fwd noWrite)
+  registerWbI_ wOConfig (0 :: Unsigned 32) -< (wO, Fwd noWrite)
+  registerWbI_ wNConfig (0 :: Unsigned 32) -< (wN, Fwd noWrite)
+  registerWbI_ rMcConfig (0 :: Unsigned 32) -< (rMC, Fwd noWrite)
+  registerWbI_ rOConfig (0 :: Unsigned 32) -< (rO, Fwd noWrite)
+  registerWbI_ rNConfig (0 :: Unsigned 32) -< (rN, Fwd noWrite)
 
-  registerWbCI_ bufferConfig (repeat 0 :: Vec (bufferSize * 3) (BitVector 64))
+  registerWbI_ bufferConfig (repeat 0 :: Vec (bufferSize * 3) (BitVector 64))
     -< (buffer, Fwd noWrite)
 
   idC -< ()

--- a/bittide/src/Bittide/Sync.hs
+++ b/bittide/src/Bittide/Sync.hs
@@ -49,9 +49,9 @@ import Clash.Explicit.Signal.Extra (changepoints)
 import GHC.Stack (HasCallStack)
 import Protocols.MemoryMap (ConstBwd, MM)
 import Protocols.MemoryMap.Registers.WishboneStandard (
-  deviceWbC,
+  deviceWb,
   registerConfig,
-  registerWbC,
+  registerWb,
  )
 import Protocols.Wishbone (Wishbone, WishboneMode (Standard))
 
@@ -134,8 +134,8 @@ syncOutGenerateWbC ::
     (ConstBwd MM, Wishbone dom 'Standard aw (Bytes 4))
     (CSignal counterDom Bit)
 syncOutGenerateWbC clk rst counterClk counterRst = circuit $ \(mm, wb) -> do
-  [activeWb] <- deviceWbC "SyncOutGenerator" -< (mm, wb)
-  (Fwd active, _activity) <- registerWbC clk rst config False -< (activeWb, Fwd noWrite)
+  [activeWb] <- deviceWb "SyncOutGenerator" -< (mm, wb)
+  (Fwd active, _activity) <- registerWb clk rst config False -< (activeWb, Fwd noWrite)
   let
     syncOutRst0 = rst `orReset` unsafeFromActiveLow active
     syncOutRst1 = counterRst `orReset` xpmCdcSyncRst Asserted clk counterClk syncOutRst0

--- a/bittide/src/Bittide/Wishbone.hs
+++ b/bittide/src/Bittide/Wishbone.hs
@@ -696,16 +696,16 @@ timeWb ::
     (MM.ConstBwd MM.MM, Wishbone dom 'Standard addrW (Bytes 4))
     (CSignal dom (Unsigned 64))
 timeWb = circuit $ \mmWb -> do
-  [(cmdOffset, cmdMeta, cmdWb0), cmpWb, scratchWb, freqWb] <- MM.deviceWbC "Timer" -< mmWb
+  [(cmdOffset, cmdMeta, cmdWb0), cmpWb, scratchWb, freqWb] <- MM.deviceWb "Timer" -< mmWb
   cmdWb1 <- andAck cmdWaitAck -< cmdWb0
   cmdWb2 <- idC -< (cmdOffset, cmdMeta, cmdWb1)
 
 {- FOURMOLU_DISABLE -}
   -- Registers
-  Fwd (_, cmdActivity) <- MM.registerWbCI cmdCfg Capture -< (cmdWb2, Fwd noWrite)
-  MM.registerWbCI_ cmpCfg False -< (cmpWb, Fwd cmpResultWrite)
-  Fwd (scratch, _) <- MM.registerWbCI scratchCfg (0 :: Unsigned 64) -< (scratchWb, Fwd scratchWrite)
-  MM.registerWbCI_ freqCfg freq -< (freqWb, Fwd noWrite)
+  Fwd (_, cmdActivity) <- MM.registerWbI cmdCfg Capture -< (cmdWb2, Fwd noWrite)
+  MM.registerWbI_ cmpCfg False -< (cmpWb, Fwd cmpResultWrite)
+  Fwd (scratch, _) <- MM.registerWbI scratchCfg (0 :: Unsigned 64) -< (scratchWb, Fwd scratchWrite)
+  MM.registerWbI_ freqCfg freq -< (freqWb, Fwd noWrite)
 {- FOURMOLU_ ENABLE -}
 
   -- Local circuit dependent declarations

--- a/bittide/src/Bittide/Wishbone.hs
+++ b/bittide/src/Bittide/Wishbone.hs
@@ -710,10 +710,10 @@ timeWb = circuit $ \mmWb -> do
 
   -- Local circuit dependent declarations
   let
-    scratchWrite = orNothing <$> (cmdActivity .== MM.BusWrite Capture) <*> count
+    scratchWrite = orNothing <$> (cmdActivity .== Just (MM.BusWrite Capture)) <*> count
     cmpResult = count .>=. scratch
-    cmpResultWrite = orNothing <$> (cmdActivity ./= MM.BusWrite WaitForCmp) <*> cmpResult
-    cmdWaitAck = (cmdActivity ./= MM.BusWrite WaitForCmp) .||. cmpResult
+    cmpResultWrite = orNothing <$> (cmdActivity ./= Just (MM.BusWrite WaitForCmp)) <*> cmpResult
+    cmdWaitAck = (cmdActivity ./= Just (MM.BusWrite WaitForCmp)) .||. cmpResult
   idC -< Fwd count
  where
   -- Independent declarations

--- a/cabal.project
+++ b/cabal.project
@@ -58,7 +58,7 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/clash-lang/clash-protocols.git
-  tag: 09e2a79ded25ef6477891c043daaf0e5a0bfc9cc
+  tag: 456a45fcf965357921f7f435d87ee6c6719d4c5f
   subdir:
     clash-protocols
     clash-protocols-base

--- a/clash-protocols-memmap/tests/Tests/Protocols/MemoryMap/Registers/WishboneStandard.hs
+++ b/clash-protocols-memmap/tests/Tests/Protocols/MemoryMap/Registers/WishboneStandard.hs
@@ -107,19 +107,19 @@ deviceExample ::
     ()
 deviceExample clk rst = circuit $ \(mm, wb) -> do
   [float, double, u32, readOnly, writeOnly, prio] <-
-    deviceWbC "example" -< (mm, wb)
+    deviceWb "example" -< (mm, wb)
 
-  registerWbC_ clk rst (registerConfig "f") initFloat -< (float, Fwd noWrite)
-  registerWbC_ clk rst (registerConfig "d") initDouble -< (double, Fwd noWrite)
-  registerWbC_ clk rst (registerConfig "u") initU32 -< (u32, Fwd noWrite)
+  registerWb_ clk rst (registerConfig "f") initFloat -< (float, Fwd noWrite)
+  registerWb_ clk rst (registerConfig "d") initDouble -< (double, Fwd noWrite)
+  registerWb_ clk rst (registerConfig "u") initU32 -< (u32, Fwd noWrite)
 
-  registerWbC_ clk rst (registerConfig "ro"){access = ReadOnly} initFloat
+  registerWb_ clk rst (registerConfig "ro"){access = ReadOnly} initFloat
     -< (readOnly, Fwd noWrite)
-  registerWbC_ clk rst (registerConfig "wo"){access = WriteOnly} initFloat
+  registerWb_ clk rst (registerConfig "wo"){access = WriteOnly} initFloat
     -< (writeOnly, Fwd noWrite)
 
   (_a, Fwd prioOut) <-
-    registerWbC clk rst (registerConfig "prio") initU32
+    registerWb clk rst (registerConfig "prio") initU32
       -< (prio, Fwd (overwrite <$> prioOut))
 
   idC
@@ -147,7 +147,7 @@ genWishboneTransfer genAddr genMask genData =
     , Write <$> genAddr <*> genMask <*> genData
     ]
 
-{- | Test 'deviceExample' (and therefore 'deviceWbC' and 'registerWbC') using
+{- | Test 'deviceExample' (and therefore 'deviceWb' and 'registerWb') using
 'wishbonePropWithModel'. This property generates a number of random Wishbone
 transactions and checks that the device behaves as expected.
 
@@ -160,7 +160,7 @@ It currently tests:
 It currently does NOT test:
 
   * "Oddly" shaped types (e.g. @Signed 21@)
-  * 'deviceWithOffsetsWbC' with gaps between registers
+  * 'deviceWithOffsetsWb' with gaps between registers
   * Varying the size of the Wishbone bus
 -}
 prop_wb :: Property

--- a/firmware-binaries/Cargo.lock
+++ b/firmware-binaries/Cargo.lock
@@ -38,9 +38,9 @@ dependencies = [
 
 [[package]]
 name = "bit_field"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc827186963e592360843fb5ba4b973e145841266c1357f7180c43526f2e5b61"
+checksum = "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6"
 
 [[package]]
 name = "bitflags"
@@ -67,7 +67,7 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -102,9 +102,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
 name = "clock-control"
@@ -283,9 +283,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.27"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
 name = "managed"
@@ -306,9 +306,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.5"
+version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "memmap-generate"
@@ -345,9 +345,9 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.95"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
 ]
@@ -363,9 +363,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
 dependencies = [
  "proc-macro2",
 ]
@@ -393,9 +393,9 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "regex"
-version = "1.11.1"
+version = "1.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+checksum = "8b5288124840bee7b386bc413c487869b360b2b4ec421ea56425128692f2a82c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -405,9 +405,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.9"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+checksum = "833eb9ce86d40ef33cb1306d8accf7bc8ec2bfea4355cbdebb3df68b40925cad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -416,12 +416,12 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
-name = "registerwbc_test"
+name = "registerwb_test"
 version = "0.1.0"
 dependencies = [
  "bittide-hal",
@@ -464,7 +464,7 @@ checksum = "f265be5d634272320a7de94cea15c22a3bfdd4eb42eb43edc528415f066a1f25"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -493,7 +493,7 @@ checksum = "30f19a85fe107b65031e0ba8ec60c34c2494069fe910d6c297f5e7cb5a6f76d0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -539,40 +539,51 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.142"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "030fedb782600dcbd6f02d479bf0d817ac3bb40d644745b769d6a96bc3afc5a7"
+checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
 dependencies = [
  "itoa",
  "memchr",
  "ryu",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -669,9 +680,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.104"
+version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
+checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -717,9 +728,9 @@ checksum = "e87a2ed6b42ec5e28cc3b94c09982969e9227600b2e3dcbc1db927a84c06bd69"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 
 [[package]]
 name = "void"

--- a/firmware-binaries/Cargo.toml
+++ b/firmware-binaries/Cargo.toml
@@ -17,7 +17,7 @@ members = [
   "examples/smoltcp_client",
 
   "test-cases/axi_stream_self_test",
-  "test-cases/registerwbc_test",
+  "test-cases/registerwb_test",
   "test-cases/capture_ugn_test",
   "test-cases/clock-control-wb",
   "test-cases/dna_port_e2_test",

--- a/firmware-binaries/test-cases/registerwb_test/Cargo.toml
+++ b/firmware-binaries/test-cases/registerwb_test/Cargo.toml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: CC0-1.0
 
 [package]
-name = "registerwbc_test"
+name = "registerwb_test"
 version = "0.1.0"
 edition = "2021"
 license = "Apache-2.0"

--- a/firmware-binaries/test-cases/registerwb_test/build.rs
+++ b/firmware-binaries/test-cases/registerwb_test/build.rs
@@ -18,7 +18,7 @@ fn memmap_dir() -> PathBuf {
 /// Put the linker script somewhere the linker can find it.
 fn main() {
     let memory_x = memory_x_from_memmap(
-        memmap_dir().join("RegisterWbC.json"),
+        memmap_dir().join("RegisterWb.json"),
         "DataMemory",
         "InstructionMemory",
     );

--- a/firmware-binaries/test-cases/registerwb_test/src/main.rs
+++ b/firmware-binaries/test-cases/registerwb_test/src/main.rs
@@ -9,7 +9,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use ufmt::{uwrite, uwriteln};
 
-use bittide_hal::hals::register_wb_c as hal;
+use bittide_hal::hals::register_wb as hal;
 use bittide_hal::index;
 
 use core::fmt::Write;

--- a/firmware-support/Cargo.lock
+++ b/firmware-support/Cargo.lock
@@ -48,9 +48,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.9.1"
+version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
 
 [[package]]
 name = "bittide-hal"
@@ -71,7 +71,7 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -102,9 +102,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cfg-if"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
 name = "crc32fast"
@@ -146,12 +146,12 @@ checksum = "361a90feb7004eca4019fb28352a9465666b24f840f5c3cddf0ff13920590b89"
 
 [[package]]
 name = "errno"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -209,7 +209,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi 0.14.2+wasi-0.2.4",
+ "wasi 0.14.7+wasi-0.2.4",
 ]
 
 [[package]]
@@ -286,21 +286,21 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.174"
+version = "0.2.176"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.4"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "log"
-version = "0.4.27"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
 name = "managed"
@@ -310,9 +310,9 @@ checksum = "0ca88d725a0a943b096803bd34e73a4437208b6077654cc4ecb2947a5f91618d"
 
 [[package]]
 name = "memchr"
-version = "2.7.5"
+version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "memmap-generate"
@@ -380,22 +380,22 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.95"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "proptest"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fcdab19deb5195a31cf7726a210015ff1496ba1464fd42cb4f537b8b01b471f"
+checksum = "2bb0be07becd10686a0bb407298fb425360a5c44a663774406340c59a22de4ce"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.9.1",
+ "bitflags 2.9.4",
  "lazy_static",
  "num-traits",
  "rand 0.9.2",
@@ -415,9 +415,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
 dependencies = [
  "proc-macro2",
 ]
@@ -498,9 +498,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
 name = "riscv"
@@ -523,7 +523,7 @@ checksum = "f265be5d634272320a7de94cea15c22a3bfdd4eb42eb43edc528415f066a1f25"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -534,15 +534,15 @@ checksum = "8188909339ccc0c68cfb5a04648313f09621e8b87dc03095454f1a11f6c5d436"
 
 [[package]]
 name = "rustix"
-version = "1.0.8"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.4",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -565,34 +565,45 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.142"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "030fedb782600dcbd6f02d479bf0d817ac3bb40d644745b769d6a96bc3afc5a7"
+checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
 dependencies = [
  "itoa",
  "memchr",
  "ryu",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -664,9 +675,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.104"
+version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
+checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -675,15 +686,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.20.0"
+version = "3.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
 dependencies = [
  "fastrand",
  "getrandom 0.3.3",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -733,9 +744,9 @@ checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 
 [[package]]
 name = "version_check"
@@ -760,191 +771,59 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
-version = "0.14.2+wasi-0.2.4"
+version = "0.14.7+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
 dependencies = [
- "wit-bindgen-rt",
+ "wasip2",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+dependencies = [
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "windows-link"
-version = "0.1.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
 
 [[package]]
 name = "windows-sys"
-version = "0.59.0"
+version = "0.61.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.3",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
+checksum = "6f109e41dd4a3c848907eb83d5a42ea98b3769495597450cf6d153507b166f0f"
 dependencies = [
  "windows-link",
- "windows_aarch64_gnullvm 0.53.0",
- "windows_aarch64_msvc 0.53.0",
- "windows_i686_gnu 0.53.0",
- "windows_i686_gnullvm 0.53.0",
- "windows_i686_msvc 0.53.0",
- "windows_x86_64_gnu 0.53.0",
- "windows_x86_64_gnullvm 0.53.0",
- "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
+name = "wit-bindgen"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
-
-[[package]]
-name = "wit-bindgen-rt"
-version = "0.39.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
-dependencies = [
- "bitflags 2.9.1",
-]
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.26"
+version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
+checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.26"
+version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
+checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]


### PR DESCRIPTION
Allows users of those registers to provide backpressure. This allows for the (easy) implementation of atomic operations. I.e., operations where we want the CPU to wait a little to make sure the hardware has had the time to process the bus transaction.

Fixes https://github.com/bittide/bittide-hardware/issues/772

--------------

Reviewers: note that this also renames the functions we have now, making this PR into a chonky one. The individual commits split this work out.

# TODO
- [x] Merge https://github.com/clash-lang/clash-protocols/pull/175
- [x] https://github.com/bittide/bittide-hardware/pull/995
- [X] Add tests