### PR TITLE
Use backpressure based control scheme in elastic buffer

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -42,6 +42,7 @@
   ],
   "rust-analyzer.check.allTargets": false,
   "cSpell.words": [
+    "backpressure",
     "bitstream",
     "bittide",
     "combinationally",

--- a/bittide-extra/bittide-extra.cabal
+++ b/bittide-extra/bittide-extra.cabal
@@ -147,6 +147,7 @@ library
     async,
     base,
     bytestring,
+    clash-cores,
     clash-prelude,
     containers,
     exceptions,
@@ -160,6 +161,7 @@ library
   exposed-modules:
     Bittide.Extra.Maybe
     Bittide.Extra.Wishbone
+    Clash.Cores.Xilinx.Xpm.Cdc.Extra
     Clash.Explicit.Signal.Extra
     Clash.Sized.Vector.Extra
     Control.Concurrent.Async.Extra
@@ -177,8 +179,8 @@ test-suite unittests
   hs-source-dirs: tests/unittests
   default-language: Haskell2010
   ghc-options: -threaded
-  hs-source-dirs: tests/doctests
   other-modules:
+    Tests.Clash.Cores.Xilinx.Xpm.Cdc.Extra
     Tests.Numeric.Extra
 
   build-depends:

--- a/bittide-extra/src/Clash/Cores/Xilinx/Xpm/Cdc/Extra.hs
+++ b/bittide-extra/src/Clash/Cores/Xilinx/Xpm/Cdc/Extra.hs
@@ -1,0 +1,142 @@
+-- SPDX-FileCopyrightText: 2025 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+
+module Clash.Cores.Xilinx.Xpm.Cdc.Extra (
+  safeXpmCdcHandshake,
+  xpmCdcHandshakeDf,
+) where
+
+import Clash.Explicit.Prelude
+import Protocols
+
+import Clash.Cores.Xilinx.Xpm.Cdc (xpmCdcHandshake)
+import GHC.Stack (HasCallStack)
+
+data SafeHandshakeState
+  = InReset
+  | WaitForRising
+  | WaitForFalling
+  deriving (Generic, NFDataX)
+
+-- | State machine for the source side of a safe handshake, see 'safeXpmCdcHandshake'.
+safeHandshakeSrcFsm ::
+  forall a dom.
+  (NFDataX a, KnownDomain dom) =>
+  Clock dom ->
+  Reset dom ->
+  Signal dom (Maybe a) ->
+  "src_rcv" ::: Signal dom Bool ->
+  ( "src_send" ::: Signal dom Bool
+  , "src_in" ::: Signal dom a
+  , Signal dom Ack
+  )
+safeHandshakeSrcFsm clk rst ins srcRcvs =
+  mealyB clk rst enableGen go InReset (ins, srcRcvs)
+ where
+  go :: SafeHandshakeState -> (Maybe a, Bool) -> (SafeHandshakeState, (Bool, a, Ack))
+  go InReset _ = (WaitForRising, noInput nack)
+  go WaitForRising (Nothing, _) = (WaitForRising, noInput nack)
+  go s@WaitForRising (Just a, rcv) = (if rcv then WaitForFalling else s, input a (Ack rcv))
+  go s@WaitForFalling (_, rcv) = (if rcv then s else WaitForRising, noInput nack)
+
+  noInput :: Ack -> (Bool, a, Ack)
+  noInput acknowledge = (False, deepErrorX "no input", acknowledge)
+
+  input :: a -> Ack -> (Bool, a, Ack)
+  input a acknowledge = (True, a, acknowledge)
+
+  nack :: Ack
+  nack = Ack False
+
+{- | State machine for the destination side of a safe handshake, see
+'safeXpmCdcHandshake'.
+-}
+safeHandshakeDstFsm ::
+  (KnownDomain dom) =>
+  Clock dom ->
+  Reset dom ->
+  Signal dom Ack ->
+  "dest_out" ::: Signal dom a ->
+  "dest_req" ::: Signal dom Bool ->
+  ( "dest_ack" ::: Signal dom Bool
+  , Signal dom (Maybe a)
+  )
+safeHandshakeDstFsm clk rst acks outs reqs =
+  mealyB clk rst enableGen go InReset (acks, outs, reqs)
+ where
+  go :: SafeHandshakeState -> (Ack, a, Bool) -> (SafeHandshakeState, (Bool, Maybe a))
+  go InReset _ = (WaitForRising, (False, Nothing))
+  go s@WaitForRising (~(Ack acknowledge), a, request)
+    | request = (if acknowledge then WaitForFalling else s, (acknowledge, Just a))
+    | otherwise = (s, (False, Nothing))
+  go s@WaitForFalling (_, _, request)
+    | request = (s, (True, Nothing))
+    | otherwise = (WaitForRising, (False, Nothing))
+
+{- | A wrapper around 'xpmCdcHandshake' that implements a 'Df'-like interface:
+
+  * If a 'Just' is given as an argument it should remain stable until an Ack is
+    returned. This means that it can neither transition to 'Nothing', nor can the
+    contents inside of the 'Just' change while @'Ack' 'False'@ is returned.
+
+  * The input value (@'Maybe' a@) cannot depend combinationally on the returned
+    'Ack'.
+
+This implements the state machine necessary to safely do a handshake, as described in
+the Xilinx documentation.
+
+If either side is reset, the other should be too. Though it doesn't matter in which
+order the resets are deasserted, the resets should be asserted for long enough for the
+handshake pipeline to flush. See the Xilinx documentation for more information.
+-}
+safeXpmCdcHandshake ::
+  forall a src dst.
+  ( 1 <= BitSize a
+  , BitSize a <= 1024
+  , KnownDomain src
+  , KnownDomain dst
+  , BitPack a
+  , NFDataX a
+  , HasCallStack
+  ) =>
+  Clock src ->
+  Reset src ->
+  Clock dst ->
+  Reset dst ->
+  Signal src (Maybe a) ->
+  Signal dst Ack ->
+  ( Signal src Ack
+  , Signal dst (Maybe a)
+  )
+safeXpmCdcHandshake clkSrc rstSrc clkDst rstDst srcData dstAck = (srcAck, dstData)
+ where
+  (srcSend, srcIn, srcAck) = safeHandshakeSrcFsm clkSrc rstSrc srcData srcRcv
+  (destAck, dstData) = safeHandshakeDstFsm clkDst rstDst dstAck destOut destReq
+  (destOut, destReq, srcRcv) = xpmCdcHandshake clkSrc clkDst srcIn srcSend destAck
+
+{- | 'Df' version of 'xpmCdcHandshake'.
+
+If either side is reset, the other should be too. Though it doesn't matter in which
+order the resets are deasserted, the resets should be asserted for long enough for the
+handshake pipeline to flush. See the Xilinx documentation for more information.
+-}
+xpmCdcHandshakeDf ::
+  forall a src dst.
+  ( 1 <= BitSize a
+  , BitSize a <= 1024
+  , KnownDomain src
+  , KnownDomain dst
+  , BitPack a
+  , NFDataX a
+  , HasCallStack
+  ) =>
+  Clock src ->
+  Reset src ->
+  Clock dst ->
+  Reset dst ->
+  Circuit (Df src a) (Df dst a)
+xpmCdcHandshakeDf clkSrc rstSrc clkDst rstDst = Circuit go
+ where
+  go :: (Signal src (Maybe a), Signal dst Ack) -> (Signal src Ack, Signal dst (Maybe a))
+  go (dat, ack) = safeXpmCdcHandshake clkSrc rstSrc clkDst rstDst dat ack

--- a/bittide-extra/tests/unittests/Main.hs
+++ b/bittide-extra/tests/unittests/Main.hs
@@ -9,10 +9,12 @@ import Prelude
 import Test.Tasty
 
 import Test.Tasty.Hedgehog (HedgehogTestLimit (..))
+
+import qualified Tests.Clash.Cores.Xilinx.Xpm.Cdc.Extra
 import qualified Tests.Numeric.Extra
 
 setDefaultHedgehogTestLimit :: HedgehogTestLimit -> HedgehogTestLimit
-setDefaultHedgehogTestLimit (HedgehogTestLimit Nothing) = HedgehogTestLimit (Just 10000)
+setDefaultHedgehogTestLimit (HedgehogTestLimit Nothing) = HedgehogTestLimit (Just 1000)
 setDefaultHedgehogTestLimit opt = opt
 
 tests :: TestTree
@@ -20,6 +22,7 @@ tests =
   testGroup
     "tests"
     [ Tests.Numeric.Extra.tests
+    , Tests.Clash.Cores.Xilinx.Xpm.Cdc.Extra.tests
     ]
 
 main :: IO ()

--- a/bittide-extra/tests/unittests/Tests/Clash/Cores/Xilinx/Xpm/Cdc/Extra.hs
+++ b/bittide-extra/tests/unittests/Tests/Clash/Cores/Xilinx/Xpm/Cdc/Extra.hs
@@ -1,0 +1,97 @@
+-- SPDX-FileCopyrightText: 2025 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Tests.Clash.Cores.Xilinx.Xpm.Cdc.Extra where
+
+import Clash.Explicit.Prelude
+
+import Hedgehog (Gen, Property, Range)
+import Protocols.Hedgehog (ExpectOptions (..), defExpectOptions, idWithModel)
+import Test.Tasty (TestTree, defaultMain)
+import Test.Tasty.Hedgehog (testProperty)
+import Test.Tasty.TH (testGroupGenerator)
+
+import Clash.Cores.Xilinx.Xpm.Cdc.Extra (xpmCdcHandshakeDf)
+
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
+
+createDomain vSystem{vName = "Slow", vPeriod = 10000}
+createDomain vSystem{vName = "Fast", vPeriod = 1000}
+
+smallInt :: Range Int
+smallInt = Range.linear 0 10
+
+genSmallInt :: Gen Int
+genSmallInt =
+  Gen.frequency
+    [ (90, Gen.integral smallInt)
+    , (10, Gen.constant (Range.lowerBound 99 smallInt))
+    ]
+
+genData :: Gen a -> Gen [a]
+genData genA = do
+  n <- genSmallInt
+  Gen.list (Range.singleton n) genA
+
+-- | Number of reset cycles to use in these tests
+nResetCycles :: SNat 30
+nResetCycles = d30
+
+{- | Custom expect options for these tests. The values are picked such that the
+stalls generated have more than enough time to propagate through the CDC and
+back. The 'eoStopAfterEmpty' is picked experimentally -- if the test fails it
+/probably/ means that it should be increased.
+-}
+xpmExpectOptions :: ExpectOptions
+xpmExpectOptions =
+  defExpectOptions
+    { eoConsecutiveStalls = 100
+    , eoStopAfterEmpty = Just 2000
+    , eoResetCycles = snatToNum nResetCycles
+    }
+
+prop_xpmCdcHandshakeDf_same_domain :: Property
+prop_xpmCdcHandshakeDf_same_domain =
+  idWithModel
+    xpmExpectOptions
+    (genData genSmallInt)
+    id
+    (xpmCdcHandshakeDf clk rst clk rst)
+ where
+  clk = clockGen @Fast
+  rst = resetGenN @Fast nResetCycles
+
+prop_xpmCdcHandshakeDf_slow_fast :: Property
+prop_xpmCdcHandshakeDf_slow_fast =
+  idWithModel
+    xpmExpectOptions
+    (genData genSmallInt)
+    id
+    (xpmCdcHandshakeDf clkSrc rstSrc clkDst rstDst)
+ where
+  clkSrc = clockGen @Slow
+  rstSrc = resetGenN @Slow nResetCycles
+  clkDst = clockGen @Fast
+  rstDst = resetGenN @Fast nResetCycles
+
+prop_xpmCdcHandshakeDf_fast_slow :: Property
+prop_xpmCdcHandshakeDf_fast_slow =
+  idWithModel
+    xpmExpectOptions
+    (genData genSmallInt)
+    id
+    (xpmCdcHandshakeDf clkSrc rstSrc clkDst rstDst)
+ where
+  clkSrc = clockGen @Fast
+  rstSrc = resetGenN @Fast nResetCycles
+  clkDst = clockGen @Slow
+  rstDst = resetGenN @Slow nResetCycles
+
+tests :: TestTree
+tests = $(testGroupGenerator)
+
+main :: IO ()
+main = defaultMain tests

--- a/bittide-instances/src/Bittide/Instances/Hitl/FincFdec.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/FincFdec.hs
@@ -211,7 +211,7 @@ fincFdecTests diffClk controlledDiffClock spiIn =
 
   testInput :: Signal Basic200 (Maybe Test)
   testInput = hitlVio FDec clk testDone testSuccess
-{-# NOINLINE fincFdecTests #-}
+{-# OPAQUE fincFdecTests #-}
 makeTopEntity 'fincFdecTests
 
 tests :: HitlTestGroup

--- a/bittide-instances/src/Bittide/Instances/Hitl/VexRiscv.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/VexRiscv.hs
@@ -220,7 +220,7 @@ vexRiscvTest diffClk jtagIn uartRx = (testStatusDone, testStatusSuccess, jtagOut
   --       do this once more.
   testDone = testStarted
   testSuccess = testStarted
-{-# NOINLINE vexRiscvTest #-}
+{-# OPAQUE vexRiscvTest #-}
 makeTopEntity 'vexRiscvTest
 
 tests :: HitlTestGroup

--- a/bittide-instances/src/Bittide/Instances/Pnr/ElasticBuffer.hs
+++ b/bittide-instances/src/Bittide/Instances/Pnr/ElasticBuffer.hs
@@ -21,8 +21,8 @@ elasticBuffer5 ::
   "writeData" ::: Signal Slow (Unsigned 8) ->
   ( "dataCount" ::: Signal Fast (RelDataCount 5)
   , "underflow" ::: Signal Fast Underflow
-  , "overrflow" ::: Signal Fast Overflow
-  , "ebMode" ::: Signal Fast EbMode
+  , "overflow" ::: Signal Fast Overflow
+  , "stable" ::: Signal Fast Stable
   , "readData" ::: Signal Fast (Unsigned 8)
   )
 elasticBuffer5 = resettableXilinxElasticBuffer

--- a/bittide-instances/src/Bittide/Instances/Pnr/ScatterGather.hs
+++ b/bittide-instances/src/Bittide/Instances/Pnr/ScatterGather.hs
@@ -73,7 +73,7 @@ scatterUnit1K clk rst wbCal linkIn wbScat =
   withBigEndian
     $ (\(wbA, wbB, _mm) -> (wbA, wbB))
     $ withClockResetEnable clk rst enableGen (scatterUnitWb scatterCal1K wbCal linkIn wbScat)
-{-# NOINLINE scatterUnit1K #-}
+{-# OPAQUE scatterUnit1K #-}
 
 scatterUnit1KReducedPins ::
   Clock Basic200 -> Reset Basic200 -> Signal Basic200 Bit -> Signal Basic200 Bit
@@ -116,7 +116,7 @@ gatherUnit1K clk rst wbCal wbGat =
     $ (\(link, wbA, wbB, _mm) -> (link, wbA, wbB))
     $ withClockResetEnable clk rst enableGen
     $ gatherUnitWb gatherCal1K wbCal wbGat
-{-# NOINLINE gatherUnit1K #-}
+{-# OPAQUE gatherUnit1K #-}
 
 gatherUnit1KReducedPins ::
   Clock Basic200 -> Reset Basic200 -> Signal Basic200 Bit -> Signal Basic200 Bit

--- a/bittide-instances/src/Bittide/Instances/Tests/RegisterWb.hs
+++ b/bittide-instances/src/Bittide/Instances/Tests/RegisterWb.hs
@@ -403,7 +403,7 @@ dut =
         , dBusTimeout = d0 -- No timeouts on the data bus
         , includeIlaWb = False
         }
-{-# NOINLINE dut #-}
+{-# OPAQUE dut #-}
 
 memoryMap :: MemoryMap
 memoryMap = getMMAny dut0

--- a/bittide-instances/src/Bittide/Instances/Tests/ScatterGather.hs
+++ b/bittide-instances/src/Bittide/Instances/Tests/ScatterGather.hs
@@ -95,7 +95,7 @@ dut = withBittideByteOrder $ circuit $ \mm -> do
         , dBusTimeout = d0 -- No timeouts on the data bus
         , includeIlaWb = False
         }
-{-# NOINLINE dut #-}
+{-# OPAQUE dut #-}
 
 type IMemWords = DivRU (64 * 1024) 4
 type DMemWords = DivRU (32 * 1024) 4

--- a/bittide-instances/src/Bittide/Instances/Tests/SwitchCalendar.hs
+++ b/bittide-instances/src/Bittide/Instances/Tests/SwitchCalendar.hs
@@ -92,7 +92,7 @@ dut =
         , dBusTimeout = d0 -- No timeouts on the data bus
         , includeIlaWb = False
         }
-{-# NOINLINE dut #-}
+{-# OPAQUE dut #-}
 
 type IMemWords = DivRU (128 * 1024) 4
 type DMemWords = DivRU (128 * 1024) 4

--- a/bittide-instances/tests/Tests/ClockControlWb.hs
+++ b/bittide-instances/tests/Tests/ClockControlWb.hs
@@ -157,7 +157,7 @@ dut =
         , dBusTimeout = d0
         , includeIlaWb = False
         }
-{-# NOINLINE dut #-}
+{-# OPAQUE dut #-}
 
 type IMemWords = DivRU (64 * 1024) 4
 type DMemWords = DivRU (32 * 1024) 4

--- a/bittide-instances/tests/Wishbone/Axi.hs
+++ b/bittide-instances/tests/Wishbone/Axi.hs
@@ -108,7 +108,7 @@ dut =
         , dBusTimeout = d0 -- No timeouts on the data bus
         , includeIlaWb = False
         }
-{-# NOINLINE dut #-}
+{-# OPAQUE dut #-}
 
 type IMemWords = DivRU (64 * 1024) 4
 type DMemWords = DivRU (32 * 1024) 4

--- a/bittide-instances/tests/Wishbone/DnaPortE2.hs
+++ b/bittide-instances/tests/Wishbone/DnaPortE2.hs
@@ -79,7 +79,7 @@ dut = withBittideByteOrder $ circuit $ \_unit -> do
         , dBusTimeout = d0 -- No timeouts on the data bus
         , includeIlaWb = False
         }
-{-# NOINLINE dut #-}
+{-# OPAQUE dut #-}
 
 type IMemWords = DivRU (64 * 1024) 4
 type DMemWords = DivRU (32 * 1024) 4

--- a/bittide-instances/tests/Wishbone/Time.hs
+++ b/bittide-instances/tests/Wishbone/Time.hs
@@ -83,7 +83,7 @@ dut = withBittideByteOrder
         , dBusTimeout = d0 -- No timeouts on the data bus
         , includeIlaWb = False
         }
-{-# NOINLINE dut #-}
+{-# OPAQUE dut #-}
 
 type IMemWords = DivRU (64 * 1024) 4
 type DMemWords = DivRU (32 * 1024) 4

--- a/bittide-instances/tests/Wishbone/Watchdog.hs
+++ b/bittide-instances/tests/Wishbone/Watchdog.hs
@@ -95,7 +95,7 @@ dut = withBittideByteOrder
         , dBusTimeout = d0 -- No timeouts on the data bus
         , includeIlaWb = False
         }
-{-# NOINLINE dut #-}
+{-# OPAQUE dut #-}
 
 type IMemWords = DivRU (64 * 1024) 4
 type DMemWords = DivRU (32 * 1024) 4

--- a/bittide/src/Bittide/Axi4.hs
+++ b/bittide/src/Bittide/Axi4.hs
@@ -84,7 +84,7 @@ the following holds:
 -}
 type PackedAxi4Stream dom conf userType = Axi4Stream dom conf userType
 
-{-# NOINLINE axiStreamFromByteStream #-}
+{-# OPAQUE axiStreamFromByteStream #-}
 
 {- | Transforms an 'Axi4Stream' of 1 byte wide into an 'Axi4Stream' of /n/ bytes
 wide. If it encounters '_tlast' or has captured /n/ bytes, it will present
@@ -192,7 +192,7 @@ data WbAxisRxBufferState bufferDepth wbBytes = WbAxisRxBufferState
   }
   deriving (Generic, NFDataX, Show)
 
-{-# NOINLINE wbAxisRxBuffer #-}
+{-# OPAQUE wbAxisRxBuffer #-}
 
 -- TODO: Replace with PacketStream
 

--- a/bittide/src/Bittide/Calendar.hs
+++ b/bittide/src/Bittide/Calendar.hs
@@ -168,7 +168,7 @@ data BufferControl calDepth calEntry = BufferControl
   -- ^ Write operation for buffer B.
   }
 
-{-# NOINLINE calendar #-}
+{-# OPAQUE calendar #-}
 
 {- | Hardware component that stores an active bittide calendar and a shadow bittide calendar.
 The entries of the active calendar will be sequentially provided at the output,

--- a/bittide/src/Bittide/ClockControl/Si539xSpi.hs
+++ b/bittide/src/Bittide/ClockControl/Si539xSpi.hs
@@ -329,7 +329,7 @@ si539xSpiDriver SNat incomingOpS miso = (fromSlave, decoderBusy, spiOut)
 
     spiBytes = spiCommandToBytes spiCommand
     output = orNothing (not commandAcknowledged && idleCycles == 0) spiBytes
-{-# NOINLINE si539xSpiDriver #-}
+{-# OPAQUE si539xSpiDriver #-}
 
 -- TODO: Look into replacing dcFifo with XPM_CDC_Handshake.
 
@@ -416,7 +416,7 @@ spiFrequencyController
         (True, SlowDown, _, False) ->
           Just RegisterOperation{regPage = 0x00, regAddress = 0x1D, regWrite = Just 2}
         _ -> Nothing
-{-# NOINLINE spiFrequencyController #-}
+{-# OPAQUE spiFrequencyController #-}
 
 {- | When this component receives @True@, it will hold it for @holdCycles@ number of
 clock cycles. This implementation does not scale well to large values for @holdCycles@

--- a/bittide/src/Bittide/DoubleBufferedRam.hs
+++ b/bittide/src/Bittide/DoubleBufferedRam.hs
@@ -263,7 +263,7 @@ wbStorage memoryName initContent = Circuit $ \(((), m2s), ()) ->
       , definitionLoc = locHere
       , tags = []
       }
-{-# NOINLINE wbStorage #-}
+{-# OPAQUE wbStorage #-}
 
 -- | Storage element with a single wishbone port. Allows for word-aligned addresses.
 wbStorage' ::
@@ -554,7 +554,7 @@ registerWb ::
 registerWb writePriority initVal wbIn sigIn =
   registerWbE writePriority initVal wbIn sigIn (pure maxBound)
 
-{-# NOINLINE registerWbE #-}
+{-# OPAQUE registerWbE #-}
 
 {- | Register with additional wishbone interface, this component has a configurable
 priority that determines which value gets stored in the register during a write conflict.

--- a/bittide/src/Bittide/ElasticBuffer.hs
+++ b/bittide/src/Bittide/ElasticBuffer.hs
@@ -31,7 +31,7 @@ ebModeToReadWrite = \case
   Drain -> (True, False)
   Pass -> (True, True)
 
-{-# NOINLINE sticky #-}
+{-# OPAQUE sticky #-}
 
 -- | Create a sticky version of a boolean signal.
 sticky ::
@@ -44,7 +44,7 @@ sticky clk rst a = stickyA
  where
   stickyA = E.register clk rst enableGen False (stickyA .||. a)
 
-{-# NOINLINE xilinxElasticBuffer #-}
+{-# OPAQUE xilinxElasticBuffer #-}
 
 {- | An elastic buffer backed by a Xilinx FIFO. It exposes all its control and
 monitor signals in its read domain.
@@ -118,7 +118,7 @@ xilinxElasticBuffer clkRead clkWrite rstRead ebMode wdata =
 
   writeData = mux writeEnableSynced (Just <$> wdata) (pure Nothing)
 
-{-# NOINLINE resettableXilinxElasticBuffer #-}
+{-# OPAQUE resettableXilinxElasticBuffer #-}
 
 {- | Wrapper around 'xilinxElasticBuffer' that contains a state machine to fill the
 buffer half-full. When it is, it switches to pass-through mode, which it exports

--- a/bittide/src/Bittide/ElasticBuffer.hs
+++ b/bittide/src/Bittide/ElasticBuffer.hs
@@ -4,32 +4,27 @@
 
 module Bittide.ElasticBuffer where
 
+import Bittide.ClockControl (RelDataCount, targetDataCount)
+import Bittide.Extra.Maybe (orNothing)
 import Clash.Cores.Xilinx.DcFifo
+import Clash.Cores.Xilinx.Xpm.Cdc.Extra (safeXpmCdcHandshake)
 import Clash.Prelude
 import GHC.Stack
-
-import Bittide.ClockControl (RelDataCount, targetDataCount)
+import Protocols (Ack (..))
 
 import qualified Clash.Cores.Extra as CE
 import qualified Clash.Explicit.Prelude as E
 
-data EbMode
+data EbCommand
   = -- | Disable write, enable read
     Drain
   | -- | Enable write, disable read
     Fill
-  | -- | Enable write, enable read
-    Pass
   deriving (Generic, NFDataX, Eq, Show)
 
 type Underflow = Bool
 type Overflow = Bool
-
-ebModeToReadWrite :: EbMode -> (Bool, Bool)
-ebModeToReadWrite = \case
-  Fill -> (False, True)
-  Drain -> (True, False)
-  Pass -> (True, True)
+type Stable = Bool
 
 {-# OPAQUE sticky #-}
 
@@ -64,7 +59,9 @@ xilinxElasticBuffer ::
   -- | Resetting resets the 'Underflow' and 'Overflow' signals, but not the 'RelDataCount'
   -- ones. Make sure to hold the reset at least 3 cycles in both clock domains.
   Reset readDom ->
-  Signal readDom EbMode ->
+  -- | Operating mode of the elastic buffer. Must remain stable until an acknowledgement
+  -- is received.
+  Signal readDom (Maybe EbCommand) ->
   Signal writeDom a ->
   ( Signal readDom (RelDataCount n)
   , -- Indicates whether the FIFO under or overflowed. This signal is sticky: it
@@ -72,8 +69,10 @@ xilinxElasticBuffer ::
     Signal readDom Underflow
   , Signal writeDom Overflow
   , Signal readDom a
+  , -- Acknowledgement for EbMode
+    Signal readDom Ack
   )
-xilinxElasticBuffer clkRead clkWrite rstRead ebMode wdata =
+xilinxElasticBuffer clkRead clkWrite rstRead command wdata =
   ( -- Note that this is chosen to work for 'RelDataCount' either being
     -- set to 'Signed' with 'targetDataCount' equals 0 or set to
     -- 'Unsigned' with 'targetDataCount' equals 'shiftR maxBound 1 + 1'.
@@ -86,6 +85,7 @@ xilinxElasticBuffer clkRead clkWrite rstRead ebMode wdata =
   , isUnderflowSticky
   , isOverflowSticky
   , fifoData
+  , commandAck
   )
  where
   rstWrite = unsafeFromActiveHigh rstWriteBool
@@ -112,11 +112,25 @@ xilinxElasticBuffer clkRead clkWrite rstRead ebMode wdata =
   noResetWrite = unsafeFromActiveHigh (pure False)
   noResetRead = unsafeFromActiveHigh (pure False)
 
-  (readEnable, writeEnable) = unbundle (ebModeToReadWrite <$> ebMode)
+  drain = command .== Just Drain
+  commandAck = mux drain drainAck otherAck
+  otherAck = pure $ Ack True
+  readEnable = command ./= Just Fill
 
-  writeEnableSynced = CE.safeDffSynchronizer clkRead clkWrite False writeEnable
-
-  writeData = mux writeEnableSynced (Just <$> wdata) (pure Nothing)
+  -- TODO: Instead of hoisting over a flag to drain a single element, we could
+  --       hoist over a count to drain multiple elements at once. This would
+  --       significantly reduce the overhead induced by the handshake.
+  drainFlag = orNothing <$> drain <*> pure high
+  drainSynced = drainFlagSynced .== Just high
+  writeData = mux drainSynced (pure Nothing) (Just <$> wdata)
+  (drainAck, drainFlagSynced) =
+    safeXpmCdcHandshake
+      clkRead
+      E.noReset
+      clkWrite
+      E.noReset
+      drainFlag
+      (pure (Ack True))
 
 {-# OPAQUE resettableXilinxElasticBuffer #-}
 
@@ -143,13 +157,13 @@ resettableXilinxElasticBuffer ::
   ( Signal readDom (RelDataCount n)
   , Signal readDom Underflow
   , Signal readDom Overflow
-  , Signal readDom EbMode
+  , Signal readDom Stable
   , Signal readDom a
   )
 resettableXilinxElasticBuffer clkRead clkWrite rstRead wdata =
-  (dataCount, under, over1, ebMode, readData)
+  (dataCount, under, over1, stable, readData)
  where
-  (dataCount, under, over, readData) =
+  (dataCount, under, over, readData, commandAck) =
     xilinxElasticBuffer @n clkRead clkWrite fifoReset ebMode wdata
   over1 = CE.safeDffSynchronizer clkWrite clkRead False over
 
@@ -161,21 +175,33 @@ resettableXilinxElasticBuffer clkRead clkWrite rstRead wdata =
   controllerReset = unsafeFromActiveHigh (unsafeToActiveHigh rstRead .||. under .||. over1)
 
   (ebMode, stable) =
-    unbundle
-      $ withClockResetEnable clkRead controllerReset enableGen
-      $ mealy goControl Drain dataCount
+    withClockResetEnable clkRead controllerReset enableGen
+      $ mealyB goControl InReset (commandAck, dataCount)
 
-  goControl :: EbMode -> RelDataCount n -> (EbMode, (EbMode, Bool))
-  goControl state0 datacount = (state1, (state0, stable0))
+  -- TODO: Moving the elastic buffers to their midpoints should happen in software
+  goControl ::
+    FillControlState ->
+    (Ack, RelDataCount n) ->
+    ( FillControlState
+    , (Maybe EbCommand, Stable)
+    )
+  goControl state0 (~(Ack ack), datacount) = (state1, (command, state1 == Stable))
    where
+    command = case state0 of
+      Filling -> Just Fill
+      Draining -> Just Drain
+      _ -> Nothing
+
     state1 =
       case state0 of
-        Drain
-          | datacount == minBound -> Fill
-          | otherwise -> Drain
-        Fill
-          | datacount < targetDataCount -> Fill
-          | otherwise -> Pass
-        Pass -> state0
+        InReset -> Filling
+        Filling | datacount > targetDataCount && ack -> Draining
+        Draining | datacount <= targetDataCount && ack -> Stable
+        _ -> state0
 
-    stable0 = state0 == Pass
+data FillControlState
+  = InReset
+  | Filling
+  | Draining
+  | Stable
+  deriving (Eq, Show, Generic, NFDataX)

--- a/bittide/src/Bittide/Node.hs
+++ b/bittide/src/Bittide/Node.hs
@@ -107,7 +107,7 @@ data GppeConfig nmuRemBusWidth where
     DumpVcd ->
     GppeConfig nmuRemBusWidth
 
-{-# NOINLINE gppeC #-}
+{-# OPAQUE gppeC #-}
 
 {- | A general purpose 'processingElement' to be part of a Bittide Node. It contains
 a 'processingElement', 'linkToPe' and 'peToLink' which create the interface for the

--- a/bittide/src/Bittide/ScatterGather.hs
+++ b/bittide/src/Bittide/ScatterGather.hs
@@ -201,7 +201,7 @@ addStalling endOfMetacycle metacycleCount (incomingBus@WishboneS2M{..}, wbAddr, 
     | otherwise = (incomingBus, writeOp0)
   memAddr = bitCoerce $ resize wbAddr
 
-{-# NOINLINE scatterUnitWb #-}
+{-# OPAQUE scatterUnitWb #-}
 
 scatterUnitWbC ::
   forall dom awSu nBytesCal awCal.
@@ -336,7 +336,7 @@ scatterUnitWb (ScatterConfig _memDepth calConfig) wbInCal linkIn wbInSu =
   selected = register (errorX "scatterUnitWb: Initial selection undefined") upperSelected
   scatteredData = mux selected upper lower
 
-{-# NOINLINE gatherUnitWb #-}
+{-# OPAQUE gatherUnitWb #-}
 
 gatherUnitWbC ::
   forall dom awGu nBytesCal awCal.

--- a/bittide/src/Bittide/Switch.hs
+++ b/bittide/src/Bittide/Switch.hs
@@ -53,7 +53,7 @@ switchC conf = case (cancelMulDiv @nBytes @8) of
      where
       (streamsOut, calS2M, cal, memMap) = switch conf calM2S streamsIn
 
-{-# NOINLINE switch #-}
+{-# OPAQUE switch #-}
 
 -- TODO: The switch is currently hardcoded to be bidirectional, we intend to change this when
 -- the need arises.
@@ -96,7 +96,7 @@ switch calConfig calM2S streamsIn = (streamsOut, calS2M, cal, mm)
   gatherFrames = unbundle $ crossBar 0 <$> cal <*> bundle scatterFrames
   streamsOut = register 0 <$> gatherFrames
 
-{-# NOINLINE crossBar #-}
+{-# OPAQUE crossBar #-}
 
 {- | The 'crossbar' receives a vector of indices and a vector of incoming frames.
 For each outgoing link it will select a data source. @0@ selects a null frame @Nothing@,

--- a/bittide/src/Bittide/Transceiver.hs
+++ b/bittide/src/Bittide/Transceiver.hs
@@ -685,11 +685,10 @@ transceiverPrbsWith gthCore opts args@Input{clock, reset} =
   rxUserData = sticky rxClock rxReset rxLast
   txUserData = sticky txClock txReset txLast
 
-  -- Investigate: should `txLast` be mentioned here?
-  indicateRxReady = txLast .||. withLockRxTx (prbsOkDelayed .&&. sticky rxClock rxReset args.rxReady)
+  indicateRxReady = withLockRxTx (prbsOkDelayed .&&. sticky rxClock rxReset args.rxReady)
 
   rxReadyNeighborSticky = sticky rxClock rxReset rxReadyNeighbor
-  txLast = args.txStart .&&. withLockRxTx rxReadyNeighborSticky
+  txLast = indicateRxReady .&&. args.txStart .&&. withLockRxTx rxReadyNeighborSticky
   txLastFree = xpmCdcSingle txClock clock txLast
 
   metaTx :: Signal tx Meta

--- a/bittide/src/Bittide/Wishbone.hs
+++ b/bittide/src/Bittide/Wishbone.hs
@@ -102,7 +102,7 @@ singleMasterInterconnectC = Circuit go
         }
     (s2m, m2ss) = toSignals (singleMasterInterconnect prefixes) (m2s, s2ms)
 
-{-# NOINLINE singleMasterInterconnect #-}
+{-# OPAQUE singleMasterInterconnect #-}
 
 {- | Component that maps multiple slave devices to a single master device over the wishbone
 bus. It routes the incoming control signals to a slave device based on the 'MemoryMap',

--- a/bittide/src/Clash/Cores/Xilinx/GTH/Internal.hs
+++ b/bittide/src/Clash/Cores/Xilinx/GTH/Internal.hs
@@ -159,7 +159,7 @@ xilinxGthUserClockNetworkTx clkIn rstIn = (unPort usrclk_out, unPort usrclk2_out
     , Port "gtwiz_userclk_tx_active_out" user2 Bit
     )
   go = inst (instConfig "gtwizard_ultrascale_v1_7_13_gtwiz_userclk_tx")
-{-# NOINLINE xilinxGthUserClockNetworkTx #-}
+{-# OPAQUE xilinxGthUserClockNetworkTx #-}
 
 xilinxGthUserClockNetworkRx ::
   forall user user2.
@@ -179,7 +179,7 @@ xilinxGthUserClockNetworkRx clkIn rstIn = (unPort usrclk_out, unPort usrclk2_out
     , Port "gtwiz_userclk_rx_active_out" user2 Bit
     )
   go = inst (instConfig "gtwizard_ultrascale_v1_7_13_gtwiz_userclk_rx")
-{-# NOINLINE xilinxGthUserClockNetworkRx #-}
+{-# OPAQUE xilinxGthUserClockNetworkRx #-}
 
 ibufds_gte3 :: (KnownDomain dom) => DiffClock dom -> Clock dom
 ibufds_gte3 !_clk = clockGen

--- a/bittide/tests/Tests/Transceiver.hs
+++ b/bittide/tests/Tests/Transceiver.hs
@@ -35,7 +35,7 @@ import qualified Language.Haskell.TH as TH
 
 createDomain vSystem{vName = "RefIsUnused"}
 
--- Note that these domains are a factor of ~5_000 slower than we use in practise. We
+-- Note that these domains are a factor of ~5_000 slower than we use in practice. We
 -- do this because timeouts in the transceivers are specified in milliseconds, which
 -- makes the simulation simply do "nothing" for a while. Also note the frequencies
 -- of domain A and B are slightly different - which is a realistic property of
@@ -54,7 +54,7 @@ createDomain
   vSystem{vName = "FreeFast", vResetKind = Synchronous, vPeriod = hzToPeriod 120e3}
 
 {- | A signal that changes every cycle. It is used to simulate the RX's data when
-it's receiving nothing. In theory this is white noise, in practise its a
+it's receiving nothing. In theory this is white noise, in practice its a
 rotating bit pattern.
 -}
 noise :: (KnownDomain dom) => Clock dom -> Signal dom (BitVector 64)
@@ -293,14 +293,14 @@ dutRandomized f inputA inputB Proxy = property $ do
   txDoneB <- fromIntegral <$> forAll genTimeoutMax
 
   -- XXX: Note that a single, static offset is generated. This is not realistic:
-  --      in practise, the offset is random, and "determined" after resetting the
+  --      in practice, the offset is random, and "determined" after resetting the
   --      rx subsystem. We currently don't rely on this behavior, due to the logic
   --      in "Bittide.Transceiver.WordAlign".
   aOffset <- forAll (genIndex Range.constantBounded)
   bOffset <- forAll (genIndex Range.constantBounded)
 
   -- A cable of 1km "stores" 42 words of 64 bits. In theory these links can be
-  -- assymetric, although they rarely are in practise.
+  -- asymmetric, although they rarely are in practice.
   abDelay <- fromIntegral <$> forAll (Gen.word64 (Range.linear 0 42))
   baDelay <- fromIntegral <$> forAll (Gen.word64 (Range.linear 0 42))
 
@@ -539,9 +539,9 @@ tests =
           "Very slow tests"
           -- These tests are "very slow" because they cannot exit early on some
           -- condition. Instead, they just wait for some deadline, and if they don't
-          -- see an errornous condition by then, they pass.
-          [ testPropertyNamed "prop_noTxReady" "prop_noTxReady" prop_noTxReady
-          , testPropertyNamed "prop_noTxReadyFlipped" "prop_noTxReadyFlipped" prop_noTxReadyFlipped
-          , testPropertyNamed "prop_noRxReady" "prop_noRxReady" prop_noRxReady
+          -- see an erroneous condition by then, they pass.
+          [ testPropertyThName 'prop_noTxReady prop_noTxReady
+          , testPropertyThName 'prop_noTxReadyFlipped prop_noTxReadyFlipped
+          , testPropertyThName 'prop_noRxReady prop_noRxReady
           ]
     ]

--- a/bittide/tests/Tests/Transceiver.hs
+++ b/bittide/tests/Tests/Transceiver.hs
@@ -472,6 +472,21 @@ prop_noRxReady :: Property
 prop_noRxReady =
   dutRandomized @A @A @Free testNeitherUp500ms noRxReadyInput noRxReadyInput Proxy
 
+{- | Check that neither node indicates it is sending *and* receiving user data,
+when one of the nodes never indicates it's ready to receive data. The side that
+never indicates it's ready to receive data, should also never start sending user
+data, because it would lose the ability to apply backpressure. The other side
+should then naturally also not claim it is receiving user data.
+-}
+prop_noRxReadyNoPressure :: Property
+prop_noRxReadyNoPressure =
+  dutRandomized @A @A @Free testNeitherUp500ms noRxReadyInput noPressureInput Proxy
+
+-- | Same as 'prop_noRxReadyNoPressure', but flipped.
+prop_noPressureNoRxReady :: Property
+prop_noPressureNoRxReady =
+  dutRandomized @A @A @Free testNeitherUp500ms noPressureInput noRxReadyInput Proxy
+
 {- | Check that nodes complete their handshake, even when the users never indicate
 that they're ready to receive data.
 -}
@@ -543,5 +558,7 @@ tests =
           [ testPropertyThName 'prop_noTxReady prop_noTxReady
           , testPropertyThName 'prop_noTxReadyFlipped prop_noTxReadyFlipped
           , testPropertyThName 'prop_noRxReady prop_noRxReady
+          , testPropertyThName 'prop_noRxReadyNoPressure prop_noRxReadyNoPressure
+          , testPropertyThName 'prop_noPressureNoRxReady prop_noPressureNoRxReady
           ]
     ]


### PR DESCRIPTION
This PR makes the first steps towards UGN groomable elastic buffers. Lucas started this in https://github.com/bittide/bittide-hardware/pull/964, trying to change the elastic buffers and integrate them into a CPU at the same time. He saw two issues:

1. The switch demo test became _incredibly_ slow at finding UGNs.
2. The switch demo would fail to find UGNs on some nodes for some links.

I couldn't find the root cause for :one:, but replacing the implicit state machines in the CDC code with explicit ones seems to have fixed the issue. I _think_ it had something to do with resets, which I've also added explicitly now (and I test for in the tests). Again, I'm unsure and regrettably I couldn't talk to Lucas about it, given that he is on holiday.

For :two: I have been able to track it down to the transceivers transitioning to user data too quickly. For details, see the commit.

# Future work
Once this PR is merged, #964 should be picked up again to refactor the elastic buffer into something the CPUs can directly access. This is a bit more work than it seems, because we'd probably want to move the middling algorithm to software - implying a bunch of refactors.

# Other notes
I've attributed all code to Lucas still, though I've added myself as a co-author too.