### PR TITLE
Bump docker cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
     name: Populate Cachix cache
     runs-on: [self-hosted, compute]
     container:
-      image: ghcr.io/clash-lang/nixos-bittide-hardware:2025-08-05
+      image: ghcr.io/clash-lang/nixos-bittide-hardware:2025-10-06
       options: --memory=11g
     steps:
     - uses: actions/checkout@v4
@@ -71,7 +71,7 @@ jobs:
         shell: git-nix-shell {0}
 
     container:
-      image: ghcr.io/clash-lang/nixos-bittide-hardware:2025-08-05
+      image: ghcr.io/clash-lang/nixos-bittide-hardware:2025-10-06
       options: --memory=11g
 
     steps:
@@ -138,7 +138,7 @@ jobs:
         shell: git-nix-shell {0} --ignore-environment
 
     container:
-      image: ghcr.io/clash-lang/nixos-bittide-hardware:2025-08-05
+      image: ghcr.io/clash-lang/nixos-bittide-hardware:2025-10-06
       options: --memory=11g
 
     steps:
@@ -189,7 +189,7 @@ jobs:
       fail-fast: false
 
     container:
-      image: ghcr.io/clash-lang/nixos-bittide-hardware:2025-08-05
+      image: ghcr.io/clash-lang/nixos-bittide-hardware:2025-10-06
       options: --memory=11g
 
     env:
@@ -252,7 +252,7 @@ jobs:
       run:
         shell: git-nix-shell {0}
     container:
-      image: ghcr.io/clash-lang/nixos-bittide-hardware:2025-08-05
+      image: ghcr.io/clash-lang/nixos-bittide-hardware:2025-10-06
       options: --memory=11g
     outputs:
       run_tests: ${{ steps.check.outputs.run_tests }}
@@ -284,7 +284,7 @@ jobs:
     if: ${{ needs.should-run-haskell-tests.outputs.run_tests == 'true' }}
 
     container:
-      image: ghcr.io/clash-lang/nixos-bittide-hardware:2025-08-05
+      image: ghcr.io/clash-lang/nixos-bittide-hardware:2025-10-06
       options: --memory=11g
       volumes:
         - /opt/tools:/opt/tools
@@ -358,7 +358,7 @@ jobs:
       run:
         shell: git-nix-shell {0} --ignore-environment
     container:
-      image: ghcr.io/clash-lang/nixos-bittide-hardware:2025-08-05
+      image: ghcr.io/clash-lang/nixos-bittide-hardware:2025-10-06
       options: --memory=11g
     needs: [build]
 
@@ -384,7 +384,7 @@ jobs:
       run:
         shell: git-nix-shell {0} --ignore-environment
     container:
-      image: ghcr.io/clash-lang/nixos-bittide-hardware:2025-08-05
+      image: ghcr.io/clash-lang/nixos-bittide-hardware:2025-10-06
       options: --memory=11g
     needs: [build]
 
@@ -412,7 +412,7 @@ jobs:
       run:
         shell: git-nix-shell {0} --ignore-environment
     container:
-      image: ghcr.io/clash-lang/nixos-bittide-hardware:2025-08-05
+      image: ghcr.io/clash-lang/nixos-bittide-hardware:2025-10-06
       options: --memory=11g
     needs: [build]
 
@@ -493,7 +493,7 @@ jobs:
       fail-fast: false
 
     container:
-      image: ghcr.io/clash-lang/nixos-bittide-hardware:2025-08-05
+      image: ghcr.io/clash-lang/nixos-bittide-hardware:2025-10-06
       volumes:
         - /opt/tools:/opt/tools
       options: --init --mac-address="6c:5a:b0:6c:13:0b" --memory=11g
@@ -619,7 +619,7 @@ jobs:
         shell: git-nix-shell {0} --ignore-environment
 
     container:
-      image: ghcr.io/clash-lang/nixos-bittide-hardware:2025-08-05
+      image: ghcr.io/clash-lang/nixos-bittide-hardware:2025-10-06
       options: --memory=11g
 
     strategy:
@@ -662,7 +662,7 @@ jobs:
       fail-fast: false
 
     container:
-      image: ghcr.io/clash-lang/nixos-bittide-hardware:2025-08-05
+      image: ghcr.io/clash-lang/nixos-bittide-hardware:2025-10-06
       volumes:
         - /opt/tools:/opt/tools
         - /dev:/dev


### PR DESCRIPTION
No idea when it happened, but CI is pulling from `cache.nixos.org` again, so we need a docker bump.