### PR TITLE
Implement `BusReadBehavior` for `registerWb`

### DIFF
--- a/bittide-extra/bittide-extra.cabal
+++ b/bittide-extra/bittide-extra.cabal
@@ -169,6 +169,7 @@ library
     Data.List.Extra
     Numeric.Extra
     Project.Handle
+    Protocols.Df.Extra
     Protocols.Extra
     System.Timeout.Extra
 

--- a/bittide-extra/src/Protocols/Df/Extra.hs
+++ b/bittide-extra/src/Protocols/Df/Extra.hs
@@ -1,0 +1,17 @@
+-- SPDX-FileCopyrightText: 2025 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+
+module Protocols.Df.Extra where
+
+import Clash.Prelude
+import Protocols
+
+andAck :: forall dom a. Signal dom Bool -> Circuit (Df dom a) (Df dom a)
+andAck extraAcks = Circuit go0
+ where
+  go0 :: (Signal dom (Maybe a), Signal dom Ack) -> (Signal dom Ack, Signal dom (Maybe a))
+  go0 (as, acks) = (go1 <$> acks <*> extraAcks, as)
+
+  go1 :: Ack -> Bool -> Ack
+  go1 (Ack ack) extraAck = Ack (ack && extraAck)


### PR DESCRIPTION
Allows users of `registerWb` to intercept reads from the WishBone bus. This is handy dandy in case you want to (in an ad-hoc fashion) tie a DF-FIFO to a CPU accessible address. I plan to use it as part of moving `uartInterfaceWb` over to `deviceWbC`.