### PR TITLE
Deduplicate `build.rs` scripts

### DIFF
--- a/firmware-binaries/Cargo.lock
+++ b/firmware-binaries/Cargo.lock
@@ -32,6 +32,7 @@ version = "0.1.0"
 dependencies = [
  "bittide-hal",
  "bittide-sys",
+ "memmap-generate",
  "riscv-rt",
  "ufmt",
 ]
@@ -96,6 +97,7 @@ version = "0.1.0"
 dependencies = [
  "bittide-hal",
  "bittide-sys",
+ "memmap-generate",
  "riscv-rt",
  "ufmt",
 ]
@@ -123,6 +125,7 @@ version = "0.1.0"
 dependencies = [
  "bittide-hal",
  "bittide-sys",
+ "memmap-generate",
  "rand",
  "riscv-rt",
  "ufmt",
@@ -151,6 +154,7 @@ version = "0.1.0"
 dependencies = [
  "bittide-hal",
  "bittide-sys",
+ "memmap-generate",
  "riscv-rt",
  "ufmt",
 ]
@@ -357,6 +361,7 @@ name = "processing-element-test"
 version = "0.1.0"
 dependencies = [
  "heapless 0.7.17",
+ "memmap-generate",
  "riscv-rt",
  "ufmt",
 ]
@@ -527,6 +532,7 @@ version = "0.1.0"
 dependencies = [
  "bittide-hal",
  "bittide-sys",
+ "memmap-generate",
  "riscv-rt",
  "ufmt",
 ]
@@ -663,6 +669,7 @@ dependencies = [
  "bittide-hal",
  "bittide-sys",
  "log",
+ "memmap-generate",
  "riscv-rt",
  "ufmt",
 ]
@@ -695,6 +702,7 @@ version = "0.1.0"
 dependencies = [
  "bittide-hal",
  "bittide-sys",
+ "memmap-generate",
  "riscv-rt",
  "ufmt",
 ]
@@ -744,6 +752,7 @@ version = "0.1.0"
 dependencies = [
  "bittide-hal",
  "bittide-sys",
+ "memmap-generate",
  "riscv-rt",
  "ufmt",
 ]

--- a/firmware-binaries/clock-control/build.rs
+++ b/firmware-binaries/clock-control/build.rs
@@ -2,36 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use std::env;
-use std::fs;
-use std::path::{Path, PathBuf};
+use memmap_generate::build_utils::standard_memmap_build;
 
-use memmap_generate::memory_x_from_memmap;
-
-fn memmap_dir() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("../../")
-        .join("_build")
-        .join("memory_maps")
-}
-
-/// Put the linker script somewhere the linker can find it.
 fn main() {
-    let memory_x = memory_x_from_memmap(
-        memmap_dir().join("SwitchDemoCc.json"),
-        "DataMemory",
-        "InstructionMemory",
-    );
-    let out_dir = env::var("OUT_DIR").expect("No out dir");
-    let dest_path = Path::new(&out_dir).join("memory.x");
-    fs::write(dest_path, memory_x).expect("Could not write file");
-
-    if env::var("CARGO_CFG_TARGET_ARCH").unwrap() == "riscv32" {
-        println!("cargo:rustc-link-arg=-Tmemory.x");
-        println!("cargo:rustc-link-arg=-Tlink.x"); // linker script from riscv-rt
-    }
-    println!("cargo:rustc-link-search={out_dir}");
-
-    println!("cargo:rerun-if-changed=memory.x");
+    standard_memmap_build("SwitchDemoCc.json", "DataMemory", "InstructionMemory");
     println!("cargo:rerun-if-changed=build.rs");
 }

--- a/firmware-binaries/examples/hello/build.rs
+++ b/firmware-binaries/examples/hello/build.rs
@@ -2,36 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use std::env;
-use std::fs;
-use std::path::{Path, PathBuf};
+use memmap_generate::build_utils::standard_memmap_build;
 
-use memmap_generate::memory_x_from_memmap;
-
-fn memmap_dir() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("../../../")
-        .join("_build")
-        .join("memory_maps")
-}
-
-/// Put the linker script somewhere the linker can find it.
 fn main() {
-    let memory_x = memory_x_from_memmap(
-        memmap_dir().join("VexRiscv.json"),
-        "DataMemory",
-        "InstructionMemory",
-    );
-
-    let out_dir = env::var("OUT_DIR").expect("No out dir");
-    let dest_path = Path::new(&out_dir).join("memory.x");
-    fs::write(dest_path, memory_x).expect("Could not write file");
-
-    if env::var("CARGO_CFG_TARGET_ARCH").unwrap() == "riscv32" {
-        println!("cargo:rustc-link-arg=-Tmemory.x");
-        println!("cargo:rustc-link-arg=-Tlink.x"); // linker script from riscv-rt
-    }
-    println!("cargo:rustc-link-search={out_dir}");
-
+    standard_memmap_build("VexRiscv.json", "DataMemory", "InstructionMemory");
     println!("cargo:rerun-if-changed=build.rs");
 }

--- a/firmware-binaries/examples/smoltcp_client/build.rs
+++ b/firmware-binaries/examples/smoltcp_client/build.rs
@@ -2,37 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use std::env;
-use std::fs;
-use std::path::Path;
+use memmap_generate::build_utils::standard_memmap_build;
 
-use memmap_generate::memory_x_from_memmap;
-
-fn memmap_dir() -> std::path::PathBuf {
-    std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("../../../")
-        .join("_build")
-        .join("memory_maps")
-}
-
-/// Put the linker script somewhere the linker can find it.
 fn main() {
-    let memory_x = memory_x_from_memmap(
-        memmap_dir().join("Ethernet.json"),
-        "DataMemory",
-        "InstructionMemory",
-    );
-
-    let out_dir = env::var("OUT_DIR").expect("No out dir");
-    let dest_path = Path::new(&out_dir).join("memory.x");
-    fs::write(dest_path, memory_x).expect("Could not write file");
-
-    if env::var("CARGO_CFG_TARGET_ARCH").unwrap() == "riscv32" {
-        println!("cargo:rustc-link-arg=-Tmemory.x");
-        println!("cargo:rustc-link-arg=-Tlink.x"); // linker script from riscv-rt
-    }
-    println!("cargo:rustc-link-search={out_dir}");
-
-    println!("cargo:rerun-if-changed=memory.x");
+    standard_memmap_build("Ethernet.json", "DataMemory", "InstructionMemory");
     println!("cargo:rerun-if-changed=build.rs");
 }

--- a/firmware-binaries/management-unit/build.rs
+++ b/firmware-binaries/management-unit/build.rs
@@ -2,36 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use std::env;
-use std::fs;
-use std::path::{Path, PathBuf};
+use memmap_generate::build_utils::standard_memmap_build;
 
-use memmap_generate::memory_x_from_memmap;
-
-fn memmap_dir() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("../../")
-        .join("_build")
-        .join("memory_maps")
-}
-
-/// Put the linker script somewhere the linker can find it.
 fn main() {
-    let memory_x = memory_x_from_memmap(
-        memmap_dir().join("SwitchDemoMu.json"),
-        "DataMemory",
-        "InstructionMemory",
-    );
-
-    let out_dir = env::var("OUT_DIR").expect("No out dir");
-    let dest_path = Path::new(&out_dir).join("memory.x");
-    fs::write(dest_path, memory_x).expect("Could not write file");
-
-    if env::var("CARGO_CFG_TARGET_ARCH").unwrap() == "riscv32" {
-        println!("cargo:rustc-link-arg=-Tmemory.x");
-        println!("cargo:rustc-link-arg=-Tlink.x"); // linker script from riscv-rt
-    }
-    println!("cargo:rustc-link-search={out_dir}");
-
+    standard_memmap_build("SwitchDemoMu.json", "DataMemory", "InstructionMemory");
     println!("cargo:rerun-if-changed=build.rs");
 }

--- a/firmware-binaries/processing-element-test/Cargo.toml
+++ b/firmware-binaries/processing-element-test/Cargo.toml
@@ -13,3 +13,6 @@ edition = "2021"
 riscv-rt = "0.11.0"
 heapless = { version = "0.7.16", default-features = false, features = ["ufmt-impl"] }
 ufmt = "0.2.0"
+
+[build-dependencies]
+memmap-generate = { path = "../../firmware-support/memmap-generate" }

--- a/firmware-binaries/processing-element-test/build.rs
+++ b/firmware-binaries/processing-element-test/build.rs
@@ -2,22 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use std::env;
-use std::fs;
-use std::path::Path;
+use memmap_generate::build_utils::standard_static_memory_build;
 
-/// Put the linker script somewhere the linker can find it.
 fn main() {
-    let out_dir = env::var("OUT_DIR").expect("No out dir");
-    let dest_path = Path::new(&out_dir).join("memory.x");
-    fs::write(dest_path, include_bytes!("memory.x")).expect("Could not write file");
-
-    if env::var("CARGO_CFG_TARGET_ARCH").unwrap() == "riscv32" {
-        println!("cargo:rustc-link-arg=-Tmemory.x");
-        println!("cargo:rustc-link-arg=-Tlink.x"); // linker script from riscv-rt
-    }
-    println!("cargo:rustc-link-search={out_dir}");
-
-    println!("cargo:rerun-if-changed=memory.x");
+    standard_static_memory_build("memory.x");
     println!("cargo:rerun-if-changed=build.rs");
 }

--- a/firmware-binaries/test-cases/axi_stream_self_test/Cargo.toml
+++ b/firmware-binaries/test-cases/axi_stream_self_test/Cargo.toml
@@ -16,3 +16,6 @@ riscv-rt = "0.11.0"
 bittide-sys = { path = "../../../firmware-support/bittide-sys" }
 bittide-hal = { path = "../../../firmware-support/bittide-hal" }
 ufmt = "0.2.0"
+
+[build-dependencies]
+memmap-generate = { path = "../../../firmware-support/memmap-generate" }

--- a/firmware-binaries/test-cases/axi_stream_self_test/build.rs
+++ b/firmware-binaries/test-cases/axi_stream_self_test/build.rs
@@ -2,22 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use std::env;
-use std::fs;
-use std::path::Path;
+use memmap_generate::build_utils::standard_static_memory_build;
 
-/// Put the linker script somewhere the linker can find it.
 fn main() {
-    let out_dir = env::var("OUT_DIR").expect("No out dir");
-    let dest_path = Path::new(&out_dir).join("memory.x");
-    fs::write(dest_path, include_bytes!("memory.x")).expect("Could not write file");
-
-    if env::var("CARGO_CFG_TARGET_ARCH").unwrap() == "riscv32" {
-        println!("cargo:rustc-link-arg=-Tmemory.x");
-        println!("cargo:rustc-link-arg=-Tlink.x"); // linker script from riscv-rt
-    }
-    println!("cargo:rustc-link-search={out_dir}");
-
-    println!("cargo:rerun-if-changed=memory.x");
+    standard_static_memory_build("memory.x");
     println!("cargo:rerun-if-changed=build.rs");
 }

--- a/firmware-binaries/test-cases/capture_ugn_test/Cargo.toml
+++ b/firmware-binaries/test-cases/capture_ugn_test/Cargo.toml
@@ -16,3 +16,6 @@ riscv-rt = "0.11.0"
 bittide-sys = { path = "../../../firmware-support/bittide-sys" }
 bittide-hal = { path = "../../../firmware-support/bittide-hal" }
 ufmt = "0.2.0"
+
+[build-dependencies]
+memmap-generate = { path = "../../../firmware-support/memmap-generate" }

--- a/firmware-binaries/test-cases/capture_ugn_test/build.rs
+++ b/firmware-binaries/test-cases/capture_ugn_test/build.rs
@@ -2,22 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use std::env;
-use std::fs;
-use std::path::Path;
+use memmap_generate::build_utils::standard_static_memory_build;
 
-/// Put the linker script somewhere the linker can find it.
 fn main() {
-    let out_dir = env::var("OUT_DIR").expect("No out dir");
-    let dest_path = Path::new(&out_dir).join("memory.x");
-    fs::write(dest_path, include_bytes!("memory.x")).expect("Could not write file");
-
-    if env::var("CARGO_CFG_TARGET_ARCH").unwrap() == "riscv32" {
-        println!("cargo:rustc-link-arg=-Tmemory.x");
-        println!("cargo:rustc-link-arg=-Tlink.x"); // linker script from riscv-rt
-    }
-    println!("cargo:rustc-link-search={out_dir}");
-
-    println!("cargo:rerun-if-changed=memory.x");
+    standard_static_memory_build("memory.x");
     println!("cargo:rerun-if-changed=build.rs");
 }

--- a/firmware-binaries/test-cases/clock-control-wb/Cargo.toml
+++ b/firmware-binaries/test-cases/clock-control-wb/Cargo.toml
@@ -17,3 +17,6 @@ bittide-hal = { path = "../../../firmware-support/bittide-hal" }
 rand = {version = "0.8.3", features = ["small_rng"], default-features = false }
 riscv-rt = "0.11.0"
 ufmt = "0.2.0"
+
+[build-dependencies]
+memmap-generate = { path = "../../../firmware-support/memmap-generate" }

--- a/firmware-binaries/test-cases/clock-control-wb/build.rs
+++ b/firmware-binaries/test-cases/clock-control-wb/build.rs
@@ -2,28 +2,16 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use std::env;
-use std::fs;
-use std::path::Path;
+use memmap_generate::build_utils::standard_static_memory_build;
 use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
 
 /// Put the linker script somewhere the linker can find it.
 fn main() {
-    let out_dir = env::var("OUT_DIR").expect("No out dir");
-    let dest_path = Path::new(&out_dir).join("memory.x");
-    fs::write(dest_path, include_bytes!("memory.x")).expect("Could not write file");
-
-    if env::var("CARGO_CFG_TARGET_ARCH").unwrap() == "riscv32" {
-        println!("cargo:rustc-link-arg=-Tmemory.x");
-        println!("cargo:rustc-link-arg=-Tlink.x"); // linker script from riscv-rt
-    }
-    println!("cargo:rustc-link-search={out_dir}");
+    standard_static_memory_build("memory.x");
 
     let now = SystemTime::now();
     let rng_seed = now.duration_since(UNIX_EPOCH).unwrap().as_millis();
     println!("cargo:rustc-env=RNG_SEED='{rng_seed:0128b}'");
-
-    println!("cargo:rerun-if-changed=memory.x");
     println!("cargo:rerun-if-changed=build.rs");
 }

--- a/firmware-binaries/test-cases/dna_port_e2_test/Cargo.toml
+++ b/firmware-binaries/test-cases/dna_port_e2_test/Cargo.toml
@@ -16,3 +16,6 @@ riscv-rt = "0.11.0"
 bittide-sys = { path = "../../../firmware-support/bittide-sys" }
 bittide-hal = { path = "../../../firmware-support/bittide-hal" }
 ufmt = "0.2.0"
+
+[build-dependencies]
+memmap-generate = { path = "../../../firmware-support/memmap-generate" }

--- a/firmware-binaries/test-cases/dna_port_e2_test/build.rs
+++ b/firmware-binaries/test-cases/dna_port_e2_test/build.rs
@@ -2,22 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use std::env;
-use std::fs;
-use std::path::Path;
+use memmap_generate::build_utils::standard_static_memory_build;
 
-/// Put the linker script somewhere the linker can find it.
 fn main() {
-    let out_dir = env::var("OUT_DIR").expect("No out dir");
-    let dest_path = Path::new(&out_dir).join("memory.x");
-    fs::write(dest_path, include_bytes!("memory.x")).expect("Could not write file");
-
-    if env::var("CARGO_CFG_TARGET_ARCH").unwrap() == "riscv32" {
-        println!("cargo:rustc-link-arg=-Tmemory.x");
-        println!("cargo:rustc-link-arg=-Tlink.x"); // linker script from riscv-rt
-    }
-    println!("cargo:rustc-link-search={out_dir}");
-
-    println!("cargo:rerun-if-changed=memory.x");
+    standard_static_memory_build("memory.x");
     println!("cargo:rerun-if-changed=build.rs");
 }

--- a/firmware-binaries/test-cases/registerwb_test/build.rs
+++ b/firmware-binaries/test-cases/registerwb_test/build.rs
@@ -2,36 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use std::env;
-use std::fs;
-use std::path::{Path, PathBuf};
+use memmap_generate::build_utils::standard_memmap_build;
 
-use memmap_generate::memory_x_from_memmap;
-
-fn memmap_dir() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("../../../")
-        .join("_build")
-        .join("memory_maps")
-}
-
-/// Put the linker script somewhere the linker can find it.
 fn main() {
-    let memory_x = memory_x_from_memmap(
-        memmap_dir().join("RegisterWb.json"),
-        "DataMemory",
-        "InstructionMemory",
-    );
-
-    let out_dir = env::var("OUT_DIR").expect("No out dir");
-    let dest_path = Path::new(&out_dir).join("memory.x");
-    fs::write(dest_path, memory_x).expect("Could not write file");
-
-    if env::var("CARGO_CFG_TARGET_ARCH").unwrap() == "riscv32" {
-        println!("cargo:rustc-link-arg=-Tmemory.x");
-        println!("cargo:rustc-link-arg=-Tlink.x"); // linker script from riscv-rt
-    }
-    println!("cargo:rustc-link-search={out_dir}");
-
+    standard_memmap_build("RegisterWb.json", "DataMemory", "InstructionMemory");
     println!("cargo:rerun-if-changed=build.rs");
 }

--- a/firmware-binaries/test-cases/scatter_gather_test/Cargo.toml
+++ b/firmware-binaries/test-cases/scatter_gather_test/Cargo.toml
@@ -16,3 +16,6 @@ riscv-rt = "0.11.0"
 bittide-sys = { path = "../../../firmware-support/bittide-sys" }
 bittide-hal = { path = "../../../firmware-support/bittide-hal" }
 ufmt = "0.2.0"
+
+[build-dependencies]
+memmap-generate = { path = "../../../firmware-support/memmap-generate" }

--- a/firmware-binaries/test-cases/scatter_gather_test/build.rs
+++ b/firmware-binaries/test-cases/scatter_gather_test/build.rs
@@ -2,22 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use std::env;
-use std::fs;
-use std::path::Path;
+use memmap_generate::build_utils::standard_static_memory_build;
 
-/// Put the linker script somewhere the linker can find it.
 fn main() {
-    let out_dir = env::var("OUT_DIR").expect("No out dir");
-    let dest_path = Path::new(&out_dir).join("memory.x");
-    fs::write(dest_path, include_bytes!("memory.x")).expect("Could not write file");
-
-    if env::var("CARGO_CFG_TARGET_ARCH").unwrap() == "riscv32" {
-        println!("cargo:rustc-link-arg=-Tmemory.x");
-        println!("cargo:rustc-link-arg=-Tlink.x"); // linker script from riscv-rt
-    }
-    println!("cargo:rustc-link-search={out_dir}");
-
-    println!("cargo:rerun-if-changed=memory.x");
+    standard_static_memory_build("memory.x");
     println!("cargo:rerun-if-changed=build.rs");
 }

--- a/firmware-binaries/test-cases/switch_calendar_test/build.rs
+++ b/firmware-binaries/test-cases/switch_calendar_test/build.rs
@@ -2,36 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use std::env;
-use std::fs;
-use std::path::{Path, PathBuf};
+use memmap_generate::build_utils::standard_memmap_build;
 
-use memmap_generate::memory_x_from_memmap;
-
-fn memmap_dir() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("../../../")
-        .join("_build")
-        .join("memory_maps")
-}
-
-/// Put the linker script somewhere the linker can find it.
 fn main() {
-    let memory_x = memory_x_from_memmap(
-        memmap_dir().join("SwitchC.json"),
-        "DataMemory",
-        "InstructionMemory",
-    );
-
-    let out_dir = env::var("OUT_DIR").expect("No out dir");
-    let dest_path = Path::new(&out_dir).join("memory.x");
-    fs::write(dest_path, memory_x).expect("Could not write file");
-
-    if env::var("CARGO_CFG_TARGET_ARCH").unwrap() == "riscv32" {
-        println!("cargo:rustc-link-arg=-Tmemory.x");
-        println!("cargo:rustc-link-arg=-Tlink.x"); // linker script from riscv-rt
-    }
-    println!("cargo:rustc-link-search={out_dir}");
-
+    standard_memmap_build("SwitchC.json", "DataMemory", "InstructionMemory");
     println!("cargo:rerun-if-changed=build.rs");
 }

--- a/firmware-binaries/test-cases/switch_demo_pe_test/Cargo.toml
+++ b/firmware-binaries/test-cases/switch_demo_pe_test/Cargo.toml
@@ -20,3 +20,6 @@ ufmt = "0.2.0"
 [dependencies.log]
 version = "0.4.21"
 features = ["max_level_trace", "release_max_level_info"]
+
+[build-dependencies]
+memmap-generate = { path = "../../../firmware-support/memmap-generate" }

--- a/firmware-binaries/test-cases/switch_demo_pe_test/build.rs
+++ b/firmware-binaries/test-cases/switch_demo_pe_test/build.rs
@@ -2,22 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use std::env;
-use std::fs;
-use std::path::Path;
+use memmap_generate::build_utils::standard_static_memory_build;
 
-/// Put the linker script somewhere the linker can find it.
 fn main() {
-    let out_dir = env::var("OUT_DIR").expect("No out dir");
-    let dest_path = Path::new(&out_dir).join("memory.x");
-    fs::write(dest_path, include_bytes!("memory.x")).expect("Could not write file");
-
-    if env::var("CARGO_CFG_TARGET_ARCH").unwrap() == "riscv32" {
-        println!("cargo:rustc-link-arg=-Tmemory.x");
-        println!("cargo:rustc-link-arg=-Tlink.x"); // linker script from riscv-rt
-    }
-    println!("cargo:rustc-link-search={out_dir}");
-
-    println!("cargo:rerun-if-changed=memory.x");
+    standard_static_memory_build("memory.x");
     println!("cargo:rerun-if-changed=build.rs");
 }

--- a/firmware-binaries/test-cases/time_self_test/Cargo.toml
+++ b/firmware-binaries/test-cases/time_self_test/Cargo.toml
@@ -16,3 +16,6 @@ riscv-rt = "0.11.0"
 bittide-sys = { path = "../../../firmware-support/bittide-sys" }
 bittide-hal = { path = "../../../firmware-support/bittide-hal" }
 ufmt = "0.2.0"
+
+[build-dependencies]
+memmap-generate = { path = "../../../firmware-support/memmap-generate" }

--- a/firmware-binaries/test-cases/time_self_test/build.rs
+++ b/firmware-binaries/test-cases/time_self_test/build.rs
@@ -2,22 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use std::env;
-use std::fs;
-use std::path::Path;
+use memmap_generate::build_utils::standard_static_memory_build;
 
-/// Put the linker script somewhere the linker can find it.
 fn main() {
-    let out_dir = env::var("OUT_DIR").expect("No out dir");
-    let dest_path = Path::new(&out_dir).join("memory.x");
-    fs::write(dest_path, include_bytes!("memory.x")).expect("Could not write file");
-
-    if env::var("CARGO_CFG_TARGET_ARCH").unwrap() == "riscv32" {
-        println!("cargo:rustc-link-arg=-Tmemory.x");
-        println!("cargo:rustc-link-arg=-Tlink.x"); // linker script from riscv-rt
-    }
-    println!("cargo:rustc-link-search={out_dir}");
-
-    println!("cargo:rerun-if-changed=memory.x");
+    standard_static_memory_build("memory.x");
     println!("cargo:rerun-if-changed=build.rs");
 }

--- a/firmware-binaries/test-cases/watchdog_test/Cargo.toml
+++ b/firmware-binaries/test-cases/watchdog_test/Cargo.toml
@@ -16,3 +16,6 @@ riscv-rt = "0.11.0"
 bittide-sys = { path = "../../../firmware-support/bittide-sys" }
 bittide-hal = { path = "../../../firmware-support/bittide-hal" }
 ufmt = "0.2.0"
+
+[build-dependencies]
+memmap-generate = { path = "../../../firmware-support/memmap-generate" }

--- a/firmware-binaries/test-cases/watchdog_test/build.rs
+++ b/firmware-binaries/test-cases/watchdog_test/build.rs
@@ -2,22 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use std::env;
-use std::fs;
-use std::path::Path;
+use memmap_generate::build_utils::standard_static_memory_build;
 
-/// Put the linker script somewhere the linker can find it.
 fn main() {
-    let out_dir = env::var("OUT_DIR").expect("No out dir");
-    let dest_path = Path::new(&out_dir).join("memory.x");
-    fs::write(dest_path, include_bytes!("memory.x")).expect("Could not write file");
-
-    if env::var("CARGO_CFG_TARGET_ARCH").unwrap() == "riscv32" {
-        println!("cargo:rustc-link-arg=-Tmemory.x");
-        println!("cargo:rustc-link-arg=-Tlink.x"); // linker script from riscv-rt
-    }
-    println!("cargo:rustc-link-search={out_dir}");
-
-    println!("cargo:rerun-if-changed=memory.x");
+    standard_static_memory_build("memory.x");
     println!("cargo:rerun-if-changed=build.rs");
 }

--- a/firmware-binaries/test-cases/wb_to_df_test/build.rs
+++ b/firmware-binaries/test-cases/wb_to_df_test/build.rs
@@ -2,36 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use std::env;
-use std::fs;
-use std::path::{Path, PathBuf};
+use memmap_generate::build_utils::standard_memmap_build;
 
-use memmap_generate::memory_x_from_memmap;
-
-fn memmap_dir() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("../../../")
-        .join("_build")
-        .join("memory_maps")
-}
-
-/// Put the linker script somewhere the linker can find it.
 fn main() {
-    let memory_x = memory_x_from_memmap(
-        memmap_dir().join("WbToDfTest.json"),
-        "DataMemory",
-        "InstructionMemory",
-    );
-
-    let out_dir = env::var("OUT_DIR").expect("No out dir");
-    let dest_path = Path::new(&out_dir).join("memory.x");
-    fs::write(dest_path, memory_x).expect("Could not write file");
-
-    if env::var("CARGO_CFG_TARGET_ARCH").unwrap() == "riscv32" {
-        println!("cargo:rustc-link-arg=-Tmemory.x");
-        println!("cargo:rustc-link-arg=-Tlink.x"); // linker script from riscv-rt
-    }
-    println!("cargo:rustc-link-search={out_dir}");
-
+    standard_memmap_build("WbToDfTest.json", "DataMemory", "InstructionMemory");
     println!("cargo:rerun-if-changed=build.rs");
 }

--- a/firmware-support/memmap-generate/src/build_utils.rs
+++ b/firmware-support/memmap-generate/src/build_utils.rs
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: 2025 Google LLC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Common utilities for build.rs scripts
+
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::memory_x_from_memmap;
+
+/// Standard build script setup for RISC-V targets.
+///
+/// This function handles:
+/// - Setting up cargo link arguments for RISC-V
+/// - Setting up the linker search path
+fn setup_riscv_linker(out_dir: &str) {
+    if env::var("CARGO_CFG_TARGET_ARCH").unwrap() == "riscv32" {
+        println!("cargo:rustc-link-arg=-Tmemory.x");
+        println!("cargo:rustc-link-arg=-Tlink.x"); // linker script from riscv-rt
+    }
+    println!("cargo:rustc-link-search={out_dir}");
+}
+
+/// Get the path to the memory maps directory using git to find the project root.
+pub fn memmap_dir() -> PathBuf {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+
+    // Try to find git root from the manifest directory
+    let output = std::process::Command::new("git")
+        .args(["rev-parse", "--show-toplevel"])
+        .current_dir(&manifest_dir)
+        .output()
+        .expect("Failed to execute git command - make sure git is installed and this is a git repository");
+
+    if !output.status.success() {
+        panic!(
+            "Failed to find git root: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    let git_root = String::from_utf8(output.stdout)
+        .expect("Git output is not valid UTF-8")
+        .trim()
+        .to_string();
+
+    PathBuf::from(git_root).join("_build").join("memory_maps")
+}
+
+/// Generates a memory.x file from a JSON memory map file and set up the linker
+/// configuration for RISC-V targets.
+///
+/// # Arguments
+/// * `memmap_json_name` - Name of the JSON file in the memory maps directory (e.g., "VexRiscv.json")
+/// * `data_device_name` - Name of the data memory device (usually "DataMemory")
+/// * `instr_device_name` - Name of the instruction memory device (usually "InstructionMemory")
+pub fn standard_memmap_build(
+    memmap_json_name: &str,
+    data_device_name: &str,
+    instr_device_name: &str,
+) {
+    let memmap_path = memmap_dir().join(memmap_json_name);
+    let memory_x = memory_x_from_memmap(&memmap_path, data_device_name, instr_device_name);
+
+    let out_dir = env::var("OUT_DIR").expect("No out dir");
+    let dest_path = Path::new(&out_dir).join("memory.x");
+    fs::write(dest_path, memory_x).expect("Could not write file");
+
+    setup_riscv_linker(&out_dir);
+    println!("cargo:rerun-if-changed={}", memmap_path.display());
+}
+
+/// Reads an existing memory.x file and copies it to the output directory, then
+/// sets up the linker configuration for RISC-V targets.
+///
+/// # Arguments
+/// * `source_file` - The name of the source file to read (e.g., "memory.x")
+pub fn standard_static_memory_build(source_file: &str) {
+    let memory_x_content =
+        fs::read(source_file).unwrap_or_else(|_| panic!("Could not read file: {}", source_file));
+
+    let out_dir = env::var("OUT_DIR").expect("No out dir");
+    let dest_path = Path::new(&out_dir).join("memory.x");
+    fs::write(dest_path, memory_x_content).expect("Could not write file");
+
+    setup_riscv_linker(&out_dir);
+    println!("cargo:rerun-if-changed={}", source_file);
+}

--- a/firmware-support/memmap-generate/src/lib.rs
+++ b/firmware-support/memmap-generate/src/lib.rs
@@ -9,6 +9,8 @@ pub mod hal_set;
 
 pub mod format;
 
+pub mod build_utils;
+
 use std::io::Write;
 
 use parse::{MemoryMapTree, PathComp};


### PR DESCRIPTION
I was bitten once more by broken cache invalidation logic which we only fixed for *some* `build.rs`s, but not for others. This commit deduplicates the logic.