### PR TITLE
Add `delayWishboneC` component to break combinatorial paths

### DIFF
--- a/bittide-extra/bittide-extra.cabal
+++ b/bittide-extra/bittide-extra.cabal
@@ -171,6 +171,7 @@ library
     Project.Handle
     Protocols.Df.Extra
     Protocols.Extra
+    Protocols.Wishbone.Extra
     System.Timeout.Extra
 
 test-suite unittests

--- a/bittide-extra/src/Protocols/Wishbone/Extra.hs
+++ b/bittide-extra/src/Protocols/Wishbone/Extra.hs
@@ -1,0 +1,55 @@
+-- SPDX-FileCopyrightText: 2025 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+
+module Protocols.Wishbone.Extra (delayWishboneC) where
+
+import Clash.Prelude
+import Protocols
+import Protocols.Wishbone
+
+data DelayWishboneState aw n a
+  = WaitingForManager
+  | WaitingForSubordinate (WishboneM2S aw n a)
+  | AcknowledgingManager (WishboneS2M a)
+  deriving (Generic, NFDataX)
+
+{- | Breaks the combinatorial path between a Wishbone manager and subordinate by inserting
+a Moore machine. It introduces two cycles of delay for each transaction, one to forward
+the request from manager to subordinate, and one to forward the response from subordinate
+to manager.
+-}
+delayWishboneC ::
+  forall dom aw a.
+  (HiddenClockResetEnable dom, 1 <= DomainPeriod dom, KnownNat aw, NFDataX a, BitPack a) =>
+  Circuit (Wishbone dom 'Standard aw a) (Wishbone dom 'Standard aw a)
+delayWishboneC = Circuit go
+ where
+  go ::
+    forall n.
+    (KnownNat n, n ~ BitSize a `DivRU` 8) =>
+    ( Signal dom (WishboneM2S aw n a)
+    , Signal dom (WishboneS2M a)
+    ) ->
+    ( Signal dom (WishboneS2M a)
+    , Signal dom (WishboneM2S aw n a)
+    )
+  go = mooreB mooreTransfer mooreOut WaitingForManager
+   where
+    mooreTransfer ::
+      DelayWishboneState aw n a ->
+      (WishboneM2S aw n a, WishboneS2M a) ->
+      DelayWishboneState aw n a
+    mooreTransfer WaitingForManager (m2s, _s2m)
+      | m2s.busCycle && m2s.strobe = WaitingForSubordinate m2s
+    mooreTransfer (WaitingForSubordinate _) (_m2s, s2m)
+      | hasTerminateFlag s2m = AcknowledgingManager s2m
+    mooreTransfer (AcknowledgingManager _) _ = WaitingForManager
+    mooreTransfer s _ = s
+
+    mooreOut ::
+      DelayWishboneState aw n a ->
+      (WishboneS2M a, WishboneM2S aw n a)
+    mooreOut WaitingForManager = (emptyWishboneS2M, emptyWishboneM2S)
+    mooreOut (WaitingForSubordinate m2s) = (emptyWishboneS2M, m2s)
+    mooreOut (AcknowledgingManager s2m) = (s2m, emptyWishboneM2S)

--- a/bittide-instances/bittide-instances.cabal
+++ b/bittide-instances/bittide-instances.cabal
@@ -208,6 +208,7 @@ library
     Bittide.Instances.Pnr.Si539xSpi
     Bittide.Instances.Pnr.Switch
     Bittide.Instances.Pnr.Synchronizer
+    Bittide.Instances.Tests.DelayWishboneC
     Bittide.Instances.Tests.ElasticBufferWb
     Bittide.Instances.Tests.RegisterWb
     Bittide.Instances.Tests.ScatterGather
@@ -294,6 +295,7 @@ test-suite unittests
     Tests.ClockControlWb
     Wishbone.Axi
     Wishbone.CaptureUgn
+    Wishbone.DelayWishboneC
     Wishbone.DnaPortE2
     Wishbone.RegisterWb
     Wishbone.ScatterGather

--- a/bittide-instances/src/Bittide/Instances/MemoryMaps.hs
+++ b/bittide-instances/src/Bittide/Instances/MemoryMaps.hs
@@ -23,6 +23,7 @@ import System.FilePath
 
 import qualified Bittide.Instances.Hitl.Dut.SwitchDemo as SwitchDemo
 import qualified Bittide.Instances.Hitl.SwCcTopologies as SwCcTopologies
+import qualified Bittide.Instances.Tests.DelayWishboneC as DelayWishboneC
 import qualified Bittide.Instances.Tests.ElasticBufferWb as ElasticBufferWb
 import qualified Bittide.Instances.Tests.RegisterWb as RegisterWb
 import qualified Bittide.Instances.Tests.ScatterGather as ScatterGather
@@ -38,7 +39,8 @@ $( do
     -- Add new memory maps here  --
     -------------------------------
     let memoryMaps =
-          [ ("Ethernet", vexRiscvEthernetMM)
+          [ ("DelayWishboneC", DelayWishboneC.delayMm)
+          , ("Ethernet", vexRiscvEthernetMM)
           , ("ElasticBufferWbTest", ElasticBufferWb.dutMM)
           , ("Freeze", freezeMM)
           , ("ProcessingElement", vexRiscvUartHelloMM)

--- a/bittide-instances/src/Bittide/Instances/Tests/DelayWishboneC.hs
+++ b/bittide-instances/src/Bittide/Instances/Tests/DelayWishboneC.hs
@@ -1,0 +1,69 @@
+-- SPDX-FileCopyrightText: 2025 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+
+module Bittide.Instances.Tests.DelayWishboneC where
+
+import Clash.Prelude hiding (unzip)
+
+import Bittide.DoubleBufferedRam
+import Bittide.ProcessingElement
+import Bittide.ProcessingElement.Util
+import Bittide.SharedTypes (withBittideByteOrder)
+import Bittide.Wishbone hiding (MemoryMap)
+import Project.FilePath
+
+import Clash.Class.BitPackC (ByteOrder (BigEndian))
+import Protocols
+import Protocols.Idle
+import Protocols.MemoryMap (ConstBwd, MM, MemoryMap)
+import Protocols.Vec (unzip)
+import Protocols.Wishbone.Extra
+import System.FilePath
+import System.IO.Unsafe (unsafePerformIO)
+import VexRiscv (DumpVcd (NoDumpVcd))
+
+whoAmID :: BitVector 32
+whoAmID = $(makeWhoAmIdTh "helo")
+
+delayMm :: MemoryMap
+delayMm = mm
+ where
+  Circuit circFn =
+    withClockResetEnable clockGen resetGen enableGen $ dutCpu @System
+  (SimOnly mm, _) = circFn ((), pure (Ack False))
+
+dutCpu ::
+  (HiddenClockResetEnable dom, 1 <= DomainPeriod dom) =>
+  Circuit (ConstBwd MM) (Df dom (BitVector 8))
+dutCpu = withBittideByteOrder $ circuit $ \mm -> do
+  (uartRx, jtag) <- idleSource
+  mmWbs <- processingElement NoDumpVcd peConfig -< (mm, jtag)
+  ([whoAmIMm, uartMm], wbs) <- unzip -< mmWbs
+  [whoAmIBus, uartBus] <- repeatC delayWishboneC -< wbs
+  whoAmIC whoAmID -< (whoAmIMm, whoAmIBus)
+  (uartTx, _uartStatus) <- uartInterfaceWb d2 d2 uartBytes -< ((uartMm, uartBus), uartRx)
+  idC -< uartTx
+ where
+  peConfig = unsafePerformIO $ do
+    root <- findParentContaining "cabal.project"
+    let elfPath = root </> firmwareBinariesDir "riscv32imc" Release </> "delay_wishbone_c"
+    pure
+      PeConfig
+        { initI =
+            Reloadable @IMemWords
+              $ Vec
+              $ unsafePerformIO
+              $ vecFromElfInstr BigEndian elfPath
+        , initD =
+            Reloadable @DMemWords
+              $ Vec
+              $ unsafePerformIO
+              $ vecFromElfData BigEndian elfPath
+        , iBusTimeout = d0
+        , dBusTimeout = d0
+        , includeIlaWb = False
+        }
+
+type IMemWords = DivRU (64 * 1024) 4
+type DMemWords = DivRU (32 * 1024) 4

--- a/bittide-instances/tests/Wishbone/DelayWishboneC.hs
+++ b/bittide-instances/tests/Wishbone/DelayWishboneC.hs
@@ -1,0 +1,40 @@
+-- SPDX-FileCopyrightText: 2025 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+
+module Wishbone.DelayWishboneC where
+
+import Clash.Prelude
+
+import Bittide.Instances.Tests.DelayWishboneC
+
+import Data.Char
+import Data.Maybe
+import Protocols
+import Protocols.MemoryMap (ignoreMM)
+import Test.Tasty
+import Test.Tasty.HUnit
+import Test.Tasty.TH
+
+simCpu :: IO ()
+simCpu = putStr simResult
+
+simResult :: String
+simResult = takeWhile (/= '\x04') $ chr . fromIntegral <$> catMaybes uartStream
+ where
+  uartStream = sampleC def dutFn
+
+dutFn :: Circuit () (Df System (BitVector 8))
+dutFn = circuit $ \_unit -> do
+  mm <- ignoreMM
+  uartTx <- withClockResetEnable clockGen (resetGenN d2) enableGen dutCpu -< mm
+  idC -< uartTx
+
+case_test_wishboneDelayC :: Assertion
+case_test_wishboneDelayC = assertEqual msg simResult expected
+ where
+  expected = "WhoAmID: helo\n"
+  msg = "Simulation result " <> simResult <> " not equal to expected string "
+
+tests :: TestTree
+tests = $(testGroupGenerator)

--- a/bittide-instances/tests/unittests.hs
+++ b/bittide-instances/tests/unittests.hs
@@ -20,6 +20,7 @@ import qualified Df.WbToDf as WbToDf
 import qualified Tests.ClockControlWb as ClockControlWb
 import qualified Wishbone.Axi as Axi
 import qualified Wishbone.CaptureUgn as CaptureUgn
+import qualified Wishbone.DelayWishboneC as DelayWishboneC
 import qualified Wishbone.DnaPortE2 as DnaPortE2
 import qualified Wishbone.RegisterWb as RegisterWb
 import qualified Wishbone.ScatterGather as ScatterGather
@@ -68,6 +69,7 @@ tests =
         [ Axi.tests
         , CaptureUgn.tests
         , ClockControlWb.tests
+        , DelayWishboneC.tests
         , DnaPortE2.tests
         , ElasticBufferWb.tests
         , ScatterGather.tests

--- a/bittide/bittide.cabal
+++ b/bittide/bittide.cabal
@@ -289,6 +289,7 @@ test-suite unittests
     Tests.ClockControl.Freeze
     Tests.ClockControl.Si539xSpi
     Tests.Counter
+    Tests.DelayWishboneC
     Tests.Df
     Tests.DoubleBufferedRam
     Tests.ElasticBuffer

--- a/bittide/tests/Tests/DelayWishboneC.hs
+++ b/bittide/tests/Tests/DelayWishboneC.hs
@@ -1,0 +1,74 @@
+-- SPDX-FileCopyrightText: 2025 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+-- Don't warn about partial functions: this is a test, so we'll see it fail.
+{-# OPTIONS_GHC -Wno-x-partial #-}
+
+module Tests.DelayWishboneC where
+
+import Clash.Prelude
+
+import Bittide.SharedTypes (Bytes, withBittideByteOrder)
+import Bittide.Wishbone (makeWhoAmIdTh, whoAmIC)
+
+import Protocols
+import Protocols.MemoryMap (ConstBwd, MM)
+import Protocols.Wishbone
+import Protocols.Wishbone.Extra
+import Test.Tasty
+import Test.Tasty.HUnit
+import Test.Tasty.TH
+import Tests.Wishbone (wbRead)
+
+import qualified Data.List as L
+
+whoAmID :: BitVector 32
+whoAmID = $(makeWhoAmIdTh "helo")
+
+simSimple :: IO ()
+simSimple = mapM_ (putStrLn . show) simResult
+
+-- | Calculate how many cycles a given WishboneM2S transaction will take
+
+--- through the delayWishboneC component.
+m2sToCycles :: WishboneM2S aw sw a -> Int
+m2sToCycles m2s
+  | not (m2s.lock || m2s.busCycle || m2s.strobe || m2s.writeEnable) = 1
+  | otherwise = 3
+
+simResult :: [WishboneS2M (Bytes 4)]
+simResult = simulateN len (dutSimpleFn @System) input
+ where
+  input = [wbRead 0x0000_0000, emptyWishboneM2S]
+  len = L.foldl (\acc m2s -> acc + m2sToCycles m2s) 0 input
+
+dutSimple ::
+  (HiddenClockResetEnable dom, 1 <= DomainPeriod dom) =>
+  Circuit (ConstBwd MM, Wishbone dom 'Standard 0 (Bytes 4)) ()
+dutSimple = withBittideByteOrder $ circuit $ \(mm, wb) -> do
+  wbDelayed <- delayWishboneC -< wb
+  whoAmIC whoAmID -< (mm, wbDelayed)
+
+dutSimpleFn ::
+  (HiddenClockResetEnable dom, 1 <= DomainPeriod dom) =>
+  Signal dom (WishboneM2S 0 4 (Bytes 4)) ->
+  Signal dom (WishboneS2M (Bytes 4))
+dutSimpleFn m2s = let ((_, s2m), _) = circFn (((), m2s), ()) in s2m
+ where
+  Circuit circFn = dutSimple
+
+case_test_wishboneDelayC :: Assertion
+case_test_wishboneDelayC = assertEqual msg readResult.readData whoAmID
+ where
+  topEntityInput = [wbRead 0x0000_0000, emptyWishboneM2S]
+  simulateLength = L.foldl (\acc m2s -> acc + m2sToCycles m2s) 0 topEntityInput
+  simOut = simulateN simulateLength (dutSimpleFn @System) topEntityInput
+  readResult = simOut L.!! ((m2sToCycles $ L.head topEntityInput) - 1)
+  msg =
+    "Simulation result "
+      <> show readResult.readData
+      <> " not equal to expected data "
+      <> show whoAmID
+
+tests :: TestTree
+tests = $(testGroupGenerator)

--- a/bittide/tests/Tests/Wishbone.hs
+++ b/bittide/tests/Tests/Wishbone.hs
@@ -6,7 +6,7 @@
 {-# LANGUAGE RecordWildCards #-}
 {-# OPTIONS_GHC -fplugin Protocols.Plugin #-}
 
-module Tests.Wishbone (tests, simpleSlave, simpleSlave') where
+module Tests.Wishbone (tests, simpleSlave, simpleSlave', wbRead) where
 
 import Clash.Prelude hiding (sample)
 

--- a/bittide/tests/UnitTests.hs
+++ b/bittide/tests/UnitTests.hs
@@ -15,6 +15,7 @@ import qualified Tests.Axi4.Properties
 import qualified Tests.Calendar
 import qualified Tests.ClockControl.Freeze
 import qualified Tests.ClockControl.Si539xSpi
+import qualified Tests.DelayWishboneC
 import qualified Tests.Df
 import qualified Tests.DoubleBufferedRam
 import qualified Tests.ElasticBuffer
@@ -37,6 +38,7 @@ tests =
     , Tests.Calendar.tests
     , Tests.ClockControl.Freeze.tests
     , Tests.ClockControl.Si539xSpi.tests
+    , Tests.DelayWishboneC.tests
     , Tests.Df.tests
     , Tests.DoubleBufferedRam.tests
     , Tests.ElasticBuffer.tests

--- a/firmware-binaries/Cargo.lock
+++ b/firmware-binaries/Cargo.lock
@@ -150,6 +150,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
+name = "delay_wishbone_c"
+version = "0.1.0"
+dependencies = [
+ "bittide-hal",
+ "bittide-sys",
+ "memmap-generate",
+ "riscv-rt",
+ "ufmt",
+]
+
+[[package]]
 name = "derivative"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/firmware-binaries/Cargo.toml
+++ b/firmware-binaries/Cargo.toml
@@ -20,6 +20,7 @@ members = [
   "test-cases/registerwb_test",
   "test-cases/capture_ugn_test",
   "test-cases/clock-control-wb",
+  "test-cases/delay_wishbone_c",
   "test-cases/dna_port_e2_test",
   "test-cases/elastic_buffer_wb_test",
   "test-cases/wb_to_df_test",

--- a/firmware-binaries/test-cases/delay_wishbone_c/Cargo.toml
+++ b/firmware-binaries/test-cases/delay_wishbone_c/Cargo.toml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2025 Google LLC
+#
+# SPDX-License-Identifier: CC0-1.0
+
+[package]
+name = "delay_wishbone_c"
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0"
+authors = ["Google LLC"]
+
+[dependencies]
+riscv-rt = "0.11.0"
+bittide-sys = { path = "../../../firmware-support/bittide-sys" }
+ufmt = "0.2.0"
+bittide-hal = { path = "../../../firmware-support/bittide-hal" }
+
+[build-dependencies]
+memmap-generate = { path = "../../../firmware-support/memmap-generate" }

--- a/firmware-binaries/test-cases/delay_wishbone_c/build.rs
+++ b/firmware-binaries/test-cases/delay_wishbone_c/build.rs
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: 2025 Google LLC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use memmap_generate::build_utils::standard_memmap_build;
+
+fn main() {
+    standard_memmap_build("DelayWishboneC.json", "DataMemory", "InstructionMemory");
+    println!("cargo:rerun-if-changed=memory.x");
+    println!("cargo:rerun-if-changed=build.rs");
+}

--- a/firmware-binaries/test-cases/delay_wishbone_c/src/main.rs
+++ b/firmware-binaries/test-cases/delay_wishbone_c/src/main.rs
@@ -1,0 +1,50 @@
+#![no_std]
+#![cfg_attr(not(test), no_main)]
+// SPDX-FileCopyrightText: 2025 Google LLC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use ufmt::uwriteln;
+
+use bittide_hal::hals::delay_wishbone_c as hal;
+
+#[cfg(not(test))]
+use riscv_rt::entry;
+
+#[cfg_attr(not(test), entry)]
+#[allow(clippy::empty_loop)]
+fn main() -> ! {
+    let mut instances = unsafe { hal::DeviceInstances::new() };
+    let uart = &mut instances.uart;
+    let whoami = instances.who_am_i.identifier().to_le_bytes();
+    match core::str::from_utf8(&whoami) {
+        Ok(whoami) => {
+            let mut valid = true;
+            for c in whoami.chars() {
+                if !c.is_ascii_graphic() {
+                    uwriteln!(
+                        uart,
+                        "Encountered non-printable ASCII char code: {}",
+                        c as u8
+                    )
+                    .unwrap();
+                    valid = false;
+                }
+            }
+            if valid {
+                uwriteln!(uart, "WhoAmID: {}", whoami).unwrap();
+            } else {
+                uwriteln!(uart, "WhoAmID was invalid.").unwrap();
+            }
+        }
+        Err(_) => uwriteln!(uart, "Read nonsense WhoAmID. Raw: {:?}", whoami).unwrap(),
+    }
+    uwriteln!(uart, "\x04").unwrap();
+    loop {}
+}
+
+#[panic_handler]
+#[allow(clippy::empty_loop)]
+fn panic_handler(_info: &core::panic::PanicInfo) -> ! {
+    loop {}
+}


### PR DESCRIPTION
In one of my other PRs, I have had issues where certain Wishbone paths would become too long and fail synthesis. As such, this PR introduces a new Wishbone component that breaks combinatorial paths by introducing a registered delay. It also includes two unit tests: one which does a simple test of the component directly, and another that uses it in a larger simulated system including a RISC-V CPU and ensures the output arrives intact, but without testing timing.