### PR TITLE
Replace "hello" binary references with "vexriscv-hello"

### DIFF
--- a/bittide-instances/src/Bittide/Instances/Hitl/Driver/VexRiscv.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/Driver/VexRiscv.hs
@@ -114,7 +114,7 @@ driverFunc _name targets = do
           -- program the FPGA
           Gdb.withGdb $ \gdb -> do
             Gdb.setLogging gdb gdbOutLog
-            Gdb.setFile gdb $ firmwareBinariesDir "riscv32imc" Debug </> "hello"
+            Gdb.setFile gdb $ firmwareBinariesDir "riscv32imc" Debug </> "vexriscv-hello"
             Gdb.setTarget gdb gdbPort
             errorToException =<< Gdb.loadBinary gdb
 

--- a/bittide-instances/src/Bittide/Instances/Hitl/VexRiscv.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/VexRiscv.hs
@@ -154,7 +154,7 @@ vexRiscvTestC =
     maybeBinaryName <- lookupEnv "TEST_BINARY_NAME"
     let
       elfDir = root </> firmwareBinariesDir "riscv32imc" Release
-      elfPath = elfDir </> fromMaybe "hello" maybeBinaryName
+      elfPath = elfDir </> fromMaybe "vexriscv-hello" maybeBinaryName
     pure
       peConfigRtl
         { initI =

--- a/bittide-instances/src/Bittide/Instances/Pnr/ProcessingElement.hs
+++ b/bittide-instances/src/Bittide/Instances/Pnr/ProcessingElement.hs
@@ -62,7 +62,7 @@ vexRiscvUartHelloC baudSnat = withBittideByteOrder $ circuit $ \(mm, (uartRx, jt
     maybeBinaryName <- lookupEnv "TEST_BINARY_NAME"
     let
       elfDir = root </> firmwareBinariesDir "riscv32imc" Debug
-      elfPath = elfDir </> fromMaybe "hello" maybeBinaryName
+      elfPath = elfDir </> fromMaybe "vexrscv-hello" maybeBinaryName
     pure
       peConfigRtl
         { initI =


### PR DESCRIPTION
Leftovers from #1039 that were missed because "hello" was cached