### PR TITLE
Reduce number of HITL tests run for every PR

### DIFF
--- a/.github/synthesis/main.json
+++ b/.github/synthesis/main.json
@@ -1,12 +1,6 @@
 [
   {"top": "safeDffSynchronizer",   "stage": "hdl" , "cc_report": false},
 
-
-  {"top": "linkConfigurationTest", "stage": "test", "cc_report": false},
   {"top": "softUgnDemoTest",       "stage": "test", "cc_report": true},
-  {"top": "swCcTopologyTest",      "stage": "test", "cc_report": true},
-  {"top": "switchDemoTest",        "stage": "test", "cc_report": true},
-  {"top": "transceiversUpTest",    "stage": "test", "cc_report": false},
-  {"top": "vexRiscvTcpTest",       "stage": "test", "cc_report": false},
-  {"top": "vexRiscvTest",          "stage": "test", "cc_report": false}
+  {"top": "switchDemoTest",        "stage": "test", "cc_report": true}
 ]


### PR DESCRIPTION
`swCcTopologyTest` is basically the same as `switchDemoTest`. The `vexRiscvTest`s we implicitly test through the others (the relevant parts, that is). The `linkConfigurationTest` is implicitly tested in the `switchDemoTest`.

Note that all these tests are still run at night.