### PR TITLE
Add abstraction trait over calendar types

### DIFF
--- a/bittide-instances/src/Bittide/Instances/Hitl/SoftUgnDemo/Core.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/SoftUgnDemo/Core.hs
@@ -72,7 +72,7 @@ muConfig ::
 muConfig =
   PeConfig
     { cpu = Riscv32imc.vexRiscv1
-    , initI = Undefined @(Div (64 * 1024) 4)
+    , initI = Undefined @(Div (96 * 1024) 4)
     , initD = Undefined @(Div (64 * 1024) 4)
     , iBusTimeout = d0
     , dBusTimeout = d0

--- a/firmware-binaries/Cargo.lock
+++ b/firmware-binaries/Cargo.lock
@@ -39,11 +39,13 @@ name = "bittide-hal"
 version = "0.1.0"
 dependencies = [
  "bittide-macros",
+ "const_panic",
  "log",
  "memmap-generate",
  "proc-macro2",
  "quote",
  "smoltcp 0.11.0",
+ "subst_macros",
  "ufmt",
 ]
 
@@ -191,6 +193,15 @@ dependencies = [
  "rand",
  "riscv-rt",
  "ufmt",
+]
+
+[[package]]
+name = "const_panic"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e262cdaac42494e3ae34c43969f9cdeb7da178bdb4b66fa6a1ea2edb4c8ae652"
+dependencies = [
+ "typewit",
 ]
 
 [[package]]
@@ -684,6 +695,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "subst_macros"
+version = "0.1.0"
+source = "git+https://github.com/QBayLogic/subst_macros.git?rev=1273588cd7b854b8b6294cf54c7e238f77778ac4#1273588cd7b854b8b6294cf54c7e238f77778ac4"
+
+[[package]]
 name = "switch-demo1-boot"
 version = "0.1.0"
 dependencies = [
@@ -784,6 +800,12 @@ dependencies = [
  "riscv-rt",
  "ufmt",
 ]
+
+[[package]]
+name = "typewit"
+version = "1.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8c1ae7cc0fdb8b842d65d127cb981574b0d2b249b74d1c7a2986863dc134f71"
 
 [[package]]
 name = "ufmt"

--- a/firmware-support/Cargo.lock
+++ b/firmware-support/Cargo.lock
@@ -57,11 +57,13 @@ name = "bittide-hal"
 version = "0.1.0"
 dependencies = [
  "bittide-macros",
+ "const_panic",
  "log",
  "memmap-generate",
  "proc-macro2",
  "quote",
  "smoltcp 0.11.0",
+ "subst_macros",
  "ufmt",
 ]
 
@@ -123,6 +125,15 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "const_panic"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e262cdaac42494e3ae34c43969f9cdeb7da178bdb4b66fa6a1ea2edb4c8ae652"
+dependencies = [
+ "typewit",
+]
 
 [[package]]
 name = "crc32fast"
@@ -706,6 +717,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "subst_macros"
+version = "0.1.0"
+source = "git+https://github.com/QBayLogic/subst_macros.git?rev=1273588cd7b854b8b6294cf54c7e238f77778ac4#1273588cd7b854b8b6294cf54c7e238f77778ac4"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -751,6 +767,12 @@ dependencies = [
  "structmeta",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "typewit"
+version = "1.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8c1ae7cc0fdb8b842d65d127cb981574b0d2b249b74d1c7a2986863dc134f71"
 
 [[package]]
 name = "ufmt"

--- a/firmware-support/bittide-hal/Cargo.toml
+++ b/firmware-support/bittide-hal/Cargo.toml
@@ -10,15 +10,20 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ufmt = "0.2.0"
-smoltcp = { git = "https://github.com/smoltcp-rs/smoltcp.git", rev = "dc08e0b42e668c331bb2b6f8d80016301d0efe03", default-features = false, features = [
-  "log",
-  "medium-ethernet",
-  "proto-ipv4",
-  "socket-tcp",
-] }
-log = "0.4.21"
+const_panic = "0.2.15"
 bittide-macros = { path = "../bittide-macros" }
+log = "0.4.21"
+ufmt = "0.2.0"
+
+[dependencies.smoltcp]
+git = "https://github.com/smoltcp-rs/smoltcp.git"
+rev = "dc08e0b42e668c331bb2b6f8d80016301d0efe03"
+default-features = false
+features = ["log", "medium-ethernet", "proto-ipv4", "socket-tcp"]
+
+[dependencies.subst_macros]
+git = "https://github.com/QBayLogic/subst_macros.git"
+rev = "1273588cd7b854b8b6294cf54c7e238f77778ac4"
 
 [build-dependencies]
 memmap-generate = { path = "../memmap-generate" }

--- a/firmware-support/bittide-hal/src/manual_additions/calendar.rs
+++ b/firmware-support/bittide-hal/src/manual_additions/calendar.rs
@@ -2,92 +2,363 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 /*! Calendar Interface
- *
+
 The `calendar` module provides a hardware abstraction layer over based on the generated
 peripheral access code for the `Calendar` device.
  */
 
-use crate::{self as bittide_hal, hals};
+use crate::manual_additions::{FromAs, IntoAs};
 
-use bittide_hal::{
-    hals::switch_c::devices::calendar::Calendar,
-    types::{ValidEntry_12, ValidEntry_16},
-};
+pub trait ValidEntryType {
+    type Inner;
+    type Repeat;
 
-pub type EntryType = ValidEntry_12<[u8; 16]>;
+    const REPEAT_MASK: Self::Repeat;
 
-/// Generic Calendar implementations
-impl Calendar {
-    /// Reads entry n from the shadow calendar.
-    pub fn read_shadow_entry(&self, n: usize) -> EntryType {
-        self.set_read_addr(n as _);
-        self.shadow_entry()
+    fn new(entry: Self::Inner, repeat: Self::Repeat) -> Self;
+}
+
+pub type ValidEntryInner<T> = <T as ValidEntryType>::Inner;
+pub type ValidEntryRepeat<T> = <T as ValidEntryType>::Repeat;
+
+pub const fn valid_entry_repeat_mask<T: ValidEntryType>() -> ValidEntryRepeat<T> {
+    <T as ValidEntryType>::REPEAT_MASK
+}
+
+macro_rules! impl_valid_entry_type {
+    (
+        type: [$($valid:tt)+],
+        repeat: $repeat:ty,
+        mask: $mask:literal,
+    ) => {
+        impl<T> ValidEntryType for $($valid)+<T> {
+            type Inner = T;
+            type Repeat = $repeat;
+
+            const REPEAT_MASK: Self::Repeat = $mask as $repeat;
+
+            fn new(entry: Self::Inner, repeat: Self::Repeat) -> Self {
+                let repeat = repeat & Self::REPEAT_MASK;
+                Self {
+                    ve_entry: entry,
+                    ve_repeat: repeat,
+                }
+            }
+        }
+    }
+}
+
+impl_valid_entry_type! {
+    type: [crate::types::ValidEntry_12],
+    repeat: u16,
+    mask: 12,
+}
+
+impl_valid_entry_type! {
+    type: [crate::types::ValidEntry_16],
+    repeat: u16,
+    mask: 16,
+}
+
+/// Abstraction trait over all the methods that a calendar type should provide
+pub trait CalendarInterface {
+    type EntryType: Copy + ValidEntryType;
+    type MetacycleCount;
+
+    type ShadowIndex: Ord + FromAs<usize> + IntoAs<usize> + IntoAs<u128>;
+    const SHADOW_INDEX_MAX: Self::ShadowIndex;
+
+    type WriteIndex: Ord + FromAs<usize> + IntoAs<u128>;
+    const WRITE_ADDR_MAX: Self::WriteIndex;
+
+    type ReadIndex: Ord + FromAs<usize> + IntoAs<u128>;
+    const READ_ADDR_MAX: Self::ReadIndex;
+
+    fn calint_shadow_depth_index(&self) -> Self::ShadowIndex;
+    fn calint_shadow_entry(&self) -> Self::EntryType;
+    fn calint_metacycle_count(&self) -> u32;
+    fn calint_set_shadow_depth_index(&self, val: Self::ShadowIndex);
+    fn calint_set_write_addr(&self, val: Self::WriteIndex);
+    fn calint_set_read_addr(&self, val: Self::ReadIndex);
+    fn calint_set_shadow_entry(&self, val: Self::EntryType);
+    fn calint_set_swap_active(&self, val: bool);
+    fn calint_set_end_of_metacycle(&self, val: bool);
+}
+
+/// Type alias for retrieving the entry type of a calendar type.
+pub type CalendarEntryType<T> = <T as CalendarInterface>::EntryType;
+
+/// Type alias for retrieving the metacycle count type of a calendar type.
+pub type CalendarMetacycleCount<T> = <T as CalendarInterface>::MetacycleCount;
+
+/// Type alias for retrieving the shadow index type of a calendar type.
+pub type CalendarShadowIndex<T> = <T as CalendarInterface>::ShadowIndex;
+
+/// Type alias for retrieving the write index type of a calendar type.
+pub type CalendarWriteIndex<T> = <T as CalendarInterface>::WriteIndex;
+
+/// Type alias for retrieving the read index type of a calendar type.
+pub type CalendarReadIndex<T> = <T as CalendarInterface>::ReadIndex;
+
+macro_rules! impl_calendar_interface {
+    (
+        cal: $cty:ty,
+        metacycle: $mc:ty,
+        shadow: $si:ty,
+        write: $wi:ty,
+        read: $ri:ty,
+        entry: $et:ty,
+    ) => {
+        // Assertions that must be met for the implementation to be valid
+        const _: () = {
+            // Assert that the metacycle count type is minimally sized
+            let mc_min_bytes = <$cty>::METACYCLE_COUNT_WIDTH
+                .div_ceil(8)
+                .next_power_of_two();
+            if mc_min_bytes as usize * 8 != <$mc>::BITS as usize {
+                const_panic::concat_panic!(
+                    "Metacycle count type for type ",
+                    stringify!($cty),
+                    " is not minimally sized. Should be of type u",
+                    <$cty>::METACYCLE_COUNT_WIDTH.next_power_of_two(),
+                );
+            }
+            // Assert that the shadow index type can hold the maximum shadow depth index
+            if (<$cty>::SHADOW_DEPTH_INDEX_SIZE as u128 - 1) > (<$si>::MAX as u128) {
+                const_panic::concat_panic!(
+                    "Shadow index type ",
+                    stringify!($si),
+                    " cannot fit the maximum value ",
+                    <$cty>::SHADOW_DEPTH_INDEX_SIZE as u128 - 1,
+                );
+            }
+            // Assert that the write index type can hold the maximum write address
+            if <$cty>::WRITE_ADDR_SIZE as u128 - 1 > <$wi>::MAX as u128 {
+                const_panic::concat_panic!(
+                    "Write index type ",
+                    stringify!($wi),
+                    " cannot fit the maximum value ",
+                    <$cty>::WRITE_ADDR_SIZE as u128 - 1,
+                );
+            }
+            // Assert that the read index type can hold the maximum read address
+            if <$cty>::READ_ADDR_SIZE as u128 - 1 > <$ri>::MAX as u128 {
+                const_panic::concat_panic!(
+                    "Read index type ",
+                    stringify!($ri),
+                    " cannot fit the maximum value ",
+                    <$cty>::READ_ADDR_SIZE as u128 - 1,
+                );
+            }
+        };
+        impl CalendarInterface for $cty {
+            type EntryType = $et;
+            type MetacycleCount = $mc;
+
+            type ShadowIndex = $si;
+            const SHADOW_INDEX_MAX: $si = (<$cty>::SHADOW_DEPTH_INDEX_SIZE - 1) as $si;
+
+            type WriteIndex = $wi;
+            const WRITE_ADDR_MAX: $wi = (<$cty>::WRITE_ADDR_SIZE - 1) as $wi;
+
+            type ReadIndex = $ri;
+            const READ_ADDR_MAX: $ri = (<$cty>::READ_ADDR_SIZE - 1) as $ri;
+
+            fn calint_shadow_depth_index(&self) -> Self::ShadowIndex {
+                self.shadow_depth_index()
+            }
+
+            fn calint_shadow_entry(&self) -> Self::EntryType {
+                self.shadow_entry()
+            }
+
+            fn calint_metacycle_count(&self) -> Self::MetacycleCount {
+                self.metacycle_count()
+            }
+
+            fn calint_set_shadow_depth_index(&self, val: Self::ShadowIndex) {
+                self.set_shadow_depth_index(val)
+            }
+
+            fn calint_set_write_addr(&self, val: Self::WriteIndex) {
+                self.set_write_addr(val)
+            }
+
+            fn calint_set_read_addr(&self, val: Self::ReadIndex) {
+                self.set_read_addr(val)
+            }
+
+            fn calint_set_shadow_entry(&self, val: Self::EntryType) {
+                self.set_shadow_entry(val)
+            }
+
+            fn calint_set_swap_active(&self, val: bool) {
+                self.set_swap_active(val)
+            }
+
+            fn calint_set_end_of_metacycle(&self, val: bool) {
+                self.set_end_of_metacycle(val)
+            }
+        }
+    };
+}
+
+/// Abstraction over the interface that should be provided by all calendar types.
+pub trait CalendarType: CalendarInterface {
+    /// Reads entry `n` from the shadow calendar.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `n` is an invalid value for a `Self::ReadIndex` type instance.
+    fn read_shadow_entry(&self, n: usize) -> Self::EntryType {
+        assert!(
+            n as u128 <= Self::READ_ADDR_MAX.into_as(),
+            "Shadow entry read index is out of bounds."
+        );
+        self.calint_set_read_addr(Self::ReadIndex::from_as(n));
+        self.calint_shadow_entry()
     }
 
     /// Writes entry `entry` to the shadow calendar at address `n`.
-    pub fn write_shadow_entry(&self, n: usize, entry: EntryType) {
-        let n1 = n as u8;
-        self.set_shadow_entry(entry);
-        self.set_write_addr(n1);
+    ///
+    /// # Panics
+    ///
+    /// Panics if `n` is an invalid value for a `Self::WriteIndex` type instance.
+    fn write_shadow_entry(&self, n: usize, entry: Self::EntryType) {
+        assert!(
+            n as u128 <= Self::WRITE_ADDR_MAX.into_as(),
+            "Shadow entry write index is out of bounds."
+        );
+        self.calint_set_shadow_entry(entry);
+        self.calint_set_write_addr(Self::WriteIndex::from_as(n));
     }
 
     /// Swaps the active and shadow calendar at the end of the metacycle.
-    pub fn swap_calendar(&self) {
-        self.set_swap_active(true);
+    fn swap_calendar(&self) {
+        self.calint_set_swap_active(true);
     }
 
     /// Stalls until the end of the metacycle.
-    pub fn wait_for_end_of_metacycle(&self) {
-        self.set_end_of_metacycle(true);
+    fn wait_for_end_of_metacycle(&self) {
+        self.calint_set_end_of_metacycle(true);
     }
 
     /// Returns the number of entries in the shadow calendar.
-    pub fn shadow_depth(&self) -> usize {
-        self.shadow_depth_index() as usize + 1
+    fn shadow_depth(&self) -> usize {
+        <Self::ShadowIndex as IntoAs<usize>>::into_as(self.calint_shadow_depth_index()) + 1
     }
 
     /// Returns an iterator over the shadow calendar entries.
-    pub fn read_shadow_calendar<'a>(&'a self) -> impl Iterator<Item = EntryType> + 'a {
-        (0..self.shadow_depth()).map(move |n| {
-            let n1 = n as u8;
-            self.set_read_addr(n1);
-            self.shadow_entry()
+    fn read_shadow_calendar<'a>(&'a self) -> impl Iterator<Item = Self::EntryType> + 'a {
+        (0..self.shadow_depth()).map(|n| {
+            self.calint_set_read_addr(Self::ReadIndex::from_as(n));
+            self.calint_shadow_entry()
         })
     }
 
     /// Writes a calendar to the shadow calendar.
-    pub fn write_shadow_calendar(&self, entries: &[EntryType]) {
+    ///
+    /// # Panics
+    ///
+    /// Panics if the length of the slice passed to this method is longer than the length
+    /// of the shadow calendar.
+    fn write_shadow_calendar(&self, entries: &[Self::EntryType]) {
+        if entries.is_empty() {
+            return;
+        }
         assert!(
-            entries.len() <= Self::SHADOW_DEPTH_INDEX_SIZE,
+            entries.len() as u128
+                <= <Self::ShadowIndex as IntoAs<u128>>::into_as(Self::SHADOW_INDEX_MAX),
             "Entries exceed shadow calendar size"
         );
         for (n, entry) in entries.iter().enumerate() {
-            let n1 = n as u8;
-            self.set_shadow_entry(*entry);
-            self.set_write_addr(n1);
+            self.calint_set_shadow_entry(*entry);
+            self.calint_set_write_addr(Self::WriteIndex::from_as(n));
         }
-        self.set_shadow_depth_index((entries.len() - 1) as u8);
+        self.calint_set_shadow_depth_index(Self::ShadowIndex::from_as(entries.len() - 1));
     }
 }
 
-type RingbufferCalendar = hals::soft_ugn_demo_mu::devices::calendar::Calendar;
+impl<T: CalendarInterface> CalendarType for T {}
 
-/// Ringbuffer related calendar implementations
-impl RingbufferCalendar {
-    pub fn initialize_as_ringbuffer(&self, size: usize) {
-        assert!(
-            size <= Self::SHADOW_DEPTH_INDEX_SIZE,
-            "Size exceeds shadow calendar size"
-        );
-        for n in 0..size {
-            let entry = ValidEntry_16 {
-                ve_entry: n as u16,
-                ve_repeat: 0,
-            };
-            self.set_shadow_entry(entry);
-            self.set_write_addr(n as u16);
+impl_calendar_interface! {
+    cal: crate::hals::switch_c::devices::Calendar,
+    metacycle: u32,
+    shadow: u8,
+    write: u8,
+    read: u8,
+    entry: crate::types::ValidEntry_12<[u8; 16]>,
+}
+
+impl_calendar_interface! {
+    cal: crate::hals::switch_demo_mu::devices::Calendar,
+    metacycle: u32,
+    shadow: u8,
+    write: u8,
+    read: u8,
+    entry: crate::types::ValidEntry_12<[u8; 8]>,
+}
+
+impl_calendar_interface! {
+    cal: crate::hals::switch_demo_gppe_mu::devices::Calendar,
+    metacycle: u32,
+    shadow: u16,
+    write: u16,
+    read: u16,
+    entry: crate::types::ValidEntry_12<u16>,
+}
+
+impl_calendar_interface! {
+    cal: crate::hals::scatter_gather_pe::devices::Calendar,
+    metacycle: u32,
+    shadow: u8,
+    write: u8,
+    read: u8,
+    entry: crate::types::ValidEntry_12<u8>,
+}
+
+impl_calendar_interface! {
+    cal: crate::hals::soft_ugn_demo_mu::devices::Calendar,
+    metacycle: u32,
+    shadow: u16,
+    write: u16,
+    read: u16,
+    entry: crate::types::ValidEntry_16<u16>,
+}
+
+pub trait RingbufferCalendar {
+    fn initialize_as_ringbuffer(&self, size: usize);
+}
+
+impl<T> RingbufferCalendar for T
+where
+    T: CalendarType,
+    ValidEntryInner<CalendarEntryType<T>>: FromAs<usize>,
+    ValidEntryRepeat<CalendarEntryType<T>>: FromAs<u8>,
+{
+    /// Initializes a calendar type which contains entries derivable from `usize` and repeats
+    /// derivable from `u8` as a ringbuffer.
+    ///
+    /// # Panics
+    ///
+    /// Panics if:
+    /// - Attempting to initialize a ringbuffer of size 0
+    /// - Attempting to initialize a ringbuffer of a size greater than the maximum size of the
+    ///   calendar (compared against [`Self::SHADOW_INDEX_MAX`])
+    fn initialize_as_ringbuffer(&self, size: usize) {
+        assert!(size > 0, "Cannot have a ringbuffer of size 0!");
+        let size_max_index: CalendarShadowIndex<T> = (size - 1).into_as();
+        if size_max_index > Self::SHADOW_INDEX_MAX {
+            panic!(
+                "Size ({size}) exceeds calendar size ({})",
+                <CalendarShadowIndex<T> as IntoAs<u128>>::into_as(Self::SHADOW_INDEX_MAX)
+            );
         }
-        self.set_shadow_depth_index((size - 1) as u16);
-        self.set_swap_active(true);
+        for n in 0..size {
+            let entry = CalendarEntryType::<Self>::new(n.into_as(), 0.into_as());
+            self.write_shadow_entry(n, entry);
+        }
+        self.calint_set_shadow_depth_index(size_max_index);
+        self.calint_set_swap_active(true);
     }
 }

--- a/firmware-support/bittide-hal/src/manual_additions/mod.rs
+++ b/firmware-support/bittide-hal/src/manual_additions/mod.rs
@@ -11,3 +11,95 @@ pub mod si539x_spi;
 pub mod soft_ugn_demo_gppe;
 pub mod timer;
 pub mod uart;
+
+// Sealing the `FromAs` and `IntoAs` traits with a supertrait
+mod seal {
+    pub trait Seal {}
+
+    subst_macros::repeat_parallel_subst! {
+        groups: [
+            [group [sub [TYPE] = [u8]]]
+            [group [sub [TYPE] = [u16]]]
+            [group [sub [TYPE] = [u32]]]
+            [group [sub [TYPE] = [u64]]]
+            [group [sub [TYPE] = [u128]]]
+            [group [sub [TYPE] = [usize]]]
+            [group [sub [TYPE] = [i8]]]
+            [group [sub [TYPE] = [i16]]]
+            [group [sub [TYPE] = [i32]]]
+            [group [sub [TYPE] = [i64]]]
+            [group [sub [TYPE] = [i128]]]
+            [group [sub [TYPE] = [isize]]]
+        ],
+        callback: NONE,
+        in: {
+            impl Seal for TYPE {}
+        }
+    }
+}
+
+/// Trait-level guarantee that `self as U` is valid for `self: T`
+pub trait FromAs<T>: seal::Seal {
+    fn from_as(other: T) -> Self;
+}
+
+subst_macros::repeat_parallel_subst! {
+    groups: [
+        [group [sub [SELF] = [u8]]]
+        [group [sub [SELF] = [u16]]]
+        [group [sub [SELF] = [u32]]]
+        [group [sub [SELF] = [u64]]]
+        [group [sub [SELF] = [u128]]]
+        [group [sub [SELF] = [usize]]]
+        [group [sub [SELF] = [i8]]]
+        [group [sub [SELF] = [i16]]]
+        [group [sub [SELF] = [i32]]]
+        [group [sub [SELF] = [i64]]]
+        [group [sub [SELF] = [i128]]]
+        [group [sub [SELF] = [isize]]]
+    ],
+    callback: [
+        macro: subst_macros::repeat_parallel_subst,
+        prefix: [
+            @callback
+            groups: [
+                [group [sub [OTHER] = [u8]]]
+                [group [sub [OTHER] = [u16]]]
+                [group [sub [OTHER] = [u32]]]
+                [group [sub [OTHER] = [u64]]]
+                [group [sub [OTHER] = [u128]]]
+                [group [sub [OTHER] = [usize]]]
+                [group [sub [OTHER] = [i8]]]
+                [group [sub [OTHER] = [i16]]]
+                [group [sub [OTHER] = [i32]]]
+                [group [sub [OTHER] = [i64]]]
+                [group [sub [OTHER] = [i128]]]
+                [group [sub [OTHER] = [isize]]]
+            ],
+            callback: NONE,
+        ],
+        suffix: [],
+    ],
+    in: {
+        impl FromAs<OTHER> for SELF {
+            fn from_as(other: OTHER) -> SELF {
+                other as SELF
+            }
+        }
+    }
+}
+
+/// Inverse of [`FromAs`]
+pub trait IntoAs<T>: seal::Seal {
+    fn into_as(self) -> T;
+}
+
+impl<T, U> IntoAs<U> for T
+where
+    T: seal::Seal,
+    U: FromAs<T>,
+{
+    fn into_as(self) -> U {
+        U::from_as(self)
+    }
+}


### PR DESCRIPTION
Previously abstractions were only made over a single switch calendar, however those abstractions should be useable for all other calendar types. As such, it was necessary to make those abstractions agnostic over what calendar they were used on. Now to use the HAL for calendars, one only needs to provide an implementation of the `CalendarInterface` trait. In order to facilitate this, a helper macro is provided (`impl_calendar_interface`). I also then use this helper macro to implement the `CalendarInterface` trait for all the calendar types that currently exist.