### PR TITLE
Bump Docker image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
     name: Populate Cachix cache
     runs-on: [self-hosted, compute]
     container:
-      image: ghcr.io/clash-lang/nixos-bittide-hardware:2025-11-05
+      image: ghcr.io/clash-lang/nixos-bittide-hardware:2025-11-24
       options: --memory=11g
     steps:
     - uses: actions/checkout@v4
@@ -72,7 +72,7 @@ jobs:
         shell: git-nix-shell {0}
 
     container:
-      image: ghcr.io/clash-lang/nixos-bittide-hardware:2025-11-05
+      image: ghcr.io/clash-lang/nixos-bittide-hardware:2025-11-24
       options: --memory=11g
 
     steps:
@@ -133,7 +133,7 @@ jobs:
         shell: git-nix-shell {0} --ignore-environment
 
     container:
-      image: ghcr.io/clash-lang/nixos-bittide-hardware:2025-11-05
+      image: ghcr.io/clash-lang/nixos-bittide-hardware:2025-11-24
       options: --memory=11g
 
     steps:
@@ -186,7 +186,7 @@ jobs:
       fail-fast: false
 
     container:
-      image: ghcr.io/clash-lang/nixos-bittide-hardware:2025-11-05
+      image: ghcr.io/clash-lang/nixos-bittide-hardware:2025-11-24
       options: --memory=11g
 
     env:
@@ -249,7 +249,7 @@ jobs:
       run:
         shell: git-nix-shell {0}
     container:
-      image: ghcr.io/clash-lang/nixos-bittide-hardware:2025-11-05
+      image: ghcr.io/clash-lang/nixos-bittide-hardware:2025-11-24
       options: --memory=11g
     outputs:
       run_tests: ${{ steps.check.outputs.run_tests }}
@@ -281,7 +281,7 @@ jobs:
     if: ${{ needs.should-run-haskell-tests.outputs.run_tests == 'true' }}
 
     container:
-      image: ghcr.io/clash-lang/nixos-bittide-hardware:2025-11-05
+      image: ghcr.io/clash-lang/nixos-bittide-hardware:2025-11-24
       options: --memory=11g
       volumes:
         - /opt/tools:/opt/tools
@@ -355,7 +355,7 @@ jobs:
       run:
         shell: git-nix-shell {0} --ignore-environment
     container:
-      image: ghcr.io/clash-lang/nixos-bittide-hardware:2025-11-05
+      image: ghcr.io/clash-lang/nixos-bittide-hardware:2025-11-24
       options: --memory=11g
     needs: [build]
 
@@ -381,7 +381,7 @@ jobs:
       run:
         shell: git-nix-shell {0} --ignore-environment
     container:
-      image: ghcr.io/clash-lang/nixos-bittide-hardware:2025-11-05
+      image: ghcr.io/clash-lang/nixos-bittide-hardware:2025-11-24
       options: --memory=11g
     needs: [build]
 
@@ -409,7 +409,7 @@ jobs:
       run:
         shell: git-nix-shell {0} --ignore-environment
     container:
-      image: ghcr.io/clash-lang/nixos-bittide-hardware:2025-11-05
+      image: ghcr.io/clash-lang/nixos-bittide-hardware:2025-11-24
       options: --memory=11g
     needs: [build]
 
@@ -490,7 +490,7 @@ jobs:
       fail-fast: false
 
     container:
-      image: ghcr.io/clash-lang/nixos-bittide-hardware:2025-11-05
+      image: ghcr.io/clash-lang/nixos-bittide-hardware:2025-11-24
       volumes:
         - /opt/tools:/opt/tools
       options: --init --mac-address="6c:5a:b0:6c:13:0b" --memory=11g
@@ -616,7 +616,7 @@ jobs:
         shell: git-nix-shell {0} --ignore-environment
 
     container:
-      image: ghcr.io/clash-lang/nixos-bittide-hardware:2025-11-05
+      image: ghcr.io/clash-lang/nixos-bittide-hardware:2025-11-24
       options: --memory=11g
 
     strategy:
@@ -659,7 +659,7 @@ jobs:
       fail-fast: false
 
     container:
-      image: ghcr.io/clash-lang/nixos-bittide-hardware:2025-11-05
+      image: ghcr.io/clash-lang/nixos-bittide-hardware:2025-11-24
       volumes:
         - /opt/tools:/opt/tools
         - /dev:/dev
@@ -719,7 +719,7 @@ jobs:
       run:
         shell: git-nix-shell {0} --ignore-environment
     container:
-      image: ghcr.io/clash-lang/nixos-bittide-hardware:2025-11-05
+      image: ghcr.io/clash-lang/nixos-bittide-hardware:2025-11-24
       options: --memory=11g
     steps:
       - name: Checkout

--- a/.github/workflows/deploy-documentation.yml
+++ b/.github/workflows/deploy-documentation.yml
@@ -23,7 +23,7 @@ jobs:
       run:
         shell: git-nix-shell {0} --ignore-environment
     container:
-      image: ghcr.io/clash-lang/nixos-bittide-hardware:2025-11-05
+      image: ghcr.io/clash-lang/nixos-bittide-hardware:2025-11-24
       options: --memory=11g
     steps:
       - name: Checkout


### PR DESCRIPTION
https://github.com/bittide/bittide-hardware/pull/1077 changed the Nix flake a tiny bit but didn't update the docker image.