### PR TITLE
Do not halt CPUs in OpenOCD

### DIFF
--- a/bittide-instances/data/openocd/vexriscv-2chain.tcl
+++ b/bittide-instances/data/openocd/vexriscv-2chain.tcl
@@ -22,8 +22,3 @@ foreach tap $tap_list {
 }
 
 echo "Initialization complete"
-echo "Halting processor"
-
-halt
-
-sleep 1000

--- a/bittide-instances/data/openocd/vexriscv-3chain.tcl
+++ b/bittide-instances/data/openocd/vexriscv-3chain.tcl
@@ -25,8 +25,3 @@ foreach tap $tap_list {
 }
 
 echo "Initialization complete"
-echo "Halting processor"
-
-halt
-
-sleep 1000

--- a/bittide-instances/data/openocd/vexriscv_init.tcl
+++ b/bittide-instances/data/openocd/vexriscv_init.tcl
@@ -19,8 +19,3 @@ foreach tap $tap_list {
 }
 
 echo "Initialization complete"
-echo "Halting processor"
-
-halt
-
-sleep 1000

--- a/bittide-instances/src/Bittide/Instances/Hitl/Driver/Si539xConfiguration.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/Driver/Si539xConfiguration.hs
@@ -61,7 +61,7 @@ initOpenOcd hitlDir (_, d) targetIndex = do
     Ocd.startOpenOcdWithEnv openocdEnv d.usbAdapterLocation gdbPort 6666 4444
   hSetBuffering ocd.stderrHandle LineBuffering
   T.tryWithTimeout T.PrintActionTime "Waiting for OpenOCD to start" 15_000_000
-    $ expectLine ocd.stderrHandle Ocd.waitForHalt
+    $ expectLine ocd.stderrHandle Ocd.waitForInitComplete
 
   let
     ocdProcName = "OpenOCD (" <> d.deviceId <> ")"

--- a/bittide-instances/src/Bittide/Instances/Hitl/Driver/VexRiscv.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/Driver/VexRiscv.hs
@@ -79,7 +79,7 @@ driverFunc _name targets = do
     liftIO $ Ocd.withOpenOcdWithEnv openocdEnv deviceInfo.usbAdapterLocation gdbPort 6666 4444 $ \ocd -> do
       -- make sure OpenOCD is started properly
       hSetBuffering ocd.stderrHandle LineBuffering
-      expectLine ocd.stderrHandle Ocd.waitForHalt
+      expectLine ocd.stderrHandle Ocd.waitForInitComplete
 
       putStrLn "Starting Picocom..."
       putStrLn $ "Logging output to '" <> hitlDir

--- a/bittide-instances/src/Bittide/Instances/Hitl/Driver/VexRiscvTcp.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/Driver/VexRiscvTcp.hs
@@ -86,7 +86,7 @@ driverFunc _name [d@(_, dI)] = do
     liftIO $ do
       hSetBuffering ocd.stderrHandle LineBuffering
       putStr "Waiting for OpenOCD to halt..."
-      expectLine ocd.stderrHandle Ocd.waitForHalt
+      expectLine ocd.stderrHandle Ocd.waitForInitComplete
       putStrLn "  Done"
 
       putStrLn "Starting Picocom..."

--- a/bittide-instances/src/Bittide/Instances/Hitl/Utils/OpenOcd.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/Utils/OpenOcd.hs
@@ -21,11 +21,11 @@ import Text.Read (readMaybe)
 getStartPath :: IO FilePath
 getStartPath = getDataFileName "data/openocd/start.sh"
 
--- | Wait until we see "Halting processor", fail if we see an error.
-waitForHalt :: String -> Filter
-waitForHalt s
+-- | Wait until we see \"Initialization complete\", fail if we see an error.
+waitForInitComplete :: String -> Filter
+waitForInitComplete s
   | "Error:" `isPrefixOf` s = Stop (Error ("Found error in OpenOCD output: " <> s))
-  | "Halting processor" `isPrefixOf` s = Stop Ok
+  | initCompleteMarker `isPrefixOf` s = Stop Ok
   | otherwise = Continue
 
 initCompleteMarker :: String
@@ -46,7 +46,7 @@ withOpenOcd ::
   m a
 withOpenOcd = withOpenOcdWithEnv []
 
-{- | Run an action with an openocd process initialzed according to the scripts
+{- | Run an action with an openocd process initialized according to the scripts
 located in the data/openocd directory.
 -}
 withOpenOcdWithEnv ::

--- a/gdb-hs/src/Gdb/Commands/Basic.hs
+++ b/gdb-hs/src/Gdb/Commands/Basic.hs
@@ -33,6 +33,14 @@ continue gdb =
   -- Note that we can't use 'readCommand' here, because this command won't return
   hPutStrLn gdb.stdin "continue"
 
+{- | Send the \"interrupt\" command to GDB. This is different from sending a
+SIGINT to the GDB process itself. Can be used to pause execution of the
+target program if the GDB prompt is already active.
+-}
+interruptCommand :: (HasCallStack) => Gdb -> IO ()
+interruptCommand gdb =
+  hPutStrLn gdb.stdin "interrupt"
+
 {- | Send @SIGINT@ to the GDB process. This will pause the execution of the
 program being debugged and return control to GDB.
 -}


### PR DESCRIPTION
This seems unnecessary and causes issues when one of the targets is still in reset.