### PR TITLE
Allow clock control to work independently of links

### DIFF
--- a/firmware-binaries/Cargo.lock
+++ b/firmware-binaries/Cargo.lock
@@ -163,6 +163,7 @@ version = "0.1.0"
 dependencies = [
  "bittide-hal",
  "bittide-sys",
+ "itertools",
  "memmap-generate",
  "riscv-rt",
  "ufmt",

--- a/firmware-binaries/demos/clock-control/Cargo.toml
+++ b/firmware-binaries/demos/clock-control/Cargo.toml
@@ -16,6 +16,7 @@ riscv-rt = "0.11.0"
 bittide-sys = { path = "../../../firmware-support/bittide-sys" }
 bittide-hal = { path = "../../../firmware-support/bittide-hal" }
 ufmt = "0.2.0"
+itertools = { version = "0.14.0", default-features = false }
 
 [build-dependencies]
 memmap-generate = { path = "../../../firmware-support/memmap-generate" }

--- a/firmware-binaries/demos/switch-demo1-boot/src/main.rs
+++ b/firmware-binaries/demos/switch-demo1-boot/src/main.rs
@@ -9,7 +9,7 @@ use core::panic::PanicInfo;
 use ufmt::uwriteln;
 
 use bittide_hal::manual_additions::si539x_spi::{Config, WriteError};
-use bittide_hal::shared_devices::transceivers::Transceivers;
+use bittide_hal::shared_devices::Transceivers;
 use bittide_hal::switch_demo_boot::DeviceInstances;
 use bittide_macros::load_clock_config_csv;
 
@@ -49,20 +49,11 @@ fn main() -> ! {
 
     uwriteln!(uart, "Enabling bittide domain..").unwrap();
     transceivers.set_transceiver_enable(true);
-    uwriteln!(uart, "Done.").unwrap();
 
     uwriteln!(uart, "Enabling all transceiver channels..").unwrap();
     for channel in 0..Transceivers::CHANNEL_ENABLES_LEN {
         transceivers.set_channel_enables(channel, true);
     }
-
-    for channel in 0..Transceivers::HANDSHAKES_DONE_LEN {
-        while !transceivers.handshakes_done(channel).unwrap_or(false) {}
-        uwriteln!(uart, "Channel {} handshake done.", channel).unwrap();
-        uwriteln!(uart, "{:?}", transceivers.statistics(channel)).unwrap();
-    }
-
-    uwriteln!(uart, "Done.").unwrap();
 
     uwriteln!(uart, "Going into infinite loop..").unwrap();
     #[allow(clippy::empty_loop)]

--- a/firmware-binaries/demos/switch-demo1-mu/src/main.rs
+++ b/firmware-binaries/demos/switch-demo1-mu/src/main.rs
@@ -19,7 +19,13 @@ fn main() -> ! {
     let mut uart = INSTANCES.uart;
     let transceivers = &INSTANCES.transceivers;
 
-    uwriteln!(uart, "Hello from management unit..").unwrap();
+    // Channels should be enabled by boot program, so we can simply wait here
+    uwriteln!(uart, "Waiting for channel negotiations..").unwrap();
+    for channel in 0..Transceivers::HANDSHAKES_DONE_LEN {
+        while !transceivers.handshakes_done(channel).unwrap_or(false) {}
+        uwriteln!(uart, "Channel {} negotiation done.", channel).unwrap();
+        uwriteln!(uart, "{:?}", transceivers.statistics(channel)).unwrap();
+    }
 
     uwriteln!(uart, "Centering buffer occupancies").unwrap();
     for (i, eb) in [

--- a/firmware-binaries/demos/switch-demo2-mu/src/main.rs
+++ b/firmware-binaries/demos/switch-demo2-mu/src/main.rs
@@ -19,7 +19,13 @@ fn main() -> ! {
     let mut uart = INSTANCES.uart;
     let transceivers = &INSTANCES.transceivers;
 
-    uwriteln!(uart, "Hello from management unit..").unwrap();
+    // Channels should be enabled by boot program, so we can simply wait here
+    uwriteln!(uart, "Waiting for channel negotiations..").unwrap();
+    for channel in 0..Transceivers::HANDSHAKES_DONE_LEN {
+        while !transceivers.handshakes_done(channel).unwrap_or(false) {}
+        uwriteln!(uart, "Channel {} negotiation done.", channel).unwrap();
+        uwriteln!(uart, "{:?}", transceivers.statistics(channel)).unwrap();
+    }
 
     uwriteln!(uart, "Centering buffer occupancies").unwrap();
     for (i, eb) in [


### PR DESCRIPTION
# TODO
- [ ] ~~Don't wait for `"[BT] Going into infinite loop.."` as early as we do. We can delay it, thereby increasing the change of CC seeing links that aren't up yet.~~ Something is wrong and it's probably related to OpenOCD. Postponing..