### PR TITLE
Generalize MU for SwitchDemo

### DIFF
--- a/bittide-instances/src/Bittide/Instances/Hitl/SoftUgnDemo/Core.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/SoftUgnDemo/Core.hs
@@ -20,6 +20,7 @@ import Bittide.ProcessingElement (
   PeConfig (..),
   PeInternalBusses,
   PrefixWidth,
+  RemainingBusWidth,
   processingElement,
  )
 import Bittide.ScatterGather
@@ -40,10 +41,28 @@ import qualified Protocols.Vec as Vec
 
 type FifoSize = 5 -- = 2^5 = 32
 
+{- Internal busses:
+    - Instruction memory
+    - Data memory
+    - `timeWb`
+    - DNA
+    - UART
+-}
 type NmuInternalBusses = 3 + PeInternalBusses
-type NmuExternalBusses = (LinkCount * PeripheralsPerLink) + LinkCount + 1 -- +1 for tranceivers
-type PeripheralsPerLink = 3 -- Scatter calendar, Gather calendar, UGN component.
-type NmuRemBusWidth = 30 - CLog 2 (NmuExternalBusses + NmuInternalBusses)
+
+{- Busses per link:
+    - UGN component
+    - Elastic buffer
+    - Scatter calendar
+    - Gather calendar
+-}
+type PeripheralsPerLink = 4
+
+{- External busses:
+    - Transceivers
+-}
+type NmuExternalBusses = 1 + (LinkCount * PeripheralsPerLink)
+type NmuRemBusWidth = RemainingBusWidth (NmuExternalBusses + NmuInternalBusses)
 
 muConfig ::
   ( KnownNat n

--- a/bittide-instances/src/Bittide/Instances/Hitl/SwitchDemo/BringUp.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/SwitchDemo/BringUp.hs
@@ -159,7 +159,6 @@ bringUp refClk refRst = withBittideByteOrder $ circuit $ \(bootMm, muMm, ccMm, j
       -< ( muMm
          , ccMm
          , otherJtagBittide
-         , Fwd 0
          , Fwd (pure maxBound)
          , Fwd linksSuitableForCc
          , Fwd tOutputs.rxDatas

--- a/bittide-instances/src/Bittide/Instances/Hitl/SwitchDemoGppe/Core.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/SwitchDemoGppe/Core.hs
@@ -20,6 +20,7 @@ import Bittide.ProcessingElement (
   PeConfig (..),
   PeInternalBusses,
   PrefixWidth,
+  RemainingBusWidth,
   processingElement,
  )
 import Bittide.ScatterGather
@@ -40,10 +41,29 @@ import qualified Protocols.Vec as Vec
 
 type FifoSize = 5 -- = 2^5 = 32
 
-type NmuInternalBusses = 4 + PeInternalBusses
-type NmuExternalBusses = 2 + (LinkCount * PeripheralsPerLink) + 1 + 1 -- +2 for SG calendars, +1 for the switch calendar, +1 for tranceivers
-type PeripheralsPerLink = 2 -- UGN component, Elastic buffer
-type NmuRemBusWidth = 30 - CLog 2 (NmuExternalBusses + NmuInternalBusses)
+{- Internal busses:
+    - Instruction memory
+    - Data memory
+    - `timeWb`
+    - DNA
+    - UART
+-}
+type NmuInternalBusses = 3 + PeInternalBusses
+
+{- Busses per link:
+    - UGN component
+    - Elastic buffer
+-}
+type PeripheralsPerLink = 2
+
+{- External busses:
+    - Scatter calendar
+    - Gather calendar
+    - Switch calendar
+    - Transceivers
+-}
+type NmuExternalBusses = 4 + (LinkCount * PeripheralsPerLink)
+type NmuRemBusWidth = RemainingBusWidth (NmuExternalBusses + NmuInternalBusses)
 
 muConfig ::
   ( KnownNat n


### PR DESCRIPTION
The SwitchDemo was the last demo which used a specific MU. It is now generalized by once again copy-pasting `managementUnit`, but all 3 versions are identical except for a hardcoded type for the number of internal/external busses. This should make it easier to generalize the CPUs further and move them to the `bittide` module (as was intended with `node`).