### PR TITLE
Update flake to include latest HLS

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,15 +3,15 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1761588595,
-        "narHash": "sha256-XKUZz9zewJNUj46b4AJdiRZJAvSZ0Dqj2BNfXvFlJC4=",
-        "owner": "edolstra",
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "NixOS",
         "repo": "flake-compat",
-        "rev": "f387cd2afec9419c8ee37694406ca490c3f34ee5",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
         "type": "github"
       },
       "original": {
-        "owner": "edolstra",
+        "owner": "NixOS",
         "repo": "flake-compat",
         "type": "github"
       }
@@ -73,6 +73,23 @@
         "type": "github"
       }
     },
+    "hls-source": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1768383429,
+        "narHash": "sha256-caJqWfzwzwx7khDPPLGQOsKbVMApvXcz3mJrXKyEV1Q=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "e53cb899809293cceaa401a6168f5b9f336bb9c0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.13.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
     "mdbook-drawio-flake": {
       "inputs": {
         "flake-utils": "flake-utils_2",
@@ -82,11 +99,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1765898843,
-        "narHash": "sha256-BvfU+yKYB+rq0Qde9ETOmIXzr6CoL36UrbX0FTnJJ9Q=",
+        "lastModified": 1768295294,
+        "narHash": "sha256-SqT/iWj/rm4/5H6pXwavNktZ5oO/825SrL4NxVJdvw8=",
         "owner": "QBayLogic",
         "repo": "mdbook-drawio",
-        "rev": "326693f8d7141a3cd6ccf09c05bf0282e11cfb6c",
+        "rev": "b6574150273ada90618512c9818ccac0b5b353ac",
         "type": "github"
       },
       "original": {
@@ -113,16 +130,16 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1765687488,
-        "narHash": "sha256-7YAJ6xgBAQ/Nr+7MI13Tui1ULflgAdKh63m1tfYV7+M=",
+        "lastModified": 1769318308,
+        "narHash": "sha256-Mjx6p96Pkefks3+aA+72lu1xVehb6mv2yTUUqmSet6Q=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d02bcc33948ca19b0aaa0213fe987ceec1f4ebe1",
+        "rev": "1cd347bf3355fce6c64ab37d3967b4a2cb4b878c",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-25.05",
+        "ref": "nixos-25.11",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -136,11 +153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1765911976,
-        "narHash": "sha256-t3T/xm8zstHRLx+pIHxVpQTiySbKqcQbK+r+01XVKc0=",
+        "lastModified": 1767281941,
+        "narHash": "sha256-6MkqajPICgugsuZ92OMoQcgSHnD6sJHwk8AxvMcIgTE=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "b68b780b69702a090c8bb1b973bab13756cc7a27",
+        "rev": "f0927703b7b1c8d97511c4116eb9b4ec6645a0fa",
         "type": "github"
       },
       "original": {
@@ -152,6 +169,7 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
+        "hls-source": "hls-source",
         "mdbook-drawio-flake": "mdbook-drawio-flake",
         "nixpkgs": "nixpkgs_2",
         "pre-commit-hooks": "pre-commit-hooks",
@@ -183,11 +201,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1765939271,
-        "narHash": "sha256-7F/d+ZrTYyOxnBZcleQZjOOEWc1IMXR/CLLRLLsVtHo=",
+        "lastModified": 1768359079,
+        "narHash": "sha256-a016mOfKconYrYo3fZLN6c2cnmqYYd44g2bUrBZAsQc=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "8028944c1339469124639da276d403d8ab7929a8",
+        "rev": "0357d1826057686637e41147545402cbbda420ce",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 {
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
     flake-utils.url = "github:numtide/flake-utils";
     rust-overlay = {
       url = "github:oxalica/rust-overlay";
@@ -17,9 +17,13 @@
       url = "github:QBayLogic/mdbook-drawio";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    hls-source = {
+      url = "github:haskell/haskell-language-server?ref=2.13.0.0";
+      flake = false;
+    };
   };
 
-  outputs = { self, nixpkgs, flake-utils, rust-overlay, pre-commit-hooks, mdbook-drawio-flake }: flake-utils.lib.eachDefaultSystem (
+  outputs = { self, nixpkgs, flake-utils, rust-overlay, pre-commit-hooks, mdbook-drawio-flake, hls-source }: flake-utils.lib.eachDefaultSystem (
     system:
       let
         verilog-ethernet = import ./nix/verilog-ethernet.nix {
@@ -32,17 +36,48 @@
           inherit pkgs;
         };
 
-        hls-overlay = final: prev: {
-          haskell-language-server =
-            (prev.haskell-language-server.override { supportedGhcVersions = [ "910" ]; })
-            .overrideDerivation (old: {
-              src = pkgs.fetchFromGitHub {
-                owner = "haskell";
-                repo = "haskell-language-server";
-                rev = "88ccebe0649f7c41be97d49a986bbfd4185982f6";
-                sha256 = "sha256-hR4MtfespgqAEa/vWXNsIOcEcLQNIVaEAHqZJbTaV/g=";
-              };
-            });
+        # What GHC version HLS should support
+        hlsGhcVersion = "910";
+        # What the HLS version should be
+        # NOTE: this does not *SET* the version! It merely 'pretends' to be the version set by this value
+        # To update the actual HLS version, run: `nix flake update hls-source`
+        # If weird HLS dependency issues accur, this is the variable you should most likely update
+        hlsVersion = "2.13.0.0";
+
+        hls-overlay = final: prev: let
+          setSource = pkg: src-path: (prev.haskell.lib.compose.overrideCabal (drv: {
+            version = hlsVersion;
+            src = hls-source // {
+              outPath = "${hls-source.outPath}/${src-path}";
+            };
+            # Disable HLS tests for faster compilation :)
+            doCheck = false;
+          }) pkg);
+
+          setSourceDirect = pkg: prev.haskell.lib.compose.overrideCabal (drv: {
+            version = hlsVersion;
+            src = hls-source;
+          }) pkg;
+
+          addEditDistance = pkg: pkg.overrideAttrs (drv: {
+            # edit-distance doesn't get automatically added to the dependencies list for some reason
+            # This manually adds it to the dependencies
+            propagatedBuildInputs = drv.propagatedBuildInputs ++ [ prev.haskell.packages."ghc${hlsGhcVersion}".edit-distance ];
+          });
+
+          # Make the new package set containing the up-to-date versions of HLS and it's in-repository plugins
+          latestHLSPackages = prev.haskell.packages."ghc${hlsGhcVersion}".extend (_: p: {
+            ghcide = setSource p.ghcide "ghcide";
+            hls-graph = addEditDistance (setSource p.hls-graph "hls-graph");
+            hls-test-utils = setSource p.hls-test-utils "hls-test-utils";
+            hls-plugin-api = setSource p.hls-plugin-api "hls-plugin-api";
+            haskell-language-server = setSourceDirect p.haskell-language-server;
+          });
+        in {
+          # Override haskell-* sets to match the one containing the latest HLS packages
+          haskell = prev.haskell // { "ghc${hlsGhcVersion}" = latestHLSPackages; };
+          haskellPackages = latestHLSPackages;
+          haskell-language-server = latestHLSPackages.haskell-language-server;
         };
         overlays = [ (import rust-overlay) hls-overlay ];
 
@@ -73,10 +108,13 @@
             pkgs.haskell-language-server
             pkgs.haskell.compiler.ghc910
             pkgs.pkg-config
-            pkgs.python3Full
+            # python3Full is removed
+            # Bluetooth is enabled by default and tkinter has been split off into the package set
+            pkgs.python3
+            pkgs.python3Packages.tkinter
             pkgs.python3Packages.matplotlib
             pkgs.python3Packages.scipy
-            pkgs.python3Packages.GitPython
+            pkgs.python3Packages.gitpython
             pkgs.python3Packages.pyaml
             pkgs.libz
             pkgs.sbt
@@ -94,7 +132,7 @@
             # Simulation report generation
             pkgs.dot2tex
             pkgs.texlive.combined.scheme-medium
-            pkgs.poppler_utils
+            pkgs.poppler-utils
 
             (pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml)
 
@@ -107,7 +145,7 @@
 
             # CI scripts
             pkgs.python3Packages.docopt
-            pkgs.python3Packages.dateutil
+            pkgs.python3Packages.python-dateutil
             mc
             pkgs.pcre
             pkgs.getent


### PR DESCRIPTION
Updates the Nix flake to include the latest unpublished versions of HLS. In specific, this updates HLS to version 2.13.0.0.

Due to how HLS is set up, this required a few changes to accomplish:
1. Changed nixpkgs from nixos-25.05 to 25.11. HLS required newer packages than those available in 25.05.
2. Due to the newer version of nixpkgs, some packages have been renamed/removed. Notably the python3Full has been removed. See the comment in the code.
3. Included the HLS source as a flake input, rather than a hardcoded source inside of the flake