### PR TITLE
Prevent undefined output from elastic buffer

### DIFF
--- a/bittide-instances/src/Bittide/Instances/Pnr/ElasticBuffer.hs
+++ b/bittide-instances/src/Bittide/Instances/Pnr/ElasticBuffer.hs
@@ -12,7 +12,13 @@ import Protocols
 import Protocols.Wishbone
 
 import Bittide.ClockControl (RelDataCount)
-import Bittide.ElasticBuffer
+import Bittide.ElasticBuffer (
+  ElasticBufferData,
+  Overflow,
+  Stable,
+  Underflow,
+  xilinxElasticBufferWb,
+ )
 import Bittide.SharedTypes (Bytes, withBittideByteOrder)
 
 createDomain vXilinxSystem{vPeriod = hzToPeriod 201e6, vName = "Fast"}
@@ -29,7 +35,7 @@ elasticBufferWb ::
   , "underflow" ::: Signal Fast Underflow
   , "overflow" ::: Signal Fast Overflow
   , "stable" ::: Signal Fast Stable
-  , "readData" ::: Signal Fast (Unsigned 64)
+  , "readData" ::: Signal Fast (ElasticBufferData (Unsigned 64))
   )
 elasticBufferWb clkRead rstRead clkWrite wbIn wdata = (wbOut, dataCount, underflow, overflow, stable, readData)
  where

--- a/bittide-instances/tests/Wishbone/CaptureUgn.hs
+++ b/bittide-instances/tests/Wishbone/CaptureUgn.hs
@@ -11,6 +11,7 @@ import Clash.Explicit.Prelude
 import Clash.Prelude (HiddenClockResetEnable, withClockResetEnable)
 import qualified Prelude as P
 
+import Bittide.ElasticBuffer (ElasticBufferData (Data))
 import Clash.Class.BitPackC (ByteOrder (BigEndian))
 import Clash.Signal.Internal
 import Data.Char
@@ -98,7 +99,7 @@ dut eb localCounter = withBittideByteOrder $ circuit $ do
     processingElement @dom NoDumpVcd peConfig -< (mm, jtagIdle)
   (uartTx, _uartStatus) <- uartInterfaceWb d2 d2 uartBytes -< (uartBus, uartRx)
   mm <- ignoreMM
-  _bittideData <- captureUgn localCounter eb -< ugnBus
+  _bittideData <- captureUgn localCounter (Data <$> eb) -< ugnBus
   idC -< uartTx
  where
   peConfig = unsafePerformIO $ do

--- a/bittide/src/Bittide/CaptureUgn.hs
+++ b/bittide/src/Bittide/CaptureUgn.hs
@@ -6,9 +6,10 @@ module Bittide.CaptureUgn (captureUgn, sendUgn, sendUgnC) where
 
 import Clash.Explicit.Prelude
 
+import Bittide.ElasticBuffer (ElasticBufferData (Data), fromData)
 import Bittide.SharedTypes (BitboneMm)
 import Bittide.Shutter (shutter)
-import Data.Maybe (fromJust, fromMaybe, isJust)
+import Data.Maybe (fromJust)
 import GHC.Stack (HasCallStack)
 import Protocols
 import Protocols.MemoryMap (Access (ReadOnly))
@@ -23,21 +24,19 @@ import Clash.Class.BitPackC (ByteOrder)
 
 import qualified Clash.Prelude as C
 
+data HasCaptured = HasCaptured | HasNotCaptured
+  deriving (Eq, Show, Generic, NFDataX)
+
 {- | Captures the remote counter from a bittide link and pairs it with the corresponding
-local counter. All frames except for the first frame will be forwarded to the output.
+local counter. All frames except for the first frame will be forwarded to the output. If
+a link goes down, this component should be reset.
 
 Assumes that:
 - When a link is not up, it produces `Nothing` consistently
-- When a link comes down, it will at some point switch from only producing `Nothing`,
+- When a link comes up, it will at some point switch from only producing `Nothing`,
   to only producing `Just data`
 - When a link comes up, the first frame will contain the remote counter value.
 - When a link goes down, it will start producing consistently `Nothing`
-
-The register layout is as follows:
-- Address 0: lsbs local counter
-- Address 1: msbs local counter
-- Address 2: lsbs remote counter
-- Address 3: msbs remote counter
 -}
 captureUgn ::
   forall dom addrW.
@@ -50,27 +49,35 @@ captureUgn ::
   -- | Local counter
   Signal dom (Unsigned 64) ->
   -- | Data from link
-  Signal dom (Maybe (BitVector 64)) ->
+  Signal dom (ElasticBufferData (Maybe (BitVector 64))) ->
   Circuit
     (BitboneMm dom addrW)
     (CSignal dom (BitVector 64))
 captureUgn localCounter (C.dflipflop -> linkIn) = circuit $ \bus -> do
   [wbLocalCounter, wbRemoteCounter, wbHasCaptured] <- deviceWb "CaptureUgn" -< bus
-
-  let trigger = C.isRising False (isJust <$> linkIn)
+  let
+    rawLinkIn = fromJust . fromData <$> linkIn
+    trigger = C.mealy goTrigger HasNotCaptured linkIn
   capturedLocalCounter <- shutter trigger -< Fwd localCounter
-  capturedRemoteCounter <- shutter trigger -< Fwd (fromMaybe 0 <$> linkIn)
-  capturedHasCaptured <- shutter trigger -< Fwd (isJust <$> linkIn)
+  capturedRemoteCounter <- shutter trigger -< Fwd rawLinkIn
+  capturedHasCaptured <- shutter trigger -< Fwd (pure True)
 
   registerWbI_ localCounterConfig 0 -< (wbLocalCounter, capturedLocalCounter)
   registerWbI_ remoteCounterConfig 0 -< (wbRemoteCounter, capturedRemoteCounter)
   registerWbI_ hasCapturedConfig False -< (wbHasCaptured, capturedHasCaptured)
 
-  idC -< Fwd (fromJust <$> linkIn)
+  idC -< Fwd rawLinkIn
  where
   localCounterConfig = (registerConfig "local_counter"){access = ReadOnly}
   remoteCounterConfig = (registerConfig "remote_counter"){access = ReadOnly}
   hasCapturedConfig = (registerConfig "has_captured"){access = ReadOnly}
+
+  goTrigger ::
+    HasCaptured ->
+    ElasticBufferData (Maybe (BitVector 64)) ->
+    (HasCaptured, Bool)
+  goTrigger HasNotCaptured (Data (Just _)) = (HasCaptured, True)
+  goTrigger s _ = (s, False)
 
 {- | Outputs the local counter when the link is *not* sampling and the very first
 cycle that it is. Otherwise, outputs the switch data. In effect, this makes sure

--- a/bittide/src/Bittide/Node.hs
+++ b/bittide/src/Bittide/Node.hs
@@ -22,6 +22,7 @@ import VexRiscv
 
 import Bittide.Calendar
 import Bittide.CaptureUgn (captureUgn)
+import Bittide.ElasticBuffer (ElasticBufferData)
 import Bittide.Jtag
 import Bittide.MetaPeConfig (metaPeConfig)
 import Bittide.ProcessingElement
@@ -70,7 +71,7 @@ node ::
     ( ToConstBwd Mm
     , Vec gppes (ToConstBwd Mm)
     , Jtag dom
-    , Vec linkCount (CSignal dom (Maybe (BitVector 64)))
+    , Vec linkCount (CSignal dom (ElasticBufferData (Maybe (BitVector 64))))
     )
     ( Vec linkCount (CSignal dom (BitVector 64))
     , CSignal dom (Unsigned 64)


### PR DESCRIPTION
Makes components after the elastic buffer more reliable