### PR TITLE
Workspace-level Clippy lints

### DIFF
--- a/bittide-instances/bittide-instances.cabal
+++ b/bittide-instances/bittide-instances.cabal
@@ -228,6 +228,7 @@ library
     Bittide.Instances.Pnr.Switch
     Bittide.Instances.Pnr.Synchronizer
     Bittide.Instances.Tests.AddressableBytesWb
+    Bittide.Instances.Tests.ClockControlWb
     Bittide.Instances.Tests.ElasticBufferWb
     Bittide.Instances.Tests.NestedInterconnect
     Bittide.Instances.Tests.RegisterWb

--- a/bittide-instances/src/Bittide/Instances/MemoryMaps.hs
+++ b/bittide-instances/src/Bittide/Instances/MemoryMaps.hs
@@ -27,6 +27,7 @@ import qualified Bittide.Instances.Hitl.SwitchDemo.MemoryMaps as SwitchDemo
 import qualified Bittide.Instances.Hitl.SwitchDemoGppe.MemoryMaps as SwitchDemoGppe
 import qualified Bittide.Instances.Hitl.WireDemo.MemoryMaps as WireDemo
 import qualified Bittide.Instances.Tests.AddressableBytesWb as AddressableBytesWb
+import qualified Bittide.Instances.Tests.ClockControlWb as ClockControlWb
 import qualified Bittide.Instances.Tests.ElasticBufferWb as ElasticBufferWb
 import qualified Bittide.Instances.Tests.NestedInterconnect as NestedInterconnect
 import qualified Bittide.Instances.Tests.RegisterWb as RegisterWb
@@ -45,6 +46,7 @@ $( do
     -------------------------------
     let memoryMaps =
           [ ("AddressableBytesWb", AddressableBytesWb.memoryMap)
+          , ("ClockControlWb", ClockControlWb.dutMm)
           , ("Ethernet", vexRiscvEthernetMM)
           , ("ElasticBufferWbTest", ElasticBufferWb.dutMM)
           , ("Freeze", freezeMM)

--- a/bittide-instances/src/Bittide/Instances/Tests/ClockControlWb.hs
+++ b/bittide-instances/src/Bittide/Instances/Tests/ClockControlWb.hs
@@ -1,0 +1,103 @@
+-- SPDX-FileCopyrightText: 2026 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+module Bittide.Instances.Tests.ClockControlWb where
+
+import Clash.Prelude
+
+import Bittide.ClockControl (SpeedChange)
+import Bittide.ClockControl.Registers (clockControlWb)
+import Bittide.Cpus.Riscv32imc (vexRiscv0)
+import Bittide.DoubleBufferedRam
+import Bittide.Instances.Hitl.Setup hiding (linkMask)
+import Bittide.ProcessingElement
+import Bittide.ProcessingElement.Util
+import Bittide.SharedTypes (withLittleEndian)
+import Bittide.Wishbone hiding (MemoryMap)
+import GHC.Stack (HasCallStack)
+import Project.FilePath
+import Protocols
+import Protocols.Idle
+import Protocols.MemoryMap
+import System.FilePath
+import System.IO.Unsafe (unsafePerformIO)
+import VexRiscv (DumpVcd (NoDumpVcd))
+
+linkMask :: BitVector LinkCount
+linkMask = 0b1011011
+
+linksOk :: BitVector LinkCount
+linksOk = 0b1111000
+
+dataCounts :: Vec LinkCount (Signed 32)
+dataCounts = iterateI (satSucc SatWrap) 0
+
+type IMemWords = DivRU (8 * 1024) 4
+type DMemWords = DivRU (8 * 1024) 4
+
+dut ::
+  (HasCallStack) =>
+  Circuit (ToConstBwd Mm, ()) (Df System (BitVector 8), CSignal System (Maybe SpeedChange))
+dut =
+  withLittleEndian
+    $ withClockResetEnable clockGen (resetGenN d2) enableGen
+    $ circuit
+    $ \(mm, _unit) -> do
+      (uartRx, jtag) <- idleSource
+      [ uartBus
+        , (mmCC, ccWb)
+        ] <-
+        processingElement NoDumpVcd peConfig -< (mm, jtag)
+      (uartTx, _uartStatus) <- uartInterfaceWb d2 d2 uartBytes -< (uartBus, uartRx)
+
+      ccd <-
+        clockControlWb
+          (pure linkMask)
+          (pure linksOk)
+          (pure <$> dataCounts)
+          -< (mmCC, ccWb)
+
+      idC -< (uartTx, ccd)
+ where
+  peConfig = unsafePerformIO $ do
+    root <- findParentContaining "cabal.project"
+    let
+      elfDir = root </> firmwareBinariesDir "riscv32imc" Release
+      elfPath = elfDir </> "clock-control-wb"
+    pure
+      PeConfig
+        { cpu = vexRiscv0
+        , depthI = SNat @IMemWords
+        , depthD = SNat @DMemWords
+        , initI =
+            Just
+              $ Vec
+              $ unsafePerformIO
+              $ vecFromElfInstr elfPath
+        , initD =
+            Just
+              $ Vec
+              $ unsafePerformIO
+              $ vecFromElfData elfPath
+        , iBusTimeout = d0
+        , dBusTimeout = d0
+        , includeIlaWb = False
+        }
+{-# OPAQUE dut #-}
+
+dutMm :: (HasCallStack) => MemoryMap
+dutMm = getMMAny dut
+
+-- dutMm = mm
+--  where
+-- Circuit circuitFn = dut
+-- (SimOnly mm, _) = circuitFn ((), (pure $ deepErrorX "uart_bwd", ()))
+
+dutNoMm ::
+  (HasCallStack) => Circuit () (Df System (BitVector 8), CSignal System (Maybe SpeedChange))
+dutNoMm = unMemmap dut
+
+-- dutNoMm = Circuit circuitFnNoMm
+--  where
+-- Circuit circuitFn = dut
+-- circuitFnNoMm (fwdL, bwdR) = let (_, fwdR) = circuitFn (fwdL, bwdR) in ((), fwdR)

--- a/bittide-instances/tests/Tests/ClockControlWb.hs
+++ b/bittide-instances/tests/Tests/ClockControlWb.hs
@@ -10,34 +10,20 @@ import Clash.Explicit.Prelude hiding (PeriodToCycles, many)
 
 -- external imports
 
-import Bittide.Cpus.Riscv32imc (vexRiscv0)
-import Clash.Signal (withClockResetEnable)
 import Data.Char (chr)
 import Data.Maybe (catMaybes)
 import Data.String.Interpolate
-import Project.FilePath
 import Protocols
-import Protocols.Idle
-import Protocols.MemoryMap
-import System.FilePath
-import System.IO.Unsafe (unsafePerformIO)
 import Test.Tasty
 import Test.Tasty.HUnit
 import Test.Tasty.TH
 import Text.Parsec
 import Text.Parsec.String
-import VexRiscv (DumpVcd (NoDumpVcd))
 
 -- internal imports
 import Bittide.Arithmetic.Time (PeriodToCycles)
-import Bittide.ClockControl (SpeedChange)
-import Bittide.ClockControl.Registers (clockControlWb)
-import Bittide.DoubleBufferedRam
 import Bittide.Instances.Hitl.Setup (LinkCount)
-import Bittide.ProcessingElement
-import Bittide.ProcessingElement.Util
-import Bittide.SharedTypes (withLittleEndian)
-import Bittide.Wishbone
+import Bittide.Instances.Tests.ClockControlWb
 
 -- qualified imports
 import qualified Data.List as L
@@ -61,7 +47,7 @@ sim =
   putStr
     $ fmap (chr . fromIntegral)
     $ catMaybes
-    $ fst (sampleC def dut)
+    $ fst (sampleC def dutNoMm)
 
 case_clock_control_wb_self_test :: Assertion
 case_clock_control_wb_self_test = do
@@ -89,7 +75,7 @@ case_clock_control_wb_self_test = do
       assertEqual "Expected and actual differ" expected actual
  where
   uartString = chr . fromIntegral <$> catMaybes uartStream
-  (uartStream, ccData) = sampleC def dut
+  (uartStream, ccData) = sampleC def dutNoMm
 
 type Margin = SNat 2
 type Framesize = PeriodToCycles System (Seconds 1)
@@ -103,69 +89,14 @@ framesize = SNat
 linkCount :: Int
 linkCount = snatToNum (SNat @LinkCount)
 
-linkMask :: BitVector LinkCount
-linkMask = 0b1011011
-
-linksOk :: BitVector LinkCount
-linksOk = 0b1111000
-
 linkMaskPopcnt :: Int
 linkMaskPopcnt = fromIntegral $ popCount linkMask
-
-dataCounts :: Vec LinkCount (Signed 27)
-dataCounts = iterateI (satSucc SatWrap) 0
 
 expectedDataCounts :: [(Int, Int)]
 expectedDataCounts = L.zip [0 ..] $ toList $ applyMask linkMask dataCounts
  where
   applyMask m = zipWith go (bitCoerce m)
   go m v = if m then fromIntegral v else 0
-
-dut :: Circuit () (Df System (BitVector 8), CSignal System (Maybe SpeedChange))
-dut =
-  withLittleEndian
-    $ withClockResetEnable clockGen (resetGenN d2) enableGen
-    $ circuit
-    $ \_unit -> do
-      (uartRx, jtag) <- idleSource
-      [ uartBus
-        , (mmCC, ccWb)
-        ] <-
-        processingElement NoDumpVcd peConfig -< (mm, jtag)
-      (uartTx, _uartStatus) <- uartInterfaceWb d2 d2 uartBytes -< (uartBus, uartRx)
-
-      mm <- ignoreMM
-
-      ccd <-
-        clockControlWb
-          (pure linkMask)
-          (pure linksOk)
-          (pure <$> dataCounts)
-          -< (mmCC, ccWb)
-
-      idC -< (uartTx, ccd)
- where
-  peConfig = unsafePerformIO $ do
-    root <- findParentContaining "cabal.project"
-    let
-      elfDir = root </> firmwareBinariesDir "riscv32imc" Release
-      elfPath = elfDir </> "clock-control-wb"
-    (iMem, dMem) <- vecsFromElf @IMemWords @DMemWords elfPath Nothing
-    pure
-      PeConfig
-        { cpu = vexRiscv0
-        , depthI = SNat @IMemWords
-        , depthD = SNat @DMemWords
-        , initI = Just (Vec iMem)
-        , initD = Just (Vec dMem)
-        , iBusTimeout = d0
-        , dBusTimeout = d0
-        , includeIlaWb = False
-        }
-{-# OPAQUE dut #-}
-
-type IMemWords = DivRU (8 * 1024) 4
-type DMemWords = DivRU (8 * 1024) 4
 
 -- | Parse the output of the UART
 resultParser :: Parser SerialResult

--- a/firmware-binaries/Cargo.toml
+++ b/firmware-binaries/Cargo.toml
@@ -54,3 +54,8 @@ members = [
   "demos/wire-demo-mu",
 ]
 resolver = "2"
+
+[workspace.lints.clippy]
+format_push_string = "forbid"
+print_literal = "forbid"
+uninlined_format_args = "forbid"

--- a/firmware-binaries/demos/clock-control/Cargo.toml
+++ b/firmware-binaries/demos/clock-control/Cargo.toml
@@ -9,6 +9,9 @@ edition = "2021"
 license = "Apache-2.0"
 authors = ["Google LLC"]
 
+[lints]
+workspace = true
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/firmware-binaries/demos/soft-ugn-mu/Cargo.toml
+++ b/firmware-binaries/demos/soft-ugn-mu/Cargo.toml
@@ -9,6 +9,9 @@ edition = "2021"
 license = "Apache-2.0"
 authors = ["Google LLC"]
 
+[lints]
+workspace = true
+
 [dependencies]
 riscv-rt = "0.11.0"
 bittide-sys = { path = "../../../firmware-support/bittide-sys" }

--- a/firmware-binaries/demos/soft-ugn-mu/src/main.rs
+++ b/firmware-binaries/demos/soft-ugn-mu/src/main.rs
@@ -147,5 +147,7 @@ fn main() -> ! {
 
 #[panic_handler]
 fn panic_handler(_: &PanicInfo) -> ! {
-    loop {}
+    loop {
+        continue;
+    }
 }

--- a/firmware-binaries/demos/switch-demo1-boot/Cargo.toml
+++ b/firmware-binaries/demos/switch-demo1-boot/Cargo.toml
@@ -9,6 +9,9 @@ edition = "2021"
 license = "Apache-2.0"
 authors = ["Google LLC"]
 
+[lints]
+workspace = true
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/firmware-binaries/demos/switch-demo1-boot/src/main.rs
+++ b/firmware-binaries/demos/switch-demo1-boot/src/main.rs
@@ -56,12 +56,14 @@ fn main() -> ! {
     }
 
     uwriteln!(uart, "Going into infinite loop..").unwrap();
-    #[allow(clippy::empty_loop)]
-    loop {}
+    loop {
+        continue;
+    }
 }
 
 #[panic_handler]
 fn panic_handler(_info: &PanicInfo) -> ! {
-    #[allow(clippy::empty_loop)]
-    loop {}
+    loop {
+        continue;
+    }
 }

--- a/firmware-binaries/demos/switch-demo1-mu/Cargo.toml
+++ b/firmware-binaries/demos/switch-demo1-mu/Cargo.toml
@@ -10,6 +10,9 @@ edition = "2021"
 license = "Apache-2.0"
 authors = ["Google LLC"]
 
+[lints]
+workspace = true
+
 [dependencies]
 riscv-rt = "0.11.0"
 bittide-sys = { path = "../../../firmware-support/bittide-sys" }

--- a/firmware-binaries/demos/switch-demo1-mu/src/main.rs
+++ b/firmware-binaries/demos/switch-demo1-mu/src/main.rs
@@ -114,6 +114,7 @@ fn main() -> ! {
 
 #[panic_handler]
 fn panic_handler(_: &PanicInfo) -> ! {
-    #[allow(clippy::empty_loop)]
-    loop {}
+    loop {
+        continue;
+    }
 }

--- a/firmware-binaries/demos/switch-demo2-gppe/Cargo.toml
+++ b/firmware-binaries/demos/switch-demo2-gppe/Cargo.toml
@@ -9,6 +9,9 @@ edition = "2021"
 license = "Apache-2.0"
 authors = ["Google LLC"]
 
+[lints]
+workspace = true
+
 [dependencies]
 riscv-rt = "0.11.0"
 bittide-sys = { path = "../../../firmware-support/bittide-sys" }

--- a/firmware-binaries/demos/switch-demo2-gppe/src/main.rs
+++ b/firmware-binaries/demos/switch-demo2-gppe/src/main.rs
@@ -12,17 +12,19 @@ use riscv_rt::entry;
 const INSTANCES: hal::DeviceInstances = unsafe { hal::DeviceInstances::new() };
 
 #[cfg_attr(not(test), entry)]
-#[allow(clippy::empty_loop)]
 fn main() -> ! {
     let uart = &mut INSTANCES.uart;
 
     ufmt::uwriteln!(uart, "Hello!").unwrap();
 
-    loop {}
+    loop {
+        continue;
+    }
 }
 
 #[panic_handler]
-#[allow(clippy::empty_loop)]
 fn panic_handler(_: &core::panic::PanicInfo) -> ! {
-    loop {}
+    loop {
+        continue;
+    }
 }

--- a/firmware-binaries/demos/switch-demo2-mu/Cargo.toml
+++ b/firmware-binaries/demos/switch-demo2-mu/Cargo.toml
@@ -10,6 +10,9 @@ edition = "2021"
 license = "Apache-2.0"
 authors = ["Google LLC"]
 
+[lints]
+workspace = true
+
 [dependencies]
 riscv-rt = "0.11.0"
 bittide-sys = { path = "../../../firmware-support/bittide-sys" }

--- a/firmware-binaries/demos/switch-demo2-mu/src/main.rs
+++ b/firmware-binaries/demos/switch-demo2-mu/src/main.rs
@@ -115,12 +115,14 @@ fn main() -> ! {
     }
     uwriteln!(uart, "All UGNs captured").unwrap();
 
-    #[allow(clippy::empty_loop)]
-    loop {}
+    loop {
+        continue;
+    }
 }
 
 #[panic_handler]
 fn panic_handler(_: &PanicInfo) -> ! {
-    #[allow(clippy::empty_loop)]
-    loop {}
+    loop {
+        continue;
+    }
 }

--- a/firmware-binaries/examples/c_hello/Cargo.toml
+++ b/firmware-binaries/examples/c_hello/Cargo.toml
@@ -9,6 +9,9 @@ edition = "2021"
 license = "Apache-2.0"
 authors = ["Google LLC"]
 
+[lints]
+workspace = true
+
 [dependencies]
 riscv-rt = "0.11.0"
 

--- a/firmware-binaries/examples/c_hello/src/main.rs
+++ b/firmware-binaries/examples/c_hello/src/main.rs
@@ -21,5 +21,7 @@ fn main() -> ! {
 // Panic handler required for no_std
 #[panic_handler]
 fn panic_handler(_info: &core::panic::PanicInfo) -> ! {
-    loop {}
+    loop {
+        continue;
+    }
 }

--- a/firmware-binaries/examples/smoltcp_client/Cargo.toml
+++ b/firmware-binaries/examples/smoltcp_client/Cargo.toml
@@ -9,6 +9,9 @@ edition = "2021"
 license = "Apache-2.0"
 authors = ["Google LLC"]
 
+[lints]
+workspace = true
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/firmware-binaries/hitl-tests/clock-board/Cargo.toml
+++ b/firmware-binaries/hitl-tests/clock-board/Cargo.toml
@@ -9,6 +9,9 @@ edition = "2021"
 license = "Apache-2.0"
 authors = ["Google LLC"]
 
+[lints]
+workspace = true
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/firmware-binaries/hitl-tests/vexriscv-hello/Cargo.toml
+++ b/firmware-binaries/hitl-tests/vexriscv-hello/Cargo.toml
@@ -9,6 +9,9 @@ edition = "2021"
 license = "Apache-2.0"
 authors = ["Google LLC"]
 
+[lints]
+workspace = true
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/firmware-binaries/sim-tests/addressable_bytes_wb_test/Cargo.toml
+++ b/firmware-binaries/sim-tests/addressable_bytes_wb_test/Cargo.toml
@@ -8,6 +8,9 @@ version = "0.1.0"
 authors = ["Google LLC"]
 edition = "2021"
 
+[lints]
+workspace = true
+
 [dependencies]
 bittide-hal = { path = "../../../firmware-support/bittide-hal" }
 bittide-sys = { path = "../../../firmware-support/bittide-sys" }

--- a/firmware-binaries/sim-tests/axi_stream_self_test/Cargo.toml
+++ b/firmware-binaries/sim-tests/axi_stream_self_test/Cargo.toml
@@ -9,6 +9,9 @@ edition = "2021"
 license = "Apache-2.0"
 authors = ["Google LLC"]
 
+[lints]
+workspace = true
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/firmware-binaries/sim-tests/c_registerwb_test/Cargo.toml
+++ b/firmware-binaries/sim-tests/c_registerwb_test/Cargo.toml
@@ -9,6 +9,9 @@ edition = "2021"
 license = "Apache-2.0"
 authors = ["Google LLC"]
 
+[lints]
+workspace = true
+
 [dependencies]
 riscv-rt = "0.11.0"
 bittide-sys = { path = "../../../firmware-support/bittide-sys" }

--- a/firmware-binaries/sim-tests/c_registerwb_test/src/main.rs
+++ b/firmware-binaries/sim-tests/c_registerwb_test/src/main.rs
@@ -21,5 +21,7 @@ fn main() -> ! {
 // Panic handler required for no_std
 #[panic_handler]
 fn panic_handler(_info: &core::panic::PanicInfo) -> ! {
-    loop {}
+    loop {
+        continue;
+    }
 }

--- a/firmware-binaries/sim-tests/c_scatter_gather_test/Cargo.toml
+++ b/firmware-binaries/sim-tests/c_scatter_gather_test/Cargo.toml
@@ -9,6 +9,9 @@ edition = "2021"
 license = "Apache-2.0"
 authors = ["Google LLC"]
 
+[lints]
+workspace = true
+
 [dependencies]
 riscv-rt = "0.11.0"
 bittide-sys = { path = "../../../firmware-support/bittide-sys" }

--- a/firmware-binaries/sim-tests/c_scatter_gather_test/src/main.rs
+++ b/firmware-binaries/sim-tests/c_scatter_gather_test/src/main.rs
@@ -21,5 +21,7 @@ fn main() -> ! {
 // Panic handler required for no_std
 #[panic_handler]
 fn panic_handler(_info: &core::panic::PanicInfo) -> ! {
-    loop {}
+    loop {
+        continue;
+    }
 }

--- a/firmware-binaries/sim-tests/c_timer_wb/Cargo.toml
+++ b/firmware-binaries/sim-tests/c_timer_wb/Cargo.toml
@@ -9,6 +9,9 @@ edition = "2021"
 license = "Apache-2.0"
 authors = ["Google LLC"]
 
+[lints]
+workspace = true
+
 [dependencies]
 riscv-rt = "0.11.0"
 bittide-sys = { path = "../../../firmware-support/bittide-sys" }

--- a/firmware-binaries/sim-tests/c_timer_wb/src/main.rs
+++ b/firmware-binaries/sim-tests/c_timer_wb/src/main.rs
@@ -21,5 +21,7 @@ fn main() -> ! {
 // Panic handler required for no_std
 #[panic_handler]
 fn panic_handler(_info: &core::panic::PanicInfo) -> ! {
-    loop {}
+    loop {
+        continue;
+    }
 }

--- a/firmware-binaries/sim-tests/capture_ugn_test/Cargo.toml
+++ b/firmware-binaries/sim-tests/capture_ugn_test/Cargo.toml
@@ -9,6 +9,9 @@ edition = "2021"
 license = "Apache-2.0"
 authors = ["Google LLC"]
 
+[lints]
+workspace = true
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/firmware-binaries/sim-tests/clock-control-wb/Cargo.toml
+++ b/firmware-binaries/sim-tests/clock-control-wb/Cargo.toml
@@ -9,6 +9,9 @@ edition = "2021"
 license = "Apache-2.0"
 authors = ["Google LLC"]
 
+[lints]
+workspace = true
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/firmware-binaries/sim-tests/clock-control-wb/src/main.rs
+++ b/firmware-binaries/sim-tests/clock-control-wb/src/main.rs
@@ -7,14 +7,14 @@
 
 use core::panic::PanicInfo;
 
-use bittide_hal::shared_devices::clock_control::ClockControl;
-use bittide_hal::shared_devices::uart::Uart;
 use bittide_hal::types::SpeedChange;
 use core::fmt::Write;
 use rand::{distributions::Uniform, rngs::SmallRng, Rng, SeedableRng};
 
 #[cfg(not(test))]
 use riscv_rt::entry;
+
+use bittide_hal::hals::clock_control_wb as hal;
 
 const RNG_SEED: [u8; 16] = {
     let rng_seed = core::env!("RNG_SEED").as_bytes();
@@ -37,11 +37,10 @@ const RNG_SEED: [u8; 16] = {
 };
 
 #[cfg_attr(not(test), entry)]
-#[allow(clippy::empty_loop)]
 fn main() -> ! {
-    #[allow(clippy::zero_ptr)] // we might want to change the address!
-    let mut uart = unsafe { Uart::new((0b010 << 29) as *mut u8) };
-    let cc = unsafe { ClockControl::new((0b011 << 29) as *mut u8) };
+    let peripherals = unsafe { hal::DeviceInstances::new() };
+    let mut uart = peripherals.uart;
+    let cc = peripherals.clock_control;
 
     writeln!(uart, "nLinks: {}", cc.n_links()).unwrap();
     writeln!(uart, "linkMask: {}", cc.link_mask()[0]).unwrap();
@@ -78,7 +77,9 @@ fn main() -> ! {
         cc.set_change_speed(SpeedChange::NoChange);
     }
 
-    loop {}
+    loop {
+        continue;
+    }
 }
 
 #[panic_handler]

--- a/firmware-binaries/sim-tests/dna_port_e2_test/Cargo.toml
+++ b/firmware-binaries/sim-tests/dna_port_e2_test/Cargo.toml
@@ -9,6 +9,9 @@ edition = "2021"
 license = "Apache-2.0"
 authors = ["Google LLC"]
 
+[lints]
+workspace = true
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/firmware-binaries/sim-tests/elastic_buffer_wb_test/Cargo.toml
+++ b/firmware-binaries/sim-tests/elastic_buffer_wb_test/Cargo.toml
@@ -9,6 +9,9 @@ edition = "2021"
 license = "Apache-2.0"
 authors = ["Google LLC"]
 
+[lints]
+workspace = true
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/firmware-binaries/sim-tests/nested_interconnect_test/Cargo.toml
+++ b/firmware-binaries/sim-tests/nested_interconnect_test/Cargo.toml
@@ -9,6 +9,9 @@ edition = "2021"
 license = "Apache-2.0"
 authors = ["Google LLC"]
 
+[lints]
+workspace = true
+
 [dependencies]
 riscv-rt = "0.11.0"
 bittide-sys = { path = "../../../firmware-support/bittide-sys" }

--- a/firmware-binaries/sim-tests/nested_interconnect_test/src/main.rs
+++ b/firmware-binaries/sim-tests/nested_interconnect_test/src/main.rs
@@ -1,7 +1,6 @@
 #![no_std]
 #![cfg_attr(not(test), no_main)]
 #![allow(const_item_mutation)]
-#![allow(clippy::empty_loop)]
 
 // SPDX-FileCopyrightText: 2025 Google LLC
 //
@@ -20,7 +19,9 @@ const INSTANCES: hal::DeviceInstances = unsafe { hal::DeviceInstances::new() };
 fn test_result(result: &str) -> ! {
     let uart = &mut INSTANCES.uart;
     uwriteln!(uart, "RESULT: {}", result).unwrap();
-    loop {}
+    loop {
+        continue;
+    }
 }
 
 fn test_ok() -> ! {
@@ -29,7 +30,7 @@ fn test_ok() -> ! {
 
 fn test_fail(msg: &str) -> ! {
     let mut full_msg = heapless::String::<150>::new();
-    write!(full_msg, "FAIL: {}", msg).unwrap();
+    write!(full_msg, "FAIL: {msg}").unwrap();
     test_result(&full_msg)
 }
 
@@ -70,23 +71,23 @@ fn main() -> ! {
         let mut name_buf = heapless::String::<50>::new();
 
         // Read initial values (should be 0)
-        write!(name_buf, "peripheral{}.status.init", i).unwrap();
+        write!(name_buf, "peripheral{i}.status.init").unwrap();
         expect(&name_buf, 0u32, peripheral.status());
         name_buf.clear();
 
-        write!(name_buf, "peripheral{}.control.init", i).unwrap();
+        write!(name_buf, "peripheral{i}.control.init").unwrap();
         expect(&name_buf, 0u32, peripheral.control());
         name_buf.clear();
 
         // Write and read back status
         peripheral.set_status(*status_val);
-        write!(name_buf, "peripheral{}.status.readback", i).unwrap();
+        write!(name_buf, "peripheral{i}.status.readback").unwrap();
         expect(&name_buf, *status_val, peripheral.status());
         name_buf.clear();
 
         // Write and read back control
         peripheral.set_control(*control_val);
-        write!(name_buf, "peripheral{}.control.readback", i).unwrap();
+        write!(name_buf, "peripheral{i}.control.readback").unwrap();
         expect(&name_buf, *control_val, peripheral.control());
     }
 
@@ -95,7 +96,7 @@ fn main() -> ! {
         peripherals.iter_mut().zip(test_values.iter()).enumerate()
     {
         let mut name_buf = heapless::String::<50>::new();
-        write!(name_buf, "peripheral{}.status.final", i).unwrap();
+        write!(name_buf, "peripheral{i}.status.final").unwrap();
         expect(&name_buf, *status_val, peripheral.status());
     }
 
@@ -106,5 +107,7 @@ fn main() -> ! {
 fn panic_handler(_info: &core::panic::PanicInfo) -> ! {
     let uart = unsafe { &mut hal::DeviceInstances::new().uart };
     uwriteln!(uart, "RESULT: PANIC").unwrap();
-    loop {}
+    loop {
+        continue;
+    }
 }

--- a/firmware-binaries/sim-tests/registerwb_test/Cargo.toml
+++ b/firmware-binaries/sim-tests/registerwb_test/Cargo.toml
@@ -9,6 +9,9 @@ edition = "2021"
 license = "Apache-2.0"
 authors = ["Google LLC"]
 
+[lints]
+workspace = true
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/firmware-binaries/sim-tests/registerwb_test/src/main.rs
+++ b/firmware-binaries/sim-tests/registerwb_test/src/main.rs
@@ -1,7 +1,6 @@
 #![no_std]
 #![cfg_attr(not(test), no_main)]
 #![allow(const_item_mutation)]
-#![allow(clippy::empty_loop)]
 #![allow(clippy::approx_constant)]
 
 // SPDX-FileCopyrightText: 2025 Google LLC
@@ -29,7 +28,9 @@ where
     let uart = &mut INSTANCES.uart;
     uwrite!(uart, "RESULT: ").unwrap();
     result(uart);
-    loop {}
+    loop {
+        continue;
+    }
 }
 
 fn test_ok() -> ! {

--- a/firmware-binaries/sim-tests/scatter_gather_test/Cargo.toml
+++ b/firmware-binaries/sim-tests/scatter_gather_test/Cargo.toml
@@ -9,6 +9,9 @@ edition = "2021"
 license = "Apache-2.0"
 authors = ["Google LLC"]
 
+[lints]
+workspace = true
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/firmware-binaries/sim-tests/scatter_gather_test/src/main.rs
+++ b/firmware-binaries/sim-tests/scatter_gather_test/src/main.rs
@@ -59,9 +59,9 @@ fn main() -> ! {
     } else {
         writeln!(uart, "Could not read back written data").unwrap();
         writeln!(uart, "Written to gather memory:").unwrap();
-        writeln!(uart, "{:?}", source).unwrap();
+        writeln!(uart, "{source:?}").unwrap();
         writeln!(uart, "Read from scatter memory:").unwrap();
-        writeln!(uart, "{:?}", destination).unwrap();
+        writeln!(uart, "{destination:?}").unwrap();
     }
     loop {
         continue;

--- a/firmware-binaries/sim-tests/switch_calendar_test/Cargo.toml
+++ b/firmware-binaries/sim-tests/switch_calendar_test/Cargo.toml
@@ -9,6 +9,9 @@ edition = "2021"
 license = "Apache-2.0"
 authors = ["Google LLC"]
 
+[lints]
+workspace = true
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/firmware-binaries/sim-tests/switch_calendar_test/src/main.rs
+++ b/firmware-binaries/sim-tests/switch_calendar_test/src/main.rs
@@ -4,7 +4,6 @@
 #![no_std]
 #![cfg_attr(not(test), no_main)]
 #![allow(const_item_mutation)]
-#![allow(clippy::empty_loop)]
 #![allow(clippy::approx_constant)]
 
 // Non-aliased imports
@@ -26,7 +25,9 @@ const INSTANCES: hal::DeviceInstances = unsafe { hal::DeviceInstances::new() };
 fn test_result(result: &str) -> ! {
     let uart = &mut INSTANCES.uart;
     uwriteln!(uart, "RESULT: {}", result).unwrap();
-    loop {}
+    loop {
+        continue;
+    }
 }
 
 fn test_ok() -> ! {

--- a/firmware-binaries/sim-tests/switch_demo_pe_test/Cargo.toml
+++ b/firmware-binaries/sim-tests/switch_demo_pe_test/Cargo.toml
@@ -9,6 +9,9 @@ edition = "2021"
 license = "Apache-2.0"
 authors = ["Google LLC"]
 
+[lints]
+workspace = true
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/firmware-binaries/sim-tests/time_self_test/Cargo.toml
+++ b/firmware-binaries/sim-tests/time_self_test/Cargo.toml
@@ -9,6 +9,9 @@ edition = "2021"
 license = "Apache-2.0"
 authors = ["Google LLC"]
 
+[lints]
+workspace = true
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/firmware-binaries/sim-tests/watchdog_test/Cargo.toml
+++ b/firmware-binaries/sim-tests/watchdog_test/Cargo.toml
@@ -9,6 +9,9 @@ edition = "2021"
 license = "Apache-2.0"
 authors = ["Google LLC"]
 
+[lints]
+workspace = true
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/firmware-binaries/sim-tests/wb_to_df_test/Cargo.toml
+++ b/firmware-binaries/sim-tests/wb_to_df_test/Cargo.toml
@@ -9,6 +9,9 @@ edition = "2021"
 license = "Apache-2.0"
 authors = ["Google LLC"]
 
+[lints]
+workspace = true
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/firmware-support/Cargo.toml
+++ b/firmware-support/Cargo.toml
@@ -30,3 +30,8 @@ members = [
 ]
 
 resolver = "2"
+
+[workspace.lints.clippy]
+format_push_string = "forbid"
+print_literal = "forbid"
+uninlined_format_args = "forbid"

--- a/firmware-support/bittide-hal-c/Cargo.toml
+++ b/firmware-support/bittide-hal-c/Cargo.toml
@@ -7,6 +7,9 @@ name = "bittide-hal-c"
 version = "0.1.0"
 edition = "2021"
 
+[lints]
+workspace = true
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [build-dependencies]

--- a/firmware-support/bittide-hal-c/build.rs
+++ b/firmware-support/bittide-hal-c/build.rs
@@ -40,8 +40,8 @@ fn main() {
     let (shared, deduped_hals) = match deduplicate(&ctx, &input_mapping, hals.iter()) {
         Ok(result) => result,
         Err(err) => {
-            println!("ERROR while deduplicating!! {:?}", err);
-            panic!("ERROR {:?}", err)
+            println!("ERROR while deduplicating!! {err:?}");
+            panic!("ERROR {err:?}")
         }
     };
 
@@ -126,7 +126,7 @@ fn main() {
                     generate_type_ref_imports(&ctx, &refs, file);
                     writeln!(file).unwrap();
 
-                    writeln!(file, "{}", code).unwrap();
+                    writeln!(file, "{code}").unwrap();
                 },
             );
         }
@@ -144,7 +144,7 @@ fn main() {
                 writeln!(file, "{}", gen_imports()).unwrap();
 
                 generate_type_ref_imports(&ctx, &refs, file);
-                writeln!(file, "{}", code).unwrap();
+                writeln!(file, "{code}").unwrap();
             });
         }
     }
@@ -167,7 +167,7 @@ fn main() {
             let (dev_name, code, refs) =
                 backend_c::device_desc::generate_device_desc(&ctx, &varis, *dev);
             let file_name = ident(IdentType::Module, dev_name);
-            let file_path = shared_devices_path.join(format!("{}.h", file_name));
+            let file_path = shared_devices_path.join(format!("{file_name}.h"));
             let mut file = File::create(&file_path).unwrap();
             with_guard(
                 &mut file,
@@ -178,7 +178,7 @@ fn main() {
                     generate_type_ref_imports(&ctx, &refs, file);
                     writeln!(file).unwrap();
 
-                    write!(file, "{}", code).unwrap();
+                    write!(file, "{code}").unwrap();
                 },
             );
         }
@@ -216,7 +216,7 @@ fn main() {
             let (dev_name, code, refs) =
                 backend_c::device_desc::generate_device_desc(&ctx, &varis, *dev);
             let file_name = ident(IdentType::Module, dev_name);
-            let file_path = hal_path.join("devices").join(format!("{}.h", file_name));
+            let file_path = hal_path.join("devices").join(format!("{file_name}.h"));
             let mut file = File::create(&file_path).unwrap();
             with_guard(
                 &mut file,
@@ -230,7 +230,7 @@ fn main() {
                     generate_type_ref_imports(&ctx, &refs, file);
                     writeln!(file).unwrap();
 
-                    write!(file, "{}", code).unwrap();
+                    write!(file, "{code}").unwrap();
                 },
             );
         }
@@ -262,7 +262,7 @@ fn generate_type_ref_imports(ctx: &IrCtx, refs: &backend_c::TypeReferences, file
     for ty in &refs.references {
         let name = &ctx.type_names[*ty];
         let mod_name = ident(IdentType::Module, &name.base);
-        writeln!(file, "#include \"types/{}.h\"", mod_name).unwrap();
+        writeln!(file, "#include \"types/{mod_name}.h\"").unwrap();
     }
 }
 

--- a/firmware-support/bittide-hal/Cargo.toml
+++ b/firmware-support/bittide-hal/Cargo.toml
@@ -7,6 +7,9 @@ name = "bittide-hal"
 version = "0.1.0"
 edition = "2021"
 
+[lints]
+workspace = true
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/firmware-support/bittide-hal/build.rs
+++ b/firmware-support/bittide-hal/build.rs
@@ -63,8 +63,8 @@ fn main() {
     let (shared, deduped_hals) = match deduplicate(&ctx, &input_mapping, hals.iter()) {
         Ok(result) => result,
         Err(err) => {
-            println!("ERROR!! {:?}", err);
-            panic!("ERROR {:?}", err)
+            println!("ERROR!! {err:?}");
+            panic!("ERROR {err:?}")
         }
     };
 
@@ -158,7 +158,7 @@ fn main() {
 
             writeln!(file, "{}", lint_disables_generated_code()).unwrap();
             writeln!(file, "{}", generate_type_ref_imports(&ctx, &refs)).unwrap();
-            writeln!(file, "{}", code).unwrap();
+            writeln!(file, "{code}").unwrap();
         }
     }
 
@@ -182,11 +182,11 @@ fn main() {
 
             let (dev_name, code, refs) = backend_rust::generate_device_desc(&ctx, &varis, *dev);
             let file_name = ident(IdentType::Module, dev_name);
-            let file_path = shared_devices_path.join(format!("{}.rs", file_name));
+            let file_path = shared_devices_path.join(format!("{file_name}.rs"));
             let mut file = File::create(&file_path).unwrap();
             writeln!(file, "{}", lint_disables_generated_code()).unwrap();
             writeln!(file, "{}", generate_type_ref_imports(&ctx, &refs)).unwrap();
-            write!(file, "{}", code).unwrap();
+            write!(file, "{code}").unwrap();
             generated_files.push(file_path);
 
             writeln!(mod_file, "pub mod {file_name};").unwrap();
@@ -235,13 +235,13 @@ fn main() {
             }
             let (dev_name, code, refs) = backend_rust::generate_device_desc(&ctx, &varis, *dev);
             let file_name = ident(IdentType::Module, dev_name);
-            let file_path = hal_path.join("devices").join(format!("{}.rs", file_name));
+            let file_path = hal_path.join("devices").join(format!("{file_name}.rs"));
 
             let mut file = File::create(&file_path).unwrap();
 
             writeln!(file, "{}", lint_disables_generated_code()).unwrap();
             writeln!(file, "{}", generate_type_ref_imports(&ctx, &refs)).unwrap();
-            write!(file, "{}", code).unwrap();
+            write!(file, "{code}").unwrap();
             generated_files.push(file_path);
 
             writeln!(mod_file, "pub mod {file_name};").unwrap();

--- a/firmware-support/bittide-hal/src/manual_additions/si539x_spi.rs
+++ b/firmware-support/bittide-hal/src/manual_additions/si539x_spi.rs
@@ -22,13 +22,12 @@ pub struct ConfigEntry {
     pub data: u8,
 }
 
-#[allow(clippy::from_over_into)]
-impl Into<RegisterOperation> for ConfigEntry {
-    fn into(self) -> RegisterOperation {
+impl From<ConfigEntry> for RegisterOperation {
+    fn from(value: ConfigEntry) -> Self {
         RegisterOperation {
-            page: [self.page],
-            address: [self.address],
-            write: Just([self.data]),
+            page: [value.page],
+            address: [value.address],
+            write: Just([value.data]),
         }
     }
 }

--- a/firmware-support/bittide-macros/Cargo.toml
+++ b/firmware-support/bittide-macros/Cargo.toml
@@ -6,6 +6,9 @@ name = "bittide-macros"
 version = "0.1.0"
 edition = "2024"
 
+[lints]
+workspace = true
+
 [lib]
 proc-macro = true
 

--- a/firmware-support/bittide-sys/Cargo.toml
+++ b/firmware-support/bittide-sys/Cargo.toml
@@ -10,6 +10,9 @@ license = "Apache-2.0"
 authors = ["Google LLC"]
 resolver = "2"
 
+[lints]
+workspace = true
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]

--- a/firmware-support/bittide-sys/tests/elf_common.rs
+++ b/firmware-support/bittide-sys/tests/elf_common.rs
@@ -186,12 +186,9 @@ pub unsafe fn with_32bit_addr_buffer<R: 'static>(size: u32, f: impl FnOnce(&mut 
     }
 }
 
+#[allow(clippy::reversed_empty_ranges)]
 pub fn mem_config_from_segs(segs: &[Segment]) -> MemoryConfiguration {
-    // The ranges are inversed so that they don't default to 0..MAX
-    // but instead are properly read from the segments.
-    // Since they are not used as iterators but instead as a pair, it does not
-    // matter that they yield no values when iterated.
-    #[allow(clippy::reversed_empty_ranges)]
+    // Assume that instr and data memory are empty at first, and correct the start and end later
     let mut config = MemoryConfiguration {
         instruction_memory: u32::MAX..0,
         data_memory: u32::MAX..0,

--- a/firmware-support/gdb-trace/Cargo.toml
+++ b/firmware-support/gdb-trace/Cargo.toml
@@ -7,6 +7,9 @@ name = "gdb-trace"
 version = "0.1.0"
 edition = "2021"
 
+[lints]
+workspace = true
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/firmware-support/gdb-trace/src/lib.rs
+++ b/firmware-support/gdb-trace/src/lib.rs
@@ -10,11 +10,12 @@ use core::{fmt::Write, panic::PanicInfo};
 /// the panic info to the provided write-able interface. It's expected that the user will
 /// be running a GDB process and set a breakpoint to the panic handler so that the output
 /// can be read.
-#[allow(clippy::empty_loop)]
 pub fn gdb_panic_internal<W: Write>(writer: &mut W, info: &PanicInfo) -> ! {
     riscv::interrupt::machine::disable();
-    writeln!(writer, "{:?}", info).unwrap();
-    loop {}
+    writeln!(writer, "{info:?}").unwrap();
+    loop {
+        continue;
+    }
 }
 
 #[macro_export]

--- a/firmware-support/memmap-generate/Cargo.toml
+++ b/firmware-support/memmap-generate/Cargo.toml
@@ -7,6 +7,9 @@ name = "memmap-generate"
 version = "0.1.0"
 edition = "2021"
 
+[lints]
+workspace = true
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/firmware-support/memmap-generate/src/backends/c/device_instances.rs
+++ b/firmware-support/memmap-generate/src/backends/c/device_instances.rs
@@ -69,7 +69,7 @@ pub fn generate_device_instances(
             }
         };
 
-        let hex_addr = format!("0x{:X}", addr);
+        let hex_addr = format!("0x{addr:X}");
 
         writeln!(device_type, "  {dev_ident} {instance_name};").unwrap();
 

--- a/firmware-support/memmap-generate/src/backends/c/mod.rs
+++ b/firmware-support/memmap-generate/src/backends/c/mod.rs
@@ -347,7 +347,7 @@ fn type_to_ident(ctx: &IrCtx, ty: Handle<TypeRef>) -> String {
             let name = &ctx.identifiers[*handle];
             format!("var_{name}")
         }
-        TypeRef::Nat(n) => format!("{}", n),
+        TypeRef::Nat(n) => format!("{n}"),
         TypeRef::Reference { name, args } => {
             let type_name = &ctx.type_names[*name];
             let mut ident = type_name.base.clone();

--- a/firmware-support/memmap-generate/src/backends/rust/mod.rs
+++ b/firmware-support/memmap-generate/src/backends/rust/mod.rs
@@ -154,7 +154,7 @@ pub fn generate_device_instances(
             };
 
             use std::str::FromStr;
-            let addr = Literal::from_str(&format!("0x{:X}", abs_addr)).unwrap();
+            let addr = Literal::from_str(&format!("0x{abs_addr:X}")).unwrap();
 
             let field_def = quote! { pub #instance_name_ident: #dev_ident };
             let field_init =
@@ -396,7 +396,7 @@ fn generate_repr(ctx: &IrCtx, desc: &TypeDescription) -> TokenStream {
                 .map(|handle| &ctx.type_constructors[handle])
                 .all(|con| con.field_types.len == 0);
             let n = po2_type(constructors.len.ilog2() as u64);
-            let repr = ident(IdentType::Raw, format!("u{}", n));
+            let repr = ident(IdentType::Raw, format!("u{n}"));
 
             if fieldless {
                 quote! { #[repr(#repr) ]}
@@ -888,7 +888,7 @@ fn type_to_ident(ctx: &IrCtx, ty: Handle<TypeRef>) -> String {
             let name = &ctx.identifiers[*handle];
             format!("var_{name}")
         }
-        TypeRef::Nat(n) => format!("{}", n),
+        TypeRef::Nat(n) => format!("{n}"),
         TypeRef::Reference { name, args } => {
             let type_name = &ctx.type_names[*name];
             let mut ident = type_name.base.clone();

--- a/firmware-support/memmap-generate/src/build_utils.rs
+++ b/firmware-support/memmap-generate/src/build_utils.rs
@@ -79,12 +79,12 @@ pub fn standard_memmap_build(
 /// * `source_file` - The name of the source file to read (e.g., "memory.x")
 pub fn standard_static_memory_build(source_file: &str) {
     let memory_x_content =
-        fs::read(source_file).unwrap_or_else(|_| panic!("Could not read file: {}", source_file));
+        fs::read(source_file).unwrap_or_else(|_| panic!("Could not read file: {source_file}"));
 
     let out_dir = env::var("OUT_DIR").expect("No out dir");
     let dest_path = Path::new(&out_dir).join("memory.x");
     fs::write(dest_path, memory_x_content).expect("Could not write file");
 
     setup_riscv_linker(&out_dir);
-    println!("cargo:rerun-if-changed={}", source_file);
+    println!("cargo:rerun-if-changed={source_file}");
 }

--- a/firmware-support/memmap-generate/src/deprecated/generators/device_instances.rs
+++ b/firmware-support/memmap-generate/src/deprecated/generators/device_instances.rs
@@ -38,7 +38,7 @@ pub fn generate_device_instances_struct(
                     let instance_name = match name_idx {
                         Some(n) => {
                             name_idx = Some(n + 1);
-                            &format!("{}_{}", device_name, n)
+                            &format!("{device_name}_{n}")
                         }
                         None => {
                             name_idx = Some(1);
@@ -69,7 +69,7 @@ pub fn generate_device_instances_struct(
                     let instance_name = match name_idx {
                         Some(n) => {
                             name_idx = Some(n + 1);
-                            &format!("{}_{}", device_name, n)
+                            &format!("{device_name}_{n}")
                         }
                         None => {
                             name_idx = Some(1);

--- a/firmware-support/memmap-generate/src/deprecated/generators/mod.rs
+++ b/firmware-support/memmap-generate/src/deprecated/generators/mod.rs
@@ -129,12 +129,12 @@ pub(crate) fn generate_tag_docs<'a>(
     toks.extend(quote::quote! { #[doc = ""] });
 
     for tag in tags {
-        let msg = format!(" - `{}`", tag);
+        let msg = format!(" - `{tag}`");
         toks.extend(quote::quote! { #[doc = #msg] });
     }
 
     for tag in ann_tags {
-        let msg = format!(" - `{}`", tag);
+        let msg = format!(" - `{tag}`");
         toks.extend(quote::quote! { #[doc = #msg] });
     }
 

--- a/firmware-support/memmap-generate/src/deprecated/generators/types.rs
+++ b/firmware-support/memmap-generate/src/deprecated/generators/types.rs
@@ -420,7 +420,7 @@ impl TypeGenerator {
                         Constructor::Record { fields } => fields.is_empty(),
                     });
                 let n = clog2(&(named_constructors.len() as u64));
-                let repr = ident(IdentType::Raw, format!("u{}", n));
+                let repr = ident(IdentType::Raw, format!("u{n}"));
                 if fieldless {
                     quote! { #[repr(#repr)] }
                 } else {

--- a/firmware-support/memmap-generate/src/format.rs
+++ b/firmware-support/memmap-generate/src/format.rs
@@ -19,7 +19,7 @@ fn rustfmt_files(files: &[impl AsRef<Path>]) -> Result<(), String> {
 
     let status = command.status().expect("failed to run rustfmt");
     if !status.success() {
-        return Err(format!("`rustfmt` failed: {:?}", command));
+        return Err(format!("`rustfmt` failed: {command:?}"));
     }
 
     Ok(())

--- a/firmware-support/memmap-generate/src/ir/input_to_ir.rs
+++ b/firmware-support/memmap-generate/src/ir/input_to_ir.rs
@@ -231,7 +231,7 @@ impl IrCtx {
                 }
                 TypeRef::Tuple(handle_range) => *handle_range = range,
                 TypeRef::Reference { name: _, args } => *args = range,
-                other => panic!("Shouldn't need patching: {:?}", other),
+                other => panic!("Shouldn't need patching: {other:?}"),
             }
         }
     }

--- a/firmware-support/memmap-generate/src/lib.rs
+++ b/firmware-support/memmap-generate/src/lib.rs
@@ -98,14 +98,12 @@ fn memory_x_file(
     writeln!(buf, "{{").unwrap();
     writeln!(
         buf,
-        "  IMEM : ORIGIN = 0x{:X}, LENGTH = 0x{:X}",
-        instr_mem_address, instr_mem_size
+        "  IMEM : ORIGIN = 0x{instr_mem_address:X}, LENGTH = 0x{instr_mem_size:X}",
     )
     .unwrap();
     writeln!(
         buf,
-        "  DMEM : ORIGIN = 0x{:X}, LENGTH = 0x{:X}",
-        data_mem_address, data_mem_size
+        "  DMEM : ORIGIN = 0x{data_mem_address:X}, LENGTH = 0x{data_mem_size:X}",
     )
     .unwrap();
     writeln!(

--- a/firmware-support/memmap-generate/src/storage.rs
+++ b/firmware-support/memmap-generate/src/storage.rs
@@ -261,15 +261,6 @@ impl<T> Storage<T> {
         self.0.get_mut(idx.0)
     }
 
-    /// Iterator over all the elements in the storage, consuming the storage.
-    #[allow(clippy::should_implement_trait)]
-    pub fn into_iter(self) -> impl DoubleEndedIterator<Item = (Handle<T>, T)> + ExactSizeIterator {
-        self.0
-            .into_iter()
-            .enumerate()
-            .map(|(idx, val)| (Handle(idx, PhantomData), val))
-    }
-
     /// Iterator over all the elements in the storage.
     pub fn iter(&self) -> impl DoubleEndedIterator<Item = (Handle<T>, &T)> + ExactSizeIterator {
         self.0
@@ -352,6 +343,19 @@ impl<T> Index<HandleRange<T>> for Storage<T> {
 impl<T> IndexMut<HandleRange<T>> for Storage<T> {
     fn index_mut(&mut self, index: HandleRange<T>) -> &mut Self::Output {
         &mut self.0[index.start.0..(index.start.0 + index.len)]
+    }
+}
+
+impl<T> IntoIterator for Storage<T> {
+    type Item = (Handle<T>, T);
+    type IntoIter =
+        std::iter::Map<std::iter::Enumerate<std::vec::IntoIter<T>>, fn((usize, T)) -> Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0
+            .into_iter()
+            .enumerate()
+            .map(|(idx, val)| (Handle(idx, PhantomData), val))
     }
 }
 


### PR DESCRIPTION
Okay, so. You can set up clippy lints in `Cargo.toml` to catch some extra
things that might not be included by default in the lint group you're using.
We've discussed wanting to allow a couple things/disallow a couple others that
aren't in the default lint group, so I've done these things:
  1. Added those lints into the workspace `Cargo.toml`s
  2. Inherited those lints in the individual crates' `Cargo.toml`s
  3. Adjusted code to respect these new lints and remove now-unnecessary `#[allow(clippy::<something>)]`s
  4. Adjusted the rest of the code where it was simple to remove any other `#[allow(clippy::<something>)]`s. If it was a simple rewrite of something I immediately understood, then I made the change. Otherwise, I left it alone.

--------------

Closes #1035