### PR TITLE
Fail SwitchDemo HITL test when elastic buffer under/overflowed

### DIFF
--- a/firmware-binaries/demos/switch-demo1-mu/src/main.rs
+++ b/firmware-binaries/demos/switch-demo1-mu/src/main.rs
@@ -99,8 +99,18 @@ fn main() -> ! {
 
     uwriteln!(uart, "All UGNs captured").unwrap();
 
-    #[allow(clippy::empty_loop)]
-    loop {}
+    loop {
+        for (i, eb) in elastic_buffers.iter().enumerate() {
+            if eb.overflow() {
+                uwriteln!(uart, "[ERROR] Channel {} elastic buffer overflowed", i).unwrap();
+                panic!();
+            }
+            if eb.underflow() {
+                uwriteln!(uart, "[ERROR] Channel {} elastic buffer underflowed", i).unwrap();
+                panic!();
+            }
+        }
+    }
 }
 
 #[panic_handler]


### PR DESCRIPTION
After around 400 HITL tests with seemingly random failure rates we found out the elastic buffers could overflow silently. This PR makes these failures explicit by failing the test and printing debug information on which elastic buffers under- or overflowed. 

**Depends on:**
- #1140