### PR TITLE
Add Clash numeric types plus basic `impl`s

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -383,6 +383,34 @@ jobs:
         run: |
           ./cargo.sh clippy --all-features -- -Dwarnings
 
+  rust-tests:
+    name: Rust Tests
+    runs-on: [self-hosted, compute]
+    defaults:
+      run:
+        shell: git-nix-shell {0} --ignore-environment
+    container:
+      image: ghcr.io/clash-lang/nixos-bittide-hardware:2025-12-17
+      options: --memory=15g
+    needs: [build]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - run: cache pull cargo
+      - run: cache pull build
+
+      - name: Run Rust tests (debug mode, little endian)
+        run: |
+          cd firmware-support/bittide-hal
+          cargo test --locked
+
+      - name: Run Rust tests (release mode, little endian)
+        run: |
+          cd firmware-support/bittide-hal
+          cargo test --locked --release
+
   firmware-support-tests:
     name: Firmware Support Unit Tests
     runs-on: [self-hosted, compute]
@@ -759,6 +787,7 @@ jobs:
         firmware-support-tests,
         generate-control-reports,
         haskell-tests,
+        rust-tests,
         lint,
         mdbook,
         rust-lints,

--- a/bittide-instances/src/Bittide/Instances/Tests/RegisterWb.hs
+++ b/bittide-instances/src/Bittide/Instances/Tests/RegisterWb.hs
@@ -434,7 +434,7 @@ memoryMap =
     $ dutWithVcdAndPeConfig NoDumpVcd
     $ emptyPeConfig (SNat @IMemWords) (SNat @DMemWords) d0 d0 False vexRiscv0
 
-type IMemWords = DivRU (40 * 1024) 4
+type IMemWords = DivRU (48 * 1024) 4
 type DMemWords = DivRU (16 * 1024) 4
 
 getDumpVcd :: IO DumpVcd

--- a/firmware-binaries/Cargo.lock
+++ b/firmware-binaries/Cargo.lock
@@ -7,6 +7,7 @@ name = "addressable_bytes_wb_test"
 version = "0.1.0"
 dependencies = [
  "bittide-hal",
+ "bittide-macros",
  "bittide-sys",
  "heapless",
  "memmap-generate",
@@ -74,6 +75,7 @@ dependencies = [
 name = "bittide-macros"
 version = "0.1.0"
 dependencies = [
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 2.0.111",
@@ -84,6 +86,7 @@ name = "bittide-sys"
 version = "0.1.0"
 dependencies = [
  "bittide-hal",
+ "bittide-macros",
  "fdt",
  "heapless",
  "itertools",
@@ -189,6 +192,7 @@ name = "clock-control"
 version = "0.1.0"
 dependencies = [
  "bittide-hal",
+ "bittide-macros",
  "bittide-sys",
  "itertools",
  "memmap-generate",
@@ -256,6 +260,7 @@ name = "elastic_buffer_wb_test"
 version = "0.1.0"
 dependencies = [
  "bittide-hal",
+ "bittide-macros",
  "bittide-sys",
  "memmap-generate",
  "riscv-rt 0.11.0",
@@ -277,6 +282,12 @@ name = "embedded-hal"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "361a90feb7004eca4019fb28352a9465666b24f840f5c3cddf0ff13920590b89"
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "fdt"
@@ -307,6 +318,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
 name = "heapless"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -322,6 +339,16 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
 
 [[package]]
 name = "itertools"
@@ -395,6 +422,7 @@ name = "nested_interconnect_test"
 version = "0.1.0"
 dependencies = [
  "bittide-hal",
+ "bittide-macros",
  "bittide-sys",
  "heapless",
  "memmap-generate",
@@ -407,6 +435,15 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -481,6 +518,7 @@ name = "registerwb_test"
 version = "0.1.0"
 dependencies = [
  "bittide-hal",
+ "bittide-macros",
  "bittide-sys",
  "heapless",
  "memmap-generate",
@@ -604,6 +642,7 @@ name = "scatter_gather_test"
 version = "0.1.0"
 dependencies = [
  "bittide-hal",
+ "bittide-macros",
  "bittide-sys",
  "memmap-generate",
  "riscv-rt 0.11.0",
@@ -714,6 +753,7 @@ version = "0.1.0"
 dependencies = [
  "bittide-hal",
  "bittide-hal-c",
+ "bittide-macros",
  "bittide-sys",
  "cc",
  "memmap-generate",
@@ -782,6 +822,7 @@ name = "switch_calendar_test"
 version = "0.1.0"
 dependencies = [
  "bittide-hal",
+ "bittide-macros",
  "bittide-sys",
  "heapless",
  "memmap-generate",
@@ -832,6 +873,36 @@ dependencies = [
  "memmap-generate",
  "riscv-rt 0.11.0",
  "ufmt",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.11+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
 ]
 
 [[package]]
@@ -910,6 +981,15 @@ dependencies = [
  "memmap-generate",
  "riscv-rt 0.11.0",
  "ufmt",
+]
+
+[[package]]
+name = "winnow"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/firmware-binaries/demos/clock-control/Cargo.toml
+++ b/firmware-binaries/demos/clock-control/Cargo.toml
@@ -15,11 +15,12 @@ workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-riscv-rt = "0.11.0"
+bittide-macros = { path = "../../../firmware-support/bittide-macros" }
 bittide-sys = { path = "../../../firmware-support/bittide-sys" }
 bittide-hal = { path = "../../../firmware-support/bittide-hal" }
-ufmt = "0.2.0"
 itertools = { version = "0.14.0", default-features = false }
+riscv-rt = "0.11.0"
+ufmt = "0.2.0"
 
 [build-dependencies]
 memmap-generate = { path = "../../../firmware-support/memmap-generate" }

--- a/firmware-binaries/demos/clock-control/src/main.rs
+++ b/firmware-binaries/demos/clock-control/src/main.rs
@@ -8,15 +8,13 @@
 use core::panic::PanicInfo;
 use itertools::izip;
 
-use bittide_hal::manual_additions::timer::Duration;
-use bittide_hal::manual_additions::timer::Instant;
-use bittide_hal::manual_additions::timer::WaitResult;
-use bittide_hal::shared_devices::Timer;
-use bittide_hal::shared_devices::Uart;
-use bittide_hal::switch_demo_cc::devices::DomainDiffCounters;
-use bittide_hal::switch_demo_cc::DeviceInstances;
-use bittide_sys::sample_store::SampleStore;
-use bittide_sys::stability_detector::StabilityDetector;
+use bittide_hal::{
+    manual_additions::timer::{Duration, Instant, WaitResult},
+    shared_devices::{Timer, Uart},
+    switch_demo_cc::{devices::DomainDiffCounters, DeviceInstances},
+};
+use bittide_macros::unsigned;
+use bittide_sys::{sample_store::SampleStore, stability_detector::StabilityDetector};
 use ufmt::uwriteln;
 
 use bittide_sys::callisto::Callisto;
@@ -68,7 +66,7 @@ fn main() -> ! {
                 )
                 .map(|(i, counter)| {
                     if domain_diff_counters.enable(i).unwrap_or(false) {
-                        Some(counter)
+                        Some(counter.into_inner())
                     } else {
                         None
                     }
@@ -81,7 +79,7 @@ fn main() -> ! {
 
         // Store debug information. Stop capturing samples if we are stable to
         // reduce plot sizes.
-        let has_sense_of_global_time = freeze.number_of_sync_pulses_seen() != 0;
+        let has_sense_of_global_time = freeze.number_of_sync_pulses_seen() != unsigned!(0, n = 32);
         if !prev_all_stable && has_sense_of_global_time {
             sample_store.store(&freeze, stability, callisto.accumulated_speed_requests);
         }

--- a/firmware-binaries/demos/soft-ugn-mu/Cargo.toml
+++ b/firmware-binaries/demos/soft-ugn-mu/Cargo.toml
@@ -13,10 +13,11 @@ authors = ["Google LLC"]
 workspace = true
 
 [dependencies]
-riscv-rt = "0.11.0"
-bittide-sys = { path = "../../../firmware-support/bittide-sys" }
-ufmt = "0.2.0"
+bittide-macros = { path = "../../../firmware-support/bittide-macros" }
 bittide-hal = { path = "../../../firmware-support/bittide-hal" }
+bittide-sys = { path = "../../../firmware-support/bittide-sys" }
+riscv-rt = "0.11.0"
+ufmt = "0.2.0"
 
 [build-dependencies]
 memmap-generate = { path = "../../../firmware-support/memmap-generate" }

--- a/firmware-binaries/demos/soft-ugn-mu/src/main.rs
+++ b/firmware-binaries/demos/soft-ugn-mu/src/main.rs
@@ -5,11 +5,11 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use bittide_hal::hals::soft_ugn_demo_mu::DeviceInstances;
-use bittide_hal::manual_additions::calendar::RingbufferCalendar;
-use bittide_hal::shared_devices::Uart;
-use bittide_sys::link_startup::LinkStartup;
-use bittide_sys::stability_detector::Stability;
+use bittide_hal::{
+    hals::soft_ugn_demo_mu::DeviceInstances, manual_additions::calendar::RingbufferCalendar,
+    shared_devices::Uart,
+};
+use bittide_sys::{link_startup::LinkStartup, stability_detector::Stability};
 use core::panic::PanicInfo;
 use ufmt::uwriteln;
 

--- a/firmware-binaries/demos/switch-demo1-mu/src/main.rs
+++ b/firmware-binaries/demos/switch-demo1-mu/src/main.rs
@@ -6,8 +6,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use bittide_hal::hals::switch_demo_mu::DeviceInstances;
-use bittide_sys::link_startup::LinkStartup;
-use bittide_sys::stability_detector::Stability;
+use bittide_sys::{link_startup::LinkStartup, stability_detector::Stability};
 use core::panic::PanicInfo;
 use ufmt::uwriteln;
 

--- a/firmware-binaries/demos/switch-demo2-mu/src/main.rs
+++ b/firmware-binaries/demos/switch-demo2-mu/src/main.rs
@@ -106,7 +106,7 @@ fn main() -> ! {
                     "Capture UGN {}: local = {}, remote = {}",
                     i,
                     capture_ugn.local_counter(),
-                    capture_ugn.remote_counter()
+                    capture_ugn.remote_counter(),
                 )
                 .unwrap();
                 *done = true;

--- a/firmware-binaries/hitl-tests/clock-board/src/main.rs
+++ b/firmware-binaries/hitl-tests/clock-board/src/main.rs
@@ -78,7 +78,7 @@ fn check_frequency(
     domain_diff_counters.set_enable(0, false);
 
     let diff = match (start, end) {
-        (Some(s), Some(e)) => e - s,
+        (Some(s), Some(e)) => e.into_inner() - s.into_inner(),
         _ => return Err(FrequencyCheckError::CounterInaccessible),
     };
 

--- a/firmware-binaries/sim-tests/addressable_bytes_wb_test/Cargo.toml
+++ b/firmware-binaries/sim-tests/addressable_bytes_wb_test/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 
 [dependencies]
 bittide-hal = { path = "../../../firmware-support/bittide-hal" }
+bittide-macros = { path = "../../../firmware-support/bittide-macros" }
 bittide-sys = { path = "../../../firmware-support/bittide-sys" }
 heapless = "0.8.0"
 riscv = { version = "0.11.1", features = ["critical-section-single-hart"] }

--- a/firmware-binaries/sim-tests/addressable_bytes_wb_test/src/main.rs
+++ b/firmware-binaries/sim-tests/addressable_bytes_wb_test/src/main.rs
@@ -7,6 +7,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+use bittide_macros::bitvector;
 use ufmt::{uWrite, uwrite, uwriteln};
 
 use bittide_hal::hals::addressable_bytes_wb as hal;
@@ -63,7 +64,7 @@ fn main() -> ! {
     uwriteln!(uart, "Starting addressable_bytes_wb_test").unwrap();
 
     // Test data: 8 words with distinct patterns
-    let test_data: [[u8; 4]; 8] = [
+    let test_data = [
         [0x00, 0x10, 0x20, 0x30],
         [0x01, 0x11, 0x21, 0x31],
         [0x02, 0x12, 0x22, 0x32],
@@ -72,7 +73,8 @@ fn main() -> ! {
         [0x05, 0x15, 0x25, 0x35],
         [0x06, 0x16, 0x26, 0x36],
         [0x07, 0x17, 0x27, 0x37],
-    ];
+    ]
+    .map(|bytes| bitvector!(bytes, n = 32));
 
     // Test 1: Word-based access for whole memory
     uwriteln!(uart, "Test word-based access").unwrap();
@@ -86,7 +88,11 @@ fn main() -> ! {
 
     buffer.clear();
     for i in 0..8 {
-        expect("Clearing failed", Some([0u8; 4]), buffer.data(i));
+        expect(
+            "Clearing failed",
+            Some(bitvector!(0x0, n = 32)),
+            buffer.data(i),
+        );
     }
     uwriteln!(uart, "  PASS").unwrap();
 
@@ -115,7 +121,11 @@ fn main() -> ! {
 
         buffer.clear();
         for i in 0..8 {
-            expect("Clearing failed", Some([0u8; 4]), buffer.data(i));
+            expect(
+                "Clearing failed",
+                Some(bitvector!(0x0, n = 32)),
+                buffer.data(i),
+            );
         }
     }
 
@@ -139,7 +149,11 @@ fn main() -> ! {
 
                 buffer.clear();
                 for i in 0..8 {
-                    expect("Test 3 clear", Some([0u8; 4]), buffer.data(i));
+                    expect(
+                        "Test 3 clear",
+                        Some(bitvector!(0x0, n = 32)),
+                        buffer.data(i),
+                    );
                 }
             }
         }

--- a/firmware-binaries/sim-tests/capture_ugn_test/src/main.rs
+++ b/firmware-binaries/sim-tests/capture_ugn_test/src/main.rs
@@ -26,9 +26,9 @@ fn main() -> ! {
     }
     uwriteln!(
         uart,
-        "(0x{:16X},0x{:16X})",
+        "({},{})",
         capture_ugn.local_counter(),
-        capture_ugn.remote_counter()
+        capture_ugn.remote_counter(),
     )
     .unwrap();
     loop {

--- a/firmware-binaries/sim-tests/clock-control-wb/src/main.rs
+++ b/firmware-binaries/sim-tests/clock-control-wb/src/main.rs
@@ -73,7 +73,7 @@ fn main() -> ! {
     writeln!(uart, "]").unwrap();
 
     // Mark end of transmission - should hopefully be unique enough?
-    for _ in 0..cc.link_mask_pop_count() {
+    for _ in 0..cc.link_mask_pop_count().into_inner() {
         cc.set_change_speed(SpeedChange::NoChange);
     }
 

--- a/firmware-binaries/sim-tests/elastic_buffer_wb_test/Cargo.toml
+++ b/firmware-binaries/sim-tests/elastic_buffer_wb_test/Cargo.toml
@@ -15,9 +15,10 @@ workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-riscv-rt = "0.11.0"
-bittide-sys = { path = "../../../firmware-support/bittide-sys" }
 bittide-hal = { path = "../../../firmware-support/bittide-hal" }
+bittide-macros = { path = "../../../firmware-support/bittide-macros" }
+bittide-sys = { path = "../../../firmware-support/bittide-sys" }
+riscv-rt = "0.11.0"
 ufmt = "0.2.0"
 
 [build-dependencies]

--- a/firmware-binaries/sim-tests/elastic_buffer_wb_test/src/main.rs
+++ b/firmware-binaries/sim-tests/elastic_buffer_wb_test/src/main.rs
@@ -4,9 +4,11 @@
 #![no_std]
 #![cfg_attr(not(test), no_main)]
 
-use bittide_hal::elastic_buffer_wb_test::DeviceInstances;
-use bittide_hal::manual_additions::timer::Duration;
-use bittide_hal::shared_devices::ElasticBuffer;
+use bittide_hal::{
+    elastic_buffer_wb_test::DeviceInstances, manual_additions::timer::Duration,
+    shared_devices::ElasticBuffer,
+};
+use bittide_macros::{signed, unsigned};
 #[cfg(not(test))]
 use riscv_rt::entry;
 use ufmt::uwriteln;
@@ -34,7 +36,7 @@ fn test_set_occupancy_to_midpoint(
     }
 
     // Action: Calculate how many elements to add/remove to reach 0
-    let count_before = elastic_buffer.data_count();
+    let count_before = elastic_buffer.data_count().into_inner();
     let target = 0i8;
     let delta = target - count_before;
 
@@ -60,7 +62,7 @@ fn test_set_occupancy_to_midpoint(
     .unwrap();
 
     // Verify: Count is exactly at the midpoint (0)
-    if !underflow_initial && !overflow_initial && count_after == target {
+    if !underflow_initial && !overflow_initial && count_after.into_inner() == target {
         uwriteln!(uart, "  PASS").unwrap();
         true
     } else {
@@ -88,7 +90,7 @@ fn test_zero_adjustment(
     uwriteln!(uart, "  Before adjustment(0): count={}", count_before).unwrap();
 
     // Test single zero adjustment
-    elastic_buffer.set_adjustment(0);
+    elastic_buffer.set_adjustment(signed!(0, n = 32));
 
     timer.wait(Duration::from_micros(1));
     let count_after_first = elastic_buffer.data_count();
@@ -106,9 +108,9 @@ fn test_zero_adjustment(
     }
 
     // Test multiple zero adjustments in succession
-    elastic_buffer.set_adjustment(0);
-    elastic_buffer.set_adjustment(0);
-    elastic_buffer.set_adjustment(0);
+    elastic_buffer.set_adjustment(signed!(0, n = 32));
+    elastic_buffer.set_adjustment(signed!(0, n = 32));
+    elastic_buffer.set_adjustment(signed!(0, n = 32));
 
     timer.wait(Duration::from_micros(1));
     let count_after_multiple = elastic_buffer.data_count();
@@ -156,12 +158,12 @@ fn test_multiple_drain_commands(
     }
 
     // Action: Use set_adjustment HAL function to remove 5 frames
-    let count_before = elastic_buffer.data_count() as i32;
+    let count_before = elastic_buffer.data_count().into_inner();
     uwriteln!(uart, "  Before set_adjustment(-5): count={}", count_before).unwrap();
 
-    elastic_buffer.set_adjustment(-5);
+    elastic_buffer.set_adjustment(signed!(-5, n = 32));
 
-    let count_after = elastic_buffer.data_count() as i32;
+    let count_after = elastic_buffer.data_count().into_inner();
     uwriteln!(uart, "  After set_adjustment(-5): count={}", count_after).unwrap();
 
     // Verify: Count decreased by exactly 5
@@ -204,7 +206,7 @@ fn test_underflow_flag_sticky(
     }
 
     // Action 1: Drain past empty to trigger underflow
-    let count_before = elastic_buffer.data_count();
+    let count_before = elastic_buffer.data_count().into_inner();
     let drains_needed = count_before as i32 - (ElasticBuffer::MIN_OCCUPANCY as i32 - 1);
     uwriteln!(
         uart,
@@ -214,7 +216,7 @@ fn test_underflow_flag_sticky(
     )
     .unwrap();
 
-    elastic_buffer.set_adjustment(-drains_needed);
+    elastic_buffer.set_adjustment(signed!(-drains_needed, n = 32));
 
     let count_after_drain = elastic_buffer.data_count();
     let underflow_after_drain = elastic_buffer.underflow();
@@ -237,7 +239,7 @@ fn test_underflow_flag_sticky(
     }
 
     // Action 2: Issue Fill adjustment to test stickiness
-    elastic_buffer.set_adjustment(1);
+    elastic_buffer.set_adjustment(signed!(1, n = 32));
     timer.wait(Duration::from_micros(1));
 
     let underflow_after_fill = elastic_buffer.underflow();
@@ -311,7 +313,7 @@ fn test_overflow_flag_sticky(
     }
 
     // Action 1: Fill past capacity to trigger overflow
-    let count_before = elastic_buffer.data_count() as i32;
+    let count_before = elastic_buffer.data_count().into_inner() as i32;
     let fills_needed = ElasticBuffer::MAX_OCCUPANCY as i32 - count_before + 1;
     uwriteln!(
         uart,
@@ -321,9 +323,9 @@ fn test_overflow_flag_sticky(
     )
     .unwrap();
 
-    elastic_buffer.set_adjustment(fills_needed);
+    elastic_buffer.set_adjustment(signed!(fills_needed, n = 32));
 
-    let count_after_fill = elastic_buffer.data_count() as i32;
+    let count_after_fill = elastic_buffer.data_count().into_inner() as i32;
     let overflow_after_fill = elastic_buffer.overflow();
     uwriteln!(
         uart,
@@ -344,7 +346,7 @@ fn test_overflow_flag_sticky(
     }
 
     // Action 2: Issue Drain adjustment to test stickiness
-    elastic_buffer.set_adjustment(-1);
+    elastic_buffer.set_adjustment(signed!(-1, n = 32));
 
     timer.wait(Duration::from_micros(1));
     let overflow_after_drain = elastic_buffer.overflow();
@@ -393,14 +395,14 @@ fn test_multiple_items_command(
     elastic_buffer.set_occupancy(0);
 
     timer.wait(Duration::from_micros(1));
-    let count_before = elastic_buffer.data_count();
+    let count_before = elastic_buffer.data_count().into_inner();
     uwriteln!(uart, "  Initial count: {}", count_before).unwrap();
 
     // Test 1: Fill multiple items (n=10)
-    elastic_buffer.set_adjustment(10);
+    elastic_buffer.set_adjustment(signed!(10, n = 32));
 
     timer.wait(Duration::from_micros(1));
-    let count_after_fill = elastic_buffer.data_count();
+    let count_after_fill = elastic_buffer.data_count().into_inner();
     uwriteln!(uart, "  After filling 10: count={}", count_after_fill).unwrap();
 
     if count_after_fill != count_before + 10 {
@@ -415,10 +417,10 @@ fn test_multiple_items_command(
     }
 
     // Test 2: Drain multiple items (n=5)
-    elastic_buffer.set_adjustment(-5);
+    elastic_buffer.set_adjustment(signed!(-5, n = 32));
 
     timer.wait(Duration::from_micros(1));
-    let count_after_drain = elastic_buffer.data_count();
+    let count_after_drain = elastic_buffer.data_count().into_inner();
     uwriteln!(uart, "  After draining 5: count={}", count_after_drain).unwrap();
 
     if count_after_drain != count_after_fill - 5 {
@@ -449,17 +451,17 @@ fn test_back_to_back(
     elastic_buffer.set_occupancy(0);
 
     timer.wait(Duration::from_micros(1));
-    let count_initial = elastic_buffer.data_count();
+    let count_initial = elastic_buffer.data_count().into_inner();
     uwriteln!(uart, "  Initial count: {}", count_initial).unwrap();
 
     // Submit two adjustments back-to-back without waiting between them
     // The second should stall until the first completes
-    elastic_buffer.set_adjustment_async(3);
-    elastic_buffer.set_adjustment_async(-2);
+    elastic_buffer.set_adjustment_async(signed!(3, n = 32));
+    elastic_buffer.set_adjustment_async(signed!(-2, n = 32));
     elastic_buffer.set_adjustment_wait(());
 
     timer.wait(Duration::from_micros(1));
-    let count_after = elastic_buffer.data_count();
+    let count_after = elastic_buffer.data_count().into_inner();
     uwriteln!(uart, "  After both adjustments: count={}", count_after).unwrap();
 
     // Verify: count should be initial + 3 - 2 = initial + 1
@@ -491,15 +493,15 @@ fn test_async_wait_async_wait(
     elastic_buffer.set_occupancy(0);
 
     timer.wait(Duration::from_micros(1));
-    let count_initial = elastic_buffer.data_count();
+    let count_initial = elastic_buffer.data_count().into_inner();
     uwriteln!(uart, "  Initial count: {}", count_initial).unwrap();
 
     // First adjustment: submit and wait
-    elastic_buffer.set_adjustment_async(7);
+    elastic_buffer.set_adjustment_async(signed!(7, n = 32));
     elastic_buffer.set_adjustment_wait(());
 
     timer.wait(Duration::from_micros(1));
-    let count_after_first = elastic_buffer.data_count();
+    let count_after_first = elastic_buffer.data_count().into_inner();
     uwriteln!(
         uart,
         "  After first filling 7 + wait: count={}",
@@ -508,11 +510,11 @@ fn test_async_wait_async_wait(
     .unwrap();
 
     // Second adjustment: submit and wait
-    elastic_buffer.set_adjustment_async(-4);
+    elastic_buffer.set_adjustment_async(signed!(-4, n = 32));
     elastic_buffer.set_adjustment_wait(());
 
     timer.wait(Duration::from_micros(1));
-    let count_after_second = elastic_buffer.data_count();
+    let count_after_second = elastic_buffer.data_count().into_inner();
     uwriteln!(
         uart,
         "  After second draining 4 + wait: count={}",
@@ -553,19 +555,19 @@ fn test_auto_center_basic_centering(
     // Set buffer to +10
     elastic_buffer.set_occupancy(10);
     timer.wait(Duration::from_micros(1));
-    let count_before = elastic_buffer.data_count();
+    let count_before = elastic_buffer.data_count().into_inner();
     uwriteln!(uart, "  Initial count: {}", count_before).unwrap();
 
     // Set margin to 2 and enable auto-center
-    elastic_buffer.set_auto_center_margin(2);
+    elastic_buffer.set_auto_center_margin(unsigned!(2, n = 16));
     elastic_buffer.set_auto_center_enable(true);
 
     // Wait for it to become idle
     elastic_buffer.wait_auto_center_idle();
 
     timer.wait(Duration::from_micros(1));
-    let count_after = elastic_buffer.data_count();
-    let total_adjustments = elastic_buffer.auto_center_total_adjustments();
+    let count_after = elastic_buffer.data_count().into_inner();
+    let total_adjustments = elastic_buffer.auto_center_total_adjustments().into_inner();
     uwriteln!(
         uart,
         "  After auto-center: count={}, total_adjustments={}",
@@ -620,14 +622,14 @@ fn test_auto_center_margin_parameter(
         uwriteln!(uart, "  Testing margin={}", margin).unwrap();
 
         // Set margin and enable
-        elastic_buffer.set_auto_center_margin(margin);
+        elastic_buffer.set_auto_center_margin(unsigned!(margin, n = 16));
         elastic_buffer.set_auto_center_enable(true);
 
         // Wait for idle
         elastic_buffer.wait_auto_center_idle();
 
         timer.wait(Duration::from_micros(1));
-        let count_after = elastic_buffer.data_count();
+        let count_after = elastic_buffer.data_count().into_inner();
         let margin_signed = margin as i8;
 
         uwriteln!(
@@ -723,7 +725,7 @@ fn test_auto_center_idle_state(
     timer.wait(Duration::from_micros(1));
 
     // Enable auto-center
-    elastic_buffer.set_auto_center_margin(2);
+    elastic_buffer.set_auto_center_margin(unsigned!(2, n = 16));
     elastic_buffer.set_auto_center_enable(true);
 
     // Wait for completion
@@ -762,7 +764,7 @@ fn test_auto_center_total_adjustments_tracking(
     timer.wait(Duration::from_micros(1));
 
     // Verify total starts at 0
-    let total_initial = elastic_buffer.auto_center_total_adjustments();
+    let total_initial = elastic_buffer.auto_center_total_adjustments().into_inner();
     if total_initial != 0 {
         uwriteln!(
             uart,
@@ -776,11 +778,11 @@ fn test_auto_center_total_adjustments_tracking(
     // Set buffer to +15 and center
     elastic_buffer.set_occupancy(15);
     timer.wait(Duration::from_micros(1));
-    elastic_buffer.set_auto_center_margin(0);
+    elastic_buffer.set_auto_center_margin(unsigned!(0, n = 16));
     elastic_buffer.set_auto_center_enable(true);
     elastic_buffer.wait_auto_center_idle();
 
-    let total_after_first = elastic_buffer.auto_center_total_adjustments();
+    let total_after_first = elastic_buffer.auto_center_total_adjustments().into_inner();
     uwriteln!(
         uart,
         "  After centering from +15: total={}",
@@ -806,7 +808,7 @@ fn test_auto_center_total_adjustments_tracking(
     elastic_buffer.set_auto_center_enable(true);
     elastic_buffer.wait_auto_center_idle();
 
-    let total_after_second = elastic_buffer.auto_center_total_adjustments();
+    let total_after_second = elastic_buffer.auto_center_total_adjustments().into_inner();
     uwriteln!(
         uart,
         "  After centering from -10: total={}",
@@ -842,11 +844,11 @@ fn test_auto_center_reset_functionality(
     elastic_buffer.reset_auto_center();
     elastic_buffer.set_occupancy(12);
     timer.wait(Duration::from_micros(1));
-    elastic_buffer.set_auto_center_margin(0);
+    elastic_buffer.set_auto_center_margin(unsigned!(0, n = 16));
     elastic_buffer.set_auto_center_enable(true);
     elastic_buffer.wait_auto_center_idle();
 
-    let total_before_reset = elastic_buffer.auto_center_total_adjustments();
+    let total_before_reset = elastic_buffer.auto_center_total_adjustments().into_inner();
     uwriteln!(
         uart,
         "  Total adjustments before reset: {}",
@@ -864,7 +866,7 @@ fn test_auto_center_reset_functionality(
     timer.wait(Duration::from_micros(1));
 
     // Verify total is 0
-    let total_after_reset = elastic_buffer.auto_center_total_adjustments();
+    let total_after_reset = elastic_buffer.auto_center_total_adjustments().into_inner();
     if total_after_reset != 0 {
         uwriteln!(
             uart,
@@ -907,19 +909,19 @@ fn test_auto_center_with_manual_adjustments(
     timer.wait(Duration::from_micros(1));
 
     // Enable auto-center
-    elastic_buffer.set_auto_center_margin(2);
+    elastic_buffer.set_auto_center_margin(unsigned!(2, n = 16));
     elastic_buffer.set_auto_center_enable(true);
     timer.wait(Duration::from_micros(1));
 
     // Submit a manual adjustment while auto-center is active
-    elastic_buffer.set_adjustment(5);
+    elastic_buffer.set_adjustment(signed!(5, n = 32));
     timer.wait(Duration::from_micros(1));
 
     // Wait for auto-center to finish
     elastic_buffer.wait_auto_center_idle();
 
-    let count_final = elastic_buffer.data_count();
-    let total_adjustments = elastic_buffer.auto_center_total_adjustments();
+    let count_final = elastic_buffer.data_count().into_inner();
+    let total_adjustments = elastic_buffer.auto_center_total_adjustments().into_inner();
 
     uwriteln!(
         uart,
@@ -962,15 +964,15 @@ fn test_auto_center_already_centered(
     elastic_buffer.set_occupancy(0);
     timer.wait(Duration::from_micros(1));
 
-    let count_before = elastic_buffer.data_count();
+    let count_before = elastic_buffer.data_count().into_inner();
 
     // Enable auto-center with margin 2
-    elastic_buffer.set_auto_center_margin(2);
+    elastic_buffer.set_auto_center_margin(unsigned!(2, n = 16));
     elastic_buffer.set_auto_center_enable(true);
     elastic_buffer.wait_auto_center_idle();
 
-    let count_after = elastic_buffer.data_count();
-    let total_adjustments = elastic_buffer.auto_center_total_adjustments();
+    let count_after = elastic_buffer.data_count().into_inner();
+    let total_adjustments = elastic_buffer.auto_center_total_adjustments().into_inner();
 
     uwriteln!(
         uart,
@@ -1017,14 +1019,14 @@ fn test_auto_center_wait_idle(
     timer.wait(Duration::from_micros(1));
 
     // Enable auto-center
-    elastic_buffer.set_auto_center_margin(2);
+    elastic_buffer.set_auto_center_margin(unsigned!(2, n = 16));
     elastic_buffer.set_auto_center_enable(true);
 
     // Immediately call wait_idle
     elastic_buffer.wait_auto_center_idle();
 
     // Should not return until idle, and buffer should be centered
-    let count_after = elastic_buffer.data_count();
+    let count_after = elastic_buffer.data_count().into_inner();
     let is_idle = elastic_buffer.auto_center_is_idle();
 
     uwriteln!(
@@ -1069,12 +1071,12 @@ fn test_auto_center_zero_margin(
     timer.wait(Duration::from_micros(1));
 
     // Set margin to 0
-    elastic_buffer.set_auto_center_margin(0);
+    elastic_buffer.set_auto_center_margin(unsigned!(0, n = 16));
     elastic_buffer.set_auto_center_enable(true);
     elastic_buffer.wait_auto_center_idle();
     timer.wait(Duration::from_micros(1));
 
-    let count_after = elastic_buffer.data_count();
+    let count_after = elastic_buffer.data_count().into_inner();
     uwriteln!(
         uart,
         "  After centering with margin=0: count={}",
@@ -1109,7 +1111,7 @@ fn test_auto_center_persistence_across_multiple_perturbations(
     elastic_buffer.reset_auto_center();
     elastic_buffer.set_occupancy(0);
     timer.wait(Duration::from_micros(1));
-    elastic_buffer.set_auto_center_margin(2);
+    elastic_buffer.set_auto_center_margin(unsigned!(2, n = 16));
     elastic_buffer.set_auto_center_enable(true);
     elastic_buffer.wait_auto_center_idle();
 
@@ -1119,13 +1121,13 @@ fn test_auto_center_persistence_across_multiple_perturbations(
         uwriteln!(uart, "  Applying perturbation: {}", perturbation).unwrap();
 
         // Manually adjust buffer off-center
-        elastic_buffer.set_adjustment(perturbation);
+        elastic_buffer.set_adjustment(signed!(perturbation, n = 32));
         timer.wait(Duration::from_micros(1));
 
         // Wait for auto-center to fix it
         elastic_buffer.wait_auto_center_idle();
 
-        let count = elastic_buffer.data_count();
+        let count = elastic_buffer.data_count().into_inner();
         uwriteln!(uart, "    After re-centering: count={}", count).unwrap();
 
         // Verify it's centered again

--- a/firmware-binaries/sim-tests/nested_interconnect_test/Cargo.toml
+++ b/firmware-binaries/sim-tests/nested_interconnect_test/Cargo.toml
@@ -13,11 +13,12 @@ authors = ["Google LLC"]
 workspace = true
 
 [dependencies]
-riscv-rt = "0.11.0"
-bittide-sys = { path = "../../../firmware-support/bittide-sys" }
-ufmt = "0.2.0"
-bittide-hal = { path = "../../../firmware-support/bittide-hal" }
 heapless = "0.8.0"
+bittide-macros = { path = "../../../firmware-support/bittide-macros" }
+bittide-hal = { path = "../../../firmware-support/bittide-hal" }
+bittide-sys = { path = "../../../firmware-support/bittide-sys" }
+riscv-rt = "0.11.0"
+ufmt = "0.2.0"
 
 [build-dependencies]
 memmap-generate = { path = "../../../firmware-support/memmap-generate" }

--- a/firmware-binaries/sim-tests/nested_interconnect_test/src/main.rs
+++ b/firmware-binaries/sim-tests/nested_interconnect_test/src/main.rs
@@ -6,9 +6,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use ufmt::{uwrite, uwriteln};
-
 use bittide_hal::hals::nested_interconnect as hal;
+use bittide_macros::unsigned;
+use ufmt::{uwrite, uwriteln};
 
 use core::fmt::Write;
 #[cfg(not(test))]
@@ -72,23 +72,23 @@ fn main() -> ! {
 
         // Read initial values (should be 0)
         write!(name_buf, "peripheral{i}.status.init").unwrap();
-        expect(&name_buf, 0u32, peripheral.status());
+        expect(&name_buf, 0u32, peripheral.status().into_inner());
         name_buf.clear();
 
         write!(name_buf, "peripheral{i}.control.init").unwrap();
-        expect(&name_buf, 0u32, peripheral.control());
+        expect(&name_buf, 0u32, peripheral.control().into_inner());
         name_buf.clear();
 
         // Write and read back status
-        peripheral.set_status(*status_val);
+        peripheral.set_status(unsigned!(*status_val, n = 32));
         write!(name_buf, "peripheral{i}.status.readback").unwrap();
-        expect(&name_buf, *status_val, peripheral.status());
+        expect(&name_buf, *status_val, peripheral.status().into_inner());
         name_buf.clear();
 
         // Write and read back control
-        peripheral.set_control(*control_val);
+        peripheral.set_control(unsigned!(*control_val, n = 32));
         write!(name_buf, "peripheral{i}.control.readback").unwrap();
-        expect(&name_buf, *control_val, peripheral.control());
+        expect(&name_buf, *control_val, peripheral.control().into_inner());
     }
 
     // Verify all peripherals are still accessible
@@ -97,7 +97,7 @@ fn main() -> ! {
     {
         let mut name_buf = heapless::String::<50>::new();
         write!(name_buf, "peripheral{i}.status.final").unwrap();
-        expect(&name_buf, *status_val, peripheral.status());
+        expect(&name_buf, *status_val, peripheral.status().into_inner());
     }
 
     test_ok()

--- a/firmware-binaries/sim-tests/registerwb_test/Cargo.toml
+++ b/firmware-binaries/sim-tests/registerwb_test/Cargo.toml
@@ -15,11 +15,12 @@ workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-riscv-rt = "0.11.0"
-bittide-sys = { path = "../../../firmware-support/bittide-sys" }
-ufmt = "0.2.0"
+bittide-macros = { path = "../../../firmware-support/bittide-macros" }
 bittide-hal = { path = "../../../firmware-support/bittide-hal" }
+bittide-sys = { path = "../../../firmware-support/bittide-sys" }
 heapless = "0.8.0"
+riscv-rt = "0.11.0"
+ufmt = "0.2.0"
 
 [build-dependencies]
 memmap-generate = { path = "../../../firmware-support/memmap-generate" }

--- a/firmware-binaries/sim-tests/registerwb_test/src/main.rs
+++ b/firmware-binaries/sim-tests/registerwb_test/src/main.rs
@@ -1,15 +1,15 @@
+// SPDX-FileCopyrightText: 2025 Google LLC
+//
+// SPDX-License-Identifier: Apache-2.0
 #![no_std]
 #![cfg_attr(not(test), no_main)]
 #![allow(const_item_mutation)]
 #![allow(clippy::approx_constant)]
 
-// SPDX-FileCopyrightText: 2025 Google LLC
-//
-// SPDX-License-Identifier: Apache-2.0
 use ufmt::{uWrite, uwrite, uwriteln};
 
-use bittide_hal::hals::register_wb as hal;
-use bittide_hal::types;
+use bittide_hal::{hals::register_wb as hal, types};
+use bittide_macros::{bitvector, index, signed, unsigned};
 
 use core::fmt::Write;
 #[cfg(not(test))]
@@ -52,19 +52,18 @@ fn expect<T: ufmt::uDebug + PartialEq>(msg: &str, expected: T, actual: T) {
     }
 }
 
-fn bv16(v: u16) -> [u8; 2] {
-    v.to_le_bytes()
-}
-fn bv64(v: u64) -> [u8; 8] {
-    v.to_le_bytes()
-}
-
 #[cfg_attr(not(test), entry)]
 fn main() -> ! {
     let many_types = &mut INSTANCES.many_types;
 
     macro_rules! read_write {
-        ($name:literal, $read_fn:ident, $init_expected:expr, $write_fn:ident, $ret_expected:expr) => {
+        (
+            $name:literal,
+            $read_fn:ident,
+            $init_expected:expr,
+            $write_fn:ident,
+            $ret_expected:expr$(,)?
+        ) => {
             let name = concat!("init.", $name);
             expect(name, $init_expected, many_types.$read_fn());
             many_types.$write_fn($ret_expected);
@@ -72,7 +71,13 @@ fn main() -> ! {
             expect(name, $ret_expected, many_types.$read_fn());
         };
 
-        (array => $name:literal, $read_fn:ident, [$($init_expected:expr),*], $write_fn:ident, [$($ret_expected:expr),*]) => {
+        (
+            array => $name:literal,
+            $read_fn:ident,
+            [$($init_expected:expr),*$(,)?],
+            $write_fn:ident,
+            [$($ret_expected:expr),*$(,)?]$(,)?
+        ) => {
             let mut i = 0;
             $(
                 let mut msg = heapless::String::<150>::new();
@@ -100,25 +105,61 @@ fn main() -> ! {
     }
 
     // Test initial values:
-    read_write!("s0", s0, -8, set_s0, -16);
-    read_write!("s1", s1, 8, set_s1, 16);
-    read_write!("s2", s2, 16, set_s2, 32);
-    read_write!("s3", s3, 3721049880298531338, set_s3, 7442099760597062676);
-    read_write!("s4", s4, -12, set_s4, -13);
+    read_write!("s0", s0, signed!(-8, n = 8), set_s0, signed!(-16, n = 8));
+    read_write!("s1", s1, signed!(8, n = 8), set_s1, signed!(16, n = 8));
+    read_write!("s2", s2, signed!(16, n = 16), set_s2, signed!(32, n = 16));
+    read_write!(
+        "s3",
+        s3,
+        signed!(3721049880298531338, n = 64),
+        set_s3,
+        signed!(7442099760597062676, n = 64),
+    );
+    read_write!("s4", s4, signed!(-12, n = 8), set_s4, signed!(-13, n = 8));
 
-    read_write!("u0", u0, 8, set_u0, 16);
-    read_write!("u1", u1, 16, set_u1, 32);
-    read_write!("u2", u2, 3721049880298531338, set_u2, 7442099760597062676);
-    read_write!("u3", u3, 0xBADC_0FEE, set_u3, 24);
+    read_write!("u0", u0, unsigned!(8, n = 8), set_u0, unsigned!(16, n = 8));
+    read_write!(
+        "u1",
+        u1,
+        unsigned!(16, n = 16),
+        set_u1,
+        unsigned!(32, n = 16),
+    );
+    read_write!(
+        "u2",
+        u2,
+        unsigned!(3721049880298531338, n = 64),
+        set_u2,
+        unsigned!(7442099760597062676, n = 64),
+    );
+    read_write!(
+        "u3",
+        u3,
+        unsigned!(0xBADC_0FEE, n = 32),
+        set_u3,
+        unsigned!(24, n = 32),
+    );
 
-    read_write!("bv0", bv0, [8], set_bv0, [16]);
-    read_write!("bv1", bv1, bv16(16), set_bv1, bv16(32));
+    read_write!(
+        "bv0",
+        bv0,
+        bitvector!(0x08, n = 8),
+        set_bv0,
+        bitvector!(0x10, n = 8),
+    );
+    read_write!(
+        "bv1",
+        bv1,
+        bitvector!(0x10, n = 16),
+        set_bv1,
+        bitvector!(0x20, n = 16),
+    );
     read_write!(
         "bv2",
         bv2,
-        bv64(3721049880298531338),
+        bitvector!(0x33A3D326B2B42A0A, n = 64),
         set_bv2,
-        bv64(7442099760597062676)
+        bitvector!(0x6747A64D65685414, n = 64),
     );
 
     // floats/doubles don't implement uDebug, so go through bool instead :(
@@ -140,14 +181,32 @@ fn main() -> ! {
     read_write!(
         array => "v0",
         v0,
-        [[0x8], [0x16], [0x24], [0x32], [0x40], [0x4E], [0x5C], [0x6A]],
+        [
+            bitvector!(0x08, n = 8),
+            bitvector!(0x16, n = 8),
+            bitvector!(0x24, n = 8),
+            bitvector!(0x32, n = 8),
+            bitvector!(0x40, n = 8),
+            bitvector!(0x4E, n = 8),
+            bitvector!(0x5C, n = 8),
+            bitvector!(0x6A, n = 8),
+        ],
         set_v0,
-        [[16], [32], [64], [128], [3], [9], [27], [81]]
+        [
+            bitvector!(0x10, n = 8),
+            bitvector!(0x20, n = 8),
+            bitvector!(0x40, n = 8),
+            bitvector!(0x80, n = 8),
+            bitvector!(0x03, n = 8),
+            bitvector!(0x09, n = 8),
+            bitvector!(0x1B, n = 8),
+            bitvector!(0x51, n = 8),
+        ],
     );
 
     // also check with iterator interface
     {
-        let v0_ref = [16, 32, 64, 128, 3, 9, 27, 81];
+        let v0_ref = [16, 32, 64, 128, 3, 9, 27, 81].map(|n| bitvector!([n], n = 8));
         for (i, (got, expected)) in many_types
             .v0_volatile_iter()
             .zip(v0_ref.into_iter())
@@ -155,12 +214,30 @@ fn main() -> ! {
         {
             let mut msg = heapless::String::<64>::new();
             uwrite!(msg, "rt.v0[{:?}]", i).unwrap();
-            expect(&msg, [expected], got);
+            expect(&msg, expected, got);
         }
     }
 
-    read_write!(array => "v1", v1, [bv64(0x8), bv64(0x16), bv64(3721049880298531338u64)], set_v1, [bv64(1600), bv64(3200), bv64(7442099760597062676)]);
-    read_write!(array => "v2", v2, [[[0x8], [0x16]], [[0x24], [0x32]]], set_v2, [[[0xAB], [0xCD]], [[0x12], [0x34]]]);
+    read_write!(
+        array => "v1",
+        v1,
+        [bitvector!(0x8, n = 64), bitvector!(0x16, n = 64), bitvector!(0x33A3D326B2B42A0A, n = 64)],
+        set_v1,
+        [bitvector!(0x640, n = 64), bitvector!(0xC80, n = 64), bitvector!(0x6747A64D65685414, n = 64)],
+    );
+    read_write!(
+        array => "v2",
+        v2,
+        [
+            [bitvector!(0x08, n = 8), bitvector!(0x16, n = 8)],
+            [bitvector!(0x24, n = 8), bitvector!(0x32, n = 8)],
+        ],
+        set_v2,
+        [
+            [bitvector!(0xAB, n = 8), bitvector!(0xCD, n = 8)],
+            [bitvector!(0x12, n = 8), bitvector!(0x34, n = 8)],
+        ],
+    );
 
     expect("init.unitW", false, many_types.unit_w());
     many_types.set_unit(());
@@ -182,104 +259,160 @@ fn main() -> ! {
     read_write!(
         "e0",
         e0,
-        types::Either::Left([8]),
+        types::Either::Left(bitvector!(0x08, n = 8)),
         set_e0,
-        types::Either::Right(bv16(0x12))
+        types::Either::Right(bitvector!(0x12, n = 16)),
     );
 
     read_write!(
         "oi",
         oi,
         types::Maybe::Just(types::Inner {
-            inner_a: [0x16],
-            inner_b: bv16(0x24),
+            inner_a: bitvector!(0x16, n = 8),
+            inner_b: bitvector!(0x24, n = 16),
         }),
         set_oi,
         types::Maybe::Just(types::Inner {
-            inner_a: [2],
-            inner_b: bv16(4),
-        })
+            inner_a: bitvector!(0x02, n = 8),
+            inner_b: bitvector!(0x04, n = 16),
+        }),
     );
 
     read_write!(
         "x2",
         x2,
-        types::X2([8], types::X3(bv16(16), [32], [64])),
+        types::X2(
+            bitvector!(0x08, n = 8),
+            types::X3(
+                bitvector!(0x10, n = 16),
+                bitvector!(0x20, n = 8),
+                bitvector!(0x40, n = 8)
+            ),
+        ),
         set_x2,
-        types::X2([16], types::X3(bv16(32), [64], [128]))
+        types::X2(
+            bitvector!(0x10, n = 8),
+            types::X3(
+                bitvector!(0x20, n = 16),
+                bitvector!(0x40, n = 8),
+                bitvector!(0x80, n = 8)
+            ),
+        ),
     );
 
     read_write!(
         "me0",
         me0,
-        types::Maybe::Just(types::Either::Left([8])),
+        types::Maybe::Just(types::Either::Left(bitvector!(0x08, n = 8))),
         set_me0,
-        types::Maybe::Just(types::Either::Right(bv16(0x12)))
+        types::Maybe::Just(types::Either::Right(bitvector!(0x12, n = 16))),
     );
     read_write!(
         "me1",
         me1,
-        types::Maybe::Just(types::Either::Left(bv16(8))),
+        types::Maybe::Just(types::Either::Left(bitvector!(0x08, n = 16))),
         set_me1,
-        types::Maybe::Just(types::Either::Right([0x12]))
+        types::Maybe::Just(types::Either::Right(bitvector!(0x12, n = 8))),
     );
 
     read_write!(
         "p0",
         p0,
-        types::P0(0xBADC, 0x0F, 0xEE),
+        types::P0(
+            unsigned!(0xBADC, n = 16),
+            unsigned!(0x0F, n = 8),
+            unsigned!(0xEE, n = 8)
+        ),
         set_p0,
-        types::P0(0x1234, 0x56, 0xFE)
+        types::P0(
+            unsigned!(0x1234, n = 16),
+            unsigned!(0x56, n = 8),
+            unsigned!(0xFE, n = 8)
+        ),
     );
     read_write!(
         "p1",
         p1,
-        types::P1(0xBADC, 0x0F, 0xBEAD),
+        types::P1(
+            unsigned!(0xBADC, n = 16),
+            unsigned!(0x0F, n = 8),
+            unsigned!(0xBEAD, n = 16)
+        ),
         set_p1,
-        types::P1(0x1234, 0x56, 0xFACE)
+        types::P1(
+            unsigned!(0x1234, n = 16),
+            unsigned!(0x56, n = 8),
+            unsigned!(0xFACE, n = 16)
+        ),
     );
     read_write!(
         "p2",
         p2,
-        types::P2(0xBADC, 0x0F, 6),
+        types::P2(
+            unsigned!(0xBADC, n = 16),
+            unsigned!(0x0F, n = 8),
+            index!(6, n = 10)
+        ),
         set_p2,
-        types::P2(0x1234, 0x56, 9)
+        types::P2(
+            unsigned!(0x1234, n = 16),
+            unsigned!(0x56, n = 8),
+            index!(9, n = 10)
+        ),
     );
     read_write!(
         "p3",
         p3,
-        types::P3(types::P2(0xBADC, 0x0F, 6,), 0xEE),
+        types::P3(
+            types::P2(
+                unsigned!(0xBADC, n = 16),
+                unsigned!(0x0F, n = 8),
+                index!(6, n = 10)
+            ),
+            unsigned!(0xEE, n = 8),
+        ),
         set_p3,
-        types::P3(types::P2(0x1234, 0x56, 9), 0xBA)
+        types::P3(
+            types::P2(
+                unsigned!(0x1234, n = 16),
+                unsigned!(0x56, n = 8),
+                index!(9, n = 10)
+            ),
+            unsigned!(0xBA, n = 8),
+        ),
     );
 
-    read_write!("t0", t0, ([12], 584), set_t0, ([24], -948));
+    read_write!(
+        "t0",
+        t0,
+        (bitvector!(0x0C, n = 8), signed!(584, n = 16)),
+        set_t0,
+        (bitvector!(0x18, n = 8), signed!(-948, n = 16)),
+    );
 
-    read_write!("i20", i20, 17, set_i20, 3);
+    read_write!("i20", i20, index!(17, n = 20), set_i20, index!(3, n = 20));
     read_write!(
         "mi12",
         mi12,
-        types::Maybe::Just(5),
+        types::Maybe::Just(index!(5, n = 12)),
         set_mi12,
-        types::Maybe::Nothing
+        types::Maybe::Nothing,
     );
 
     read_write!(
         "maybe_b96",
         maybe_b96,
-        types::Maybe::Just([
-            0xF1, 0xEE, 0xDB, 0xEA, 0x5D, 0x55, 0x55, 0x55, 0xB5, 0xBA, 0xBA, 0x4A
-        ]),
+        types::Maybe::Just(bitvector!(0x4A_BA_BA_B5_55_55_55_5D_EA_DB_EE_F1, n = 96)),
         set_maybe_b96,
-        types::Maybe::Nothing
+        types::Maybe::Nothing,
     );
 
     read_write!(
         "maybe_u96",
         maybe_u96,
-        types::Maybe::Just(0x4ABABAB55555555DEADBEEF1),
+        types::Maybe::Just(unsigned!(0x4A_BA_BA_B5_55_55_55_5D_EA_DB_EE_F1, n = 128)),
         set_maybe_u96,
-        types::Maybe::Nothing
+        types::Maybe::Nothing,
     );
 
     // XXX: Writing a negative value here breaks because of lacking atomic operations.
@@ -287,33 +420,39 @@ fn main() -> ! {
     read_write!(
         "maybe_s96",
         maybe_s96,
-        types::Maybe::Just(0x4ABABAB55555555DEADBEEF1),
+        types::Maybe::Just(signed!(0x4A_BA_BA_B5_55_55_55_5D_EA_DB_EE_F1, n = 128)),
         set_maybe_s96,
-        types::Maybe::Nothing
+        types::Maybe::Nothing,
     );
 
     read_write!(
         "eitherAbc",
         either_abc,
-        types::Either::Left([0]),
+        types::Either::Left(bitvector!(0x0, n = 2)),
         set_either_abc,
-        types::Either::Left([0b11])
+        types::Either::Left(bitvector!(0x3, n = 2)),
     );
 
     read_write!(
         "eitherAbc",
         either_abc,
-        types::Either::Left([0b11]),
+        types::Either::Left(bitvector!(0x3, n = 2)),
         set_either_abc,
-        types::Either::Right(types::Abc::B)
+        types::Either::Right(types::Abc::B),
     );
 
     read_write!(
         array => "only_referenced_in_vec",
         only_referenced_in_vec,
-        [types::OnlyReferencedInVec([2], bv16(3)), types::OnlyReferencedInVec([4], bv16(5))],
+        [
+            types::OnlyReferencedInVec(bitvector!(0x02, n = 8), bitvector!(0x00_03, n = 13)),
+            types::OnlyReferencedInVec(bitvector!(0x04, n = 8), bitvector!(0x00_05, n = 13)),
+        ],
         set_only_referenced_in_vec,
-        [types::OnlyReferencedInVec([6], bv16(7)), types::OnlyReferencedInVec([8], bv16(9))]
+        [
+            types::OnlyReferencedInVec(bitvector!(0x06, n = 8), bitvector!(0x00_07, n = 13)),
+            types::OnlyReferencedInVec(bitvector!(0x08, n = 8), bitvector!(0x00_09, n = 13)),
+        ],
     );
 
     test_ok();

--- a/firmware-binaries/sim-tests/ring_buffer_test/src/main.rs
+++ b/firmware-binaries/sim-tests/ring_buffer_test/src/main.rs
@@ -57,7 +57,10 @@ fn main() -> ! {
     // Test 1: Basic loopback — data written to TX arrives at RX (possibly rotated).
     let pattern_a = make_pattern(0);
     tx.write_slice(&pattern_a, 0);
-    timer.wait(Duration::from_cycles(LEN as u32, timer.frequency()));
+    timer.wait(Duration::from_cycles(
+        LEN as u32,
+        timer.frequency().into_inner(),
+    ));
     let rx_data = read_rx(&rx);
     if !verify_loopback(&pattern_a, &rx_data) {
         all_passed = false;
@@ -69,7 +72,10 @@ fn main() -> ! {
     rx.set_enable(false);
     let pattern_b = make_pattern(0x80);
     tx.write_slice(&pattern_b, 0);
-    timer.wait(Duration::from_cycles(LEN as u32, timer.frequency()));
+    timer.wait(Duration::from_cycles(
+        LEN as u32,
+        timer.frequency().into_inner(),
+    ));
     let rx_after_rx_disable = read_rx(&rx);
     if rx_after_rx_disable != rx_data {
         all_passed = false;
@@ -79,7 +85,10 @@ fn main() -> ! {
 
     // Test 3: receive_enable=true resumes RX updates.
     rx.set_enable(true);
-    timer.wait(Duration::from_cycles(LEN as u32, timer.frequency()));
+    timer.wait(Duration::from_cycles(
+        LEN as u32,
+        timer.frequency().into_inner(),
+    ));
     let rx_after_rx_enable = read_rx(&rx);
     if !verify_loopback(&pattern_b, &rx_after_rx_enable) {
         all_passed = false;
@@ -91,7 +100,10 @@ fn main() -> ! {
     tx.set_enable(false);
     let pattern_c = make_pattern(0x40);
     tx.write_slice(&pattern_c, 0);
-    timer.wait(Duration::from_cycles(LEN as u32, timer.frequency()));
+    timer.wait(Duration::from_cycles(
+        LEN as u32,
+        timer.frequency().into_inner(),
+    ));
     let rx_after_tx_disable = read_rx(&rx);
     let all_zero = rx_after_tx_disable.iter().all(|w| *w == [0u8; 8]);
     if !all_zero {
@@ -102,7 +114,10 @@ fn main() -> ! {
 
     // Test 5: write_enable=true resumes transmission.
     tx.set_enable(true);
-    timer.wait(Duration::from_cycles(LEN as u32, timer.frequency()));
+    timer.wait(Duration::from_cycles(
+        LEN as u32,
+        timer.frequency().into_inner(),
+    ));
     let rx_after_tx_enable = read_rx(&rx);
     if !verify_loopback(&pattern_c, &rx_after_tx_enable) {
         all_passed = false;
@@ -119,7 +134,10 @@ fn main() -> ! {
     tx.clear();
     let pattern_d: [[u8; 8]; LEN] = core::array::from_fn(|i| (0x1000 + i as u64).to_le_bytes());
     tx.write_slice(&pattern_d, 0);
-    timer.wait(Duration::from_cycles(LEN as u32, timer.frequency()));
+    timer.wait(Duration::from_cycles(
+        LEN as u32,
+        timer.frequency().into_inner(),
+    ));
     let rx_aligned_data = read_rx(&rx_aligned.buffer);
     if pattern_d != rx_aligned_data {
         all_passed = false;

--- a/firmware-binaries/sim-tests/scatter_gather_test/Cargo.toml
+++ b/firmware-binaries/sim-tests/scatter_gather_test/Cargo.toml
@@ -15,9 +15,10 @@ workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-riscv-rt = "0.11.0"
+bittide-macros = { path = "../../../firmware-support/bittide-macros" }
 bittide-sys = { path = "../../../firmware-support/bittide-sys" }
 bittide-hal = { path = "../../../firmware-support/bittide-hal" }
+riscv-rt = "0.11.0"
 ufmt = "0.2.0"
 
 [build-dependencies]

--- a/firmware-binaries/sim-tests/scatter_gather_test/src/main.rs
+++ b/firmware-binaries/sim-tests/scatter_gather_test/src/main.rs
@@ -5,6 +5,7 @@
 #![cfg_attr(not(test), no_main)]
 
 use bittide_hal::scatter_gather_pe::DeviceInstances;
+use bittide_macros::{bitvector, BitVector};
 use core::fmt::Write;
 #[cfg(not(test))]
 use riscv_rt::entry;
@@ -42,8 +43,10 @@ fn main() -> ! {
     //   1: Write to the gather memory.
     //   2: Read from the scatter memory.
 
-    let source: [[u8; 8]; MEM_SIZE] = core::array::from_fn(|i| (i as u64).to_le_bytes());
-    let mut destination: [[u8; 8]; MEM_SIZE] = [99u64.to_le_bytes(); MEM_SIZE];
+    let source: [BitVector!(64); MEM_SIZE] =
+        core::array::from_fn(|i| bitvector!((i as u64).to_le_bytes(), n = 64));
+    let mut destination: [BitVector!(64); MEM_SIZE] =
+        [bitvector!(99u64.to_le_bytes(), n = 64); MEM_SIZE];
 
     // Metacycle 1: write to gather
     gather_unit.wait_for_new_metacycle();

--- a/firmware-binaries/sim-tests/switch_calendar_test/Cargo.toml
+++ b/firmware-binaries/sim-tests/switch_calendar_test/Cargo.toml
@@ -15,11 +15,12 @@ workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-riscv-rt = "0.11.0"
-bittide-sys = { path = "../../../firmware-support/bittide-sys" }
-ufmt = "0.2.0"
-bittide-hal = { path = "../../../firmware-support/bittide-hal" }
 heapless = "0.8.0"
+bittide-macros = { path = "../../../firmware-support/bittide-macros" }
+bittide-hal = { path = "../../../firmware-support/bittide-hal" }
+bittide-sys = { path = "../../../firmware-support/bittide-sys" }
+riscv-rt = "0.11.0"
+ufmt = "0.2.0"
 
 [build-dependencies]
 memmap-generate = { path = "../../../firmware-support/memmap-generate" }

--- a/firmware-binaries/sim-tests/switch_calendar_test/src/main.rs
+++ b/firmware-binaries/sim-tests/switch_calendar_test/src/main.rs
@@ -12,6 +12,7 @@ use bittide_hal::{
     manual_additions::calendar::{CalendarEntryType, CalendarType},
     types::ValidEntry_12,
 };
+use bittide_macros::{index, unsigned};
 use ufmt::{uDebug, uwrite, uwriteln};
 
 #[cfg(not(test))]
@@ -54,32 +55,32 @@ fn expect<T: uDebug + PartialEq>(msg: &str, expected: T, actual: T) {
 
 #[cfg_attr(not(test), entry)]
 fn main() -> ! {
-    let active_entry0: [u8; 16] = core::array::from_fn(|i| i as u8);
-    let mut active_entry1: [u8; 16] = active_entry0;
+    let active_entry0 = core::array::from_fn(|i| index!(i as u8, n = 17));
+    let mut active_entry1 = active_entry0;
     active_entry1.reverse();
 
     let cal_active = [
         ValidEntry_12 {
             ve_entry: active_entry0,
-            ve_repeat: 8,
+            ve_repeat: unsigned!(8, n = 16),
         },
         ValidEntry_12 {
             ve_entry: active_entry1,
-            ve_repeat: 16,
+            ve_repeat: unsigned!(16, n = 16),
         },
     ];
 
     let cal_shadow: [CalendarEntryType<Calendar>; 16] = core::array::from_fn(|i| ValidEntry_12 {
-        ve_entry: core::array::from_fn(|_j| i as u8),
-        ve_repeat: i as u16,
+        ve_entry: core::array::from_fn(|_j| index!(i as u8, n = 17)),
+        ve_repeat: unsigned!(i as u16, n = 16),
     });
 
     let calendar = &mut INSTANCES.switch_calendar;
     // Test End of metacycle register and metacycle count
     calendar.wait_for_end_of_metacycle();
-    let bootmetacycle = calendar.metacycle_count();
+    let bootmetacycle = calendar.metacycle_count().into_inner();
     calendar.wait_for_end_of_metacycle();
-    let next_metacycle = calendar.metacycle_count();
+    let next_metacycle = calendar.metacycle_count().into_inner();
     expect("(1) Metacycle increment", 1, next_metacycle - bootmetacycle);
     //
 

--- a/firmware-support/Cargo.lock
+++ b/firmware-support/Cargo.lock
@@ -90,6 +90,7 @@ name = "bittide-sys"
 version = "0.1.0"
 dependencies = [
  "bittide-hal",
+ "bittide-macros",
  "fdt",
  "heapless",
  "itertools",

--- a/firmware-support/Cargo.lock
+++ b/firmware-support/Cargo.lock
@@ -79,6 +79,7 @@ dependencies = [
 name = "bittide-macros"
 version = "0.1.0"
 dependencies = [
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 2.0.111",
@@ -172,6 +173,12 @@ name = "embedded-hal"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "361a90feb7004eca4019fb28352a9465666b24f840f5c3cddf0ff13920590b89"
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
@@ -272,6 +279,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
 name = "heapless"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -296,6 +309,16 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.0",
 ]
 
 [[package]]
@@ -390,7 +413,7 @@ dependencies = [
  "crc32fast",
  "flate2",
  "hashbrown 0.11.2",
- "indexmap",
+ "indexmap 1.9.3",
  "memchr",
 ]
 
@@ -413,6 +436,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
 ]
 
 [[package]]
@@ -769,6 +801,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.11+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+dependencies = [
+ "indexmap 2.14.0",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
 name = "typewit"
 version = "1.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -856,6 +918,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "winnow"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/firmware-support/bittide-hal/build.rs
+++ b/firmware-support/bittide-hal/build.rs
@@ -366,6 +366,30 @@ fn annotate_types(
 
 fn generate_type_ref_imports(ctx: &IrCtx, refs: &TypeReferences) -> TokenStream {
     let mut code = TokenStream::new();
+    if refs.use_bitvec {
+        code.extend(quote! {
+            use crate::manual_additions::bitvector::BitVector;
+            use bittide_macros::BitVector;
+        });
+    }
+    if refs.use_index {
+        code.extend(quote! {
+            use crate::manual_additions::index::Index;
+            use bittide_macros::Index;
+        });
+    }
+    if refs.use_signed {
+        code.extend(quote! {
+            use crate::manual_additions::signed::Signed;
+            use bittide_macros::Signed;
+        });
+    }
+    if refs.use_unsigned {
+        code.extend(quote! {
+            use crate::manual_additions::unsigned::Unsigned;
+            use bittide_macros::Unsigned;
+        });
+    }
     for ty_ref in &refs.references {
         let name = &ctx.type_names[*ty_ref].base;
         let module = ident(IdentType::Module, name);

--- a/firmware-support/bittide-hal/src/lib.rs
+++ b/firmware-support/bittide-hal/src/lib.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #![no_std]
+#![recursion_limit = "146"]
 
 // Since this module gets generated, running rustfmt on a
 // non-built source tree will error.

--- a/firmware-support/bittide-hal/src/manual_additions/addressable_buffer.rs
+++ b/firmware-support/bittide-hal/src/manual_additions/addressable_buffer.rs
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 use crate::shared_devices::addressable_buffer::AddressableBuffer;
+use bittide_macros::bitvector;
 
 impl AddressableBuffer {
     /// Returns a reference to the data as a contiguous byte slice.
@@ -31,7 +32,7 @@ impl AddressableBuffer {
     /// Clears the contents of the entire data by setting all bytes to zero.
     pub fn clear(&self) {
         for i in 0..Self::DATA_LEN {
-            unsafe { self.set_data_unchecked(i, [0u8; 4]) };
+            unsafe { self.set_data_unchecked(i, bitvector!(0x0, n = 32)) };
         }
     }
 

--- a/firmware-support/bittide-hal/src/manual_additions/bitvector.rs
+++ b/firmware-support/bittide-hal/src/manual_additions/bitvector.rs
@@ -1,0 +1,811 @@
+// SPDX-FileCopyrightText: 2026 Google LLC
+//
+// SPDX-License-Identifier: Apache-2.0
+//! Types, traits, and implementations for fixed-width arrays of bits
+//!
+//! # Note
+//!
+//! The way that this crate constrains [`BitVector<M, N>`]s to the correct size is by ensuring that
+//! evaluation of a constant succeeds. As such, when writing `impl`s on [`BitVector<M, N>`], users
+//! should make sure to force evaluation of [`BitVectorSizeCheck::SIZE_CHECK`].
+//!
+//! Alternatively, one can make use of `bittide_macros::BitVector!` and `bittide_macros::bitvector!`
+//! to make types/instances with the correct parameters.
+#![deny(missing_docs)]
+
+use crate::manual_additions::{
+    signed::{Signed, SignedInterface, SignedSizeCheck},
+    unsigned::{Unsigned, UnsignedInterface, UnsignedSizeCheck},
+};
+
+/// A fixed-width array of bits, backed by a byte array
+///
+/// This is intended to be an equivalent to a [`packC`'d][bpc] [`BitVector n`][bvn] from Clash.
+/// The bytes in this array are little-endian, which is to say that the least significant bit of the
+/// bitvector is at array index 0, bit 0.
+///
+/// [bpc]: https://github.com/QBayLogic/clash-protocols-memmap/blob/main/clash-bitpackc/src/Clash/Class/BitPackC.hs#L39-L44
+/// [bvn]: https://hackage-content.haskell.org/package/clash-prelude-1.8.4/docs/Clash-Sized-BitVector.html#t:BitVector
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(transparent)]
+pub struct BitVector<const M: usize, const N: usize>(pub(crate) [u8; N]);
+
+/// Trait for making guarantees about the size and validity of bitvectors.
+pub trait BitVectorSizeCheck {
+    /// This `const` should be instantiated in methods implemented on [`BitVector<M, N>`], since it
+    /// is how they are constrained to the correct size. If they're improperly sized, this `const`
+    /// will fail to evaluate and produce a compile error.
+    ///
+    /// # Examples
+    ///
+    /// Correctly sized bitvectors will compile successfully:
+    /// ```
+    /// # use bittide_hal::manual_additions::bitvector::{BitVector, BitVectorSizeCheck};
+    /// trait Marker {
+    ///     fn nothing();
+    /// }
+    ///
+    /// impl Marker for BitVector<8, 1> {
+    ///     fn nothing() {
+    ///         let _ = Self::SIZE_CHECK;
+    ///     }
+    /// }
+    ///
+    /// impl Marker for BitVector<9, 2> {
+    ///     fn nothing() {
+    ///         let _ = Self::SIZE_CHECK;
+    ///     }
+    /// }
+    ///
+    /// impl Marker for BitVector<32, 4> {
+    ///     fn nothing() {
+    ///         let _ = Self::SIZE_CHECK;
+    ///     }
+    /// }
+    ///
+    /// impl Marker for BitVector<255, 32> {
+    ///     fn nothing() {
+    ///         let _ = Self::SIZE_CHECK;
+    ///     }
+    /// }
+    /// ```
+    /// But improper sizes will not. For example, a bitvector with a backing array that's too large:
+    /// ```compile_fail
+    /// # use bittide_hal::manual_additions::bitvector::{BitVector, BitVectorSizeCheck};
+    /// trait Marker {
+    ///     fn nothing();
+    /// }
+    ///
+    /// impl Marker for BitVector<1, 10> {
+    ///     fn nothing() {
+    ///         let _ = Self::SIZE_CHECK;
+    ///     }
+    /// }
+    /// ```
+    /// This produces the following error message:
+    /// ```text
+    /// error[E0080]: evaluation of `<BitVector<1, 10> as BitVectorSizeCheck>::SIZE_CHECK` failed
+    ///   --> manual_additions/bitvector.rs
+    ///    |
+    ///    | /             const_panic::concat_panic!(
+    ///    | |                 const_panic::fmt::FmtArg::DISPLAY;
+    ///    | |                 "Specified bit size `",
+    ///    | |                 M,
+    /// ...  |
+    ///    | |                 "`."
+    ///    | |             );
+    ///    | |_____________^ evaluation panicked: Specified bit size `1` should be represented by `1` bytes, not `10`.
+    ///    |
+    ///    = note: this error originates in the macro `const_panic::concat_panic` (in Nightly builds, run with -Z macro-backtrace for more info)
+    ///
+    /// note: erroneous constant encountered
+    ///   --> manual_additions/bitvector.rs
+    ///    |
+    ///    |         let _ = Self::SIZE_CHECK;
+    ///    |                 ^^^^^^^^^^^^^^^^
+    /// ```
+    /// And a bitvector with a backing array that's too small:
+    /// ```compile_fail
+    /// # use bittide_hal::manual_additions::bitvector::{BitVector, BitVectorSizeCheck};
+    /// trait Marker {
+    ///     fn nothing();
+    /// }
+    ///
+    /// impl Marker for BitVector<16, 1> {
+    ///     fn nothing() {
+    ///         let _ = Self::SIZE_CHECK;
+    ///     }
+    /// }
+    /// ```
+    /// This produces the following error message:
+    /// ```text
+    /// error[E0080]: evaluation of `<BitVector<16, 1> as BitVectorSizeCheck>::SIZE_CHECK` failed
+    ///    --> manual_additions/bitvector.rs
+    ///     |
+    ///     | /             const_panic::concat_panic!(
+    ///     | |                 const_panic::fmt::FmtArg::DISPLAY;
+    ///     | |                 "Specified bit size `",
+    ///     | |                 M,
+    /// ...   |
+    ///     | |                 "`."
+    ///     | |             );
+    ///     | |_____________^ evaluation panicked: Specified bit size `16` should be represented by `2` bytes, not `1`.
+    ///     |
+    ///     = note: this error originates in the macro `const_panic::concat_panic` (in Nightly builds, run with -Z macro-backtrace for more info)
+    ///
+    /// note: erroneous constant encountered
+    ///   --> manual_additions/bitvector.rs
+    ///  |
+    ///  |         let _ = Self::SIZE_CHECK;
+    ///  |                 ^^^^^^^^^^^^^^^^
+    /// ```
+    /// And also makes sure that a bitvector is not zero-sized:
+    /// ```compile_fail
+    /// # use bittide_hal::manual_additions::bitvector::{BitVector, BitVectorSizeCheck};
+    /// trait Marker {
+    ///     fn nothing();
+    /// }
+    ///
+    /// impl Marker for BitVector<0, 0> {
+    ///     fn nothing() {
+    ///         let _ = Self::SIZE_CHECK;
+    ///     }
+    /// }
+    /// ```
+    /// Which produces the error message
+    /// ```text
+    /// error[E0080]: evaluation of `<BitVector<0, 0> as BitVectorSizeCheck>::SIZE_CHECK` failed
+    ///    --> manual_additions/bitvector.rs
+    ///     |
+    ///     |             panic!("Cannot represent a `BitVector<0, 0>`!");
+    ///     |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: Cannot represent a `BitVector<0, 0>`!
+    ///
+    /// note: erroneous constant encountered
+    ///   --> manual_additions/bitvector.rs
+    ///    |
+    ///    |         let _ = Self::SIZE_CHECK;
+    ///    |                 ^^^^^^^^^^^^^^^^
+    ///
+    /// error: aborting due to 1 previous error
+    /// ```
+    const SIZE_CHECK: ();
+    /// Backing type of a bitvector on a trait level
+    type Inner;
+    /// Perform a bounds check on an instance of a bitvector. Returns `true` if within bounds,
+    /// `false` if not.
+    fn inner_bounds_check(val: &Self::Inner) -> bool;
+}
+
+impl<const M: usize, const N: usize> BitVectorSizeCheck for BitVector<M, N> {
+    const SIZE_CHECK: () = {
+        if M == 0 {
+            panic!("Cannot represent a `BitVector<0, 0>`!");
+        }
+        let correct_size = M.div_ceil(8);
+        if correct_size != N {
+            const_panic::concat_panic!(
+                const_panic::fmt::FmtArg::DISPLAY;
+                "Specified bit size `",
+                M,
+                "` should be represented by `",
+                correct_size,
+                "` bytes, not `",
+                N,
+                "`."
+            );
+        }
+    };
+    type Inner = [u8; N];
+    #[inline]
+    fn inner_bounds_check(val: &[u8; N]) -> bool {
+        let _: () = Self::SIZE_CHECK; // READ THE REST OF THE ERROR MESSAGE
+
+        // Check that the most significant byte doesn't have bits set that shouldn't be.
+        if const { M.is_multiple_of(8) } {
+            // OPTIMIZATION: this cannot happen if the length is a multiple of 8, skip the check
+            true
+        } else {
+            // For `A * 8 + B` bits, create a constant `u8` where the first `B` bits are 1 and the
+            // rest are 0. Ensure that the most significant byte (at index `A - 1`) is less than or
+            // equal to this constant. For example, in a `BitVector<43, 6>` we will create the
+            // constant `0b0000_0111`, and ensure the value at `self.0[5]` is less than or equal to
+            // this value.
+            val[const { N - 1 }] <= const { !(!0 << (M % 8)) }
+        }
+    }
+}
+
+impl<const M: usize, const N: usize> BitVector<M, N>
+where
+    BitVector<M, N>: BitVectorSizeCheck<Inner = [u8; N]>,
+{
+    /// Instantiate a new `BitVector<M, N>`
+    ///
+    /// Byte arrays given to this function are treated as least significant byte first. So for a
+    /// `BitVector<14, 2>` the value `[0xff, 0x3f]` is in range, but `[0xff, 0x7f]` is not, since
+    /// that requires 15 bits to represent.
+    ///
+    /// This function returns `Some(_)` if `val` is in range and returns `None` otherwise.
+    ///
+    /// # Errors
+    ///
+    /// This function may error if invoked as `BitVector::<M, N>::new(...)` and the wrong backing
+    /// length `N` is chosen. Please read the whole error message carefully, it should tell you what
+    /// to do to fix it.
+    #[inline]
+    pub fn new(val: [u8; N]) -> Option<BitVector<M, N>> {
+        let _: () = Self::SIZE_CHECK; // READ THE REST OF THE ERROR MESSAGE
+        if BitVector::<M, N>::inner_bounds_check(&val) {
+            Some(BitVector(val))
+        } else {
+            None
+        }
+    }
+
+    /// Instantiate a new `BitVector<M, N>` without performing a bounds check
+    ///
+    /// # Errors
+    ///
+    /// This function may error if invoked as `BitVector::<M, N>::new_unchecked(...)` and the wrong
+    /// backing length `N` is chosen. Please read the whole error message carefully, it should tell
+    /// you what to do to fix it.
+    ///
+    /// # Safety
+    ///
+    /// Due to the intended use-case of interfacing with Clash hardware, and there being no
+    /// guarantee of behaviour in the case that an out-of-bounds value is written to a register,
+    /// this function has been marked as `unsafe`. To make calling this function safe, you must
+    /// guarantee that `val` is in range.
+    ///
+    /// There is one exception to this: it is always safe to call `new_unchecked` if `M` is a
+    /// multiple of 8. For example, `BitVector::<16, 2>::new_unchecked` is always safe.
+    #[inline]
+    pub unsafe fn new_unchecked(val: [u8; N]) -> BitVector<M, N> {
+        let _: () = Self::SIZE_CHECK; // READ THE REST OF THE ERROR MESSAGE
+        BitVector(val)
+    }
+
+    /// Unwrap the inner value contained by this `BitVector<M, N>`
+    #[inline]
+    pub fn into_inner(self) -> [u8; N] {
+        let _: () = Self::SIZE_CHECK; // READ THE REST OF THE ERROR MESSAGE
+        self.0
+    }
+}
+
+impl<const M: usize, const N: usize> core::fmt::Debug for BitVector<M, N>
+where
+    Self: BitVectorSizeCheck,
+{
+    #[inline]
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(fmt, "BitVector<{M}>(0x")?;
+        if const { M % 8 > 3 } {
+            write!(fmt, "{:02X}", self.0[const { N - 1 }])?;
+        } else {
+            write!(fmt, "{:01X}", self.0[const { N - 1 }])?;
+        }
+        for &byte in self.0[0..const { N - 1 }].iter().rev() {
+            write!(fmt, "{byte:02X}")?;
+        }
+        write!(fmt, ")")
+    }
+}
+
+impl<const M: usize, const N: usize> core::fmt::Display for BitVector<M, N>
+where
+    Self: BitVectorSizeCheck,
+{
+    #[inline]
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(fmt, "0x")?;
+        if const { M % 8 > 3 } {
+            write!(fmt, "{:02X}", self.0[const { N - 1 }])?;
+        } else {
+            write!(fmt, "{:01X}", self.0[const { N - 1 }])?;
+        }
+        for &byte in self.0[0..const { N - 1 }].iter().rev() {
+            write!(fmt, "{byte:02X}")?;
+        }
+        Ok(())
+    }
+}
+
+impl<const M: usize, const N: usize> ufmt::uDebug for BitVector<M, N>
+where
+    Self: BitVectorSizeCheck,
+{
+    #[inline]
+    fn fmt<W>(&self, fmt: &mut ufmt::Formatter<'_, W>) -> Result<(), W::Error>
+    where
+        W: ufmt::uWrite + ?Sized,
+    {
+        ufmt::uwrite!(fmt, "BitVector<{}>(0x", M)?;
+        if const { M % 8 > 3 } {
+            ufmt::uwrite!(fmt, "{:02X}", self.0[const { N - 1 }])?;
+        } else {
+            ufmt::uwrite!(fmt, "{:01X}", self.0[const { N - 1 }])?;
+        }
+        for &byte in self.0[0..const { N - 1 }].iter().rev() {
+            ufmt::uwrite!(fmt, "{:02X}", byte)?;
+        }
+        ufmt::uwrite!(fmt, ")")
+    }
+}
+
+impl<const M: usize, const N: usize> ufmt::uDisplay for BitVector<M, N>
+where
+    Self: BitVectorSizeCheck,
+{
+    #[inline]
+    fn fmt<W>(&self, fmt: &mut ufmt::Formatter<'_, W>) -> Result<(), W::Error>
+    where
+        W: ufmt::uWrite + ?Sized,
+    {
+        ufmt::uwrite!(fmt, "0x")?;
+        if const { M % 8 > 3 } {
+            ufmt::uwrite!(fmt, "{:02X}", self.0[const { N - 1 }])?;
+        } else {
+            ufmt::uwrite!(fmt, "{:01X}", self.0[const { N - 1 }])?;
+        }
+        for &byte in self.0[0..const { N - 1 }].iter().rev() {
+            ufmt::uwrite!(fmt, "{:02X}", byte)?;
+        }
+        Ok(())
+    }
+}
+
+impl<const M: usize, const N: usize> ufmt::uDisplayHex for BitVector<M, N>
+where
+    Self: BitVectorSizeCheck,
+{
+    #[inline]
+    fn fmt_hex<W>(
+        &self,
+        fmt: &mut ufmt::Formatter<'_, W>,
+        options: ufmt::HexOptions,
+    ) -> Result<(), W::Error>
+    where
+        W: ufmt::uWrite + ?Sized,
+    {
+        if options.upper_case {
+            if options.ox_prefix {
+                ufmt::uwrite!(fmt, "0X")?;
+                if const { M % 8 > 3 } {
+                    ufmt::uwrite!(fmt, "{:02X}", self.0[const { N - 1 }])?;
+                } else {
+                    ufmt::uwrite!(fmt, "{:01X}", self.0[const { N - 1 }])?;
+                }
+                for &byte in self.0[0..const { N - 1 }].iter().rev() {
+                    ufmt::uwrite!(fmt, "{:02X}", byte)?;
+                }
+            }
+        } else {
+            ufmt::uwrite!(fmt, "0x")?;
+            if const { M % 8 > 3 } {
+                ufmt::uwrite!(fmt, "{:02x}", self.0[const { N - 1 }])?;
+            } else {
+                ufmt::uwrite!(fmt, "{:01x}", self.0[const { N - 1 }])?;
+            }
+            for &byte in self.0[0..const { N - 1 }].iter().rev() {
+                ufmt::uwrite!(fmt, "{:02x}", byte)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+impl<const M: usize, const N: usize> AsRef<[u8; N]> for BitVector<M, N>
+where
+    Self: BitVectorSizeCheck,
+{
+    #[inline]
+    fn as_ref(&self) -> &[u8; N] {
+        &self.0
+    }
+}
+
+impl<const M: usize, const N: usize> super::seal::Seal for BitVector<M, N> {}
+
+/// Trait that guarantees parts of the [`BitVector<M, N>`] inherent implementations
+///
+/// Intended for use where it is not desirable to constrain a type to be `T = BitVector<M, N>` but
+/// rather to `T: BitVectorInterface`.
+pub trait BitVectorInterface: Sized + BitVectorSizeCheck + super::seal::Seal {
+    /// Instantiate a new [`BitVector<M, N>`]
+    ///
+    /// Byte arrays given to this function are treated as least significant byte first. So for a
+    /// `BitVector<14, 2>` the value `[0xff, 0x3f]` is in range, but `[0xff, 0x7f]` is not, since
+    /// that requires 15 bits to represent.
+    ///
+    /// This function returns `Some(_)` if `val` is in range and returns `None` otherwise.
+    ///
+    /// # Errors
+    ///
+    /// This function may error if invoked as `BitVector::<M, N>::bv_new(...)` and the wrong backing
+    /// length `N` is chosen. Please read the whole error message carefully, it should tell you what
+    /// to do to fix it.
+    fn bv_new(val: Self::Inner) -> Option<Self>;
+    /// Instantiate a new [`BitVector<M, N>`] without performing a bounds check
+    ///
+    /// # Errors
+    ///
+    /// This function may error if invoked as `BitVector::<M, N>::bv_new_unchecked(...)` and the
+    /// wrong backing length `N` is chosen. Please read the whole error message carefully, it should
+    /// tell you what to do to fix it.
+    ///
+    /// # Safety
+    ///
+    /// Due to the intended use-case of interfacing with Clash hardware, and there being no
+    /// guarantee of behaviour in the case that an out-of-bounds value is written to a register,
+    /// this function has been marked as `unsafe`. To make calling this function safe, you must
+    /// guarantee that `val` is in range.
+    unsafe fn bv_new_unchecked(val: Self::Inner) -> Self;
+    /// Unwrap the inner value contained by this [`BitVector<M, N>`]
+    fn bv_into_inner(self) -> Self::Inner;
+}
+
+impl<const M: usize, const N: usize> BitVectorInterface for BitVector<M, N>
+where
+    Self: BitVectorSizeCheck<Inner = [u8; N]>,
+{
+    #[inline]
+    fn bv_new(val: Self::Inner) -> Option<Self> {
+        BitVector::<M, N>::new(val)
+    }
+
+    #[inline]
+    unsafe fn bv_new_unchecked(val: Self::Inner) -> Self {
+        BitVector::<M, N>::new_unchecked(val)
+    }
+
+    #[inline]
+    fn bv_into_inner(self) -> Self::Inner {
+        self.into_inner()
+    }
+}
+
+macro_rules! impl_bvc {
+    ($(@$kind:tt [$backer:ty] $sizelist:tt;)+) => {
+        $(
+            impl_bvc! {
+                @$kind
+                backer: $backer,
+                sizes: $sizelist,
+            }
+        )+
+    };
+    (
+        @unsigned
+        backer: $backer:ty,
+        sizes: [$($size:literal),+$(,)?],
+    ) => {
+        $(
+            impl<const A: u8, const B: usize> From<BitVector<B, $size>>
+                for Unsigned<A, $backer>
+            where
+                Self: UnsignedInterface<Inner = $backer>,
+                BitVector<B, $size>: BitVectorSizeCheck<Inner = [u8; $size]>,
+            {
+                #[inline]
+                fn from(other: BitVector<B, $size>) -> Unsigned<A, $backer> {
+                    let _size_check = const {
+                        let _ = BitVector::<B, $size>::SIZE_CHECK; // READ THE REST OF THE MESSAGE
+                        let _ = Unsigned::<A, $backer>::SIZE_CHECK; // READ THE REST OF THE MESSAGE
+                        if B > A as usize {
+                            const_panic::concat_panic!(
+                                const_panic::fmt::FmtArg::DISPLAY;
+                                "`BitVector<",
+                                B,
+                                ", ",
+                                stringify!($size),
+                                ">` cannot be unconditionally converted into `Unsigned<",
+                                A,
+                                ", ",
+                                stringify!($backer),
+                                ">`",
+                            );
+                        }
+                    };
+                    let mut backer: $backer = 0;
+                    unsafe {
+                        (&mut backer as *mut $backer)
+                            .cast::<[u8; $size]>()
+                            .copy_from_nonoverlapping(other.0.as_ptr().cast(), 1);
+                    }
+                    if cfg!(target_endian = "big") {
+                        Unsigned(backer.swap_bytes())
+                    } else {
+                        Unsigned(backer)
+                    }
+                }
+            }
+
+            impl<const A: u8, const B: usize> From<Unsigned<A, $backer>>
+                for BitVector<B, $size>
+            where
+                Self: BitVectorSizeCheck<Inner = [u8; $size]>,
+                Unsigned<A, $backer>: UnsignedInterface<Inner = $backer>,
+            {
+                #[inline]
+                fn from(other: Unsigned<A, $backer>) -> BitVector<B, $size> {
+                    let _size_check: () = const {
+                        let _ = BitVector::<B, $size>::SIZE_CHECK; // READ THE REST OF THE MESSAGE
+                        let _ = Unsigned::<A, $backer>::SIZE_CHECK; // READ THE REST OF THE MESSAGE
+                        if A as usize > B {
+                            const_panic::concat_panic!(
+                                const_panic::fmt::FmtArg::DISPLAY;
+                                "`Unsigned<",
+                                A,
+                                ", ",
+                                stringify!($backer),
+                                ">` cannot be unconditionally converted into `BitVector<",
+                                B,
+                                ", ",
+                                stringify!($size),
+                                ">`",
+                            );
+                        }
+                    };
+                    let mut backer = [0; $size];
+                    unsafe {
+                        backer.as_mut_ptr()
+                            .copy_from_nonoverlapping(
+                                &other as *const Unsigned<A, $backer> as *const u8,
+                                $size,
+                            );
+                    }
+                    if cfg!(target_endian = "big") {
+                        backer[const { 0..core::mem::size_of::<$backer>() }].reverse();
+                    }
+                    BitVector(backer)
+                }
+            }
+        )+
+    };
+    (
+        @signed
+        backer: $backer:ty,
+        sizes: [$($size:literal),+$(,)?],
+    ) => {
+        $(
+            impl<const A: u8, const B: usize> From<BitVector<B, $size>>
+                for Signed<A, $backer>
+            where
+                Self: SignedInterface<Inner = $backer>,
+                BitVector<B, $size>: BitVectorSizeCheck<Inner = [u8; $size]>,
+            {
+                #[inline]
+                fn from(other: BitVector<B, $size>) -> Signed<A, $backer> {
+                    let _size_check: () = const {
+                        let _ = BitVector::<B, $size>::SIZE_CHECK; // READ THE REST OF THE MESSAGE
+                        let _ = Signed::<A, $backer>::SIZE_CHECK; // READ THE REST OF THE MESSAGE
+                        if B > A as usize {
+                            const_panic::concat_panic!(
+                                const_panic::fmt::FmtArg::DISPLAY;
+                                "`BitVector<",
+                                B,
+                                ", ",
+                                stringify!($size),
+                                ">` cannot be unconditionally converted into `Signed<",
+                                A,
+                                ", ",
+                                stringify!($backer),
+                                ">`",
+                            );
+                        }
+                    };
+                    let mut backer: $backer = 0;
+                    unsafe {
+                        (&mut backer as *mut $backer)
+                            .cast::<[u8; $size]>()
+                            .copy_from_nonoverlapping(other.0.as_ptr().cast(), 1);
+                    }
+                    let mut backer = if cfg!(target_endian = "big") {
+                        backer.swap_bytes()
+                    } else {
+                        backer
+                    };
+                    // Sign extend if most significant bit is set
+                    if backer & const { 1 << (B - 1) } != 0 {
+                        backer |= const { !0 << (B - 1) };
+                    }
+                    Signed(backer)
+                }
+            }
+
+            impl<const A: u8, const B: usize> From<Signed<A, $backer>>
+                for BitVector<B, $size>
+            where
+                Self: BitVectorSizeCheck<Inner = [u8; $size]>,
+                Signed<A, $backer>: SignedInterface<Inner = $backer>,
+            {
+                #[inline]
+                fn from(other: Signed<A, $backer>) -> BitVector<B, $size> {
+                    let _size_check: () = const {
+                        let _ = BitVector::<B, $size>::SIZE_CHECK; // READ THE REST OF THE MESSAGE
+                        let _ = Signed::<A, $backer>::SIZE_CHECK; // READ THE REST OF THE MESSAGE
+                        if A as usize > B {
+                            const_panic::concat_panic!(
+                                const_panic::fmt::FmtArg::DISPLAY;
+                                "`Signed<",
+                                A,
+                                ", ",
+                                stringify!($backer),
+                                ">` cannot be unconditionally converted into `BitVector<",
+                                B,
+                                ", ",
+                                stringify!($size),
+                                ">`",
+                            );
+                        }
+                    };
+                    let mut backer = [0; $size];
+                    unsafe {
+                        backer.as_mut_ptr()
+                            .copy_from_nonoverlapping(
+                                &other as *const Signed<A, $backer> as *const u8,
+                                $size,
+                            );
+                    }
+                    if cfg!(target_endian = "big") {
+                        backer[const { 0..core::mem::size_of::<$backer>() }].reverse();
+                    }
+                    // Mask sign extension if number is negative and there's bits that could be set
+                    // above the limit in the most significant byte
+                    if other.0 < 0 && const { !A.is_multiple_of(8) } {
+                        backer[const { $size - 1 }] &= const { !(!0 << (A % 8)) };
+                    }
+                    BitVector(backer)
+                }
+            }
+        )+
+    };
+}
+
+impl_bvc! {
+    @unsigned [u8] [1];
+    @unsigned [u16] [1, 2];
+    @unsigned [u32] [1, 2, 3, 4];
+    @unsigned [u64] [1, 2, 3, 4, 5, 6, 7, 8];
+    @unsigned [u128] [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
+    @signed [i8] [1];
+    @signed [i16] [1, 2];
+    @signed [i32] [1, 2, 3, 4];
+    @signed [i64] [1, 2, 3, 4, 5, 6, 7, 8];
+    @signed [i128] [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
+}
+
+#[cfg(target_pointer_width = "16")]
+impl_bvc! {
+    @unsigned [usize] [1, 2];
+    @signed [isize] [1, 2];
+}
+
+#[cfg(target_pointer_width = "32")]
+impl_bvc! {
+    @unsigned [usize] [1, 2, 3, 4];
+    @signed [isize] [1, 2, 3, 4];
+}
+
+#[cfg(target_pointer_width = "64")]
+impl_bvc! {
+    @unsigned [usize] [1, 2, 3, 4, 5, 6, 7, 8];
+    @signed [isize] [1, 2, 3, 4, 5, 6, 7, 8];
+}
+
+impl<const M: usize, const N: usize, T> core::ops::Index<T> for BitVector<M, N>
+where
+    Self: BitVectorSizeCheck,
+    [u8; N]: core::ops::Index<T>,
+{
+    type Output = <[u8; N] as core::ops::Index<T>>::Output;
+
+    #[inline]
+    fn index(&self, index: T) -> &Self::Output {
+        self.0.index(index)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    #[test]
+    fn bv_us_conv_prim() {
+        // Check for n = 8
+        let bv = bittide_macros::bitvector!(0xab, n = 8);
+        let us = bittide_macros::unsigned!(0xab, n = 8);
+        assert_eq!(bv, us.into(), "US -> BV conversion incorrect");
+        assert_eq!(us, bv.into(), "BV -> US conversion incorrect");
+
+        // Check for n = 16
+        let bv = bittide_macros::bitvector!(0xab_cd, n = 16);
+        let us = bittide_macros::unsigned!(0xab_cd, n = 16);
+        assert_eq!(bv, us.into(), "US -> BV conversion incorrect");
+        assert_eq!(us, bv.into(), "BV -> US conversion incorrect");
+
+        // Check for n = 32
+        let bv = bittide_macros::bitvector!(0xab_cd_ef_01, n = 32);
+        let us = bittide_macros::unsigned!(0xab_cd_ef_01, n = 32);
+        assert_eq!(bv, us.into(), "US -> BV conversion incorrect");
+        assert_eq!(us, bv.into(), "BV -> US conversion incorrect");
+
+        // Check for n = 64
+        let bv = bittide_macros::bitvector!(0xab_cd_ef_01_23_45_67_89, n = 64);
+        let us = bittide_macros::unsigned!(0xab_cd_ef_01_23_45_67_89, n = 64);
+        assert_eq!(bv, us.into(), "US -> BV conversion incorrect");
+        assert_eq!(us, bv.into(), "BV -> US conversion incorrect");
+
+        // Check for n = 128
+        let bv =
+            bittide_macros::bitvector!(0xab_cd_ef_01_23_45_67_89_ab_cd_ef_01_23_45_67_89, n = 128);
+        let us =
+            bittide_macros::unsigned!(0xab_cd_ef_01_23_45_67_89_ab_cd_ef_01_23_45_67_89, n = 128);
+        assert_eq!(bv, us.into(), "US -> BV conversion incorrect");
+        assert_eq!(us, bv.into(), "BV -> US conversion incorrect");
+    }
+
+    #[test]
+    fn bv_us_conv_nonprim() {
+        // Check for n = 24 (non-primitive-sized)
+        let bv = bittide_macros::bitvector!(0xab_cd_ef, n = 24);
+        let us = bittide_macros::unsigned!(0xab_cd_ef, n = 24);
+        assert_eq!(bv, us.into(), "US -> BV conversion incorrect");
+        assert_eq!(us, bv.into(), "BV -> US conversion incorrect");
+
+        // Check for n = 25 (non-primitive-sized)
+        let bv = bittide_macros::bitvector!(0x1_ab_cd_ef, n = 25);
+        let us = bittide_macros::unsigned!(0x1_ab_cd_ef, n = 25);
+        assert_eq!(bv, us.into(), "US -> BV conversion incorrect");
+        assert_eq!(us, bv.into(), "BV -> US conversion incorrect");
+    }
+
+    #[test]
+    fn bv_sn_conv_prim() {
+        // Check for n = 8
+        let bv = bittide_macros::bitvector!(0xab, n = 8);
+        let sn = bittide_macros::signed!(0xab, n = 8);
+        assert_eq!(bv, sn.into(), "SN -> BV conversion incorrect");
+        assert_eq!(sn, bv.into(), "BV -> SN conversion incorrect");
+
+        // Check for n = 16
+        let bv = bittide_macros::bitvector!(0xab_cd, n = 16);
+        let sn = bittide_macros::signed!(0xab_cd, n = 16);
+        assert_eq!(bv, sn.into(), "SN -> BV conversion incorrect");
+        assert_eq!(sn, bv.into(), "BV -> SN conversion incorrect");
+
+        // Check for n = 32
+        let bv = bittide_macros::bitvector!(0xab_cd_ef_01, n = 32);
+        let sn = bittide_macros::signed!(0xab_cd_ef_01, n = 32);
+        assert_eq!(bv, sn.into(), "SN -> BV conversion incorrect");
+        assert_eq!(sn, bv.into(), "BV -> SN conversion incorrect");
+
+        // Check for n = 64
+        let bv = bittide_macros::bitvector!(0xab_cd_ef_01_23_45_67_89, n = 64);
+        let sn = bittide_macros::signed!(0xab_cd_ef_01_23_45_67_89, n = 64);
+        assert_eq!(bv, sn.into(), "SN -> BV conversion incorrect");
+        assert_eq!(sn, bv.into(), "BV -> SN conversion incorrect");
+
+        // Check for n = 128
+        let bv =
+            bittide_macros::bitvector!(0xab_cd_ef_01_23_45_67_89_ab_cd_ef_01_23_45_67_89, n = 128);
+        let sn =
+            bittide_macros::signed!(0xab_cd_ef_01_23_45_67_89_ab_cd_ef_01_23_45_67_89, n = 128);
+        assert_eq!(bv, sn.into(), "SN -> BV conversion incorrect");
+        assert_eq!(sn, bv.into(), "BV -> SN conversion incorrect");
+    }
+
+    #[test]
+    fn bv_sn_conv_nonprim() {
+        // Check for n = 24 (non-primitive-sized, no sign extension needed)
+        let bv = bittide_macros::bitvector!(0x2b_cd_ef, n = 24);
+        let sn = bittide_macros::signed!(0x2b_cd_ef, n = 24);
+        assert_eq!(bv, sn.into(), "SN -> BV conversion incorrect");
+        assert_eq!(sn, bv.into(), "BV -> SN conversion incorrect");
+
+        // Check for n = 25 (non-primitive-sized, sign extension needed)
+        let bv = bittide_macros::bitvector!(0x1_ab_cd_ef, n = 25);
+        let sn = bittide_macros::signed!(0x1_ab_cd_ef, n = 25);
+        assert_eq!(bv, sn.into(), "SN -> BV conversion incorrect");
+        assert_eq!(sn, bv.into(), "BV -> SN conversion incorrect");
+    }
+}

--- a/firmware-support/bittide-hal/src/manual_additions/calendar.rs
+++ b/firmware-support/bittide-hal/src/manual_additions/calendar.rs
@@ -7,23 +7,22 @@ The `calendar` module provides a hardware abstraction layer over based on the ge
 peripheral access code for the `Calendar` device.
  */
 
-use crate::manual_additions::{FromAs, IntoAs};
+use crate::manual_additions::{
+    index::{IndexInner, IndexInterface, IndexSizeCheck},
+    unsigned::{UnsignedInterface, UnsignedSizeCheck},
+    FromAs, IntoAs,
+};
+use bittide_macros::{Index, Unsigned};
 
 pub trait ValidEntryType {
     type Inner;
     type Repeat;
-
-    const REPEAT_MASK: Self::Repeat;
 
     fn new(entry: Self::Inner, repeat: Self::Repeat) -> Self;
 }
 
 pub type ValidEntryInner<T> = <T as ValidEntryType>::Inner;
 pub type ValidEntryRepeat<T> = <T as ValidEntryType>::Repeat;
-
-pub const fn valid_entry_repeat_mask<T: ValidEntryType>() -> ValidEntryRepeat<T> {
-    <T as ValidEntryType>::REPEAT_MASK
-}
 
 macro_rules! impl_valid_entry_type {
     (
@@ -35,10 +34,8 @@ macro_rules! impl_valid_entry_type {
             type Inner = T;
             type Repeat = $repeat;
 
-            const REPEAT_MASK: Self::Repeat = $mask as $repeat;
-
+            #[inline]
             fn new(entry: Self::Inner, repeat: Self::Repeat) -> Self {
-                let repeat = repeat & Self::REPEAT_MASK;
                 Self {
                     ve_entry: entry,
                     ve_repeat: repeat,
@@ -50,36 +47,28 @@ macro_rules! impl_valid_entry_type {
 
 impl_valid_entry_type! {
     type: [crate::types::ValidEntry_12],
-    repeat: u16,
+    repeat: Unsigned!(16),
     mask: 12,
 }
 
 impl_valid_entry_type! {
     type: [crate::types::ValidEntry_16],
-    repeat: u16,
+    repeat: Unsigned!(16),
     mask: 16,
 }
 
 /// Abstraction trait over all the methods that a calendar type should provide
 pub trait CalendarInterface {
     type EntryType: Copy + ValidEntryType;
-    type MetacycleCount;
+    type MetacycleCount: UnsignedInterface;
+    type Index: IndexInterface<Inner: FromAs<usize> + PartialOrd> + IntoAs<usize>;
 
-    type ShadowIndex: Ord + FromAs<usize> + IntoAs<usize> + IntoAs<u128>;
-    const SHADOW_INDEX_MAX: Self::ShadowIndex;
-
-    type WriteIndex: Ord + FromAs<usize> + IntoAs<u128>;
-    const WRITE_ADDR_MAX: Self::WriteIndex;
-
-    type ReadIndex: Ord + FromAs<usize> + IntoAs<u128>;
-    const READ_ADDR_MAX: Self::ReadIndex;
-
-    fn calint_shadow_depth_index(&self) -> Self::ShadowIndex;
+    fn calint_shadow_depth_index(&self) -> Self::Index;
     fn calint_shadow_entry(&self) -> Self::EntryType;
-    fn calint_metacycle_count(&self) -> u32;
-    fn calint_set_shadow_depth_index(&self, val: Self::ShadowIndex);
-    fn calint_set_write_addr(&self, val: Self::WriteIndex);
-    fn calint_set_read_addr(&self, val: Self::ReadIndex);
+    fn calint_metacycle_count(&self) -> Self::MetacycleCount;
+    fn calint_set_shadow_depth_index(&self, val: Self::Index);
+    fn calint_set_write_addr(&self, val: Self::Index);
+    fn calint_set_read_addr(&self, val: Self::Index);
     fn calint_set_shadow_entry(&self, val: Self::EntryType);
     fn calint_set_swap_active(&self, val: bool);
     fn calint_set_end_of_metacycle(&self, val: bool);
@@ -91,22 +80,14 @@ pub type CalendarEntryType<T> = <T as CalendarInterface>::EntryType;
 /// Type alias for retrieving the metacycle count type of a calendar type.
 pub type CalendarMetacycleCount<T> = <T as CalendarInterface>::MetacycleCount;
 
-/// Type alias for retrieving the shadow index type of a calendar type.
-pub type CalendarShadowIndex<T> = <T as CalendarInterface>::ShadowIndex;
-
-/// Type alias for retrieving the write index type of a calendar type.
-pub type CalendarWriteIndex<T> = <T as CalendarInterface>::WriteIndex;
-
-/// Type alias for retrieving the read index type of a calendar type.
-pub type CalendarReadIndex<T> = <T as CalendarInterface>::ReadIndex;
+/// Type alias for retrieving the index type of a calendar type.
+pub type CalendarIndex<T> = <T as CalendarInterface>::Index;
 
 macro_rules! impl_calendar_interface {
     (
         cal: $cty:ty,
         metacycle: $mc:ty,
-        shadow: $si:ty,
-        write: $wi:ty,
-        read: $ri:ty,
+        index: $ix:ty,
         entry: $et:ty,
     ) => {
         // Assertions that must be met for the implementation to be valid
@@ -124,7 +105,7 @@ macro_rules! impl_calendar_interface {
                 );
             }
             // Assert that the shadow index type can hold the maximum shadow depth index
-            if (<$cty>::SHADOW_DEPTH_INDEX_SIZE as u128 - 1) > (<$si>::MAX as u128) {
+            if (<$cty>::SHADOW_DEPTH_INDEX_SIZE as u128 - 1) > (<$ix>::MAX as u128) {
                 const_panic::concat_panic!(
                     "Shadow index type ",
                     stringify!($si),
@@ -132,70 +113,53 @@ macro_rules! impl_calendar_interface {
                     <$cty>::SHADOW_DEPTH_INDEX_SIZE as u128 - 1,
                 );
             }
-            // Assert that the write index type can hold the maximum write address
-            if <$cty>::WRITE_ADDR_SIZE as u128 - 1 > <$wi>::MAX as u128 {
-                const_panic::concat_panic!(
-                    "Write index type ",
-                    stringify!($wi),
-                    " cannot fit the maximum value ",
-                    <$cty>::WRITE_ADDR_SIZE as u128 - 1,
-                );
-            }
-            // Assert that the read index type can hold the maximum read address
-            if <$cty>::READ_ADDR_SIZE as u128 - 1 > <$ri>::MAX as u128 {
-                const_panic::concat_panic!(
-                    "Read index type ",
-                    stringify!($ri),
-                    " cannot fit the maximum value ",
-                    <$cty>::READ_ADDR_SIZE as u128 - 1,
-                );
-            }
         };
         impl CalendarInterface for $cty {
             type EntryType = $et;
             type MetacycleCount = $mc;
+            type Index = $ix;
 
-            type ShadowIndex = $si;
-            const SHADOW_INDEX_MAX: $si = (<$cty>::SHADOW_DEPTH_INDEX_SIZE - 1) as $si;
-
-            type WriteIndex = $wi;
-            const WRITE_ADDR_MAX: $wi = (<$cty>::WRITE_ADDR_SIZE - 1) as $wi;
-
-            type ReadIndex = $ri;
-            const READ_ADDR_MAX: $ri = (<$cty>::READ_ADDR_SIZE - 1) as $ri;
-
-            fn calint_shadow_depth_index(&self) -> Self::ShadowIndex {
+            #[inline]
+            fn calint_shadow_depth_index(&self) -> Self::Index {
                 self.shadow_depth_index()
             }
 
+            #[inline]
             fn calint_shadow_entry(&self) -> Self::EntryType {
                 self.shadow_entry()
             }
 
+            #[inline]
             fn calint_metacycle_count(&self) -> Self::MetacycleCount {
                 self.metacycle_count()
             }
 
-            fn calint_set_shadow_depth_index(&self, val: Self::ShadowIndex) {
+            #[inline]
+            fn calint_set_shadow_depth_index(&self, val: Self::Index) {
                 self.set_shadow_depth_index(val)
             }
 
-            fn calint_set_write_addr(&self, val: Self::WriteIndex) {
+            #[inline]
+            fn calint_set_write_addr(&self, val: Self::Index) {
                 self.set_write_addr(val)
             }
 
-            fn calint_set_read_addr(&self, val: Self::ReadIndex) {
+            #[inline]
+            fn calint_set_read_addr(&self, val: Self::Index) {
                 self.set_read_addr(val)
             }
 
+            #[inline]
             fn calint_set_shadow_entry(&self, val: Self::EntryType) {
                 self.set_shadow_entry(val)
             }
 
+            #[inline]
             fn calint_set_swap_active(&self, val: bool) {
                 self.set_swap_active(val)
             }
 
+            #[inline]
             fn calint_set_end_of_metacycle(&self, val: bool) {
                 self.set_end_of_metacycle(val)
             }
@@ -211,11 +175,10 @@ pub trait CalendarType: CalendarInterface {
     ///
     /// Panics if `n` is an invalid value for a `Self::ReadIndex` type instance.
     fn read_shadow_entry(&self, n: usize) -> Self::EntryType {
-        assert!(
-            n as u128 <= Self::READ_ADDR_MAX.into_as(),
-            "Shadow entry read index is out of bounds."
+        let n_inner = n.into_as();
+        self.calint_set_read_addr(
+            Self::Index::idx_new(n_inner).expect("Shadow entry read index is out of bounds."),
         );
-        self.calint_set_read_addr(Self::ReadIndex::from_as(n));
         self.calint_shadow_entry()
     }
 
@@ -225,12 +188,11 @@ pub trait CalendarType: CalendarInterface {
     ///
     /// Panics if `n` is an invalid value for a `Self::WriteIndex` type instance.
     fn write_shadow_entry(&self, n: usize, entry: Self::EntryType) {
-        assert!(
-            n as u128 <= Self::WRITE_ADDR_MAX.into_as(),
-            "Shadow entry write index is out of bounds."
-        );
+        let n_inner = n.into_as();
         self.calint_set_shadow_entry(entry);
-        self.calint_set_write_addr(Self::WriteIndex::from_as(n));
+        self.calint_set_write_addr(
+            Self::Index::idx_new(n_inner).expect("Shadow entry write index is out of bounds."),
+        );
     }
 
     /// Swaps the active and shadow calendar at the end of the metacycle.
@@ -245,13 +207,13 @@ pub trait CalendarType: CalendarInterface {
 
     /// Returns the number of entries in the shadow calendar.
     fn shadow_depth(&self) -> usize {
-        <Self::ShadowIndex as IntoAs<usize>>::into_as(self.calint_shadow_depth_index()) + 1
+        self.calint_shadow_depth_index().into_as() + 1
     }
 
     /// Returns an iterator over the shadow calendar entries.
     fn read_shadow_calendar<'a>(&'a self) -> impl Iterator<Item = Self::EntryType> + 'a {
         (0..self.shadow_depth()).map(|n| {
-            self.calint_set_read_addr(Self::ReadIndex::from_as(n));
+            self.calint_set_read_addr(unsafe { Self::Index::idx_new_unchecked(n.into_as()) });
             self.calint_shadow_entry()
         })
     }
@@ -267,63 +229,56 @@ pub trait CalendarType: CalendarInterface {
             return;
         }
         assert!(
-            entries.len() as u128
-                <= <Self::ShadowIndex as IntoAs<u128>>::into_as(Self::SHADOW_INDEX_MAX),
-            "Entries exceed shadow calendar size"
+            entries.len() <= Self::Index::IMAX.into_as(),
+            "Input slice (length {}) is too long for calendar of size {}",
+            entries.len(),
+            Self::Index::N_,
         );
         for (n, entry) in entries.iter().enumerate() {
             self.calint_set_shadow_entry(*entry);
-            self.calint_set_write_addr(Self::WriteIndex::from_as(n));
+            self.calint_set_write_addr(unsafe { Self::Index::idx_new_unchecked(n.into_as()) });
         }
-        self.calint_set_shadow_depth_index(Self::ShadowIndex::from_as(entries.len() - 1));
+        self.calint_set_shadow_depth_index(unsafe {
+            Self::Index::idx_new_unchecked((entries.len() - 1).into_as())
+        });
     }
 }
 
-impl<T: CalendarInterface> CalendarType for T {}
+impl<T> CalendarType for T where T: CalendarInterface {}
 
 impl_calendar_interface! {
     cal: crate::hals::switch_c::devices::Calendar,
-    metacycle: u32,
-    shadow: u8,
-    write: u8,
-    read: u8,
-    entry: crate::types::ValidEntry_12<[u8; 16]>,
+    metacycle: Unsigned!(32),
+    index: Index!(256),
+    entry: crate::types::ValidEntry_12<[Index!(17); 16]>,
 }
 
 impl_calendar_interface! {
     cal: crate::hals::switch_demo_mu::devices::Calendar,
-    metacycle: u32,
-    shadow: u8,
-    write: u8,
-    read: u8,
-    entry: crate::types::ValidEntry_12<[u8; 8]>,
+    metacycle: Unsigned!(32),
+    index: Index!(7),
+    entry: crate::types::ValidEntry_12<[Index!(9); 8]>,
 }
 
 impl_calendar_interface! {
     cal: crate::hals::switch_demo_gppe_mu::devices::Calendar,
-    metacycle: u32,
-    shadow: u16,
-    write: u16,
-    read: u16,
-    entry: crate::types::ValidEntry_12<u16>,
+    metacycle: Unsigned!(32),
+    index: Index!(1024),
+    entry: crate::types::ValidEntry_12<Index!(1024)>,
 }
 
 impl_calendar_interface! {
     cal: crate::hals::scatter_gather_pe::devices::Calendar,
-    metacycle: u32,
-    shadow: u8,
-    write: u8,
-    read: u8,
-    entry: crate::types::ValidEntry_12<u8>,
+    metacycle: Unsigned!(32),
+    index: Index!(32),
+    entry: crate::types::ValidEntry_12<Index!(16)>,
 }
 
 impl_calendar_interface! {
     cal: crate::hals::soft_ugn_demo_mu::devices::Calendar,
-    metacycle: u32,
-    shadow: u16,
-    write: u16,
-    read: u16,
-    entry: crate::types::ValidEntry_16<u16>,
+    metacycle: Unsigned!(32),
+    index: Index!(4000),
+    entry: crate::types::ValidEntry_16<Index!(4000)>,
 }
 
 pub trait RingbufferCalendar {
@@ -333,7 +288,8 @@ pub trait RingbufferCalendar {
 impl<T> RingbufferCalendar for T
 where
     T: CalendarType,
-    ValidEntryInner<CalendarEntryType<T>>: FromAs<usize>,
+    core::ops::Range<IndexInner<T::Index>>: IntoIterator<Item = IndexInner<T::Index>>,
+    ValidEntryInner<CalendarEntryType<T>>: From<T::Index>,
     ValidEntryRepeat<CalendarEntryType<T>>: FromAs<u8>,
 {
     /// Initializes a calendar type which contains entries derivable from `usize` and repeats
@@ -347,18 +303,19 @@ where
     ///   calendar (compared against [`Self::SHADOW_INDEX_MAX`])
     fn initialize_as_ringbuffer(&self, size: usize) {
         assert!(size > 0, "Cannot have a ringbuffer of size 0!");
-        let size_max_index: CalendarShadowIndex<T> = (size - 1).into_as();
-        if size_max_index > Self::SHADOW_INDEX_MAX {
-            panic!(
-                "Size ({size}) exceeds calendar size ({})",
-                <CalendarShadowIndex<T> as IntoAs<u128>>::into_as(Self::SHADOW_INDEX_MAX)
-            );
+        let size_max_index: IndexInner<T::Index> = (size - 1).into_as();
+        if <usize as IntoAs<IndexInner<T::Index>>>::into_as(size) > T::Index::N_AS_INNER {
+            panic!("Size ({size}) exceeds calendar size ({})", T::Index::N_);
         }
-        for n in 0..size {
-            let entry = CalendarEntryType::<Self>::new(n.into_as(), 0.into_as());
+        for (n, idx) in (IndexInner::<T::Index>::from_as(0usize)..T::Index::N_AS_INNER)
+            .into_iter()
+            .map(|n| unsafe { T::Index::idx_new_unchecked(n) })
+            .enumerate()
+        {
+            let entry = CalendarEntryType::<Self>::new(idx.into(), 0.into_as());
             self.write_shadow_entry(n, entry);
         }
-        self.calint_set_shadow_depth_index(size_max_index);
+        self.calint_set_shadow_depth_index(unsafe { T::Index::idx_new_unchecked(size_max_index) });
         self.calint_set_swap_active(true);
     }
 }

--- a/firmware-support/bittide-hal/src/manual_additions/capture_ugn.rs
+++ b/firmware-support/bittide-hal/src/manual_additions/capture_ugn.rs
@@ -13,6 +13,6 @@ impl CaptureUgn {
     }
 
     pub fn ugn_unchecked(&self) -> u64 {
-        self.local_counter() - self.remote_counter()
+        self.local_counter().into_inner() - self.remote_counter().into_inner()
     }
 }

--- a/firmware-support/bittide-hal/src/manual_additions/dna.rs
+++ b/firmware-support/bittide-hal/src/manual_additions/dna.rs
@@ -10,7 +10,7 @@ impl Dna {
     pub fn dna(&self) -> [u8; 12] {
         loop {
             match self.maybe_dna() {
-                Maybe::Just(value) => return value,
+                Maybe::Just(value) => return value.into_inner(),
                 Maybe::Nothing => continue,
             }
         }

--- a/firmware-support/bittide-hal/src/manual_additions/elastic_buffer.rs
+++ b/firmware-support/bittide-hal/src/manual_additions/elastic_buffer.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::shared_devices::elastic_buffer::ElasticBuffer;
+use bittide_macros::Signed;
 
 impl ElasticBuffer {
     /// Minimum occupancy value for the elastic buffer (signed 8-bit).
@@ -18,7 +19,7 @@ impl ElasticBuffer {
     /// 2. Waits for completion with `adjustment_wait`
     ///
     /// Negative values drain (remove frames), positive values fill (add frames).
-    pub fn set_adjustment(&self, adjustment: i32) {
+    pub fn set_adjustment(&self, adjustment: Signed!(32)) {
         self.set_adjustment_async(adjustment);
         self.set_adjustment_wait(());
     }
@@ -34,9 +35,9 @@ impl ElasticBuffer {
     ///
     /// Returns the number of frames added or dropped
     pub fn set_occupancy(&self, target: i8) -> i8 {
-        let current = self.data_count();
+        let current = self.data_count().into_inner();
         let delta = target - current;
-        self.set_adjustment(delta as i32);
+        self.set_adjustment(delta.into());
         delta
     }
 
@@ -50,9 +51,9 @@ impl ElasticBuffer {
     ///
     /// Returns the number of frames added or dropped
     pub fn set_occupancy_async(&self, target: i8) -> i8 {
-        let current = self.data_count();
+        let current = self.data_count().into_inner();
         let delta = target - current;
-        self.set_adjustment_async(delta as i32);
+        self.set_adjustment_async(delta.into());
         delta
     }
 

--- a/firmware-support/bittide-hal/src/manual_additions/index.rs
+++ b/firmware-support/bittide-hal/src/manual_additions/index.rs
@@ -1,0 +1,661 @@
+// SPDX-FileCopyrightText: 2026 Google LLC
+//
+// SPDX-License-Identifier: Apache-2.0
+//! Types, traits, and implementations for index types
+//!
+//! # Note
+//!
+//! The way that this crate constrains [`Index<N, T>`]s to the correct size is by ensuring that
+//! evaluation of a constant succeeds. As such, when writing `impl`s on [`Index<N, T>`], users
+//! should make sure to force evaluation of [`IndexSizeCheck::SIZE_CHECK`].
+//!
+//! Alternatively, one can make use of `bittide_macros::Index!` and `bittide_macros::index!` to make
+//! types/instances with the correct parameters.
+#![deny(missing_docs)]
+
+use super::{signed::Signed, unsigned::Unsigned, FromAs};
+
+/// Type used to represent values in the range `0..N`, backed by the smallest useable unsigned type
+///
+/// This is an equivalent to a [`packC`'d][bpc] [`Index n`][idx] from Clash. This type should be
+/// backed by the smallest unsigned integer capable of representing all values in `0..N`. For
+/// example, an `Index<256, _>` should be `Index<256, u8>`, and `Index<257, _>` should be
+/// `Index<257, u16>`.
+///
+/// [bpc]: https://github.com/QBayLogic/clash-protocols-memmap/blob/main/clash-bitpackc/src/Clash/Class/BitPackC.hs#L39-L44
+/// [idx]: https://hackage-content.haskell.org/package/clash-prelude-1.8.4/docs/Clash-Sized-Index.html#t:Index
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(transparent)]
+pub struct Index<const N: u128, T>(pub(crate) T);
+
+/// Trait for making guarantees about the size and validity of index types
+pub trait IndexSizeCheck {
+    /// This `const` should be instantiated in methods implemented on [`Index<N, T>`], since it is
+    /// how they are constrained to the correct size. If they're improperly sized, this `const` will
+    /// fail to evaluate and produce a compile error.
+    ///
+    /// # Examples
+    ///
+    /// Indices with an appropriate backing type will compile successfully:
+    /// ```
+    /// # use bittide_hal::manual_additions::index::{Index, IndexSizeCheck};
+    /// trait Marker {
+    ///     fn nothing();
+    /// }
+    ///
+    /// impl Marker for Index<256, u8> {
+    ///     fn nothing() {
+    ///         let _ = Self::SIZE_CHECK;
+    ///     }
+    /// }
+    ///
+    /// impl Marker for Index<257, u16> {
+    ///     fn nothing() {
+    ///         let _ = Self::SIZE_CHECK;
+    ///     }
+    /// }
+    ///
+    /// impl Marker for Index<65_536, u16> {
+    ///     fn nothing() {
+    ///         let _ = Self::SIZE_CHECK;
+    ///     }
+    /// }
+    ///
+    /// impl Marker for Index<65_537, u32> {
+    ///     fn nothing() {
+    ///         let _ = Self::SIZE_CHECK;
+    ///     }
+    /// }
+    /// ```
+    /// But indices with an improperly sized backing type will produce an error. For example, when
+    /// the backing type is too small:
+    /// ```compile_fail
+    /// # use bittide_hal::manual_additions::index::{Index, IndexSizeCheck};
+    /// trait Marker {
+    ///     fn nothing();
+    /// }
+    ///
+    /// impl Marker for Index<100_000, u8> {
+    ///     fn nothing() {
+    ///         let _ = Self::SIZE_CHECK;
+    ///     }
+    /// }
+    /// ```
+    /// This produces the error
+    /// ```text
+    /// error[E0080]: evaluation of `<Index<100000, u8> as IndexSizeCheck>::SIZE_CHECK` failed
+    ///    --> manual_additions/index.rs
+    ///     |
+    ///     | impl_isc!(u8, u16, u32, u64); // READ THE REST OF THE ERROR MESSAGE
+    ///     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: Max bound 100000 cannot fit in type `u8` (max value: 256)
+    ///     |
+    ///     = note: this error originates in the macro `const_panic::concat_panic` which comes from the expansion of the macro `impl_isc` (in Nightly builds, run with -Z macro-backtrace for more info)
+    ///
+    /// note: erroneous constant encountered
+    ///   --> manual_additions/index.rs
+    ///    |
+    ///    |         let _ = Self::SIZE_CHECK;
+    ///    |                 ^^^^^^^^^^^^^^^^
+    /// ```
+    /// Or when the backing type is too large:
+    /// ```compile_fail
+    /// # use bittide_hal::manual_additions::index::{Index, IndexSizeCheck};
+    /// trait Marker {
+    ///     fn nothing();
+    /// }
+    ///
+    /// impl Marker for Index<10, u128> {
+    ///     fn nothing() {
+    ///         let _ = Self::SIZE_CHECK;
+    ///     }
+    /// }
+    /// ```
+    /// This produces the error
+    /// ```text
+    /// error[E0080]: evaluation of `<Index<10, u128> as IndexSizeCheck>::SIZE_CHECK` failed
+    ///    --> manual_additions/index.rs
+    ///     |
+    ///     | /             const_panic::concat_panic!(
+    ///     | |                 const_panic::fmt::FmtArg::DISPLAY;
+    ///     | |                 "Type u128 is not optimally sized for bound ",
+    ///     | |                 N,
+    /// ...   |
+    ///     | |                 "` instead.",
+    ///     | |             );
+    ///     | |_____________^ evaluation panicked: Type u128 is not optimally sized for bound 10. Use type `u8` instead.
+    ///     |
+    ///     = note: this error originates in the macro `const_panic::concat_panic` (in Nightly builds, run with -Z macro-backtrace for more info)
+    ///
+    /// note: erroneous constant encountered
+    ///   --> manual_additions/index.rs
+    ///    |
+    ///    |         let _ = Self::SIZE_CHECK;
+    ///    |                 ^^^^^^^^^^^^^^^^
+    /// ```
+    /// Or when the index bound is 0:
+    /// ```compile_fail
+    /// # use bittide_hal::manual_additions::index::{Index, IndexSizeCheck};
+    /// trait Marker {
+    ///     fn nothing();
+    /// }
+    ///
+    /// impl Marker for Index<0, u128> {
+    ///     fn nothing() {
+    ///         let _ = Self::SIZE_CHECK;
+    ///     }
+    /// }
+    /// ```
+    /// ```text
+    /// error[E0080]: evaluation of `<Index<0, u128> as IndexSizeCheck>::SIZE_CHECK` failed
+    ///    --> manual_additions/index.rs:230:13
+    ///     |
+    ///     |             panic!("Cannot represent `Index<0, T>`!");
+    ///     |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: Cannot represent `Index<0, T>`!
+    ///
+    /// note: erroneous constant encountered
+    ///   --> manual_additions/index.rs:143:17
+    ///    |
+    ///    |         let _ = Self::SIZE_CHECK;
+    ///    |                 ^^^^^^^^^^^^^^^^
+    /// ```
+    const SIZE_CHECK: ();
+    /// Generic parameter to the type in case it's not useable directly
+    const N_: u128;
+    /// Backing type of an index
+    type Inner: Copy;
+    /// Generic parameter to the type casted to the inner type of the index
+    const N_AS_INNER: Self::Inner;
+    /// Perform a bounds check on an instance of an index. Returns `true` if within bounds, `false`
+    /// if not.
+    fn inner_bounds_check(val: Self::Inner) -> bool;
+    /// The maximum value allowed in the index type (`N - 1`)
+    const MAX: Self::Inner;
+    /// Index instance containing the maximum allowable value
+    const IMAX: Self;
+}
+
+/// Type alias for retrieving the backing type of an index type
+pub type IndexInner<T> = <T as IndexSizeCheck>::Inner;
+
+macro_rules! impl_isc {
+    ($($t:ty),+$(,)?) => {
+        $(
+            impl<const N: u128> IndexSizeCheck for Index<N, $t> {
+                const SIZE_CHECK: () = {
+                    if N == 0 {
+                        panic!("Cannot represent `Index<0, T>`!");
+                    }
+                    // `u128::BITS - N.leading_zeros()` is equivalent to `N.clog2()`
+                    let correct_size = match
+                        (u128::BITS - (N - 1).leading_zeros()).next_power_of_two()
+                    {
+                        size if size >= 8 => size,
+                        _ => 8,
+                    };
+                    if N - 1 > <$t>::MAX as u128 {
+                        const_panic::concat_panic!(
+                            const_panic::fmt::FmtArg::DISPLAY;
+                            "Max bound ",
+                            N,
+                            " cannot fit in type `",
+                            stringify!($t),
+                            "` (max value: ",
+                            <$t>::MAX as u128 + 1,
+                            ")"
+                        );
+                    } else if correct_size != <$t>::BITS {
+                        const_panic::concat_panic!(
+                            const_panic::fmt::FmtArg::DISPLAY;
+                            "Type `",
+                            stringify!($t),
+                            "` is not optimally sized for bound ",
+                            N,
+                            ". Use type `u",
+                            correct_size,
+                            "` instead.",
+                        );
+                    }
+                };
+                const N_: u128 = N;
+                type Inner = $t;
+                // NOTE
+                // Casting `N` as `$t` will always work, because the above `const SIZE_CHECK` will
+                // produce a compile error if `N` doesn't fit into the type `$t`.
+                const N_AS_INNER: $t = {
+                    let _: () = Self::SIZE_CHECK; // READ THE REST OF THE ERROR MESSAGE
+                    N as $t
+                };
+                #[inline]
+                fn inner_bounds_check(val: $t) -> bool {
+                    let _: () = Self::SIZE_CHECK; // READ THE REST OF THE ERROR MESSAGE
+                    if const { N - 1 == <$t>::MAX as u128 } {
+                        true
+                    } else {
+                        // NOTE
+                        // Casting `N` as `$t` will always work, because the above
+                        // `const SIZE_CHECK` will produce a compile error if `N` doesn't fit into
+                        // the type `$t`.
+                        val < Self::N_AS_INNER
+                    }
+                }
+                const MAX: $t = (N - 1) as $t;
+                const IMAX: Self = Index(Self::MAX);
+            }
+        )+
+    };
+}
+
+impl_isc!(u8, u16, u32, u64); // READ THE REST OF THE ERROR MESSAGE
+
+impl<const N: u128> IndexSizeCheck for Index<N, u128> {
+    const SIZE_CHECK: () = {
+        if N == 0 {
+            panic!("Cannot represent `Index<0, T>`!");
+        }
+        // `u128::BITS - (N - 1).leading_zeros()` is equivalent to `N.clog2()`
+        let correct_size = match (u128::BITS - (N - 1).leading_zeros()).next_power_of_two() {
+            size if size >= 8 => size,
+            _ => 8,
+        };
+        if correct_size != u128::BITS {
+            const_panic::concat_panic!(
+                const_panic::fmt::FmtArg::DISPLAY;
+                "Type u128 is not optimally sized for bound ",
+                N,
+                ". Use type `u",
+                correct_size,
+                "` instead.",
+            );
+        }
+    };
+    const N_: u128 = N;
+    type Inner = u128;
+    const N_AS_INNER: u128 = {
+        let _: () = Self::SIZE_CHECK; // READ THE REST OF THE ERROR MESSAGE
+        N
+    };
+    #[inline]
+    fn inner_bounds_check(val: u128) -> bool {
+        let _: () = Self::SIZE_CHECK; // READ THE REST OF THE ERROR MESSAGE
+        val < N
+    }
+    const MAX: u128 = N - 1;
+    const IMAX: Self = Index(Self::MAX);
+}
+
+impl<const N: u128, T> Index<N, T>
+where
+    T: Copy,
+    Index<N, T>: IndexSizeCheck<Inner = T>,
+{
+    /// Instantiate a new `Index<N, T>`
+    ///
+    /// Returns `Some(_)` if `val` is in the range `0..N`, returns `None` otherwise.
+    ///
+    /// # Errors
+    ///
+    /// This function may error if invoked as `Index::<N, T>::new(...)` and the wrong backing type
+    /// `T` is chosen. Please read the whole error message carefully, it should tell you what to do
+    /// to fix it.
+    #[inline]
+    pub fn new(val: T) -> Option<Index<N, T>> {
+        let _: () = Self::SIZE_CHECK; // READ THE REST OF THE ERROR MESSAGE
+        if Index::<N, T>::inner_bounds_check(val) {
+            Some(Index(val))
+        } else {
+            None
+        }
+    }
+
+    /// Instantiate a new `Index<N, T>` without performing a bounds check
+    ///
+    /// # Errors
+    ///
+    /// This function may error if invoked as `Index::<N, T>::new_unchecked(...)` and the wrong
+    /// backing type `T` is chosen. Please read the whole error message carefully, it should tell
+    /// you what to do to fix it.
+    ///
+    /// # Safety
+    ///
+    /// Due to the intended use-case of interfacing with Clash hardware, and there being no
+    /// guarantee of behaviour in the case that an out-of-bounds value is written to a register,
+    /// this function has been marked as `unsafe`. To make calling this function safe, you must
+    /// guarantee that `val` is in the range `0..N`.
+    ///
+    /// There's one exception to this: it is always safe to call `new_unchecked` if `N` is equal to
+    /// the exclusive upper bound for type `T`. For example, `Index::<65536, u16>::new_unchecked` is
+    /// always safe.
+    #[inline]
+    pub unsafe fn new_unchecked(val: T) -> Index<N, T> {
+        let _: () = Self::SIZE_CHECK; // READ THE REST OF THE ERROR MESSAGE
+        Index(val)
+    }
+
+    /// Unwrap the inner value contained by this `Index<N, T>`
+    #[inline]
+    pub fn into_inner(self) -> T {
+        let _: () = Self::SIZE_CHECK; // READ THE REST OF THE ERROR MESSAGE
+        self.0
+    }
+}
+
+impl<const N: u128, T> core::fmt::Debug for Index<N, T>
+where
+    Self: IndexSizeCheck,
+    T: core::fmt::Debug,
+{
+    #[inline]
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "Index<{N}>({:?})", self.0)
+    }
+}
+
+impl<const N: u128, T> core::fmt::Display for Index<N, T>
+where
+    Self: IndexSizeCheck,
+    T: core::fmt::Display,
+{
+    #[inline]
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+#[inline]
+const fn clog2_cgu128<const N: u128>() -> usize {
+    let mut m = 0;
+    let mut n = 1;
+    while n - 1 < N {
+        m += 1;
+        let Some(n_next) = n.checked_mul(10) else {
+            break;
+        };
+        n = n_next;
+    }
+    m
+}
+
+const U128_MAXLEN: usize = clog2_cgu128::<{ u128::MAX }>() + 1;
+type CGu128FmtData = [u8; U128_MAXLEN];
+
+struct CGU128Formatter<const N: u128>;
+
+impl<const N: u128> CGU128Formatter<N> {
+    const DATA: CGu128FmtData = {
+        let clog2 = clog2_cgu128::<N>();
+        let mut data = [0; U128_MAXLEN];
+        let mut idx = 0;
+        let mut acc = N;
+        while idx < clog2 {
+            data[clog2 - idx - 1] = b'0' + (acc % 10) as u8;
+            acc /= 10;
+            idx += 1;
+        }
+        data
+    };
+    const STR: &'static str = {
+        let clog2 = clog2_cgu128::<N>();
+        unsafe {
+            core::str::from_utf8_unchecked(core::slice::from_raw_parts(Self::DATA.as_ptr(), clog2))
+        }
+    };
+}
+
+impl<const N: u128, T> ufmt::uDebug for Index<N, T>
+where
+    T: ufmt::uDebug,
+{
+    #[inline]
+    fn fmt<W>(&self, w: &mut ufmt::Formatter<'_, W>) -> Result<(), W::Error>
+    where
+        W: ufmt::uWrite + ?Sized,
+    {
+        ufmt::uwrite!(w, "Index<{}>({:?})", CGU128Formatter::<N>::STR, self.0)
+    }
+}
+
+impl<const N: u128, T> ufmt::uDisplay for Index<N, T>
+where
+    T: ufmt::uDisplay,
+{
+    #[inline]
+    fn fmt<W>(&self, w: &mut ufmt::Formatter<'_, W>) -> Result<(), W::Error>
+    where
+        W: ufmt::uWrite + ?Sized,
+    {
+        ufmt::uwrite!(w, "Index<{}>({})", CGU128Formatter::<N>::STR, self.0)
+    }
+}
+
+impl<const N: u128, T> ufmt::uDisplayHex for Index<N, T>
+where
+    Self: IndexSizeCheck,
+    T: ufmt::uDisplayHex,
+{
+    #[inline]
+    fn fmt_hex<W>(
+        &self,
+        fmt: &mut ufmt::Formatter<'_, W>,
+        options: ufmt::HexOptions,
+    ) -> Result<(), W::Error>
+    where
+        W: ufmt::uWrite + ?Sized,
+    {
+        <T as ufmt::uDisplayHex>::fmt_hex(&self.0, fmt, options)
+    }
+}
+
+impl<const N: u128, T> super::seal::Seal for Index<N, T> where T: super::seal::Seal {}
+
+/// Trait that guarantees parts of the [`Index<N, T>`] inherent implementations
+///
+/// Intended for use where it is not desirable to constrain a type to be `T = Index<N, T>` but
+/// rather to `T: IndexInterface`.
+pub trait IndexInterface: Sized + IndexSizeCheck + super::seal::Seal {
+    /// Instantiate a new [`Index<N, T>`]
+    ///
+    /// Returns `Some(_)` if `val` is in the range `0..N`, returns `None` otherwise.
+    ///
+    /// # Errors
+    ///
+    /// This function may error if invoked as `Index::<N, T>::idx_new(...)` and the wrong backing
+    /// type `T` is chosen. Please read the whole error message carefully, it should tell you what
+    /// to do to fix it.
+    fn idx_new(val: Self::Inner) -> Option<Self>;
+    /// Instantiate a new [`Index<N, T>`] without performing a bounds check
+    ///
+    /// # Errors
+    ///
+    /// This function may error if invoked as `Index::<N, T>::idx_new_unchecked(...)` and the wrong
+    /// backing type `T` is chosen. Please read the whole error message carefully, it should tell
+    /// you what to do to fix it.
+    ///
+    /// # Safety
+    ///
+    /// Due to the intended use-case of interfacing with Clash hardware, and there being no
+    /// guarantee of behaviour in the case that an out-of-bounds value is written to a register,
+    /// this function has been marked as `unsafe`. To make calling this function safe, you must
+    /// guarantee that `val` is in the range `0..N`.
+    unsafe fn idx_new_unchecked(val: Self::Inner) -> Self;
+    /// Unwrap the inner value contained by this [`Index<N, T>`]
+    fn idx_into_inner(self) -> Self::Inner;
+}
+
+impl<const N: u128, T> IndexInterface for Index<N, T>
+where
+    T: Copy + super::seal::Seal,
+    Index<N, T>: IndexSizeCheck<Inner = T>,
+{
+    #[inline]
+    fn idx_new(val: Self::Inner) -> Option<Self> {
+        Index::<N, T>::new(val)
+    }
+
+    #[inline]
+    unsafe fn idx_new_unchecked(val: Self::Inner) -> Self {
+        Index::<N, T>::new_unchecked(val)
+    }
+
+    #[inline]
+    fn idx_into_inner(self) -> Self::Inner {
+        self.into_inner()
+    }
+}
+
+macro_rules! def_index_from {
+    // Entry
+    ($($t:ty),+$(,)?) => {
+        def_index_from! {
+            @run
+            sup: [$($t),+],
+            sub: [],
+        }
+    };
+    // Base case
+    (
+        @run
+        sup: [],
+        sub: $sub:tt,
+    ) => {};
+    // Recursive case
+    (
+        @run
+        sup: [$h:ty$(, $t:ty)*],
+        sub: [$($sub:ty),*],
+    ) => {
+        // Expand defs for current head of big type
+        $( // for $sub in $($sub),*:
+            def_index_from! {
+                @def
+                sup: $h,
+                sub: $sub,
+            }
+        )*
+
+        // Push big type to list of smaller types
+        def_index_from! {
+            @run
+            sup: [$($t),*],
+            sub: [$($sub,)* $h],
+        }
+    };
+    // Expand to `impl`s
+    (
+        @def
+        sup: $sup:ty,
+        sub: $sub:ty,
+    ) => {
+        impl<const N: u128> From<$sub> for Index<N, $sup> {
+            #[inline]
+            fn from(value: $sub) -> Self {
+                Index(value as $sup)
+            }
+        }
+
+        impl<const M: u128, const N: u128> From<Index<N, $sub>> for Index<M, $sup> {
+            #[inline]
+            fn from(value: Index<N, $sub>) -> Self {
+                Index(value.0 as $sup)
+            }
+        }
+
+        impl<const M: u128, const N: u8> From<Unsigned<N, $sub>> for Index<M, $sup> {
+            #[inline]
+            fn from(value: Unsigned<N, $sub>) -> Self {
+                Index(value.0 as $sup)
+            }
+        }
+
+        impl<const M: u128, const N: u8> From<Signed<N, $sub>> for Index<M, $sup> {
+            #[inline]
+            fn from(value: Signed<N, $sub>) -> Self {
+                Index(value.0 as $sup)
+            }
+        }
+        impl<const N: u128> FromAs<$sub> for Index<N, $sup> {
+            #[inline]
+            fn from_as(value: $sub) -> Self {
+                Index(value as $sup)
+            }
+        }
+
+        impl<const M: u128, const N: u128> FromAs<Index<N, $sub>> for Index<M, $sup> {
+            #[inline]
+            fn from_as(value: Index<N, $sub>) -> Self {
+                Index(value.0 as $sup)
+            }
+        }
+
+        impl<const M: u128, const N: u8> FromAs<Unsigned<N, $sub>> for Index<M, $sup> {
+            #[inline]
+            fn from_as(value: Unsigned<N, $sub>) -> Self {
+                Index(value.0 as $sup)
+            }
+        }
+
+        impl<const M: u128, const N: u8> FromAs<Signed<N, $sub>> for Index<M, $sup> {
+            #[inline]
+            fn from_as(value: Signed<N, $sub>) -> Self {
+                Index(value.0 as $sup)
+            }
+        }
+    }
+}
+
+def_index_from!(u8, u16, u32, u64, u128);
+
+#[cfg(target_pointer_width = "16")]
+def_index_from! {
+    @run
+    sup: [usize],
+    sub: [u8],
+}
+
+#[cfg(target_pointer_width = "32")]
+def_index_from! {
+    @run
+    sup: [usize],
+    sub: [u8, u16],
+}
+
+#[cfg(target_pointer_width = "64")]
+def_index_from! {
+    @run
+    sup: [usize],
+    sub: [u8, u16, u32],
+}
+
+subst_macros::repeat_parallel_subst! {
+    groups: [
+        [group [sub [INTO] = [u8]]]
+        [group [sub [INTO] = [u16]]]
+        [group [sub [INTO] = [u32]]]
+        [group [sub [INTO] = [u64]]]
+        [group [sub [INTO] = [u128]]]
+        [group [sub [INTO] = [usize]]]
+    ],
+    callback: NONE,
+    in: {
+        impl<const N: u128, T> From<Index<N, T>> for INTO
+        where
+            Index<N, T>: IndexSizeCheck,
+            INTO: From<T>,
+        {
+            #[inline]
+            fn from(other: Index<N, T>) -> INTO {
+                INTO::from(other.0)
+            }
+        }
+
+        impl<const N: u128, T> FromAs<Index<N, T>> for INTO
+        where
+            Index<N, T>: IndexSizeCheck,
+            INTO: FromAs<T>,
+        {
+            #[inline]
+            fn from_as(other: Index<N, T>) -> INTO {
+                INTO::from_as(other.0)
+            }
+        }
+    }
+}

--- a/firmware-support/bittide-hal/src/manual_additions/mod.rs
+++ b/firmware-support/bittide-hal/src/manual_additions/mod.rs
@@ -4,16 +4,22 @@
 
 pub mod addressable_buffer;
 pub mod aligned;
+pub mod bitvector;
 pub mod calendar;
 pub mod capture_ugn;
 pub mod dna;
 pub mod elastic_buffer;
+pub mod index;
 pub mod ring_buffer;
 pub mod scatter_gather_pe;
 pub mod si539x_spi;
+pub mod signed;
 pub mod soft_ugn_demo_mu;
 pub mod timer;
 pub mod uart;
+pub mod unsigned;
+
+use crate::types::Maybe;
 
 // Sealing the `FromAs` and `IntoAs` traits with a supertrait
 mod seal {
@@ -37,6 +43,30 @@ mod seal {
         callback: NONE,
         in: {
             impl Seal for TYPE {}
+        }
+    }
+}
+
+pub trait ConvertOptional<Target> {
+    fn conv_optional(self) -> Target;
+}
+
+impl<T> ConvertOptional<Option<T>> for Maybe<T> {
+    #[inline]
+    fn conv_optional(self) -> Option<T> {
+        match self {
+            Maybe::Just(val) => Some(val),
+            Maybe::Nothing => None,
+        }
+    }
+}
+
+impl<T> ConvertOptional<Maybe<T>> for Option<T> {
+    #[inline]
+    fn conv_optional(self) -> Maybe<T> {
+        match self {
+            Some(val) => Maybe::Just(val),
+            None => Maybe::Nothing,
         }
     }
 }

--- a/firmware-support/bittide-hal/src/manual_additions/ring_buffer.rs
+++ b/firmware-support/bittide-hal/src/manual_additions/ring_buffer.rs
@@ -2,6 +2,10 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::manual_additions::{
+    index::{Index, IndexInterface, IndexSizeCheck},
+    FromAs, IntoAs,
+};
 use log::{debug, trace, warn};
 
 const ALIGNMENT_ANNOUNCE: u64 = 0xBADC0FFEE;
@@ -96,9 +100,11 @@ pub trait ReceiveRingBufferInterface {
     const DATA_LEN: usize;
     const CLEAR_AT_COUNT_SIZE: usize;
 
+    type CountIdx: IndexInterface + IndexSizeCheck<Inner: FromAs<usize>>;
+
     fn base_ptr(&self) -> *const [u8; 8];
 
-    fn set_clear_at_count(&self, count: usize);
+    fn set_clear_at_count(&self, count: Self::CountIdx);
 
     /// Sets the enable register for the receive ring_buffer. When enabled, incoming frames from
     /// the network will be written to the buffer at an address determined by an internal free
@@ -141,7 +147,7 @@ pub trait ReceiveRingBufferInterface {
 }
 
 macro_rules! impl_ring_buffer_interfaces {
-    (rx: $rx:ty, tx: $tx:ty) => {
+    (rx: $rx:ty, tx: $tx:ty, cidx: $cidx:ty$(,)?) => {
         const _: () = {
             if <$rx>::DATA_LEN != <$tx>::DATA_LEN {
                 const_panic::concat_panic!(
@@ -157,11 +163,13 @@ macro_rules! impl_ring_buffer_interfaces {
             const DATA_LEN: usize = <$rx>::DATA_LEN;
             const CLEAR_AT_COUNT_SIZE: usize = <$rx>::CLEAR_AT_COUNT_SIZE;
 
+            type CountIdx = $cidx;
+
             fn base_ptr(&self) -> *const [u8; 8] {
                 self.0.cast::<[u8; 8]>()
             }
-            fn set_clear_at_count(&self, count: usize) {
-                assert!(count < Self::CLEAR_AT_COUNT_SIZE);
+            fn set_clear_at_count(&self, count: $cidx) {
+                assert!(usize::from_as(count.into_inner()) < Self::CLEAR_AT_COUNT_SIZE);
                 <$rx>::set_clear_at_count(self, count.try_into().unwrap());
             }
             fn set_enable(&self, enabled: bool) {
@@ -191,7 +199,8 @@ macro_rules! impl_ring_buffer_interfaces {
 
 impl_ring_buffer_interfaces! {
     rx: crate::shared_devices::ReceiveRingBuffer,
-    tx: crate::shared_devices::TransmitRingBuffer
+    tx: crate::shared_devices::TransmitRingBuffer,
+    cidx: Index<16, u8>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -256,7 +265,9 @@ where
                             self.phase = AlignPhase::AcknowledgingAlignment;
                             return false;
                         } else {
-                            self.buffer.set_clear_at_count(rx_idx);
+                            self.buffer.set_clear_at_count(unsafe {
+                                Rx::CountIdx::idx_new_unchecked(rx_idx.into_as())
+                            });
                         }
                     }
                 }

--- a/firmware-support/bittide-hal/src/manual_additions/scatter_gather_pe/scatter_gather.rs
+++ b/firmware-support/bittide-hal/src/manual_additions/scatter_gather_pe/scatter_gather.rs
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 use crate::hals::scatter_gather_pe::devices::{GatherUnit, ScatterUnit};
+use bittide_macros::BitVector;
 
 impl GatherUnit {
     /// Write a slice to the gather memory.
@@ -10,7 +11,7 @@ impl GatherUnit {
     ///
     /// The source memory size must be smaller or equal to the memory size of
     /// the `GatherUnit` memory.
-    pub fn write_slice(&self, src: &[[u8; 8]], offset: usize) {
+    pub fn write_slice(&self, src: &[BitVector!(64)], offset: usize) {
         assert!(src.len() + offset <= Self::GATHER_MEMORY_LEN);
         let mut off = offset;
         for &val in src {
@@ -38,7 +39,7 @@ impl ScatterUnit {
     ///
     /// The destination memory size must be smaller or equal to the memory size
     ///  of the `ScatterUnit`.
-    pub fn read_slice(&self, dst: &mut [[u8; 8]], offset: usize) {
+    pub fn read_slice(&self, dst: &mut [BitVector!(64)], offset: usize) {
         assert!(dst.len() + offset <= Self::SCATTER_MEMORY_LEN);
         let mut off = offset;
         for val in dst {

--- a/firmware-support/bittide-hal/src/manual_additions/si539x_spi.rs
+++ b/firmware-support/bittide-hal/src/manual_additions/si539x_spi.rs
@@ -1,12 +1,12 @@
 // SPDX-FileCopyrightText: 2025 Google LLC
 //
 // SPDX-License-Identifier: Apache-2.0
-use crate::manual_additions::timer::Duration;
-use crate::shared_devices::Si539xSpi;
-use crate::shared_devices::Timer;
-use crate::types::Maybe::{Just, Nothing};
-use crate::types::RegisterOperation;
-
+use crate::{
+    manual_additions::{bitvector::BitVector, timer::Duration, ConvertOptional},
+    shared_devices::{Si539xSpi, Timer},
+    types::{Maybe::Nothing, RegisterOperation},
+};
+use bittide_macros::bitvector;
 use ufmt::derive::uDebug;
 
 pub struct Config<const PRE_LEN: usize, const CFG_LEN: usize, const PST_LEN: usize> {
@@ -25,9 +25,9 @@ pub struct ConfigEntry {
 impl From<ConfigEntry> for RegisterOperation {
     fn from(value: ConfigEntry) -> Self {
         RegisterOperation {
-            page: [value.page],
-            address: [value.address],
-            write: Just([value.data]),
+            page: bitvector!([value.page], n = 8),
+            address: bitvector!([value.address], n = 8),
+            write: BitVector::new([value.data]).conv_optional(),
         }
     }
 }
@@ -149,8 +149,8 @@ impl Si539xSpi {
     /// Perform a read operation.
     pub fn read(&self, page: u8, address: u8) -> u8 {
         let read_op = RegisterOperation {
-            page: [page],
-            address: [address],
+            page: bitvector!([page], n = 8),
+            address: bitvector!([address], n = 8),
             write: Nothing,
         };
         self.set_register_operation(read_op);
@@ -158,7 +158,7 @@ impl Si539xSpi {
         while self.commit() {
             continue;
         }
-        self.read_data()[0]
+        self.read_data().into_inner()[0]
     }
 
     /// Perform a write operation.

--- a/firmware-support/bittide-hal/src/manual_additions/signed.rs
+++ b/firmware-support/bittide-hal/src/manual_additions/signed.rs
@@ -1,0 +1,573 @@
+// SPDX-FileCopyrightText: 2026 Google LLC
+//
+// SPDX-License-Identifier: Apache-2.0
+//! Types, traits, and implementations for signed types
+//!
+//! # Note
+//!
+//! The way that this crate constrains [`Signed<N, T>`]s to the correct size is by ensuring that
+//! evaulation of a constant succeeds. As such, when writing `impl`s on [`Signed<N, T>`], users
+//! should make sure to force evaluation of [`SignedSizeCheck::SIZE_CHECK`].
+//!
+//! Alternatively, one can make use of `bittide_macros::Signed!` and `bittide_macros::signed!` to
+//! make types/instances with the correct parameters.
+#![deny(missing_docs)]
+
+use super::{index::Index, unsigned::Unsigned, FromAs};
+
+/// Type representing a signed value of `N` bits, backed by the smallest useable signed type
+///
+/// This is equivalent to a [`packC`'d][bpc] [`Signed n`][sgn] from Clash. This type should be
+/// backed by the smallest signed integer of `N` bits or more. For example, a `Signed<7, _>` should
+/// be `Signed<7, i8>` and `Signed<65, _>` should be `Signed<65, i128>`.
+///
+/// [bpc]: https://github.com/QBayLogic/clash-protocols-memmap/blob/main/clash-bitpackc/src/Clash/Class/BitPackC.hs#L39-L44
+/// [sgn]: https://hackage-content.haskell.org/package/clash-prelude-1.8.4/docs/Clash-Sized-Signed.html#t:Signed
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(transparent)]
+pub struct Signed<const N: u8, T>(pub(crate) T);
+
+/// Trait for making guarantees about the size and validity of signed types
+pub trait SignedSizeCheck {
+    /// The correct size of the backing type in bits
+    const CORRECT_SIZE: u8;
+    /// This `const` should be instantiated in methods implemented on [`Signed<N, T>`], since it is
+    /// how they are constrained to the correct size. If they're improperly sized, this `const` will
+    /// fail to evaluate and produce a compile error.
+    ///
+    /// # Examples
+    ///
+    /// Signed types with an appropriate backing type will compile successfully:
+    /// ```
+    /// # use bittide_hal::manual_additions::signed::{Signed, SignedSizeCheck};
+    /// trait Marker {
+    ///     fn nothing();
+    /// }
+    ///
+    /// impl Marker for Signed<3, i8> {
+    ///     fn nothing() {
+    ///         let _ = Self::SIZE_CHECK;
+    ///     }
+    /// }
+    ///
+    /// impl Marker for Signed<14, i16> {
+    ///     fn nothing() {
+    ///         let _ = Self::SIZE_CHECK;
+    ///     }
+    /// }
+    ///
+    /// impl Marker for Signed<26, i32> {
+    ///     fn nothing() {
+    ///         let _ = Self::SIZE_CHECK;
+    ///     }
+    /// }
+    ///
+    /// impl Marker for Signed<43, i64> {
+    ///     fn nothing() {
+    ///         let _ = Self::SIZE_CHECK;
+    ///     }
+    /// }
+    ///
+    /// impl Marker for Signed<97, i128> {
+    ///     fn nothing() {
+    ///         let _ = Self::SIZE_CHECK;
+    ///     }
+    /// }
+    /// ```
+    /// But signed types with improperly sized backing types will produce an error. For example,
+    /// when the backing type is too small:
+    /// ```compile_fail
+    /// # use bittide_hal::manual_additions::signed::{Signed, SignedSizeCheck};
+    /// trait Marker {
+    ///     fn nothing();
+    /// }
+    ///
+    /// impl Marker for Signed<15, i8> {
+    ///     fn nothing() {
+    ///         let _ = Self::SIZE_CHECK;
+    ///     }
+    /// }
+    /// ```
+    /// This produces the error
+    /// ```text
+    /// error[E0080]: evaluation of `<Signed<15, i8> as SignedSizeCheck>::SIZE_CHECK` failed
+    ///    --> manual_additions/signed.rs
+    ///     |
+    ///     | impl_usc!(i8, i16, i32, i64, i128);
+    ///     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: Specified bit size `15` is too large for backing type `i8`
+    ///     |
+    ///     = note: this error originates in the macro `const_panic::concat_panic` which comes from the expansion of the macro `impl_usc` (in Nightly builds, run with -Z macro-backtrace for more info)
+    ///
+    /// note: erroneous constant encountered
+    ///   --> manual_additions/signed.rs
+    ///    |
+    ///    |         let _ = Self::SIZE_CHECK;
+    ///    |                 ^^^^^^^^^^^^^^^^
+    /// ```
+    /// Or when the backing type is too large:
+    /// ```compile_fail
+    /// # use bittide_hal::manual_additions::signed::{Signed, SignedSizeCheck};
+    /// trait Marker {
+    ///     fn nothing();
+    /// }
+    ///
+    /// impl Marker for Signed<15, i32> {
+    ///     fn nothing() {
+    ///         let _ = Self::SIZE_CHECK;
+    ///     }
+    /// }
+    /// ```
+    /// This produces the error
+    /// ```text
+    /// error[E0080]: evaluation of `<Signed<15, i32> as SignedSizeCheck>::SIZE_CHECK` failed
+    ///    --> manual_additions/signed.rs
+    ///     |
+    ///     | impl_usc!(i8, i16, i32, i64, i128);
+    ///     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: Type `i32` is not optimally sized for bound 15. Use type `i16` instead.
+    ///     |
+    ///     = note: this error originates in the macro `const_panic::concat_panic` which comes from the expansion of the macro `impl_usc` (in Nightly builds, run with -Z macro-backtrace for more info)
+    ///
+    /// note: erroneous constant encountered
+    ///   --> manual_additions/signed.rs
+    ///    |
+    ///    |         let _ = Self::SIZE_CHECK;
+    ///    |                 ^^^^^^^^^^^^^^^^
+    /// ```
+    /// Or when requesting a signed 0 bit number:
+    /// ```compile_fail
+    /// # use bittide_hal::manual_additions::signed::{Signed, SignedSizeCheck};
+    /// trait Marker {
+    ///     fn nothing();
+    /// }
+    ///
+    /// impl Marker for Signed<0, i32> {
+    ///     fn nothing() {
+    ///         let _ = Self::SIZE_CHECK;
+    ///     }
+    /// }
+    /// ```
+    /// ```text
+    /// error[E0080]: evaluation of `<Signed<0, i32> as SignedSizeCheck>::SIZE_CHECK` failed
+    ///    --> manual_additions/signed.rs
+    ///     |
+    ///     | impl_usc!(i8, i16, i32, i64, i128);
+    ///     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: Cannot represent Signed<0, T>!
+    ///     |
+    ///     = note: this error originates in the macro `const_panic::concat_panic` which comes from the expansion of the macro `impl_usc` (in Nightly builds, run with -Z macro-backtrace for more info)
+    ///
+    /// note: erroneous constant encountered
+    ///   --> manual_additions/signed.rs
+    ///    |
+    ///    |         let _ = Self::SIZE_CHECK;
+    ///    |                 ^^^^^^^^^^^^^^^^
+    /// ```
+    const SIZE_CHECK: ();
+    /// Backing type of a signed number
+    type Inner: Copy;
+    /// Perform a bounds check on an instance of a signed number. Returns `true` if within bounds,
+    /// `false` if not.
+    fn inner_bounds_check(val: Self::Inner) -> bool;
+}
+
+macro_rules! impl_snc {
+    ($($t:ty | $ut:ty),+$(,)?) => {
+        $(
+            impl<const N: u8> SignedSizeCheck for Signed<N, $t> {
+                const CORRECT_SIZE: u8 = {
+                    match N.div_ceil(8).next_power_of_two() * 8 {
+                        size if size >= 8 => size,
+                        _ => 8,
+                    }
+                };
+                const SIZE_CHECK: () = {
+                    if N < 2 {
+                        const_panic::concat_panic!(
+                            const_panic::fmt::FmtArg::DISPLAY;
+                            "Cannot represent Signed<", N, ", T>!",
+                        );
+                    }
+                    if N > <$t>::BITS as u8 {
+                        const_panic::concat_panic!(
+                            const_panic::fmt::FmtArg::DISPLAY;
+                            "Specified bit size `",
+                            N,
+                            "` is too large for backing type `",
+                            stringify!($t),
+                            "`",
+                        );
+                    } else if Self::CORRECT_SIZE != <$t>::BITS as u8 {
+                        const_panic::concat_panic!(
+                            const_panic::fmt::FmtArg::DISPLAY;
+                            "Type `",
+                            stringify!($t),
+                            "` is not optimally sized for bound ",
+                            N,
+                            ". Use type `i",
+                            Self::CORRECT_SIZE,
+                            "` instead.",
+                        );
+                    }
+                };
+                type Inner = $t;
+                #[inline]
+                fn inner_bounds_check(val: $t) -> bool {
+                    let _: () = Self::SIZE_CHECK; // READ THE REST OF THE ERROR MESSAGE
+                    if const { Self::CORRECT_SIZE == N } {
+                        true
+                    } else if val.is_negative() {
+                        // val >= const { 1 << (N - 1) }
+                        val > const {
+                            let ut: $ut = !0;
+                            ut.unbounded_shl(N as u32) as $t
+                        }
+                    } else {
+                        // val <= const { !(!0 << (N - 1)) }
+                        val < const {
+                            let t: $t = 1;
+                            t.unbounded_shl(N as u32 - 1)
+                        }
+                    }
+                }
+            }
+        )+
+    };
+}
+
+impl_snc!(i8 | u8, i16 | u16, i32 | u32, i64 | u64, i128 | u128);
+
+impl<const N: u8, T> Signed<N, T>
+where
+    T: Copy,
+    Signed<N, T>: SignedSizeCheck<Inner = T>,
+{
+    /// Instantiate a new `Signed<N, T>`
+    ///
+    /// Returns `Some(_)` if `val` fits within `N` bits, returns `None` otherwise.
+    ///
+    /// # Errors
+    ///
+    /// This function may error if invoked as `Signed::<N, T>::new(...)` and the wrong backing type
+    /// `T` is chosen. Please read the whole error message carefully, it should tell you what
+    /// to do to fix it.
+    #[inline]
+    pub fn new(val: T) -> Option<Signed<N, T>> {
+        let _: () = Self::SIZE_CHECK; // READ THE REST OF THE ERROR MESSAGE
+        if Signed::<N, T>::inner_bounds_check(val) {
+            Some(Signed(val))
+        } else {
+            None
+        }
+    }
+
+    /// Instantiate a new `Signed<N, T>` without performing a bounds check
+    ///
+    /// # Errors
+    ///
+    /// This function may error if invoked as `Signed::<N, T>::new_unchecked(...)` and the wrong
+    /// backing type `T` is chosen. Please read the whole error message carefully, it should tell
+    /// you what to do to fix it.
+    ///
+    /// # Safety
+    ///
+    /// Due to the intended use-case of interfacing with Clash hardware, and there being no
+    /// guarantee of behaviour in the case that an out-of-bounds value is written to a register,
+    /// this function has been marked as `unsafe`. To make calling this function safe, you must
+    /// guarantee that `val` is in the range `-2.pow(N - 1)..2.pow(N - 1)`.
+    ///
+    /// There's one exception to this: it is always safe to call `new_unchecked` if `N` is the same
+    /// number of bits as `T`. For example, `Signed::<32, i32>::new_unchecked` is always safe.
+    #[inline]
+    pub unsafe fn new_unchecked(val: T) -> Signed<N, T> {
+        let _: () = Self::SIZE_CHECK; // READ THE REST OF THE ERROR MESSAGE
+        Signed(val)
+    }
+
+    /// Unwrap the inner value contained by this `Signed<N, T>`
+    #[inline]
+    pub fn into_inner(self) -> T {
+        let _: () = Self::SIZE_CHECK; // READ THE REST OF THE ERROR MESSAGE
+        self.0
+    }
+}
+
+impl<const N: u8, T> core::fmt::Debug for Signed<N, T>
+where
+    Self: SignedSizeCheck,
+    T: core::fmt::Debug,
+{
+    #[inline]
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "Signed<{N}>({:?})", self.0)
+    }
+}
+
+impl<const N: u8, T> core::fmt::Display for Signed<N, T>
+where
+    Self: SignedSizeCheck,
+    T: core::fmt::Display,
+{
+    #[inline]
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl<const N: u8, T> ufmt::uDebug for Signed<N, T>
+where
+    Self: SignedSizeCheck,
+    T: ufmt::uDebug,
+{
+    #[inline]
+    fn fmt<W>(&self, fmt: &mut ufmt::Formatter<'_, W>) -> Result<(), W::Error>
+    where
+        W: ufmt::uWrite + ?Sized,
+    {
+        ufmt::uwrite!(fmt, "Signed<{}>({:?})", N, self.0)
+    }
+}
+
+impl<const N: u8, T> ufmt::uDisplay for Signed<N, T>
+where
+    Self: SignedSizeCheck,
+    T: ufmt::uDisplay,
+{
+    #[inline]
+    fn fmt<W>(&self, fmt: &mut ufmt::Formatter<'_, W>) -> Result<(), W::Error>
+    where
+        W: ufmt::uWrite + ?Sized,
+    {
+        ufmt::uwrite!(fmt, "{}", self.0)
+    }
+}
+
+impl<const N: u8, T> ufmt::uDisplayHex for Signed<N, T>
+where
+    Self: SignedSizeCheck,
+    T: ufmt::uDisplayHex,
+{
+    #[inline]
+    fn fmt_hex<W>(
+        &self,
+        fmt: &mut ufmt::Formatter<'_, W>,
+        options: ufmt::HexOptions,
+    ) -> Result<(), W::Error>
+    where
+        W: ufmt::uWrite + ?Sized,
+    {
+        <T as ufmt::uDisplayHex>::fmt_hex(&self.0, fmt, options)
+    }
+}
+
+impl<const N: u8, T> super::seal::Seal for Signed<N, T> where T: super::seal::Seal {}
+
+/// Trait that guarantees parts of the [`Signed<N, T>`] inherent implementations
+///
+/// Intended for use where it is not desirable to constrain a type to be `T = Signed<N, T>` but
+/// rather to `T: SignedInterface`.
+pub trait SignedInterface: Sized + SignedSizeCheck + super::seal::Seal {
+    /// Instantiate a new [`Signed<N, T>`]
+    ///
+    /// Returns `Some(_)` if `val` fits within `N` bits, returns `None` otherwise.
+    ///
+    /// # Errors
+    ///
+    /// This function may error if invoked as `Signed::<N, T>::sgn_new(...)` and the wrong backing
+    /// type `T` is chosen. Please read the whole error message carefully, it should tell you what
+    /// to do to fix it.
+    fn sgn_new(val: Self::Inner) -> Option<Self>;
+    /// Instantiate a new [`Signed<N, T>`] without performing a bounds check
+    ///
+    /// # Errors
+    ///
+    /// This function may error if invoked as `Signed::<N, T>::sgn_new_unchecked(...)` and the wrong
+    /// backing type `T` is chosen. Please read the whole error message carefully, it should tell
+    /// you what to do to fix it.
+    ///
+    /// # Safety
+    ///
+    /// Due to the intended use-case of interfacing with Clash hardware, and there being no
+    /// guarantee of behaviour in the case that an out-of-bounds value is written to a register,
+    /// this function has been marked as `unsafe`. To make calling this function safe, you must
+    /// guarantee that `val` is in the range `-2.pow(N - 1)..2.pow(N - 1)`.
+    unsafe fn sgn_new_unchecked(val: Self::Inner) -> Self;
+    /// Unwrap the inner value contained by this [`Signed<N, T>`]
+    fn sgn_into_inner(self) -> Self::Inner;
+}
+
+impl<const N: u8, T> SignedInterface for Signed<N, T>
+where
+    T: Copy + super::seal::Seal,
+    Signed<N, T>: SignedSizeCheck<Inner = T>,
+{
+    #[inline]
+    fn sgn_new(val: Self::Inner) -> Option<Self> {
+        Self::new(val)
+    }
+
+    #[inline]
+    unsafe fn sgn_new_unchecked(val: Self::Inner) -> Self {
+        Self::new_unchecked(val)
+    }
+
+    #[inline]
+    fn sgn_into_inner(self) -> Self::Inner {
+        self.into_inner()
+    }
+}
+
+macro_rules! def_signed_from {
+    // Entry
+    ($($t:ty),+$(,)?) => {
+        def_signed_from! {
+            @run
+            sup: [$($t),+],
+            sub: [],
+        }
+    };
+    // Base case
+    (
+        @run
+        sup: [],
+        sub: $sub:tt,
+    ) => {};
+    // Recursive case
+    (
+        @run
+        sup: [$h:ty$(, $t:ty)*],
+        sub: [$($sub:ty),*],
+    ) => {
+        // Expand defs for current head of big type
+        $( // for $sub in $($sub),*:
+            def_signed_from! {
+                @def
+                sup: $h,
+                sub: $sub,
+            }
+        )*
+
+        // Push big type to list of smaller types
+        def_signed_from! {
+            @run
+            sup: [$($t),*],
+            sub: [$($sub,)* $h],
+        }
+    };
+    // Expand to `impl`s
+    (
+        @def
+        sup: $sup:ty,
+        sub: $sub:ty,
+    ) => {
+        impl<const N: u8> From<$sub> for Signed<N, $sup> {
+            #[inline]
+            fn from(value: $sub) -> Self {
+                Signed(value as $sup)
+            }
+        }
+
+        impl<const M: u8, const N: u8> From<Signed<N, $sub>> for Signed<M, $sup> {
+            #[inline]
+            fn from(value: Signed<N, $sub>) -> Self {
+                Signed(value.0 as $sup)
+            }
+        }
+
+        impl<const M: u8, const N: u128> From<Index<N, $sub>> for Signed<M, $sup> {
+            #[inline]
+            fn from(value: Index<N, $sub>) -> Self {
+                Signed(value.0 as $sup)
+            }
+        }
+
+        impl<const M: u8, const N: u8> From<Unsigned<N, $sub>> for Signed<M, $sup> {
+            #[inline]
+            fn from(value: Unsigned<N, $sub>) -> Self {
+                Signed(value.0 as $sup)
+            }
+        }
+        impl<const N: u8> FromAs<$sub> for Signed<N, $sup> {
+            fn from_as(value: $sub) -> Self {
+                Signed(value as $sup)
+            }
+        }
+
+        impl<const M: u8, const N: u8> FromAs<Signed<N, $sub>> for Signed<M, $sup> {
+            #[inline]
+            fn from_as(value: Signed<N, $sub>) -> Self {
+                Signed(value.0 as $sup)
+            }
+        }
+
+        impl<const M: u8, const N: u128> FromAs<Index<N, $sub>> for Signed<M, $sup> {
+            #[inline]
+            fn from_as(value: Index<N, $sub>) -> Self {
+                Signed(value.0 as $sup)
+            }
+        }
+
+        impl<const M: u8, const N: u8> FromAs<Unsigned<N, $sub>> for Signed<M, $sup> {
+            #[inline]
+            fn from_as(value: Unsigned<N, $sub>) -> Self {
+                Signed(value.0 as $sup)
+            }
+        }
+    }
+}
+
+def_signed_from!(i8, i16, i32, i64, i128);
+
+#[cfg(target_pointer_width = "16")]
+def_signed_from! {
+    @run
+    sup: [isize],
+    sub: [i8],
+}
+
+#[cfg(target_pointer_width = "32")]
+def_signed_from! {
+    @run
+    sup: [isize],
+    sub: [i8, i16],
+}
+
+#[cfg(target_pointer_width = "64")]
+def_signed_from! {
+    @run
+    sup: [isize],
+    sub: [i8, i16, i32],
+}
+
+subst_macros::repeat_parallel_subst! {
+    groups: [
+        [group [sub [INTO] = [i8]]]
+        [group [sub [INTO] = [i16]]]
+        [group [sub [INTO] = [i32]]]
+        [group [sub [INTO] = [i64]]]
+        [group [sub [INTO] = [i128]]]
+        [group [sub [INTO] = [isize]]]
+    ],
+    callback: NONE,
+    in: {
+        impl<const N: u8, T> From<Signed<N, T>> for INTO
+        where
+            Signed<N, T>: SignedSizeCheck,
+            INTO: From<T>,
+        {
+            #[inline]
+            fn from(other: Signed<N, T>) -> INTO {
+                INTO::from(other.0)
+            }
+        }
+
+        impl<const N: u8, T> FromAs<Signed<N, T>> for INTO
+        where
+            Signed<N, T>: SignedSizeCheck,
+            INTO: FromAs<T>,
+        {
+            #[inline]
+            fn from_as(other: Signed<N, T>) -> INTO {
+                INTO::from_as(other.0)
+            }
+        }
+    }
+}

--- a/firmware-support/bittide-hal/src/manual_additions/soft_ugn_demo_mu/scatter_gather.rs
+++ b/firmware-support/bittide-hal/src/manual_additions/soft_ugn_demo_mu/scatter_gather.rs
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 use crate::soft_ugn_demo_mu::devices::{GatherUnit, ScatterUnit};
+use bittide_macros::BitVector;
 
 impl GatherUnit {
     /// Write a slice to the gather memory.
@@ -10,7 +11,7 @@ impl GatherUnit {
     ///
     /// The source memory size must be smaller or equal to the memory size of
     /// the `GatherUnit` memory.
-    pub fn write_slice(&self, src: &[[u8; 8]], offset: usize) {
+    pub fn write_slice(&self, src: &[BitVector!(64)], offset: usize) {
         assert!(src.len() + offset <= Self::GATHER_MEMORY_LEN);
         let mut off = offset;
         for &val in src {
@@ -38,7 +39,7 @@ impl ScatterUnit {
     ///
     /// The destination memory size must be smaller or equal to the memory size
     ///  of the `ScatterUnit`.
-    pub fn read_slice(&self, dst: &mut [[u8; 8]], offset: usize) {
+    pub fn read_slice(&self, dst: &mut [BitVector!(64)], offset: usize) {
         assert!(dst.len() + offset <= Self::SCATTER_MEMORY_LEN);
         let mut off = offset;
         for val in dst {

--- a/firmware-support/bittide-hal/src/manual_additions/timer.rs
+++ b/firmware-support/bittide-hal/src/manual_additions/timer.rs
@@ -13,9 +13,9 @@ insignificant for timing purposes.
  - [`Clock`] Manages time and provides utility methods for waiting and updating time.
 */
 
-use crate::shared_devices::Timer;
-use crate::types::TimeCmd;
+use crate::{shared_devices::Timer, types::TimeCmd};
 
+use bittide_macros::{unsigned, Unsigned};
 use core::cmp;
 use core::fmt;
 use core::ops;
@@ -301,7 +301,7 @@ impl Timer {
     ///
     /// Returns:
     /// - The current value of the time counter as a `u64`.
-    fn get_counter(&self) -> u64 {
+    fn get_counter(&self) -> Unsigned!(64) {
         self.freeze();
         self.scratchpad()
     }
@@ -310,30 +310,30 @@ impl Timer {
     pub fn now(&self) -> Instant {
         let cycles = self.get_counter();
         let frequency = self.frequency();
-        Instant::from_cycles(cycles, frequency)
+        Instant::from_cycles(cycles.into(), frequency.into())
     }
 
     /// Wait for a `Duration` without stalling.
     pub fn wait(&self, duration: Duration) {
-        let now = self.get_counter();
-        let cycles = duration.cycles(self.frequency());
+        let now = self.get_counter().into_inner();
+        let cycles = duration.cycles(self.frequency().into_inner());
         let _ = self.wait_until_raw(now + cycles);
     }
 
     /// Wait until we have passed an `Instant`.
     #[must_use]
     pub fn wait_until(&self, target: Instant) -> WaitResult {
-        let target_cycles = target.get_cycles(self.frequency());
+        let target_cycles = target.get_cycles(self.frequency().into());
         self.wait_until_raw(target_cycles)
     }
 
     #[must_use]
     pub fn wait_until_raw(&self, target: u64) -> WaitResult {
-        let now = self.get_counter();
+        let now = self.get_counter().into_inner();
         if now > target {
             return WaitResult::AlreadyPassed;
         }
-        self.set_scratchpad(target);
+        self.set_scratchpad(unsigned!(target, n = 64));
         while !self.cmp_result() {
             continue;
         }
@@ -342,24 +342,24 @@ impl Timer {
 
     /// Stall the CPU until the comparison set by `timer_cmp` is `True`.
     pub fn wait_stall(&self, duration: Duration) {
-        let now = self.get_counter();
-        let duration = duration.cycles(self.frequency());
+        let now = self.get_counter().into_inner();
+        let duration = duration.cycles(self.frequency().into());
         let _ = self.wait_until_stall_raw(now + duration);
     }
 
     #[must_use]
     pub fn wait_until_stall(&self, target: Instant) -> WaitResult {
-        let target_cycles = target.get_cycles(self.frequency());
+        let target_cycles = target.get_cycles(self.frequency().into_inner());
         self.wait_until_stall_raw(target_cycles)
     }
 
     #[must_use]
     pub fn wait_until_stall_raw(&self, target: u64) -> WaitResult {
-        let now = self.get_counter();
+        let now = self.get_counter().into_inner();
         if now > target {
             return WaitResult::AlreadyPassed;
         }
-        self.set_scratchpad(target);
+        self.set_scratchpad(unsigned!(target, n = 64));
         self.wait_for_cmp();
         WaitResult::Success
     }

--- a/firmware-support/bittide-hal/src/manual_additions/timer/self_test.rs
+++ b/firmware-support/bittide-hal/src/manual_additions/timer/self_test.rs
@@ -75,7 +75,7 @@ pub fn self_test(timer: Timer) -> impl Iterator<Item = (&'static str, TestReturn
 
 /// Obtain the value of the counter, check if it's not 0.
 pub fn now_not_null(timer: Timer) -> TestReturn {
-    let frequency = timer.frequency();
+    let frequency = timer.frequency().into_inner();
     let now = timer.now();
     if now == Instant::from_cycles(0, frequency) {
         Some((
@@ -89,7 +89,7 @@ pub fn now_not_null(timer: Timer) -> TestReturn {
 
 /// Read the frequency value, check if it's not 0.
 pub fn freq_not_null(timer: Timer) -> TestReturn {
-    let frequency: u64 = timer.frequency();
+    let frequency: u64 = timer.frequency().into_inner();
     if frequency == 0 {
         Some(("freq_not_null test failed: frequency is null", None))
     } else {

--- a/firmware-support/bittide-hal/src/manual_additions/uart.rs
+++ b/firmware-support/bittide-hal/src/manual_additions/uart.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::shared_devices::uart::Uart;
+use bittide_macros::bitvector;
 
 pub struct UartStatus {
     pub receive_buffer_empty: bool,
@@ -65,7 +66,7 @@ impl Uart {
         if self.read_status().transmit_buffer_full {
             Err(TransmitBufferFull)
         } else {
-            self.set_data([data]);
+            self.set_data(bitvector!([data], n = 8));
             Ok(())
         }
     }

--- a/firmware-support/bittide-hal/src/manual_additions/unsigned.rs
+++ b/firmware-support/bittide-hal/src/manual_additions/unsigned.rs
@@ -1,0 +1,568 @@
+// SPDX-FileCopyrightText: 2026 Google LLC
+//
+// SPDX-License-Identifier: Apache-2.0
+//! Types, traits, and implementations for unsigned types
+//!
+//! # Note
+//!
+//! The way that this crate constrains [`Unsigned<N, T>`]s to the correct size is by ensuring that
+//! evaulation of a constant succeeds. As such, when writing `impl`s on [`Unsigned<N, T>`], users
+//! should make sure to force evaluation of [`UnsignedSizeCheck::SIZE_CHECK`].
+//!
+//! Alternatively, one can make use of `bittide_macros::Unsigned!` and `bittide_macros::unsigned!`
+//! to make types/instances with the correct parameters.
+#![deny(missing_docs)]
+
+use super::{index::Index, signed::Signed, FromAs};
+
+/// Type representing an unsigned value of `N` bits, backed by the smallest useable unsigned type
+///
+/// This is equivalent to a [`packC`'d][bpc] [`Unsigned n`][usn] from Clash. This type should be
+/// backed by the smallest signed integer of `N` bits or more. For example, a `Unsigned<7, _>` should
+/// be `Unsigned<7, u8>` and `Unsigned<65, _>` should be `Unsigned<65, u128>`.
+///
+/// [bpc]: https://github.com/QBayLogic/clash-protocols-memmap/blob/main/clash-bitpackc/src/Clash/Class/BitPackC.hs#L39-L44
+/// [usn]: https://hackage-content.haskell.org/package/clash-prelude-1.8.4/docs/Clash-Sized-Unsigned.html#t:Unsigned
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(transparent)]
+pub struct Unsigned<const N: u8, T>(pub(crate) T);
+
+/// Trait for making guarantees about the size and validity of unsigned types
+pub trait UnsignedSizeCheck {
+    /// The correct size of the backing type in bits
+    const CORRECT_SIZE: u8;
+    /// Generic parameter to the unsigned type exposed as a `u32`
+    const BITS: u32;
+    /// This `const` should be instantiated in methods implemented on [`Unsigned<N, T>`], since it is
+    /// how they are constrained to the correct size. If they're improperly sized, this `const` will
+    /// fail to evaluate and produce a compile error.
+    ///
+    /// # Examples
+    ///
+    /// Unsigned types with an appropriate backing type will compile successfully:
+    /// ```
+    /// # use bittide_hal::manual_additions::unsigned::{Unsigned, UnsignedSizeCheck};
+    /// trait Marker {
+    ///     fn nothing();
+    /// }
+    ///
+    /// impl Marker for Unsigned<3, u8> {
+    ///     fn nothing() {
+    ///         let _ = Self::SIZE_CHECK;
+    ///     }
+    /// }
+    ///
+    /// impl Marker for Unsigned<14, u16> {
+    ///     fn nothing() {
+    ///         let _ = Self::SIZE_CHECK;
+    ///     }
+    /// }
+    ///
+    /// impl Marker for Unsigned<26, u32> {
+    ///     fn nothing() {
+    ///         let _ = Self::SIZE_CHECK;
+    ///     }
+    /// }
+    ///
+    /// impl Marker for Unsigned<43, u64> {
+    ///     fn nothing() {
+    ///         let _ = Self::SIZE_CHECK;
+    ///     }
+    /// }
+    ///
+    /// impl Marker for Unsigned<97, u128> {
+    ///     fn nothing() {
+    ///         let _ = Self::SIZE_CHECK;
+    ///     }
+    /// }
+    /// ```
+    /// But unsigned types with improperly sized backing types will produce an error. For example,
+    /// when the backing type is too small:
+    /// ```compile_fail
+    /// # use bittide_hal::manual_additions::unsigned::{Unsigned, UnsignedSizeCheck};
+    /// trait Marker {
+    ///     fn nothing();
+    /// }
+    ///
+    /// impl Marker for Unsigned<15, u8> {
+    ///     fn nothing() {
+    ///         let _ = Self::SIZE_CHECK;
+    ///     }
+    /// }
+    /// ```
+    /// This produces the error
+    /// ```text
+    /// error[E0080]: evaluation of `<Unsigned<15, u8> as UnsignedSizeCheck>::SIZE_CHECK` failed
+    ///    --> manual_additions/unsigned.rs
+    ///     |
+    ///     | impl_usc!(u8, u16, u32, u64, u128);
+    ///     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: Specified bit size `15` is too large for backing type `u8`
+    ///     |
+    ///     = note: this error originates in the macro `const_panic::concat_panic` which comes from the expansion of the macro `impl_usc` (in Nightly builds, run with -Z macro-backtrace for more info)
+    ///
+    /// note: erroneous constant encountered
+    ///   --> manual_additions/unsigned.rs
+    ///    |
+    ///    |         let _ = Self::SIZE_CHECK;
+    ///    |                 ^^^^^^^^^^^^^^^^
+    /// ```
+    /// Or when the backing type is too large:
+    /// ```compile_fail
+    /// # use bittide_hal::manual_additions::unsigned::{Unsigned, UnsignedSizeCheck};
+    /// trait Marker {
+    ///     fn nothing();
+    /// }
+    ///
+    /// impl Marker for Unsigned<15, u32> {
+    ///     fn nothing() {
+    ///         let _ = Self::SIZE_CHECK;
+    ///     }
+    /// }
+    /// ```
+    /// This produces the error
+    /// ```text
+    /// error[E0080]: evaluation of `<Unsigned<15, u32> as UnsignedSizeCheck>::SIZE_CHECK` failed
+    ///    --> manual_additions/unsigned.rs
+    ///     |
+    ///     | impl_usc!(u8, u16, u32, u64, u128);
+    ///     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: Type `u32` is not optimally sized for bound 15. Use type `u16` instead.
+    ///     |
+    ///     = note: this error originates in the macro `const_panic::concat_panic` which comes from the expansion of the macro `impl_usc` (in Nightly builds, run with -Z macro-backtrace for more info)
+    ///
+    /// note: erroneous constant encountered
+    ///   --> manual_additions/unsigned.rs
+    ///    |
+    ///    |         let _ = Self::SIZE_CHECK;
+    ///    |                 ^^^^^^^^^^^^^^^^
+    /// ```
+    /// Or when requesting a unsigned 0 bit number:
+    /// ```compile_fail
+    /// # use bittide_hal::manual_additions::unsigned::{Unsigned, UnsignedSizeCheck};
+    /// trait Marker {
+    ///     fn nothing();
+    /// }
+    ///
+    /// impl Marker for Unsigned<0, u32> {
+    ///     fn nothing() {
+    ///         let _ = Self::SIZE_CHECK;
+    ///     }
+    /// }
+    /// ```
+    /// ```text
+    /// error[E0080]: evaluation of `<Unsigned<0, u32> as UnsignedSizeCheck>::SIZE_CHECK` failed
+    ///    --> manual_additions/unsigned.rs
+    ///     |
+    ///     | impl_usc!(u8, u16, u32, u64, u128);
+    ///     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: Cannot represent Unsigned<0, T>!
+    ///     |
+    ///     = note: this error originates in the macro `const_panic::concat_panic` which comes from the expansion of the macro `impl_usc` (in Nightly builds, run with -Z macro-backtrace for more info)
+    ///
+    /// note: erroneous constant encountered
+    ///   --> manual_additions/unsigned.rs
+    ///    |
+    ///    |         let _ = Self::SIZE_CHECK;
+    ///    |                 ^^^^^^^^^^^^^^^^
+    /// ```
+    const SIZE_CHECK: ();
+    /// Backing type of this unsigned number
+    type Inner: Copy;
+    /// Perform a bounds check on an instance of an unsigned number. Returns `true` if within
+    /// bounds, `false` if not.
+    fn inner_bounds_check(val: Self::Inner) -> bool;
+}
+
+/// Type alias to access the backing type of an unsigned number
+pub type UnsignedInner<T> = <T as UnsignedSizeCheck>::Inner;
+
+macro_rules! impl_usc {
+    ($($t:ty),+$(,)?) => {
+        $(
+            impl<const N: u8> UnsignedSizeCheck for Unsigned<N, $t> {
+                const CORRECT_SIZE: u8 = {
+                    match N.div_ceil(8).next_power_of_two() * 8 {
+                        size if size >= 8 => size,
+                        _ => 8,
+                    }
+                };
+                const BITS: u32 = N as u32;
+                const SIZE_CHECK: () = {
+                    if N == 0 {
+                        panic!("Cannot represent Unsigned<0, T>!");
+                    }
+                    if N > <$t>::BITS as u8 {
+                        const_panic::concat_panic!(
+                            const_panic::fmt::FmtArg::DISPLAY;
+                            "Specified bit size `",
+                            N,
+                            "` is too large for backing type `",
+                            stringify!($t),
+                            "`",
+                        );
+                    } else if Self::CORRECT_SIZE != <$t>::BITS as u8 {
+                        const_panic::concat_panic!(
+                            const_panic::fmt::FmtArg::DISPLAY;
+                            "Type `",
+                            stringify!($t),
+                            "` is not optimally sized for bound ",
+                            N,
+                            ". Use type `u",
+                            Self::CORRECT_SIZE,
+                            "` instead.",
+                        );
+                    }
+                };
+                type Inner = $t;
+                #[inline]
+                fn inner_bounds_check(val: $t) -> bool {
+                    let _: () = Self::SIZE_CHECK; // READ THE REST OF THE ERROR MESSAGE
+                    if const { Self::CORRECT_SIZE == N } {
+                        true
+                    } else {
+                        val < const { 1 << (N - 1) }
+                    }
+                }
+            }
+        )+
+    };
+}
+
+impl_usc!(u8, u16, u32, u64, u128);
+
+impl<const N: u8, T> Unsigned<N, T>
+where
+    T: Copy,
+    Unsigned<N, T>: UnsignedSizeCheck<Inner = T>,
+{
+    /// Instantiate a new `Unsigned<N, T>`
+    ///
+    /// Returns `Some(_)` if `val` fits within `N` bits, returns `None` otherwise.
+    ///
+    /// # Errors
+    ///
+    /// This function may error if invoked as `Unsigned::<N, T>::new(...)` and the wrong backing
+    /// type `T` is chosen. Please read the whole error message carefully, it should tell you what
+    /// to do to fix it.
+    #[inline]
+    pub fn new(val: T) -> Option<Unsigned<N, T>> {
+        let _: () = Self::SIZE_CHECK; // READ THE REST OF THE ERROR MESSAGE
+        if Unsigned::<N, T>::inner_bounds_check(val) {
+            Some(Unsigned(val))
+        } else {
+            None
+        }
+    }
+
+    /// Instantiate a new `Unsigned<N, T>` without performing a bounds check
+    ///
+    /// # Errors
+    ///
+    /// This function may error if invoked as `Unsigned::<N, T>::new_unchecked(...)` and the wrong
+    /// backing type `T` is chosen. Please read the whole error message carefully, it should tell
+    /// you what to do to fix it.
+    ///
+    /// # Safety
+    ///
+    /// Due to the intended use-case of interfacing with Clash hardware, and there being no
+    /// guarantee of behaviour in the case that an out-of-bounds value is written to a register,
+    /// this function has been marked as `unsafe`. To make calling this function safe, you must
+    /// guarantee that `val` is in the range `0..2.pow(N)`.
+    ///
+    /// There's one exception to this: it is always safe to call `new_unchecked` if `N` is the same
+    /// number of bits as `T`. For example, `Unsigned::<8, u8>::new_unchecked` is always safe.
+    #[inline]
+    pub unsafe fn new_unchecked(val: T) -> Unsigned<N, T> {
+        let _: () = Self::SIZE_CHECK; // READ THE REST OF THE ERROR MESSAGE
+        Unsigned(val)
+    }
+
+    /// Unwrap the inner value contained by this `Unsigned<N, T>`
+    #[inline]
+    pub fn into_inner(self) -> T {
+        let _: () = Self::SIZE_CHECK; // READ THE REST OF THE ERROR MESSAGE
+        self.0
+    }
+}
+
+impl<const N: u8, T> core::fmt::Debug for Unsigned<N, T>
+where
+    Self: UnsignedSizeCheck,
+    T: core::fmt::Debug,
+{
+    #[inline]
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "Unsigned<{N}>({:?})", self.0)
+    }
+}
+
+impl<const N: u8, T> core::fmt::Display for Unsigned<N, T>
+where
+    Self: UnsignedSizeCheck,
+    T: core::fmt::Display,
+{
+    #[inline]
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl<const N: u8, T> ufmt::uDebug for Unsigned<N, T>
+where
+    Self: UnsignedSizeCheck,
+    T: ufmt::uDebug,
+{
+    #[inline]
+    fn fmt<W>(&self, fmt: &mut ufmt::Formatter<'_, W>) -> Result<(), W::Error>
+    where
+        W: ufmt::uWrite + ?Sized,
+    {
+        ufmt::uwrite!(fmt, "Unsigned<{}>({:?})", N, self.0)
+    }
+}
+
+impl<const N: u8, T> ufmt::uDisplay for Unsigned<N, T>
+where
+    Self: UnsignedSizeCheck,
+    T: ufmt::uDisplay,
+{
+    #[inline]
+    fn fmt<W>(&self, fmt: &mut ufmt::Formatter<'_, W>) -> Result<(), W::Error>
+    where
+        W: ufmt::uWrite + ?Sized,
+    {
+        ufmt::uwrite!(fmt, "{}", self.0)
+    }
+}
+
+impl<const N: u8, T> ufmt::uDisplayHex for Unsigned<N, T>
+where
+    Self: UnsignedSizeCheck,
+    T: ufmt::uDisplayHex,
+{
+    #[inline]
+    fn fmt_hex<W>(
+        &self,
+        fmt: &mut ufmt::Formatter<'_, W>,
+        options: ufmt::HexOptions,
+    ) -> Result<(), W::Error>
+    where
+        W: ufmt::uWrite + ?Sized,
+    {
+        <T as ufmt::uDisplayHex>::fmt_hex(&self.0, fmt, options)
+    }
+}
+
+impl<const N: u8, T> super::seal::Seal for Unsigned<N, T> where T: super::seal::Seal {}
+
+/// Trait that guarantees parts of the [`Unsigned<N, T>`] inherent implementations
+///
+/// Intended for use where it is not desirable to constrain a type to be `T = Unsigned<N, T>` but
+/// rather to `T: UnsignedInterface`.
+pub trait UnsignedInterface: Sized + UnsignedSizeCheck + super::seal::Seal {
+    /// Instantiate a new [`Unsigned<N, T>`]
+    ///
+    /// Returns `Some(_)` if `val` fits within `N` bits, returns `None` otherwise.
+    ///
+    /// # Errors
+    ///
+    /// This function may error if invoked as `Unsigned::<N, T>::uns_new(...)` and the wrong backing
+    /// type `T` is chosen. Please read the whole error message carefully, it should tell you what
+    /// to do to fix it.
+    fn uns_new(val: Self::Inner) -> Option<Self>;
+    /// Instantiate a new [`Unsigned<N, T>`] without performing a bounds check
+    ///
+    /// # Errors
+    ///
+    /// This function may error if invoked as `Unsigned::<N, T>::uns_new_unchecked(...)` and the
+    /// wrong backing type `T` is chosen. Please read the whole error message carefully, it should
+    /// tell you what to do to fix it.
+    ///
+    /// # Safety
+    ///
+    /// Due to the intended use-case of interfacing with Clash hardware, and there being no
+    /// guarantee of behaviour in the case that an out-of-bounds value is written to a register,
+    /// this function has been marked as `unsafe`. To make calling this function safe, you must
+    /// guarantee that `val` is in the range `0..2.pow(N)`.
+    unsafe fn uns_new_unchecked(val: Self::Inner) -> Self;
+    /// Unwrap the inner value contained by this [`Unsigned<N, T>`]
+    fn uns_into_inner(self) -> Self::Inner;
+}
+
+impl<const N: u8, T> UnsignedInterface for Unsigned<N, T>
+where
+    T: Copy + super::seal::Seal,
+    Unsigned<N, T>: UnsignedSizeCheck<Inner = T>,
+{
+    #[inline]
+    fn uns_new(val: Self::Inner) -> Option<Self> {
+        Self::new(val)
+    }
+
+    #[inline]
+    unsafe fn uns_new_unchecked(val: Self::Inner) -> Self {
+        Self::new_unchecked(val)
+    }
+
+    #[inline]
+    fn uns_into_inner(self) -> Self::Inner {
+        self.into_inner()
+    }
+}
+
+macro_rules! def_unsigned_from {
+    // Entry
+    ($($t:ty),+$(,)?) => {
+        def_unsigned_from! {
+            @run
+            sup: [$($t),+],
+            sub: [],
+        }
+    };
+    // Base case
+    (
+        @run
+        sup: [],
+        sub: $sub:tt,
+    ) => {};
+    // Recursive case
+    (
+        @run
+        sup: [$h:ty$(, $t:ty)*],
+        sub: [$($sub:ty),*],
+    ) => {
+        // Expand defs for current head of big type
+        $( // for $sub in $($sub),*:
+            def_unsigned_from! {
+                @def
+                sup: $h,
+                sub: $sub,
+            }
+        )*
+
+        // Push big type to list of smaller types
+        def_unsigned_from! {
+            @run
+            sup: [$($t),*],
+            sub: [$($sub,)* $h],
+        }
+    };
+    // Expand to `impl`s
+    (
+        @def
+        sup: $sup:ty,
+        sub: $sub:ty,
+    ) => {
+        impl<const N: u8> From<$sub> for Unsigned<N, $sup> {
+            #[inline]
+            fn from(value: $sub) -> Self {
+                Unsigned(value as $sup)
+            }
+        }
+
+        impl<const M: u8, const N: u8> From<Unsigned<N, $sub>> for Unsigned<M, $sup> {
+            #[inline]
+            fn from(value: Unsigned<N, $sub>) -> Self {
+                Unsigned(value.0 as $sup)
+            }
+        }
+
+        impl<const M: u8, const N: u128> From<Index<N, $sub>> for Unsigned<M, $sup> {
+            #[inline]
+            fn from(value: Index<N, $sub>) -> Self {
+                Unsigned(value.0 as $sup)
+            }
+        }
+
+        impl<const M: u8, const N: u8> From<Signed<N, $sub>> for Unsigned<M, $sup> {
+            #[inline]
+            fn from(value: Signed<N, $sub>) -> Self {
+                Unsigned(value.0 as $sup)
+            }
+        }
+
+        impl<const N: u8> FromAs<$sub> for Unsigned<N, $sup> {
+            #[inline]
+            fn from_as(value: $sub) -> Self {
+                Unsigned(value as $sup)
+            }
+        }
+
+        impl<const M: u8, const N: u8> FromAs<Unsigned<N, $sub>> for Unsigned<M, $sup> {
+            #[inline]
+            fn from_as(value: Unsigned<N, $sub>) -> Self {
+                Unsigned(value.0 as $sup)
+            }
+        }
+
+        impl<const M: u8, const N: u128> FromAs<Index<N, $sub>> for Unsigned<M, $sup> {
+            #[inline]
+            fn from_as(value: Index<N, $sub>) -> Self {
+                Unsigned(value.0 as $sup)
+            }
+        }
+
+        impl<const M: u8, const N: u8> FromAs<Signed<N, $sub>> for Unsigned<M, $sup> {
+            #[inline]
+            fn from_as(value: Signed<N, $sub>) -> Self {
+                Unsigned(value.0 as $sup)
+            }
+        }
+    }
+}
+
+def_unsigned_from!(u8, u16, u32, u64, u128);
+
+#[cfg(target_pointer_width = "16")]
+def_unsigned_from! {
+    @run
+    sup: [usize],
+    sub: [u8],
+}
+
+#[cfg(target_pointer_width = "32")]
+def_unsigned_from! {
+    @run
+    sup: [usize],
+    sub: [u8, u16],
+}
+
+#[cfg(target_pointer_width = "64")]
+def_unsigned_from! {
+    @run
+    sup: [usize],
+    sub: [u8, u16, u32],
+}
+
+subst_macros::repeat_parallel_subst! {
+    groups: [
+        [group [sub [INTO] = [u8]]]
+        [group [sub [INTO] = [u16]]]
+        [group [sub [INTO] = [u32]]]
+        [group [sub [INTO] = [u64]]]
+        [group [sub [INTO] = [u128]]]
+        [group [sub [INTO] = [usize]]]
+    ],
+    callback: NONE,
+    in: {
+        impl<const N: u8, T> From<Unsigned<N, T>> for INTO
+        where
+            Unsigned<N, T>: UnsignedSizeCheck,
+            INTO: From<T>,
+        {
+            #[inline]
+            fn from(other: Unsigned<N, T>) -> INTO {
+                INTO::from(other.0)
+            }
+        }
+
+        impl<const N: u8, T> FromAs<Unsigned<N, T>> for INTO
+        where
+            Unsigned<N, T>: UnsignedSizeCheck,
+            INTO: FromAs<T>,
+        {
+            #[inline]
+            fn from_as(other: Unsigned<N, T>) -> INTO {
+                INTO::from_as(other.0)
+            }
+        }
+    }
+}

--- a/firmware-support/bittide-macros/Cargo.toml
+++ b/firmware-support/bittide-macros/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 proc-macro = true
 
 [dependencies]
+proc-macro-crate = "3.5.0"
 proc-macro2 = "*"
-syn = "2.0"
 quote = "1.0"
+syn = {version = "2.0", features = ["full"]}

--- a/firmware-support/bittide-macros/src/lib.rs
+++ b/firmware-support/bittide-macros/src/lib.rs
@@ -5,9 +5,20 @@
 mod clock_config;
 
 use clock_config::{ClockConfigParser, ConfigEntry, ParserState};
+use proc_macro_crate::{FoundCrate, crate_name};
+use proc_macro2::{Ident, Span, TokenStream};
 use quote::quote;
-use std::fs;
+use std::{fmt::Write, fs};
 use syn::{LitInt, LitStr, Token, parse::Parse, parse_macro_input};
+
+fn get_import_prefix() -> TokenStream {
+    let prefix = match crate_name("bittide-hal") {
+        Ok(FoundCrate::Itself) => "crate",
+        _ => "bittide_hal",
+    };
+    let prefix = Ident::new(prefix, Span::call_site());
+    quote! { #prefix::manual_additions }
+}
 
 /// Macro to conveniently create an indexed type
 ///
@@ -25,12 +36,9 @@ use syn::{LitInt, LitStr, Token, parse::Parse, parse_macro_input};
 pub fn Index(toks: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let n_lit = parse_macro_input!(toks as LitInt);
 
-    fn next_pow2(n: &u128) -> u128 {
-        n.next_power_of_two().max(8)
-    }
-
-    fn clog2(n: &u128) -> u128 {
-        n.ilog2().max(8) as u128
+    fn optimal_backing_type_size(n: u128) -> u32 {
+        let clog2 = (u128::BITS - (n - 1).leading_zeros()).next_power_of_two();
+        clog2.max(8)
     }
 
     let n_val = match n_lit.base10_parse() {
@@ -39,12 +47,14 @@ pub fn Index(toks: proc_macro::TokenStream) -> proc_macro::TokenStream {
     };
 
     let ty = {
-        let type_name = format!("u{}", next_pow2(&clog2(&n_val)));
+        let type_name = format!("u{}", optimal_backing_type_size(n_val));
         syn::Ident::new(&type_name, n_lit.span())
     };
 
+    let prefix = get_import_prefix();
+
     quote! {
-        bittide_hal::manual_additions::index::IndexTy<#n_lit, #ty>
+        #prefix::index::Index<#n_lit, #ty>
     }
     .into()
 }
@@ -70,18 +80,17 @@ pub fn index(toks: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let val = args.value;
     let n_lit = args.n_lit;
 
-    fn next_pow2(n: &u128) -> u128 {
-        n.next_power_of_two().max(8)
-    }
-
-    fn clog2(n: &u128) -> u128 {
-        n.ilog2().max(8) as u128
+    fn optimal_backing_type_size(n: u128) -> u32 {
+        let clog2 = (u128::BITS - (n - 1).leading_zeros()).next_power_of_two();
+        clog2.max(8)
     }
 
     let ty = {
-        let type_name = format!("u{}", next_pow2(&clog2(&args.n_val)));
+        let type_name = format!("u{}", optimal_backing_type_size(args.n_val));
         syn::Ident::new(&type_name, n_lit.span())
     };
+
+    let prefix = get_import_prefix();
 
     match val {
         // try to detect a constant literal to skip the bounds check
@@ -97,7 +106,9 @@ pub fn index(toks: proc_macro::TokenStream) -> proc_macro::TokenStream {
             if n < args.n_val {
                 quote! {
                     unsafe {
-                        bittide_hal::manual_additions::index::IndexTy::<#n_lit, #ty>::new_unchecked(#int_lit)
+                        #prefix::index::Index::<#n_lit, #ty>::new_unchecked(
+                            #int_lit
+                        )
                     }
                 }
                 .into()
@@ -115,8 +126,16 @@ pub fn index(toks: proc_macro::TokenStream) -> proc_macro::TokenStream {
             }
         }
         // non literal case, do slow bounds check
-        _ => quote! {
-            bittide_hal::manual_additions::index::IndexTy::<#n_lit, #ty>::new(#val).unwrap()
+        _ => if args.n_val == optimal_backing_type_size(args.n_val) as u128 {
+            quote! {
+                unsafe {
+                    #prefix::index::Index::<#n_lit, #ty>::new_unchecked(#val)
+                }
+            }
+        } else {
+            quote! {
+                #prefix::index::Index::<#n_lit, #ty>::new(#val).unwrap()
+            }
         }
         .into(),
     }
@@ -144,6 +163,498 @@ impl Parse for IndexValArgs {
         let n_val = n_lit.base10_parse()?;
 
         Ok(IndexValArgs {
+            value,
+            n_lit,
+            n_val,
+        })
+    }
+}
+
+#[proc_macro]
+#[allow(non_snake_case)]
+pub fn Signed(toks: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let n_lit = parse_macro_input!(toks as LitInt);
+
+    fn optimal_backing_type_size(n: u8) -> u8 {
+        (n.div_ceil(8).next_power_of_two() * 8).max(8)
+    }
+
+    let n_val = match n_lit.base10_parse() {
+        Err(err) => return err.into_compile_error().into(),
+        Ok(v) => v,
+    };
+
+    let ty = {
+        let type_name = format!("i{}", optimal_backing_type_size(n_val));
+        syn::Ident::new(&type_name, n_lit.span())
+    };
+
+    let prefix = get_import_prefix();
+
+    quote! {
+        #prefix::signed::Signed<#n_lit, #ty>
+    }
+    .into()
+}
+
+#[proc_macro]
+pub fn signed(toks: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let args = parse_macro_input!(toks as NumericArgs);
+
+    let val = args.value;
+    let nlit = args.n_lit;
+    let nval = args.n_val;
+
+    fn optimal_backing_type_size(n: u8) -> u8 {
+        (n.div_ceil(8).next_power_of_two() * 8).max(8)
+    }
+
+    let ty = {
+        let type_name = format!("i{}", optimal_backing_type_size(nval));
+        syn::Ident::new(&type_name, nlit.span())
+    };
+
+    let uty = {
+        let type_name = format!("u{}", optimal_backing_type_size(nval));
+        syn::Ident::new(&type_name, nlit.span())
+    };
+
+    let prefix = get_import_prefix();
+
+    match val {
+        // try to detect a constant literal to skip the bounds check
+        syn::Expr::Lit(syn::ExprLit {
+            attrs: _,
+            lit: syn::Lit::Int(int_lit),
+        }) => {
+            let litval: i128 = match int_lit.base10_parse::<u128>() {
+                Err(err) => return err.into_compile_error().into(),
+                Ok(v) => v as i128,
+            };
+            let lit_is_neg = litval & (1 << (nval - 1)) != 0;
+            let litval = if lit_is_neg {
+                litval | (!0 << (nval - 1))
+            } else {
+                litval
+            };
+            let neg_bound = !0 << (nval - 1);
+            let pos_bound = !(!0 << (nval - 1));
+            if (neg_bound..=pos_bound).contains(&litval) {
+                if lit_is_neg {
+                    quote! {
+                        unsafe {
+                            #prefix::signed::Signed::<#nlit, #ty>::new_unchecked(const {
+                                const LIT: #uty = #int_lit;
+                                LIT as #ty | (!0 << (#nval - 1))
+                            })
+                        }
+                    }
+                } else {
+                    quote! {
+                        unsafe {
+                            #prefix::signed::Signed::<#nlit, #ty>::new_unchecked(const {
+                                const LIT: #uty = #int_lit;
+                                LIT as #ty
+                            })
+                        }
+                    }
+                }
+                .into()
+            } else {
+                let bounds = neg_bound..=pos_bound;
+                syn::Error::new(
+                    int_lit.span().join(nlit.span()).unwrap_or(int_lit.span()),
+                    format!(
+                        "Value not in {bounds:?}: value `{litval}`, type Signed<{nlit}, {nval}>"
+                    ),
+                )
+                .into_compile_error()
+                .into()
+            }
+        }
+        _ => if nval == optimal_backing_type_size(nval) {
+            quote! {
+                unsafe {
+                    #prefix::signed::Signed::<#nlit, #ty>::new_unchecked(#val)
+                }
+            }
+        } else {
+            quote! {
+                #prefix::signed::Signed::<#nlit, #ty>::new(#val).expect(concat!(
+                    "Failed to construct `Signed<",
+                    stringify!(#nlit),
+                    ", ",
+                    stringify!(#ty),
+                    ">` at line ",
+                    line!(),
+                    ", column ",
+                    column!(),
+                ))
+            }
+        }
+        .into(),
+    }
+}
+
+#[proc_macro]
+#[allow(non_snake_case)]
+pub fn Unsigned(toks: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let n_lit = parse_macro_input!(toks as LitInt);
+
+    fn optimal_backing_type_size(n: u8) -> u8 {
+        (n.div_ceil(8).next_power_of_two() * 8).max(8)
+    }
+
+    let n_val = match n_lit.base10_parse() {
+        Err(err) => return err.into_compile_error().into(),
+        Ok(v) => v,
+    };
+
+    let ty = {
+        let type_name = format!("u{}", optimal_backing_type_size(n_val));
+        syn::Ident::new(&type_name, n_lit.span())
+    };
+
+    let prefix = get_import_prefix();
+
+    quote! {
+        #prefix::unsigned::Unsigned<#n_lit, #ty>
+    }
+    .into()
+}
+
+#[proc_macro]
+pub fn unsigned(toks: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let args = parse_macro_input!(toks as NumericArgs);
+
+    let val = args.value;
+    let nlit = args.n_lit;
+    let nval = args.n_val;
+
+    fn optimal_backing_type_size(n: u8) -> u8 {
+        (n.div_ceil(8).next_power_of_two() * 8).max(8)
+    }
+
+    let ty = {
+        let type_name = format!("u{}", optimal_backing_type_size(nval));
+        syn::Ident::new(&type_name, nlit.span())
+    };
+
+    let prefix = get_import_prefix();
+
+    match val {
+        // try to detect a constant literal to skip the bounds check
+        syn::Expr::Lit(syn::ExprLit {
+            attrs: _,
+            lit: syn::Lit::Int(int_lit),
+        }) => {
+            let litval: u128 = match int_lit.base10_parse() {
+                Err(err) => return err.into_compile_error().into(),
+                Ok(v) => v,
+            };
+            if nval == 128 || (nval < 128 && (0..(1u128 << nval)).contains(&litval)) {
+                quote! {
+                    unsafe {
+                        #prefix::unsigned::Unsigned::<#nlit, #ty>::new_unchecked(
+                            #int_lit
+                        )
+                    }
+                }
+                .into()
+            } else {
+                syn::Error::new(
+                    int_lit.span().join(nlit.span()).unwrap(),
+                    format!("Value out of bounds: value `{litval}`, type Unsigned<{nlit}, {nval}>"),
+                )
+                .into_compile_error()
+                .into()
+            }
+        }
+        _ => if nval == optimal_backing_type_size(nval) {
+            quote! {
+                unsafe {
+                    #prefix::unsigned::Unsigned::<#nlit, #ty>::new_unchecked(#val)
+                }
+            }
+        } else {
+            quote! {
+                #prefix::unsigned::Unsigned::<#nlit, #ty>::new(#val).expect(concat!(
+                    "Failed to construct `Unigned<",
+                    stringify!(#nlit),
+                    ", ",
+                    stringify!(#ty),
+                    ">` at line ",
+                    line!(),
+                    ", column ",
+                    column!(),
+                ))
+            }
+        }
+        .into(),
+    }
+}
+
+struct NumericArgs {
+    value: syn::Expr,
+    n_lit: syn::LitInt,
+    n_val: u8,
+}
+
+impl Parse for NumericArgs {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        let value = input.parse()?;
+        input.parse::<Token![,]>()?;
+        let n_ident = input.parse::<syn::Ident>()?;
+        if n_ident != "n" {
+            return Err(syn::Error::new(
+                n_ident.span(),
+                "only `n` is allowed here. Example: `n = 20`",
+            ));
+        }
+        input.parse::<Token![=]>()?;
+        let n_lit: syn::LitInt = input.parse()?;
+        let n_val = n_lit.base10_parse()?;
+        if n_val > 128 {
+            Err(syn::Error::new(
+                n_lit.span(),
+                format!("Value `{n_val}` is outside of allowed range 0..=128!"),
+            ))
+        } else {
+            Ok(NumericArgs {
+                value,
+                n_lit,
+                n_val,
+            })
+        }
+    }
+}
+
+#[proc_macro]
+#[allow(non_snake_case)]
+pub fn BitVector(toks: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let n_lit = parse_macro_input!(toks as LitInt);
+
+    let n_val: usize = match n_lit.base10_parse() {
+        Err(err) => return err.into_compile_error().into(),
+        Ok(v) => v,
+    };
+
+    let size = n_val.div_ceil(8);
+
+    let prefix = get_import_prefix();
+
+    quote! {
+        #prefix::bitvector::BitVector<#n_val, #size>
+    }
+    .into()
+}
+
+fn read_hex_literal(
+    input: &LitInt,
+    input_str: &str,
+    size: usize,
+    buf: &mut [u8],
+) -> Result<(), proc_macro::TokenStream> {
+    let mut char_iter = input_str.chars().filter(char::is_ascii_hexdigit).rev();
+    let mut lower = true;
+    let mut idx = 0;
+    loop {
+        let Some(c) = char_iter.next() else {
+            break Ok(());
+        };
+        let val = match c {
+            '0'..='9' => c as u8 - b'0',
+            'A'..='F' => c as u8 - b'A' + 10,
+            'a'..='f' => c as u8 - b'a' + 10,
+            _ => unreachable!(),
+        };
+        match (buf.get_mut(idx), lower) {
+            (None, _) => {
+                let rem = char_iter.count();
+                return Err(syn::Error::new(
+                    input.span(),
+                    format!("Literal too long! Expected 0..={size} hexdigits, but {rem} left"),
+                )
+                .into_compile_error()
+                .into());
+            }
+            (Some(byte), true) => *byte |= val,
+            (Some(byte), false) => *byte |= val << 4,
+        }
+        if !lower {
+            idx += 1;
+        }
+        lower = !lower;
+    }
+}
+
+fn read_binary_literal(
+    input: &LitInt,
+    input_str: &str,
+    size: usize,
+    buf: &mut [u8],
+) -> Result<(), proc_macro::TokenStream> {
+    let mut char_iter = input_str.chars().filter(|&c| c == '0' || c == '1').rev();
+    let mut byte_idx = 0;
+    let mut idx = 0;
+    loop {
+        let Some(c) = char_iter.next() else {
+            break Ok(());
+        };
+        let val = c as u8 - b'0';
+        match (buf.get_mut(idx), byte_idx) {
+            (None, _) => {
+                let rem = char_iter.count();
+                return Err(syn::Error::new(
+                    input.span(),
+                    format!("Literal too long! Expected 0..={size} binary digits, but {rem} left"),
+                )
+                .into_compile_error()
+                .into());
+            }
+            (Some(byte), 7) => {
+                *byte |= val << 7;
+                byte_idx = 0;
+                idx += 1;
+            }
+            (Some(byte), shift) => {
+                *byte |= val << shift;
+                byte_idx += 1;
+            }
+        }
+    }
+}
+
+#[proc_macro]
+pub fn bitvector(toks: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let BitVectorArgs {
+        value,
+        n_lit,
+        n_val,
+    } = parse_macro_input!(toks as BitVectorArgs);
+
+    let size = n_val.div_ceil(8);
+
+    let prefix = get_import_prefix();
+
+    match value {
+        syn::Expr::Lit(syn::ExprLit {
+            attrs: _,
+            lit: syn::Lit::Int(input),
+        }) => {
+            let input_str = input.to_string();
+            let mut buf: Vec<u8> = vec![0; size];
+            if input_str.starts_with("0x") || input_str.starts_with("0X") {
+                if !input_str
+                    .chars()
+                    .skip(2)
+                    .all(|c| c.is_ascii_hexdigit() || c == ' ' || c == '_')
+                {
+                    return syn::Error::new(
+                        input.span(),
+                        "Hexadecimal literals may only contain hex digits, spaces, and underscores",
+                    )
+                    .into_compile_error()
+                    .into();
+                }
+                let input_str = input_str
+                    .trim_start_matches('0')
+                    .trim_start_matches(['x', 'X']);
+                if let Err(err) = read_hex_literal(&input, input_str, size, &mut buf) {
+                    return err;
+                }
+            } else if input_str.starts_with("0b") || input_str.starts_with("0B") {
+                if !input_str
+                    .chars()
+                    .skip(2)
+                    .all(|c| c == '0' || c == '1' || c == ' ' || c == '_')
+                {
+                    return syn::Error::new(
+                        input.span(),
+                        "Binary literals may only contain `0`s, `1`s, spaces, and underscores",
+                    )
+                    .into_compile_error()
+                    .into();
+                }
+                let input_str = input_str
+                    .trim_start_matches('0')
+                    .trim_start_matches(['b', 'B']);
+                if let Err(err) = read_binary_literal(&input, input_str, n_val, &mut buf) {
+                    return err;
+                }
+            } else {
+                return syn::Error::new(
+                    input.span(),
+                    concat!(
+                        "Expected a hexadecimal (`0x` or `0X` prefix) or binary (`0b` or `0B`",
+                        " prefix) literal! Both literals may contain spaces and/or underscores."
+                    )
+                    .to_string(),
+                )
+                .into_compile_error()
+                .into();
+            };
+            let check_bit = n_val % 8;
+            if check_bit == 0 || buf.last().unwrap().leading_zeros() as usize >= (8 - check_bit) {
+                let mut array_str = String::with_capacity(buf.len() * 6);
+                array_str.push('[');
+                write!(array_str, "0x{:02x}", buf[0]).unwrap();
+                for byte in buf.get(1..).into_iter().flatten() {
+                    write!(array_str, ", 0x{byte:02x}").unwrap();
+                }
+                array_str.push(']');
+                let toks: proc_macro2::TokenStream = array_str.parse().unwrap();
+                quote! {
+                    unsafe {
+                        #prefix::bitvector::BitVector::<#n_lit, #size>::new_unchecked(#toks)
+                    }
+                }
+                .into()
+            } else {
+                syn::Error::new(
+                    input.span(),
+                    format!("Set bits outside allowed range: {:0nb$b}", 0, nb = 1),
+                )
+                .into_compile_error()
+                .into()
+            }
+        }
+        _ => if n_val.is_multiple_of(8) {
+            quote! {
+                unsafe {
+                    #prefix::bitvector::BitVector::<#n_lit, #size>::new_unchecked(#value)
+                }
+            }
+        } else {
+            quote! {
+                #prefix::bitvector::BitVector::<#n_lit, #size>::new(#value).unwrap()
+            }
+        }
+        .into(),
+    }
+}
+
+struct BitVectorArgs {
+    value: syn::Expr,
+    n_lit: syn::LitInt,
+    n_val: usize,
+}
+
+impl Parse for BitVectorArgs {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        let value = input.parse()?;
+        input.parse::<Token![,]>()?;
+        let n_ident = input.parse::<syn::Ident>()?;
+        if n_ident != "n" {
+            return Err(syn::Error::new(
+                n_ident.span(),
+                "only `n` is allowed here. Example: `n = 20`",
+            ));
+        }
+        input.parse::<Token![=]>()?;
+        let n_lit: syn::LitInt = input.parse()?;
+        let n_val = n_lit.base10_parse()?;
+        Ok(BitVectorArgs {
             value,
             n_lit,
             n_val,

--- a/firmware-support/bittide-sys/Cargo.toml
+++ b/firmware-support/bittide-sys/Cargo.toml
@@ -19,11 +19,12 @@ workspace = true
 default = []
 
 [dependencies]
+bittide-hal = { path = "../bittide-hal" }
+bittide-macros = { path = "../bittide-macros" }
 fdt = "0.1.0"
+itertools = { version = "0.14.0", default-features = false }
 log = "0.4.21"
 ufmt = "0.2.0"
-bittide-hal = { path = "../bittide-hal" }
-itertools = { version = "0.14.0", default-features = false }
 
 [dependencies.heapless]
 version = "0.8"
@@ -40,10 +41,10 @@ default-features = false
 features = ["log", "medium-ethernet", "proto-ipv4", "socket-tcp"]
 
 [dev-dependencies]
-proptest = "1.0"
-object = { version = "0.28", features = ["write"] }
-libc = "0.2"
-test-strategy = "0.2.0"
-rand = "0.8"
 lazy_static = "1.0"
+libc = "0.2"
+object = { version = "0.28", features = ["write"] }
+proptest = "1.0"
+rand = "0.8"
 tempfile = "3"
+test-strategy = "0.2.0"

--- a/firmware-support/bittide-sys/src/callisto.rs
+++ b/firmware-support/bittide-sys/src/callisto.rs
@@ -2,10 +2,11 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use bittide_hal::shared_devices::clock_control::ClockControl;
-use bittide_hal::types::callisto_config::CallistoConfig;
-use bittide_hal::types::maybe::Maybe;
-use bittide_hal::types::speed_change::SpeedChange;
+use bittide_hal::{
+    manual_additions::IntoAs,
+    shared_devices::clock_control::ClockControl,
+    types::{callisto_config::CallistoConfig, maybe::Maybe, speed_change::SpeedChange},
+};
 
 /// Rust sibling of
 /// `Bittide.ClockControl.Callisto.Types.Stability`.
@@ -83,7 +84,7 @@ impl Callisto {
         self.accumulated_speed_requests += speed_change_to_sign(speed_request);
 
         if let Maybe::Just(wait_time) = self.config.wait_time {
-            self.update_reframe_state(wait_time as usize, cc.links_stable()[0] != 0, c_des);
+            self.update_reframe_state(wait_time.into_as(), cc.links_stable()[0] != 0, c_des);
         }
 
         speed_request

--- a/firmware-support/bittide-sys/src/sample_store.rs
+++ b/firmware-support/bittide-sys/src/sample_store.rs
@@ -2,10 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use bittide_hal::shared_devices::freeze::Freeze;
-use bittide_hal::shared_devices::sample_memory::SampleMemory;
-
 use crate::stability_detector::Stability;
+use bittide_hal::shared_devices::{freeze::Freeze, sample_memory::SampleMemory};
+use bittide_macros::bitvector;
 
 const WORDS_PER_SAMPLE: usize = 13;
 
@@ -19,7 +18,7 @@ pub struct SampleStore {
 impl SampleStore {
     pub fn new(memory: SampleMemory, store_samples_every: usize) -> Self {
         // First memory location is reserved for the number of samples stored.
-        memory.set_data(0, 0u32.to_le_bytes());
+        memory.set_data(0, bitvector!(0x0, n = 32));
 
         Self {
             memory,
@@ -37,49 +36,60 @@ impl SampleStore {
         stability: Stability,
         net_speed_change: i32,
     ) {
-        let n_samples_stored: usize = u32::from_ne_bytes(self.memory.data(0).unwrap()) as usize;
+        let n_samples_stored: usize =
+            u32::from_ne_bytes(self.memory.data(0).unwrap().into_inner()) as usize;
         let start_index = n_samples_stored * WORDS_PER_SAMPLE + 1;
 
         // Store local clock counter
-        let local_clock: u64 = freeze.local_clock_counter();
+        let local_clock: u64 = freeze.local_clock_counter().into_inner();
         let local_clock_msbs = (local_clock >> 32) as u32;
         let local_clock_lsbs = (local_clock & 0xFFFFFFFF) as u32;
-        self.memory
-            .set_data(start_index, local_clock_lsbs.to_le_bytes());
-        self.memory
-            .set_data(start_index + 1, local_clock_msbs.to_le_bytes());
+        self.memory.set_data(
+            start_index,
+            bitvector!(local_clock_lsbs.to_le_bytes(), n = 32),
+        );
+        self.memory.set_data(
+            start_index + 1,
+            bitvector!(local_clock_msbs.to_le_bytes(), n = 32),
+        );
 
         // Store number of sync pulses seen
         let number_of_sync_pulses_seen = freeze.number_of_sync_pulses_seen();
         self.memory
-            .set_data(start_index + 2, number_of_sync_pulses_seen.to_le_bytes());
+            .set_data(start_index + 2, number_of_sync_pulses_seen.into());
 
         // Store cycles since last sync pulse
         let cycles_since_sync_pulse = freeze.cycles_since_sync_pulse();
         self.memory
-            .set_data(start_index + 3, cycles_since_sync_pulse.to_le_bytes());
+            .set_data(start_index + 3, cycles_since_sync_pulse.into());
 
         // Store stability information
         self.memory.set_data(
             start_index + 4,
-            (stability.stable as u32 | ((stability.settled as u32) << 8)).to_le_bytes(),
+            bitvector!(
+                (stability.stable as u32 | ((stability.settled as u32) << 8)).to_le_bytes(),
+                n = 32
+            ),
         );
 
         // Store net speed change
-        self.memory
-            .set_data(start_index + 5, (net_speed_change as u32).to_le_bytes());
+        self.memory.set_data(
+            start_index + 5,
+            bitvector!((net_speed_change as u32).to_le_bytes(), n = 32),
+        );
 
         // Store the EB counters
         for (i, eb_counter) in freeze.eb_counters_volatile_iter().enumerate() {
-            self.memory
-                .set_data(start_index + 6 + i, (eb_counter as u32).to_le_bytes());
+            self.memory.set_data(start_index + 6 + i, eb_counter.into());
         }
 
         // Bump number of samples stored, but only if we're running "for real"
         // and the data actually fits in memory.
         if bump_counter && self.memory.data(start_index + WORDS_PER_SAMPLE).is_some() {
-            self.memory
-                .set_data(0, ((n_samples_stored + 1) as u32).to_le_bytes());
+            self.memory.set_data(
+                0,
+                bitvector!(((n_samples_stored + 1) as u32).to_le_bytes(), n = 32),
+            );
         }
     }
 

--- a/firmware-support/bittide-sys/src/stability_detector.rs
+++ b/firmware-support/bittide-sys/src/stability_detector.rs
@@ -3,7 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use bittide_hal::{
-    manual_additions::timer::{Duration, Instant},
+    manual_additions::{
+        bitvector::BitVector,
+        timer::{Duration, Instant},
+    },
     shared_devices::clock_control::ClockControl,
 };
 use itertools::izip;
@@ -79,8 +82,8 @@ impl StabilityDetector {
             .enumerate()
         {
             let active = test_bit(link_mask_rev[0], i);
-            let diff0 = data_count_stored.abs_diff(min_seen);
-            let diff1 = data_count_stored.abs_diff(max_seen);
+            let diff0 = data_count_stored.abs_diff(min_seen.into_inner());
+            let diff1 = data_count_stored.abs_diff(max_seen.into_inner());
             let height_violated = diff0 > self.margin || diff1 > self.margin;
 
             let (stable, settled) = if height_violated || !active {
@@ -88,7 +91,7 @@ impl StabilityDetector {
                 // link is inactive. The latter prevents inactive links from
                 // being considered stable.
                 *maybe_start = Some(now);
-                *data_count_stored = data_count;
+                *data_count_stored = data_count.into_inner();
                 cc.set_clear_data_counts_seen(true);
                 (false, false)
             } else {
@@ -110,7 +113,7 @@ impl StabilityDetector {
             // if it happened to stabilize very close to its margins and, just
             // by "luck", the next sample pushes it over the edge.
             if !*prev_stable && stable {
-                *data_count_stored = data_count;
+                *data_count_stored = data_count.into_inner();
                 cc.set_clear_data_counts_seen(true);
             }
             *prev_stable = stable;
@@ -119,8 +122,8 @@ impl StabilityDetector {
         // XXX: These values are currently hardcoded to 8 bits, which would
         //      break if we ever have more than 8 links. We'll cross that bridge
         //      when we get there.
-        cc.set_links_settled([settleds as u8]);
-        cc.set_links_stable([stables as u8]);
+        cc.set_links_settled(unsafe { BitVector::new_unchecked([settleds as u8 & 0x7f]) });
+        cc.set_links_stable(unsafe { BitVector::new_unchecked([stables as u8 & 0x7f]) });
 
         Stability {
             stable: stables as u8,

--- a/firmware-support/memmap-generate/Cargo.toml
+++ b/firmware-support/memmap-generate/Cargo.toml
@@ -13,10 +13,11 @@ workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-quote = "1.0"
-proc-macro2 = "1.0"
+# bittide-macros = { path = "../bittide-macros" }
 derivative = "2.2.0"
 heck = "0.5.0"
+proc-macro2 = "1.0"
+quote = "1.0"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 smallvec = { version = "1.15", features = ["write"] }

--- a/firmware-support/memmap-generate/src/backends/rust/mod.rs
+++ b/firmware-support/memmap-generate/src/backends/rust/mod.rs
@@ -77,6 +77,10 @@ pub fn generate_type_desc<'ir>(
 ) -> (&'ir str, proc_macro2::TokenStream, TypeReferences) {
     let mut refs = TypeReferences {
         references: BTreeSet::new(),
+        use_bitvec: false,
+        use_index: false,
+        use_signed: false,
+        use_unsigned: false,
     };
     let desc = &ctx.type_descs[handle];
     let type_name = &ctx.type_names[desc.name];
@@ -427,6 +431,10 @@ pub fn generate_device_desc<'ir>(
 ) -> (&'ir str, proc_macro2::TokenStream, TypeReferences) {
     let mut refs = TypeReferences {
         references: BTreeSet::new(),
+        use_bitvec: false,
+        use_index: false,
+        use_signed: false,
+        use_unsigned: false,
     };
     let desc = &ctx.device_descs[handle];
     let name = &ctx.identifiers[desc.name];
@@ -661,6 +669,10 @@ fn generate_reg_set_method(
 /// Types referenced during code generation.
 pub struct TypeReferences {
     pub references: BTreeSet<Handle<TypeName>>,
+    pub use_bitvec: bool,
+    pub use_index: bool,
+    pub use_signed: bool,
+    pub use_unsigned: bool,
 }
 
 fn generate_type_ref(
@@ -675,11 +687,12 @@ fn generate_type_ref(
         TypeRef::BitVector(handle) => {
             let size = &ctx.type_refs[lookup_sub(variant, *handle)];
 
-            if let TypeRef::Nat(n) = size {
-                // TODO maybe special case on n == 1 like the C backend?
-                let n = n.div_ceil(8) as usize;
-                let n_lit = Literal::usize_unsuffixed(n);
-                quote! { [u8; #n_lit] }
+            if let &TypeRef::Nat(n) = size {
+                refs.use_bitvec = true;
+                let n = n as usize;
+                let len = proc_macro2::Literal::usize_unsuffixed(n.div_ceil(8));
+                let n = proc_macro2::Literal::usize_unsuffixed(n);
+                quote! { BitVector<#n, #len> }
             } else {
                 quote! { compile_error!("BitVector with length not known after monomorphisation") }
             }
@@ -687,10 +700,17 @@ fn generate_type_ref(
         TypeRef::Unsigned(handle) => {
             let size = &ctx.type_refs[lookup_sub(variant, *handle)];
 
-            if let TypeRef::Nat(n) = size {
-                let n = po2_type(*n);
-                let name = format!("u{n}");
-                ident(IdentType::Raw, name).into_token_stream()
+            if let &TypeRef::Nat(n) = size {
+                if n > 128 {
+                    let msg = format!("Unsigned length {n} is outside of allowed range 0..=128!");
+                    quote! { compile_error!(#msg) }
+                } else {
+                    refs.use_unsigned = true;
+                    let n = (n as u8).div_ceil(8).next_power_of_two() * 8;
+                    let backer = ident(IdentType::Raw, format!("u{n}")).into_token_stream();
+                    let n = proc_macro2::Literal::u8_unsuffixed(n);
+                    quote! { Unsigned<#n, #backer> }
+                }
             } else {
                 quote! { compile_error!("Unsigned with length not known after monomorphisation") }
             }
@@ -698,10 +718,17 @@ fn generate_type_ref(
         TypeRef::Signed(handle) => {
             let size = &ctx.type_refs[lookup_sub(variant, *handle)];
 
-            if let TypeRef::Nat(n) = size {
-                let n = po2_type(*n);
-                let name = format!("i{n}");
-                ident(IdentType::Raw, name).into_token_stream()
+            if let &TypeRef::Nat(n) = size {
+                if n > 128 {
+                    let msg = format!("Signed length {n} is outside of allowed range 0..=128!");
+                    quote! { compile_error!(#msg) }
+                } else {
+                    refs.use_signed = true;
+                    let n = (n as u8).div_ceil(8).next_power_of_two() * 8;
+                    let backer = ident(IdentType::Raw, format!("i{n}")).into_token_stream();
+                    let n = proc_macro2::Literal::u8_unsuffixed(n);
+                    quote! { Signed<#n, #backer> }
+                }
             } else {
                 quote! { compile_error!("Signed with length not known after monomorphisation") }
             }
@@ -710,9 +737,12 @@ fn generate_type_ref(
             let size = &ctx.type_refs[lookup_sub(variant, *handle)];
 
             if let TypeRef::Nat(n) = size {
-                let n = po2_type(n.ilog2() as u64);
-                let name = format!("u{n}");
-                ident(IdentType::Raw, name).into_token_stream()
+                refs.use_index = true;
+                let n = *n as u128;
+                let backer =
+                    ident(IdentType::Raw, format!("u{}", index_size(n))).into_token_stream();
+                let n = proc_macro2::Literal::u128_unsuffixed(n);
+                quote! { Index<#n, #backer> }
             } else {
                 quote! { compile_error!("Index with length not known after monomorphisation") }
             }
@@ -902,4 +932,10 @@ fn type_to_ident(ctx: &IrCtx, ty: Handle<TypeRef>) -> String {
             ident
         }
     }
+}
+
+fn index_size(n: u128) -> u32 {
+    (u128::BITS - (n - 1).leading_zeros())
+        .next_power_of_two()
+        .max(8)
 }


### PR DESCRIPTION
This implements basic functionality for `Index<N, T>`, `Unsigned<N, T>`, `Signed<N, T>`, and `BitVec<N, M>`. This PR is currently marked as draft since I still need to:
- [x] Add documentation to the types themselves and to the size check traits, not just their methods
- [x] Create macros as aliases for the types
- [x] Create instantiation macros
- [x] Add tests?

Anywho, at least an initial review pass and/or suggestions on things I should add in this PR that I didn't (and that I don't have WIP stuff for already from before I did a lot of downscoping, like operator `impl`s).