### PR TITLE
`SoftUgnDemo` catch missed deadlines

### DIFF
--- a/bittide-instances/src/Bittide/Instances/Hitl/SoftUgnDemo/Driver.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/SoftUgnDemo/Driver.hs
@@ -224,6 +224,17 @@ driver testName targets = do
                       <> " out)"
                 error "Roundtrip latencies did not match between hardware and software"
               when (not $ L.null mismatchedUgns) $ error "Some UGN edges did not match!"
+
+              liftIO
+                $ T.tryWithTimeoutOn
+                  T.PrintActionTime
+                  "Waiting for CPU test status"
+                  (1_000_000)
+                  goDumpCcSamples
+                $ forConcurrently_ picocoms
+                $ \pico ->
+                  waitForLine pico.stdoutHandle "[PE] Test status: Success"
+
             liftIO goDumpCcSamples
 
             pure ExitSuccess

--- a/firmware-binaries/demos/soft-ugn-gppe/src/main.c
+++ b/firmware-binaries/demos/soft-ugn-gppe/src/main.c
@@ -213,6 +213,20 @@ int c_main(void) {
   uart_puts(uart, "\n========================================\n");
   uart_puts(uart, "UGN discovery protocol complete!\n");
 
+  // Print final test status
+  bool success = true;
+  if (ugn_ctx.missed_send_count > 0 || ugn_ctx.missed_receive_count > 0 ||
+      ugn_ctx.missed_invalidate_count > 0) {
+    uart_puts(uart, "[ERROR] Some events missed their deadlines.\n");
+    success = false;
+  }
+  uart_puts(uart, "Test status: ");
+  if (success) {
+    uart_puts(uart, "Success\n");
+  } else {
+    uart_puts(uart, "Failure\n");
+    uart_puts(uart, "See report above for details.\n");
+  }
   while (1) {
     // Protocol complete - idle loop
   }


### PR DESCRIPTION
_What (what did you do)_
I increased `STARTING_DELAY_READ` in the C code of `SoftUgnDemo` and added a detection mechanism to allow the C code to fail the hitl test, which I then used to fail the test on missed deadlines.

_Why (context, issues, etc.)_
In the logs of a failing HITL run I noticed that it contained a significant number (25) of missed read deadlines. I also noticed that most runs had 7 missed read deadlines. 

My suspicion is that `STARTING_DELAY_READ` was too low, causing the first deadlines for each port to be missed.
For this run however, it had not only 7, but 25 missed read deadlines. I suspect we missed the deadline for an event that captured a UGN, leading to an off by 4k on that value.  

_Dear reviewer (anything you'd like the reviewer to pay close attention to?)_
Sanity check if the infra to make the C code fail

_AI disclaimer (heads-up for more than inline autocomplete)_
I ~tried to~ use _actual intelligence_, instead of _artificial intelligence_
# TODO
_~~Cross-out~~ any that do not apply_

- [x] Write (regression) test
- [ ] ~~Update documentation, including `docs/`~~
- [ ] ~~Link to existing issue~~
