### PR TITLE
Remove `stable` register from elastic buffer

### DIFF
--- a/bittide-instances/src/Bittide/Instances/Hitl/SoftUgnDemo/Core.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/SoftUgnDemo/Core.hs
@@ -241,8 +241,8 @@ core (refClk, refRst) (bitClk, bitRst, bitEna) rxClocks rxResets =
     -- Stop management unit
 
     -- Start internal links
-    (_relDatCount, _underflow, _overflow, _ebStables, Fwd rxs1) <-
-      unzip5Vec
+    (_relDatCount, _underflow, _overflow, Fwd rxs1) <-
+      unzip4Vec
         <| ( Vec.vecCircuits
               $ xilinxElasticBufferWb
                 bitClk
@@ -331,12 +331,12 @@ core (refClk, refRst) (bitClk, bitRst, bitEna) rxClocks rxResets =
   withBittideClockResetEnable :: forall r. ((HiddenClockResetEnable Bittide) => r) -> r
   withBittideClockResetEnable = withClockResetEnable bitClk bitRst bitEna
 
-uncurry5 ::
-  (a -> b -> c -> d -> e -> f) ->
-  (a, b, c, d, e) ->
-  f
-uncurry5 fn (a, b, c, d, e) = fn a b c d e
+uncurry4 ::
+  (a -> b -> c -> d -> e) ->
+  (a, b, c, d) ->
+  e
+uncurry4 fn (a, b, c, d) = fn a b c d
 
-unzip5Vec ::
-  Circuit (Vec n (a, b, c, d, e)) (Vec n a, Vec n b, Vec n c, Vec n d, Vec n e)
-unzip5Vec = applyC unzip5 (uncurry5 zip5)
+unzip4Vec ::
+  Circuit (Vec n (a, b, c, d)) (Vec n a, Vec n b, Vec n c, Vec n d)
+unzip4Vec = applyC unzip4 (uncurry4 zip4)

--- a/bittide-instances/src/Bittide/Instances/Hitl/SwitchDemo/Core.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/SwitchDemo/Core.hs
@@ -204,8 +204,8 @@ core (refClk, refRst) (bitClk, bitRst, bitEna) rxClocks rxResets =
     -- Stop management unit
 
     -- Start internal links
-    (_relDatCount, _underflow, _overflow, _ebStables, Fwd rxs1) <-
-      unzip5Vec
+    (_relDatCount, _underflow, _overflow, Fwd rxs1) <-
+      unzip4Vec
         <| ( Vec.vecCircuits
               $ xilinxElasticBufferWb
                 bitClk
@@ -294,12 +294,12 @@ core (refClk, refRst) (bitClk, bitRst, bitEna) rxClocks rxResets =
   withBittideClockResetEnable :: forall r. ((HiddenClockResetEnable Bittide) => r) -> r
   withBittideClockResetEnable = withClockResetEnable bitClk bitRst bitEna
 
-uncurry5 ::
-  (a -> b -> c -> d -> e -> f) ->
-  (a, b, c, d, e) ->
-  f
-uncurry5 fn (a, b, c, d, e) = fn a b c d e
+uncurry4 ::
+  (a -> b -> c -> d -> e) ->
+  (a, b, c, d) ->
+  e
+uncurry4 fn (a, b, c, d) = fn a b c d
 
-unzip5Vec ::
-  Circuit (Vec n (a, b, c, d, e)) (Vec n a, Vec n b, Vec n c, Vec n d, Vec n e)
-unzip5Vec = applyC unzip5 (uncurry5 zip5)
+unzip4Vec ::
+  Circuit (Vec n (a, b, c, d)) (Vec n a, Vec n b, Vec n c, Vec n d)
+unzip4Vec = applyC unzip4 (uncurry4 zip4)

--- a/bittide-instances/src/Bittide/Instances/Hitl/SwitchDemoGppe/Core.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/SwitchDemoGppe/Core.hs
@@ -269,8 +269,8 @@ core (refClk, refRst) (bitClk, bitRst, bitEna) rxClocks rxResets =
     -- Stop management unit
 
     -- Start internal links
-    (_relDatCount, _underflow, _overflow, _ebStables, Fwd rxs1) <-
-      unzip5Vec
+    (_relDatCount, _underflow, _overflow, Fwd rxs1) <-
+      unzip4Vec
         <| ( Vec.vecCircuits
               $ xilinxElasticBufferWb
                 bitClk
@@ -357,12 +357,12 @@ core (refClk, refRst) (bitClk, bitRst, bitEna) rxClocks rxResets =
   withBittideClockResetEnable :: forall r. ((HiddenClockResetEnable Bittide) => r) -> r
   withBittideClockResetEnable = withClockResetEnable bitClk bitRst bitEna
 
-uncurry5 ::
-  (a -> b -> c -> d -> e -> f) ->
-  (a, b, c, d, e) ->
-  f
-uncurry5 fn (a, b, c, d, e) = fn a b c d e
+uncurry4 ::
+  (a -> b -> c -> d -> e) ->
+  (a, b, c, d) ->
+  e
+uncurry4 fn (a, b, c, d) = fn a b c d
 
-unzip5Vec ::
-  Circuit (Vec n (a, b, c, d, e)) (Vec n a, Vec n b, Vec n c, Vec n d, Vec n e)
-unzip5Vec = applyC unzip5 (uncurry5 zip5)
+unzip4Vec ::
+  Circuit (Vec n (a, b, c, d)) (Vec n a, Vec n b, Vec n c, Vec n d)
+unzip4Vec = applyC unzip4 (uncurry4 zip4)

--- a/bittide-instances/src/Bittide/Instances/Pnr/ElasticBuffer.hs
+++ b/bittide-instances/src/Bittide/Instances/Pnr/ElasticBuffer.hs
@@ -15,7 +15,6 @@ import Bittide.ClockControl (RelDataCount)
 import Bittide.ElasticBuffer (
   ElasticBufferData,
   Overflow,
-  Stable,
   Underflow,
   xilinxElasticBufferWb,
  )
@@ -34,15 +33,14 @@ elasticBufferWb ::
   , "dataCount" ::: Signal Fast (RelDataCount 6)
   , "underflow" ::: Signal Fast Underflow
   , "overflow" ::: Signal Fast Overflow
-  , "stable" ::: Signal Fast Stable
   , "readData" ::: Signal Fast (ElasticBufferData (Unsigned 64))
   )
-elasticBufferWb clkRead rstRead clkWrite wbIn wdata = (wbOut, dataCount, underflow, overflow, stable, readData)
+elasticBufferWb clkRead rstRead clkWrite wbIn wdata = (wbOut, dataCount, underflow, overflow, readData)
  where
-  ((SimOnly _mm, wbOut), (dataCount, underflow, overflow, stable, readData)) =
+  ((SimOnly _mm, wbOut), (dataCount, underflow, overflow, readData)) =
     withBittideByteOrder
       $ toSignals
         (xilinxElasticBufferWb clkRead rstRead d6 clkWrite wdata)
-        (((), wbIn), ((), (), (), (), ()))
+        (((), wbIn), ((), (), (), ()))
 
 makeTopEntity 'elasticBufferWb

--- a/bittide/src/Bittide/ElasticBuffer.hs
+++ b/bittide/src/Bittide/ElasticBuffer.hs
@@ -271,7 +271,6 @@ xilinxElasticBufferWb ::
     ( CSignal readDom (RelDataCount n)
     , CSignal readDom Underflow
     , CSignal readDom Overflow
-    , CSignal readDom Stable
     , CSignal readDom (ElasticBufferData a)
     )
 xilinxElasticBufferWb clkRead rstRead SNat clkWrite wdata =
@@ -281,7 +280,6 @@ xilinxElasticBufferWb clkRead rstRead SNat clkWrite wdata =
       , wbDataCount
       , wbUnderflow
       , wbOverflow
-      , wbStable
       ] <-
       deviceWb "ElasticBuffer" -< wb
 
@@ -346,11 +344,4 @@ xilinxElasticBufferWb clkRead rstRead SNat clkWrite wdata =
         False
         -< (wbOverflow, Fwd (flip orNothing True <$> overflow1))
 
-    -- Stable register: Software can set this to indicate buffer is ready
-    (stableOut, _stableActivity) <-
-      registerWbI
-        (registerConfig "stable"){access = WriteOnly}
-        False
-        -< (wbStable, Fwd (pure Nothing))
-
-    idC -< (dataCountOut, underflowOut, overflowOut, stableOut, Fwd readData)
+    idC -< (dataCountOut, underflowOut, overflowOut, Fwd readData)

--- a/firmware-binaries/demos/soft-ugn-mu/src/main.rs
+++ b/firmware-binaries/demos/soft-ugn-mu/src/main.rs
@@ -100,15 +100,8 @@ fn main() -> ! {
         }
     }
 
-    for (i, eb) in elastic_buffers.iter().enumerate() {
-        uwriteln!(
-            uart,
-            "Elastic Buffer {}, frames changed: {}",
-            i,
-            eb_changes[i]
-        )
-        .unwrap();
-        eb.set_stable(true);
+    for (i, &changes) in eb_changes.iter().enumerate() {
+        uwriteln!(uart, "Elastic Buffer {}, frames changed: {}", i, changes).unwrap();
     }
 
     uwriteln!(uart, "Switch transceiver channels to user mode..").unwrap();

--- a/firmware-binaries/demos/switch-demo1-mu/src/main.rs
+++ b/firmware-binaries/demos/switch-demo1-mu/src/main.rs
@@ -92,7 +92,6 @@ impl LinkStartup {
                 self.center_eb(elastic_buffer);
 
                 if all_stable {
-                    elastic_buffer.set_stable(true);
                     UgnCaptureState::Done
                 } else {
                     self.state

--- a/firmware-binaries/demos/switch-demo2-mu/src/main.rs
+++ b/firmware-binaries/demos/switch-demo2-mu/src/main.rs
@@ -71,15 +71,8 @@ fn main() -> ! {
         }
     }
 
-    for (i, eb) in elastic_buffers.iter().enumerate() {
-        uwriteln!(
-            uart,
-            "Elastic Buffer {}, frames changed: {}",
-            i,
-            eb_changes[i]
-        )
-        .unwrap();
-        eb.set_stable(true);
+    for (i, &changes) in eb_changes.iter().enumerate() {
+        uwriteln!(uart, "Elastic Buffer {}, frames changed: {}", i, changes).unwrap();
     }
 
     uwriteln!(uart, "Switch transceiver channels to user mode..").unwrap();


### PR DESCRIPTION
_What_
Remove `stable` register from elastic buffer

_Why_
This register has been made obsolete by moving control logic to software. We should have removed it as part of that process, but it slipped through the cracks.

_AI disclaimer_
No AIs where harmed in the making of this PR.

# TODO
- [X] ~~Write (regression) test~~ It's dead code, so no tests
- [X] ~~Update documentation, including `docs/`~~ It's dead code, so no docs
- [X] ~~Link to existing issue~~ Just thing I spotted while doing other work
