### PR TITLE
Add auto center feature to elastic buffers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,10 @@ too much, use `OverloadedRecordDot`. Both of these should be enabled by default.
 a new function has "too many" arguments or results, consider grouping them into
 records.
 
+## Executing commands
+When you execute a command you **must** wait for it to finish. Don't assume that no output
+for a while means that everything is okay.
+
 # Rust
 Before building a Rust crate, you **must** ensure that `bittide-instances` has
 been built. You can do this by running:

--- a/bittide-instances/src/Bittide/Instances/Tests/ElasticBufferWb.hs
+++ b/bittide-instances/src/Bittide/Instances/Tests/ElasticBufferWb.hs
@@ -97,5 +97,5 @@ dut = withBittideByteOrder $ withClockResetEnable clockGen (resetGenN d2) enable
         , includeIlaWb = False
         }
 
-type IMemWords = DivRU (64 * 1024) 4
+type IMemWords = DivRU (128 * 1024) 4
 type DMemWords = DivRU (32 * 1024) 4

--- a/bittide/bittide.cabal
+++ b/bittide/bittide.cabal
@@ -210,6 +210,7 @@ library
     Bittide.Df
     Bittide.DoubleBufferedRam
     Bittide.ElasticBuffer
+    Bittide.ElasticBuffer.AutoCenter
     Bittide.Ethernet.Mac
     Bittide.Jtag
     Bittide.MetaPeConfig

--- a/bittide/src/Bittide/ElasticBuffer/AutoCenter.hs
+++ b/bittide/src/Bittide/ElasticBuffer/AutoCenter.hs
@@ -1,0 +1,124 @@
+-- SPDX-FileCopyrightText: 2026 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+
+module Bittide.ElasticBuffer.AutoCenter where
+
+import Clash.Prelude
+import Protocols
+
+import Bittide.ClockControl (RelDataCount)
+
+data State
+  = InReset
+  | Idle
+      { adjustments :: Signed 32
+      -- ^ Cumulative adjustments that have been submitted to the elastic buffer
+      }
+  | Adjusting
+      { adjustments :: Signed 32
+      -- ^ Cumulative adjustments that have been submitted to the elastic buffer
+      , adjustment :: Signed 32
+      -- ^ The adjustment that is currently being submitted to the elastic buffer
+      }
+  | Waiting
+      { adjustments :: Signed 32
+      -- ^ Cumulative adjustments that have been submitted to the elastic buffer
+      , wait :: Index 256
+      -- ^ Number of cycles to wait before moving to Idle state. This should be long enough
+      -- to ensure that the adjustment has taken an effect on the buffer's occupancy count.
+      -- It is currently hardcoded to 256 cycles, which should be well above the time it
+      -- takes for an adjustment to take effect. At the same time, it should be more than
+      -- quick enough to not be too slow even for systems that are wildly out of balance.
+      }
+  deriving (Generic, NFDataX, Show)
+
+{- | If 'True', there are no pending adjustments to the elastic buffer. This means that the
+accumulated adjustments have been applied (though not necessarily reflected in the occupancy
+count yet) and that they can be used for, e.g., UGN adjustments.
+-}
+type IsIdle = Bool
+
+{- | Whether the auto-centering state machine is enabled. If 'False', the state machine will
+stay in the Idle state and will not submit any adjustments to the elastic buffer. Disabling
+the state machine while it is active is perfectly safe -- the state machine will handle
+its pending submissions and then move and stay in its 'Idle' state.
+-}
+type IsEnabled = Bool
+
+{- | State machine that tries to keep the buffer centered around 0 by submitting adjustments
+to the elastic buffer. Note that adjustments to the elastic buffer are destructive, and
+should therefore only be used during bittide initialization.
+-}
+autoCenter ::
+  (HiddenClock dom, KnownNat n, n <= 32) =>
+  Reset dom ->
+  Enable dom ->
+  -- | Correction margin. If set to 1, the circuit will try to keep the buffer at
+  --   [-1, 0, 1]. Note that if set to 0, the circuit will try to keep the buffer at exactly
+  --   0, which will cause it to submit many small adjustments, which may not be desirable.
+  Signal dom (Unsigned 16) ->
+  -- | The current number of items in the buffer. The circuit will try to keep this at 0
+  --   (or within the margin if set).
+  Signal dom (RelDataCount n) ->
+  Circuit
+    ()
+    ( Df dom (Signed 32)
+    , CSignal dom (Signed 32)
+    , CSignal dom IsIdle
+    )
+autoCenter reset enable margin relDataCount = Circuit go
+ where
+  go (_, (ack, _, _)) = ((), (adjustment, output, isIdle))
+   where
+    (adjustment, output, isIdle) =
+      withEnable enableGen
+        $ withReset reset
+        $ mooreB
+          goState
+          goOutput
+          InReset
+          ( fromEnable enable
+          , numConvert <$> relDataCount
+          , numConvert <$> margin
+          , ack
+          )
+
+-- XXX: These functions are outside of the circuit definition to avoid shadowing :-/
+
+goState :: State -> (IsEnabled, RelDataCount 32, Signed 32, Ack) -> State
+goState InReset _ = Idle 0
+goState s@Idle{} (False, _relDataCount, _margin, _ack) = s
+goState s@Idle{adjustments} (_isEnabled, relDataCount, margin, _ack)
+  | negate margin <= relDataCount && relDataCount <= margin = s -- within margin
+  | otherwise = Adjusting adjustments (negate relDataCount) -- outside margin
+goState s@Adjusting{adjustments, adjustment} (_isEnabled, _relDataCount, _margin, ~(Ack ack))
+  | ack = Waiting{adjustments = adjustments + adjustment, wait = 0}
+  | otherwise = s
+goState Waiting{adjustments, wait} (_isEnabled, _relDataCount, _margin, _ack)
+  | wait == maxBound = Idle adjustments
+  | otherwise = Waiting{adjustments, wait = wait + 1}
+
+goOutput :: State -> (Maybe (Signed 32), Signed 32, IsIdle)
+goOutput s = (adjustment_, adjustments_, isIdle)
+ where
+  -- Note! The "idle" output reflects the state of submissions, not the state of the
+  -- state machine. I.e., idle means that there are no pending adjustments to the elastic
+  -- buffer.
+  isIdle = case s of
+    InReset -> False
+    Idle{} -> True
+    Adjusting{} -> False
+    Waiting{} -> True
+
+  adjustments_ = case s of
+    InReset -> 0
+    Idle{adjustments} -> adjustments
+    Adjusting{adjustments} -> adjustments
+    Waiting{adjustments} -> adjustments
+
+  adjustment_ = case s of
+    InReset -> Nothing
+    Idle{} -> Nothing
+    Adjusting{adjustment} -> Just adjustment
+    Waiting{} -> Nothing

--- a/firmware-binaries/sim-tests/elastic_buffer_wb_test/src/main.rs
+++ b/firmware-binaries/sim-tests/elastic_buffer_wb_test/src/main.rs
@@ -537,6 +537,614 @@ fn test_async_wait_async_wait(
     }
 }
 
+/// Verifies that the auto-center state machine centers the buffer when enabled.
+fn test_auto_center_basic_centering(
+    uart: &mut bittide_hal::shared_devices::Uart,
+    elastic_buffer: &bittide_hal::shared_devices::ElasticBuffer,
+    timer: &bittide_hal::shared_devices::Timer,
+) -> bool {
+    uwriteln!(uart, "Test: Auto-center basic centering").unwrap();
+
+    // Reset and set up
+    elastic_buffer.reset_auto_center();
+    elastic_buffer.set_occupancy(0);
+    timer.wait(Duration::from_micros(1));
+
+    // Set buffer to +10
+    elastic_buffer.set_occupancy(10);
+    timer.wait(Duration::from_micros(1));
+    let count_before = elastic_buffer.data_count();
+    uwriteln!(uart, "  Initial count: {}", count_before).unwrap();
+
+    // Set margin to 2 and enable auto-center
+    elastic_buffer.set_auto_center_margin(2);
+    elastic_buffer.set_auto_center_enable(true);
+
+    // Wait for it to become idle
+    elastic_buffer.wait_auto_center_idle();
+
+    timer.wait(Duration::from_micros(1));
+    let count_after = elastic_buffer.data_count();
+    let total_adjustments = elastic_buffer.auto_center_total_adjustments();
+    uwriteln!(
+        uart,
+        "  After auto-center: count={}, total_adjustments={}",
+        count_after,
+        total_adjustments
+    )
+    .unwrap();
+
+    // Verify occupancy is exactly 0 (auto-center submits adjustment of -10)
+    if count_after != 0 {
+        uwriteln!(uart, "  FAIL: Expected count=0, got {}", count_after).unwrap();
+        return false;
+    }
+
+    // Verify total adjustments equals -10 (moved from +10 to 0)
+    if total_adjustments != -10 {
+        uwriteln!(
+            uart,
+            "  FAIL: Expected total_adjustments=-10, got {}",
+            total_adjustments
+        )
+        .unwrap();
+        return false;
+    }
+
+    elastic_buffer.set_auto_center_enable(false);
+    uwriteln!(uart, "  PASS").unwrap();
+    true
+}
+
+/// Verifies that the margin parameter works correctly with different values.
+fn test_auto_center_margin_parameter(
+    uart: &mut bittide_hal::shared_devices::Uart,
+    elastic_buffer: &bittide_hal::shared_devices::ElasticBuffer,
+    timer: &bittide_hal::shared_devices::Timer,
+) -> bool {
+    uwriteln!(uart, "Test: Auto-center margin parameter").unwrap();
+
+    let margins = [0u16, 1, 5];
+    let test_offset = 15i8;
+
+    for &margin in &margins {
+        // Reset for each test
+        elastic_buffer.reset_auto_center();
+        elastic_buffer.set_occupancy(0);
+        timer.wait(Duration::from_micros(1));
+
+        // Set buffer outside margin
+        elastic_buffer.set_occupancy(test_offset);
+        timer.wait(Duration::from_micros(1));
+
+        uwriteln!(uart, "  Testing margin={}", margin).unwrap();
+
+        // Set margin and enable
+        elastic_buffer.set_auto_center_margin(margin);
+        elastic_buffer.set_auto_center_enable(true);
+
+        // Wait for idle
+        elastic_buffer.wait_auto_center_idle();
+
+        timer.wait(Duration::from_micros(1));
+        let count_after = elastic_buffer.data_count();
+        let margin_signed = margin as i8;
+
+        uwriteln!(
+            uart,
+            "    After centering: count={}, expected range=[{}, {}]",
+            count_after,
+            -margin_signed,
+            margin_signed
+        )
+        .unwrap();
+
+        // Verify within margin
+        if count_after < -margin_signed || count_after > margin_signed {
+            uwriteln!(
+                uart,
+                "    FAIL: Count {} not within margin [{}, {}]",
+                count_after,
+                -margin_signed,
+                margin_signed
+            )
+            .unwrap();
+            return false;
+        }
+
+        elastic_buffer.set_auto_center_enable(false);
+    }
+
+    uwriteln!(uart, "  PASS").unwrap();
+    true
+}
+
+/// Verifies basic enable/disable functionality of auto-center.
+fn test_auto_center_enable_disable(
+    uart: &mut bittide_hal::shared_devices::Uart,
+    elastic_buffer: &bittide_hal::shared_devices::ElasticBuffer,
+    timer: &bittide_hal::shared_devices::Timer,
+) -> bool {
+    uwriteln!(uart, "Test: Auto-center enable/disable").unwrap();
+
+    // Reset to known state
+    elastic_buffer.reset_auto_center();
+    timer.wait(Duration::from_micros(1));
+
+    // Verify starts disabled
+    let enabled_initial = elastic_buffer.auto_center_enable();
+    if enabled_initial {
+        uwriteln!(uart, "  FAIL: Should start disabled").unwrap();
+        return false;
+    }
+
+    // Enable and verify
+    elastic_buffer.set_auto_center_enable(true);
+    let enabled_after_enable = elastic_buffer.auto_center_enable();
+    if !enabled_after_enable {
+        uwriteln!(uart, "  FAIL: Should be enabled after enable").unwrap();
+        return false;
+    }
+
+    // Disable and verify
+    elastic_buffer.set_auto_center_enable(false);
+    let enabled_after_disable = elastic_buffer.auto_center_enable();
+    if enabled_after_disable {
+        uwriteln!(uart, "  FAIL: Should be disabled after disable").unwrap();
+        return false;
+    }
+
+    uwriteln!(uart, "  PASS").unwrap();
+    true
+}
+
+/// Verifies the idle state reporting is accurate.
+fn test_auto_center_idle_state(
+    uart: &mut bittide_hal::shared_devices::Uart,
+    elastic_buffer: &bittide_hal::shared_devices::ElasticBuffer,
+    timer: &bittide_hal::shared_devices::Timer,
+) -> bool {
+    uwriteln!(uart, "Test: Auto-center idle state").unwrap();
+
+    // Reset and prepare
+    elastic_buffer.reset_auto_center();
+    elastic_buffer.set_occupancy(0);
+    timer.wait(Duration::from_micros(1));
+
+    // Verify idle when disabled
+    let idle_when_disabled = elastic_buffer.auto_center_is_idle();
+    if !idle_when_disabled {
+        uwriteln!(uart, "  FAIL: Should be idle when disabled").unwrap();
+        return false;
+    }
+
+    // Set buffer off-center
+    elastic_buffer.set_occupancy(20);
+    timer.wait(Duration::from_micros(1));
+
+    // Enable auto-center
+    elastic_buffer.set_auto_center_margin(2);
+    elastic_buffer.set_auto_center_enable(true);
+
+    // Wait for completion
+    elastic_buffer.wait_auto_center_idle();
+
+    // Verify idle when centered
+    let idle_when_centered = elastic_buffer.auto_center_is_idle();
+    if !idle_when_centered {
+        uwriteln!(uart, "  FAIL: Should be idle when centered").unwrap();
+        return false;
+    }
+
+    elastic_buffer.set_auto_center_enable(false);
+    uwriteln!(
+        uart,
+        "  Idle states: disabled={}, centered={}",
+        idle_when_disabled,
+        idle_when_centered
+    )
+    .unwrap();
+    uwriteln!(uart, "  PASS").unwrap();
+    true
+}
+
+/// Verifies that total adjustments are tracked correctly across multiple operations.
+fn test_auto_center_total_adjustments_tracking(
+    uart: &mut bittide_hal::shared_devices::Uart,
+    elastic_buffer: &bittide_hal::shared_devices::ElasticBuffer,
+    timer: &bittide_hal::shared_devices::Timer,
+) -> bool {
+    uwriteln!(uart, "Test: Auto-center total adjustments tracking").unwrap();
+
+    // Reset and start from 0
+    elastic_buffer.reset_auto_center();
+    elastic_buffer.set_occupancy(0);
+    timer.wait(Duration::from_micros(1));
+
+    // Verify total starts at 0
+    let total_initial = elastic_buffer.auto_center_total_adjustments();
+    if total_initial != 0 {
+        uwriteln!(
+            uart,
+            "  FAIL: Total should be 0 initially, got {}",
+            total_initial
+        )
+        .unwrap();
+        return false;
+    }
+
+    // Set buffer to +15 and center
+    elastic_buffer.set_occupancy(15);
+    timer.wait(Duration::from_micros(1));
+    elastic_buffer.set_auto_center_margin(0);
+    elastic_buffer.set_auto_center_enable(true);
+    elastic_buffer.wait_auto_center_idle();
+
+    let total_after_first = elastic_buffer.auto_center_total_adjustments();
+    uwriteln!(
+        uart,
+        "  After centering from +15: total={}",
+        total_after_first
+    )
+    .unwrap();
+
+    if total_after_first != -15 {
+        uwriteln!(
+            uart,
+            "  FAIL: Expected total=-15, got {}",
+            total_after_first
+        )
+        .unwrap();
+        return false;
+    }
+
+    // Manually set buffer to -10 and let it center again
+    elastic_buffer.set_auto_center_enable(false);
+    elastic_buffer.wait_auto_center_idle();
+    elastic_buffer.set_occupancy(-10);
+    timer.wait(Duration::from_micros(1));
+    elastic_buffer.set_auto_center_enable(true);
+    elastic_buffer.wait_auto_center_idle();
+
+    let total_after_second = elastic_buffer.auto_center_total_adjustments();
+    uwriteln!(
+        uart,
+        "  After centering from -10: total={}",
+        total_after_second
+    )
+    .unwrap();
+
+    // Total should be -15 + 10 = -5
+    if total_after_second != -5 {
+        uwriteln!(
+            uart,
+            "  FAIL: Expected total=-5, got {}",
+            total_after_second
+        )
+        .unwrap();
+        return false;
+    }
+
+    elastic_buffer.set_auto_center_enable(false);
+    uwriteln!(uart, "  PASS").unwrap();
+    true
+}
+
+/// Verifies the reset functionality works correctly.
+fn test_auto_center_reset_functionality(
+    uart: &mut bittide_hal::shared_devices::Uart,
+    elastic_buffer: &bittide_hal::shared_devices::ElasticBuffer,
+    timer: &bittide_hal::shared_devices::Timer,
+) -> bool {
+    uwriteln!(uart, "Test: Auto-center reset functionality").unwrap();
+
+    // Make some adjustments first
+    elastic_buffer.reset_auto_center();
+    elastic_buffer.set_occupancy(12);
+    timer.wait(Duration::from_micros(1));
+    elastic_buffer.set_auto_center_margin(0);
+    elastic_buffer.set_auto_center_enable(true);
+    elastic_buffer.wait_auto_center_idle();
+
+    let total_before_reset = elastic_buffer.auto_center_total_adjustments();
+    uwriteln!(
+        uart,
+        "  Total adjustments before reset: {}",
+        total_before_reset
+    )
+    .unwrap();
+
+    if total_before_reset == 0 {
+        uwriteln!(uart, "  FAIL: Total should be non-zero before reset").unwrap();
+        return false;
+    }
+
+    // Reset
+    elastic_buffer.reset_auto_center();
+    timer.wait(Duration::from_micros(1));
+
+    // Verify total is 0
+    let total_after_reset = elastic_buffer.auto_center_total_adjustments();
+    if total_after_reset != 0 {
+        uwriteln!(
+            uart,
+            "  FAIL: Total should be 0 after reset, got {}",
+            total_after_reset
+        )
+        .unwrap();
+        return false;
+    }
+
+    // Verify disabled
+    let enabled_after_reset = elastic_buffer.auto_center_enable();
+    if enabled_after_reset {
+        uwriteln!(uart, "  FAIL: Should be disabled after reset").unwrap();
+        return false;
+    }
+
+    // Verify idle
+    let idle_after_reset = elastic_buffer.auto_center_is_idle();
+    if !idle_after_reset {
+        uwriteln!(uart, "  FAIL: Should be idle after reset").unwrap();
+        return false;
+    }
+
+    uwriteln!(uart, "  PASS").unwrap();
+    true
+}
+
+/// Verifies interaction between manual and auto-center adjustments.
+fn test_auto_center_with_manual_adjustments(
+    uart: &mut bittide_hal::shared_devices::Uart,
+    elastic_buffer: &bittide_hal::shared_devices::ElasticBuffer,
+    timer: &bittide_hal::shared_devices::Timer,
+) -> bool {
+    uwriteln!(uart, "Test: Auto-center with manual adjustments").unwrap();
+
+    // Reset and prepare
+    elastic_buffer.reset_auto_center();
+    elastic_buffer.set_occupancy(10);
+    timer.wait(Duration::from_micros(1));
+
+    // Enable auto-center
+    elastic_buffer.set_auto_center_margin(2);
+    elastic_buffer.set_auto_center_enable(true);
+    timer.wait(Duration::from_micros(1));
+
+    // Submit a manual adjustment while auto-center is active
+    elastic_buffer.set_adjustment(5);
+    timer.wait(Duration::from_micros(1));
+
+    // Wait for auto-center to finish
+    elastic_buffer.wait_auto_center_idle();
+
+    let count_final = elastic_buffer.data_count();
+    let total_adjustments = elastic_buffer.auto_center_total_adjustments();
+
+    uwriteln!(
+        uart,
+        "  Final count={}, auto_center_total={}",
+        count_final,
+        total_adjustments
+    )
+    .unwrap();
+
+    // The manual +5 and auto-center adjustments should both be applied
+    // Auto-center should have applied adjustments to center the buffer
+    // Total adjustments should only count auto-center's contributions (not manual)
+
+    // After manual +5, buffer was at 15, auto-center should bring it to within [-2, 2]
+    if !(-2..=2).contains(&count_final) {
+        uwriteln!(
+            uart,
+            "  FAIL: Final count {} not within margin",
+            count_final
+        )
+        .unwrap();
+        return false;
+    }
+
+    elastic_buffer.set_auto_center_enable(false);
+    uwriteln!(uart, "  PASS").unwrap();
+    true
+}
+
+/// Verifies that auto-center doesn't make adjustments when already centered.
+fn test_auto_center_already_centered(
+    uart: &mut bittide_hal::shared_devices::Uart,
+    elastic_buffer: &bittide_hal::shared_devices::ElasticBuffer,
+    timer: &bittide_hal::shared_devices::Timer,
+) -> bool {
+    uwriteln!(uart, "Test: Auto-center already centered").unwrap();
+
+    // Reset and set to 0
+    elastic_buffer.reset_auto_center();
+    elastic_buffer.set_occupancy(0);
+    timer.wait(Duration::from_micros(1));
+
+    let count_before = elastic_buffer.data_count();
+
+    // Enable auto-center with margin 2
+    elastic_buffer.set_auto_center_margin(2);
+    elastic_buffer.set_auto_center_enable(true);
+    elastic_buffer.wait_auto_center_idle();
+
+    let count_after = elastic_buffer.data_count();
+    let total_adjustments = elastic_buffer.auto_center_total_adjustments();
+
+    uwriteln!(
+        uart,
+        "  Before={}, After={}, Total adjustments={}",
+        count_before,
+        count_after,
+        total_adjustments
+    )
+    .unwrap();
+
+    // Should make no adjustments
+    if total_adjustments != 0 {
+        uwriteln!(
+            uart,
+            "  FAIL: Should make no adjustments when already centered, got {}",
+            total_adjustments
+        )
+        .unwrap();
+        return false;
+    }
+
+    // Buffer should stay at 0
+    if count_after != 0 {
+        uwriteln!(uart, "  FAIL: Buffer should stay at 0, got {}", count_after).unwrap();
+        return false;
+    }
+
+    elastic_buffer.set_auto_center_enable(false);
+    uwriteln!(uart, "  PASS").unwrap();
+    true
+}
+
+/// Verifies the wait_auto_center_idle helper function.
+fn test_auto_center_wait_idle(
+    uart: &mut bittide_hal::shared_devices::Uart,
+    elastic_buffer: &bittide_hal::shared_devices::ElasticBuffer,
+    timer: &bittide_hal::shared_devices::Timer,
+) -> bool {
+    uwriteln!(uart, "Test: Auto-center wait_idle helper").unwrap();
+
+    // Reset and prepare
+    elastic_buffer.reset_auto_center();
+    elastic_buffer.set_occupancy(25);
+    timer.wait(Duration::from_micros(1));
+
+    // Enable auto-center
+    elastic_buffer.set_auto_center_margin(2);
+    elastic_buffer.set_auto_center_enable(true);
+
+    // Immediately call wait_idle
+    elastic_buffer.wait_auto_center_idle();
+
+    // Should not return until idle, and buffer should be centered
+    let count_after = elastic_buffer.data_count();
+    let is_idle = elastic_buffer.auto_center_is_idle();
+
+    uwriteln!(
+        uart,
+        "  After wait_idle: count={}, is_idle={}",
+        count_after,
+        is_idle
+    )
+    .unwrap();
+
+    if !is_idle {
+        uwriteln!(uart, "  FAIL: Should be idle after wait_idle returns").unwrap();
+        return false;
+    }
+
+    if !(-2..=2).contains(&count_after) {
+        uwriteln!(
+            uart,
+            "  FAIL: Should be centered after wait_idle, got {}",
+            count_after
+        )
+        .unwrap();
+        return false;
+    }
+
+    elastic_buffer.set_auto_center_enable(false);
+    uwriteln!(uart, "  PASS").unwrap();
+    true
+}
+
+/// Verifies edge case with margin = 0 (centers exactly at 0).
+fn test_auto_center_zero_margin(
+    uart: &mut bittide_hal::shared_devices::Uart,
+    elastic_buffer: &bittide_hal::shared_devices::ElasticBuffer,
+    timer: &bittide_hal::shared_devices::Timer,
+) -> bool {
+    uwriteln!(uart, "Test: Auto-center zero margin").unwrap();
+
+    // Reset and set off-center
+    elastic_buffer.reset_auto_center();
+    elastic_buffer.set_occupancy(8);
+    timer.wait(Duration::from_micros(1));
+
+    // Set margin to 0
+    elastic_buffer.set_auto_center_margin(0);
+    elastic_buffer.set_auto_center_enable(true);
+    elastic_buffer.wait_auto_center_idle();
+    timer.wait(Duration::from_micros(1));
+
+    let count_after = elastic_buffer.data_count();
+    uwriteln!(
+        uart,
+        "  After centering with margin=0: count={}",
+        count_after
+    )
+    .unwrap();
+
+    if count_after != 0 {
+        uwriteln!(
+            uart,
+            "  FAIL: Should be exactly 0 with margin=0, got {}",
+            count_after
+        )
+        .unwrap();
+        return false;
+    }
+
+    elastic_buffer.set_auto_center_enable(false);
+    uwriteln!(uart, "  PASS").unwrap();
+    true
+}
+
+/// Verifies that auto-center continuously maintains centering across perturbations.
+fn test_auto_center_persistence_across_multiple_perturbations(
+    uart: &mut bittide_hal::shared_devices::Uart,
+    elastic_buffer: &bittide_hal::shared_devices::ElasticBuffer,
+    timer: &bittide_hal::shared_devices::Timer,
+) -> bool {
+    uwriteln!(uart, "Test: Auto-center persistence across perturbations").unwrap();
+
+    // Reset and enable
+    elastic_buffer.reset_auto_center();
+    elastic_buffer.set_occupancy(0);
+    timer.wait(Duration::from_micros(1));
+    elastic_buffer.set_auto_center_margin(2);
+    elastic_buffer.set_auto_center_enable(true);
+    elastic_buffer.wait_auto_center_idle();
+
+    let perturbations = [7i32, -12, 18, -5];
+
+    for &perturbation in &perturbations {
+        uwriteln!(uart, "  Applying perturbation: {}", perturbation).unwrap();
+
+        // Manually adjust buffer off-center
+        elastic_buffer.set_adjustment(perturbation);
+        timer.wait(Duration::from_micros(1));
+
+        // Wait for auto-center to fix it
+        elastic_buffer.wait_auto_center_idle();
+
+        let count = elastic_buffer.data_count();
+        uwriteln!(uart, "    After re-centering: count={}", count).unwrap();
+
+        // Verify it's centered again
+        if !(-2..=2).contains(&count) {
+            uwriteln!(
+                uart,
+                "    FAIL: Should re-center after perturbation, got {}",
+                count
+            )
+            .unwrap();
+            return false;
+        }
+    }
+
+    elastic_buffer.set_auto_center_enable(false);
+    uwriteln!(uart, "  PASS").unwrap();
+    true
+}
+
 #[cfg_attr(not(test), entry)]
 fn main() -> ! {
     let mut uart = INSTANCES.uart;
@@ -553,6 +1161,23 @@ fn main() -> ! {
     all_passed &= test_multiple_items_command(&mut uart, &elastic_buffer, &timer);
     all_passed &= test_back_to_back(&mut uart, &elastic_buffer, &timer);
     all_passed &= test_async_wait_async_wait(&mut uart, &elastic_buffer, &timer);
+
+    // Auto-center tests
+    all_passed &= test_auto_center_basic_centering(&mut uart, &elastic_buffer, &timer);
+    all_passed &= test_auto_center_margin_parameter(&mut uart, &elastic_buffer, &timer);
+    all_passed &= test_auto_center_enable_disable(&mut uart, &elastic_buffer, &timer);
+    all_passed &= test_auto_center_idle_state(&mut uart, &elastic_buffer, &timer);
+    all_passed &= test_auto_center_total_adjustments_tracking(&mut uart, &elastic_buffer, &timer);
+    all_passed &= test_auto_center_reset_functionality(&mut uart, &elastic_buffer, &timer);
+    all_passed &= test_auto_center_with_manual_adjustments(&mut uart, &elastic_buffer, &timer);
+    all_passed &= test_auto_center_already_centered(&mut uart, &elastic_buffer, &timer);
+    all_passed &= test_auto_center_wait_idle(&mut uart, &elastic_buffer, &timer);
+    all_passed &= test_auto_center_zero_margin(&mut uart, &elastic_buffer, &timer);
+    all_passed &= test_auto_center_persistence_across_multiple_perturbations(
+        &mut uart,
+        &elastic_buffer,
+        &timer,
+    );
 
     if all_passed {
         uwriteln!(uart, "All elastic buffer tests passed").unwrap();

--- a/firmware-support/bittide-hal/src/manual_additions/elastic_buffer.rs
+++ b/firmware-support/bittide-hal/src/manual_additions/elastic_buffer.rs
@@ -77,4 +77,28 @@ impl ElasticBuffer {
         self.clear_underflow();
         self.clear_overflow();
     }
+
+    /// Reset the auto-centering state machine (safe wrapper).
+    ///
+    /// This function ensures safety by:
+    /// 1. Disabling the auto-centering state machine
+    /// 2. Waiting for it to become idle
+    /// 3. Resetting it
+    ///
+    /// This function always succeeds and is safe to call at any time.
+    pub fn reset_auto_center(&self) {
+        self.set_auto_center_enable(false);
+        self.wait_auto_center_idle();
+        self.set_auto_center_reset_unchecked(());
+        self.wait_auto_center_idle();
+    }
+
+    /// Wait for the auto-centering state machine to become idle.
+    ///
+    /// This is useful after disabling auto-center before performing a reset.
+    pub fn wait_auto_center_idle(&self) {
+        while !self.auto_center_is_idle() {
+            core::hint::spin_loop();
+        }
+    }
 }


### PR DESCRIPTION
_What + why_
In #1135 we employ a "simple" trick to allow ring buffers to be aligned and UGNs to remain valid while clock control is still stabilizing the system. We do all this in software, which critically relies on the software being "quick enough". This is not always the case, as seen in #1168. Although we've more or less fixed the issue by making EB control much faster (#1178), this commit adds the option to entirely offload this responsibility to hardware.

_Dear reviewer_
Do you want me to write direct tests for `autoCenter` too (instead of only Rust/integration tests)?

_AI disclaimer_
I used Claude to generate test cases after telling it what I wanted to test.

---------

Closes #1179

# TODO
- [x] Write (regression) test
- [x] Update documentation, including `docs/`
- [x] Link to existing issue
