### PR TITLE
Only return speed changes in callisto component

### DIFF
--- a/bittide-instances/src/Bittide/Instances/Hitl/SoftUgnDemo/BringUp.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/SoftUgnDemo/BringUp.hs
@@ -19,7 +19,6 @@ import Protocols
 import Bittide.BootPe (BootPeBusses, bootPe)
 import Bittide.CaptureUgn (sendUgnC)
 import Bittide.ClockControl
-import Bittide.ClockControl.Callisto.Types (CallistoResult (..))
 import Bittide.Df (asciiDebugMux)
 import Bittide.Instances.Domains (
   Basic125,
@@ -144,7 +143,7 @@ bringUp refClk refRst = withBittideByteOrder $ circuit $ \(bootMm, muMm, ccMm, g
       $ sendUgnC localCounter tOutputs.txSamplings
       -< switchDataOut
 
-  ( Fwd callistoResult
+  ( Fwd speedChanges
     , Fwd localCounter
     , switchDataOut
     , sync
@@ -191,6 +190,6 @@ bringUp refClk refRst = withBittideByteOrder $ circuit $ \(bootMm, muMm, ccMm, g
           bittideRst
           enableGen
           (SNat @Si539xHoldTime)
-          callistoResult.maybeSpeedChange
+          speedChanges
 
   idC -< (spi, sync, uartTx, Fwd frequencyAdjustments)

--- a/bittide-instances/src/Bittide/Instances/Hitl/SoftUgnDemo/Core.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/SoftUgnDemo/Core.hs
@@ -9,7 +9,7 @@ import Protocols
 
 import Bittide.Calendar (CalendarConfig (..), ValidEntry (..))
 import Bittide.CaptureUgn (captureUgn)
-import Bittide.ClockControl.Callisto.Types (CallistoResult (..), Stability (..))
+import Bittide.ClockControl (SpeedChange)
 import Bittide.ClockControl.CallistoSw (SwcccInternalBusses, callistoSwClockControlC)
 import Bittide.DoubleBufferedRam (wbStorage)
 import Bittide.ElasticBuffer (xilinxElasticBufferWb)
@@ -220,7 +220,7 @@ core ::
     , "CC_SUITABLE" ::: CSignal Bittide (BitVector LinkCount)
     , "RXS" ::: Vec LinkCount (CSignal GthRx (Maybe (BitVector 64)))
     )
-    ( CSignal Bittide (CallistoResult LinkCount)
+    ( CSignal Bittide (Maybe SpeedChange)
     , "LOCAL_COUNTER" ::: CSignal Bittide (Unsigned 64)
     , "TXS" ::: Vec LinkCount (CSignal Bittide (BitVector 64))
     , Sync Bittide Basic125
@@ -311,14 +311,7 @@ core (refClk, refRst) (bitClk, bitRst, bitEna) rxClocks rxResets =
                in
                 if simulateCc
                   then swCcOut0
-                  else
-                    pure
-                      $ CallistoResult
-                        { maybeSpeedChange = Nothing
-                        , stability = repeat (Stability{stable = True, settled = True})
-                        , allStable = True
-                        , allSettled = True
-                        }
+                  else pure Nothing
             else swCcOut0
 
     -- Use of `dflipflop` to add pipelining should be replaced by

--- a/bittide-instances/src/Bittide/Instances/Hitl/SwitchDemo/BringUp.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/SwitchDemo/BringUp.hs
@@ -19,7 +19,6 @@ import Protocols
 import Bittide.BootPe (BootPeBusses, bootPe)
 import Bittide.CaptureUgn (sendUgnC)
 import Bittide.ClockControl
-import Bittide.ClockControl.Callisto.Types (CallistoResult (..))
 import Bittide.Df (asciiDebugMux)
 import Bittide.Instances.Domains (
   Basic125,
@@ -144,7 +143,7 @@ bringUp refClk refRst = withBittideByteOrder $ circuit $ \(bootMm, muMm, ccMm, j
       $ sendUgnC localCounter tOutputs.txSamplings
       -< switchDataOut
 
-  ( Fwd callistoResult
+  ( Fwd speedChanges
     , Fwd localCounter
     , switchDataOut
     , sync
@@ -189,6 +188,6 @@ bringUp refClk refRst = withBittideByteOrder $ circuit $ \(bootMm, muMm, ccMm, j
           bittideRst
           enableGen
           (SNat @Si539xHoldTime)
-          callistoResult.maybeSpeedChange
+          speedChanges
 
   idC -< (spi, sync, uartTx, Fwd frequencyAdjustments)

--- a/bittide-instances/src/Bittide/Instances/Hitl/SwitchDemoGppe/BringUp.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/SwitchDemoGppe/BringUp.hs
@@ -19,7 +19,6 @@ import Protocols
 import Bittide.BootPe (BootPeBusses, bootPe)
 import Bittide.CaptureUgn (sendUgnC)
 import Bittide.ClockControl
-import Bittide.ClockControl.Callisto.Types (CallistoResult (..))
 import Bittide.Df (asciiDebugMux)
 import Bittide.Instances.Domains (
   Basic125,
@@ -144,7 +143,7 @@ bringUp refClk refRst = withBittideByteOrder $ circuit $ \(bootMm, muMm, ccMm, g
       $ sendUgnC localCounter tOutputs.txSamplings
       -< switchDataOut
 
-  ( Fwd callistoResult
+  ( Fwd speedChanges
     , Fwd localCounter
     , switchDataOut
     , sync
@@ -191,6 +190,6 @@ bringUp refClk refRst = withBittideByteOrder $ circuit $ \(bootMm, muMm, ccMm, g
           bittideRst
           enableGen
           (SNat @Si539xHoldTime)
-          callistoResult.maybeSpeedChange
+          speedChanges
 
   idC -< (spi, sync, uartTx, Fwd frequencyAdjustments)

--- a/bittide-instances/src/Bittide/Instances/Hitl/SwitchDemoGppe/Core.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/SwitchDemoGppe/Core.hs
@@ -9,7 +9,7 @@ import Protocols
 
 import Bittide.Calendar (CalendarConfig (..), ValidEntry (..))
 import Bittide.CaptureUgn (captureUgn)
-import Bittide.ClockControl.Callisto.Types (CallistoResult (..), Stability (..))
+import Bittide.ClockControl (SpeedChange)
 import Bittide.ClockControl.CallistoSw (SwcccInternalBusses, callistoSwClockControlC)
 import Bittide.DoubleBufferedRam (wbStorage)
 import Bittide.ElasticBuffer (xilinxElasticBufferWb)
@@ -245,7 +245,7 @@ core ::
     , CSignal Bittide (BitVector LinkCount)
     , "RXS" ::: Vec LinkCount (CSignal GthRx (Maybe (BitVector 64)))
     )
-    ( CSignal Bittide (CallistoResult LinkCount)
+    ( CSignal Bittide (Maybe SpeedChange)
     , "LOCAL_COUNTER" ::: CSignal Bittide (Unsigned 64)
     , "TXS" ::: Vec LinkCount (CSignal Bittide (BitVector 64))
     , Sync Bittide Basic125
@@ -339,14 +339,7 @@ core (refClk, refRst) (bitClk, bitRst, bitEna) rxClocks rxResets =
                in
                 if simulateCc
                   then swCcOut0
-                  else
-                    pure
-                      $ CallistoResult
-                        { maybeSpeedChange = Nothing
-                        , stability = repeat (Stability{stable = True, settled = True})
-                        , allStable = True
-                        , allSettled = True
-                        }
+                  else pure Nothing
             else swCcOut0
 
     idC

--- a/bittide-instances/tests/Tests/ClockControlWb.hs
+++ b/bittide-instances/tests/Tests/ClockControlWb.hs
@@ -14,7 +14,7 @@ import Bittide.Cpus.Riscv32imc (vexRiscv0)
 import Clash.Class.BitPackC (ByteOrder (BigEndian))
 import Clash.Signal (withClockResetEnable)
 import Data.Char (chr)
-import Data.Maybe (catMaybes, mapMaybe)
+import Data.Maybe (catMaybes)
 import Data.String.Interpolate
 import Project.FilePath
 import Protocols
@@ -31,7 +31,8 @@ import VexRiscv (DumpVcd (NoDumpVcd))
 
 -- internal imports
 import Bittide.Arithmetic.Time (PeriodToCycles)
-import Bittide.ClockControl.Registers (ClockControlData (clockMod), clockControlWb)
+import Bittide.ClockControl (SpeedChange)
+import Bittide.ClockControl.Registers (clockControlWb)
 import Bittide.DoubleBufferedRam
 import Bittide.Instances.Hitl.Setup (LinkCount)
 import Bittide.ProcessingElement
@@ -84,7 +85,7 @@ case_clock_control_wb_self_test = do
                 L.take (L.length actual.clockMod)
                   $ fromIntegral
                   . pack
-                  <$> mapMaybe (.clockMod) ccData
+                  <$> catMaybes ccData
             }
       assertEqual "Expected and actual differ" expected actual
  where
@@ -121,7 +122,7 @@ expectedDataCounts = L.zip [0 ..] $ toList $ applyMask linkMask dataCounts
   applyMask m = zipWith go (bitCoerce m)
   go m v = if m then fromIntegral v else 0
 
-dut :: Circuit () (Df System (BitVector 8), CSignal System (ClockControlData LinkCount))
+dut :: Circuit () (Df System (BitVector 8), CSignal System (Maybe SpeedChange))
 dut =
   withBittideByteOrder
     $ withClockResetEnable clockGen (resetGenN d2) enableGen

--- a/bittide/src/Bittide/ClockControl/Callisto/Types.hs
+++ b/bittide/src/Bittide/ClockControl/Callisto/Types.hs
@@ -1,19 +1,11 @@
 -- SPDX-FileCopyrightText: 2023 Google LLC
 --
 -- SPDX-License-Identifier: Apache-2.0
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE UndecidableInstances #-}
-{-# OPTIONS_GHC -fconstraint-solver-iterations=20 #-}
-
 module Bittide.ClockControl.Callisto.Types (
-  CallistoResult (..),
   Stability (..),
 ) where
 
 import Clash.Prelude
-
-import Bittide.ClockControl
 
 -- | Stability results to be returned by the 'stability_detector'.
 data Stability = Stability
@@ -24,19 +16,3 @@ data Stability = Stability
   -- 'targetDataCount'.
   }
   deriving (Generic, NFDataX, BitPack, ShowX, Show)
-
--- | Result of the clock control algorithm.
-data CallistoResult (n :: Nat) = CallistoResult
-  { maybeSpeedChange :: Maybe SpeedChange
-  -- ^ Speed change requested for clock multiplier. This is 'Just' for a single
-  -- cycle.
-  , stability :: Vec n Stability
-  -- ^ All stability indicators for all of the elastic buffers.
-  , allStable :: Bool
-  -- ^ Joint stability indicator signaling that all elastic buffers
-  -- are stable.
-  , allSettled :: Bool
-  -- ^ Joint "being-settled" indicator signaling that all elastic
-  -- buffers have been settled.
-  }
-  deriving (Generic, NFDataX)


### PR DESCRIPTION
_What_
Remove stability propagation through system.

_Why_
Stability information is now a software-only concept, so it doesn't need to be propagated anymore.

# TODO
- [X] ~~Write (regression) test~~
- [X] ~~Update documentation, including `docs/`~~
- [X] ~~Link to existing issue~~ just a cleanup
- [x] Amend tests
