### PR TITLE
Separate slow and fast busses in switchDemo managementunit

### DIFF
--- a/bittide-instances/src/Bittide/Instances/Hitl/SwitchDemo/Driver.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/SwitchDemo/Driver.hs
@@ -216,7 +216,7 @@ driver testName targets = do
     muGetUgns (_, d) gdb = do
       let
         captureUgnPrefixed :: Int -> String -> [String]
-        captureUgnPrefixed linkNr reg = ["0", "CaptureUgn" <> show linkNr, reg]
+        captureUgnPrefixed linkNr reg = ["0", "3", "CaptureUgn" <> show linkNr, reg]
 
         readUgnMmio :: Int -> IO (Unsigned 64, Unsigned 64, Signed 32)
         readUgnMmio linkNr = do

--- a/bittide-instances/src/Bittide/Instances/Hitl/SwitchDemo/Driver.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/SwitchDemo/Driver.hs
@@ -79,7 +79,7 @@ muSwitchDemoPeBuffer :: Integer
 muSwitchDemoPeBuffer =
   $( do
       val <-
-        TH.runIO $ expectRight $ getPathAddress @Integer MemoryMaps.mu ["0", "SwitchDemoPE", "buffer"]
+        TH.runIO $ expectRight $ getPathAddress @Integer MemoryMaps.mu ["0", "3", "SwitchDemoPE", "buffer"]
       lift val
    )
 sampleMemoryBase :: Integer
@@ -263,7 +263,7 @@ driver testName targets = do
     checkElasticBufferFlags (_, d) gdb = do
       let
         ebPrefixed :: Int -> String -> [String]
-        ebPrefixed linkNr reg = ["0", "ElasticBuffer" <> show linkNr, reg]
+        ebPrefixed linkNr reg = ["0", "3", "ElasticBuffer" <> show linkNr, reg]
         getEbRegister linkNr = expectRight . getPathAddress MemoryMaps.mu . ebPrefixed linkNr
 
         readEbFlag :: Int -> IO (Bool, Bool)
@@ -312,7 +312,7 @@ driver testName targets = do
       Calc.CyclePeConfig (Unsigned 64) (Index 9) ->
       VivadoM ()
     muWriteCfg target@(_, d) gdb cfg = do
-      let getSdpeRegister reg = expectRight $ getPathAddress MemoryMaps.mu ["0", "SwitchDemoPE", reg]
+      let getSdpeRegister reg = expectRight $ getPathAddress MemoryMaps.mu ["0", "3", "SwitchDemoPE", reg]
 
       liftIO $ do
         muReadPeBuffer target gdb
@@ -335,7 +335,7 @@ driver testName targets = do
         perDeviceCheck myGdb num = do
           let
             myBaseAddr = toInteger (fromIntegral muSwitchDemoPeBuffer + 24 * (L.length gdbs - num - 1))
-          dnaBaseAddr <- expectRight $ getPathAddress @Integer MemoryMaps.mu ["0", "Dna", "maybe_dna"]
+          dnaBaseAddr <- expectRight $ getPathAddress @Integer MemoryMaps.mu ["0", "3", "Dna", "maybe_dna"]
           myCounter <- Gdb.readLe @(Unsigned 64) headGdb myBaseAddr
           myDeviceDna <- Gdb.readLe @(Maybe (BitVector 96)) myGdb dnaBaseAddr
           headDeviceDna <- Gdb.readLe @(BitVector 96) headGdb (myBaseAddr + 0x08)

--- a/bittide-instances/src/Bittide/Instances/Hitl/SwitchDemoGppe/Core.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/SwitchDemoGppe/Core.hs
@@ -20,22 +20,29 @@ import Bittide.ProcessingElement (
   PeConfig (..),
   PeInternalBusses,
   PrefixWidth,
-  RemainingBusWidth,
   processingElement,
  )
 import Bittide.ScatterGather
 import Bittide.SharedTypes (Bitbone, BitboneMm)
 import Bittide.Switch (switchC)
 import Bittide.Sync (Sync)
-import Bittide.Wishbone (readDnaPortE2WbWorker, timeWb, uartBytes, uartInterfaceWb)
+import Bittide.Wishbone (
+  readDnaPortE2WbWorker,
+  singleMasterInterconnectC,
+  timeWb,
+  uartBytes,
+  uartInterfaceWb,
+ )
 import Clash.Class.BitPackC (ByteOrder)
 import Clash.Cores.Xilinx.Unisim.DnaPortE2 (readDnaPortE2, simDna2)
+import Protocols.Idle (idleSink)
 import Protocols.MemoryMap (Mm)
 import Protocols.Wishbone.Extra (delayWishbone, delayWishboneMm)
 import VexRiscv (DumpVcd (..), Jtag)
 
 import qualified Bittide.Cpus.Riscv32imc as Riscv32imc
 import qualified Protocols.MemoryMap as Mm
+import qualified Protocols.ToConst as ToConst
 import qualified Protocols.Vec as Vec
 
 type FifoSize = 5 -- = 2^5 = 32
@@ -47,7 +54,8 @@ type FifoSize = 5 -- = 2^5 = 32
     - DNA
     - UART
 -}
-type NmuInternalBusses = 3 + PeInternalBusses
+type NmuFastBusses = 2 + PeInternalBusses
+type NmuSlowBusses = 2 + NmuExternalBusses
 
 {- Busses per link:
     - UGN component
@@ -63,13 +71,10 @@ type PeripheralsPerLink = 2
     - Callisto
 -}
 type NmuExternalBusses = 5 + (LinkCount * PeripheralsPerLink)
-type NmuRemBusWidth = RemainingBusWidth (NmuExternalBusses + NmuInternalBusses)
+type NmuRemBusWidthFast = 30 - PrefixWidth NmuFastBusses
+type NmuRemBusWidthSlow = NmuRemBusWidthFast - PrefixWidth NmuSlowBusses
 
-muConfig ::
-  ( KnownNat n
-  , PrefixWidth (n + NmuInternalBusses) <= 30
-  ) =>
-  PeConfig (n + NmuInternalBusses)
+muConfig :: PeConfig NmuFastBusses
 muConfig =
   PeConfig
     { cpu = Riscv32imc.vexRiscv1
@@ -124,7 +129,6 @@ managementUnit ::
   , ?regByteOrder :: ByteOrder
   , 1 <= DomainPeriod dom
   ) =>
-  -- | External counter
   Signal dom (Unsigned 64) ->
   -- | DNA value
   Signal dom (Maybe (BitVector 96)) ->
@@ -134,14 +138,17 @@ managementUnit ::
     , Vec
         NmuExternalBusses
         ( ToConstBwd Mm.Mm
-        , Bitbone dom NmuRemBusWidth
+        , Bitbone dom NmuRemBusWidthSlow
         )
     )
 managementUnit externalCounter maybeDna =
   circuit $ \(mm, jtag) -> do
     -- Core and interconnect
-    allBusses <- processingElement NoDumpVcd muConfig -< (mm, jtag)
-    ([timeBus, uartBus, dnaBus], restBusses) <- Vec.split -< allBusses
+    [timeBus, slowBus] <- processingElement NoDumpVcd muConfig -< (mm, jtag)
+    (pfxs, slowBusses) <- Vec.unzip <| singleMasterInterconnectC <| delayWishboneMm -< slowBus
+    idleSink <| (Vec.vecCircuits $ fmap ToConst.toBwd prefixes) -< pfxs
+
+    ([uartBus, dnaBus], restBusses) <- Vec.split -< slowBusses
 
     -- Peripherals
     _localCounter <- timeWb (Just externalCounter) -< timeBus
@@ -151,6 +158,9 @@ managementUnit externalCounter maybeDna =
 
     -- Output
     idC -< (uartOut, restBusses)
+ where
+  prefixes :: Vec (NmuExternalBusses + 2) (Unsigned (PrefixWidth (NmuExternalBusses + 2)))
+  prefixes = iterate (SNat @(NmuExternalBusses + 2)) succ 0
 
 gppe ::
   ( HiddenClockResetEnable dom
@@ -165,7 +175,7 @@ gppe ::
   Signal dom (BitVector 64) ->
   Circuit
     ( ToConstBwd Mm
-    , Vec 2 ((BitboneMm dom NmuRemBusWidth))
+    , Vec 2 ((BitboneMm dom NmuRemBusWidthSlow))
     , Jtag dom
     )
     ( CSignal dom (BitVector 64)
@@ -201,7 +211,7 @@ gppe externalCounter maybeDna linkIn = circuit $ \(mm, nmuWbMms, jtag) -> do
   sgCal = ValidEntry 0 1000 :> Nil
 
 {- FOURMOLU_DISABLE -} -- Fourmolu doesn't do well with tabular code
-calendarConfig :: CalendarConfig 25 (Vec 8 (Index 9))
+calendarConfig :: CalendarConfig NmuRemBusWidthSlow (Vec 8 (Index 9))
 calendarConfig =
   CalendarConfig
     (SNat @LinkCount)
@@ -256,7 +266,7 @@ core ::
     , "CC_UART" ::: Df Bittide (BitVector 8)
     , "GPPE_UART" ::: Df Bittide (BitVector 8)
     , "MU_TRANSCEIVER"
-        ::: (BitboneMm Bittide NmuRemBusWidth)
+        ::: (BitboneMm Bittide NmuRemBusWidthSlow)
     )
 core (refClk, refRst) (bitClk, bitRst, bitEna) rxClocks rxResets =
   circuit $ \(muMM, ccMM, gppeMm, jtag, mask, linksSuitableForCc, Fwd rxs0) -> do


### PR DESCRIPTION
_What (what did you do)_
Made all busses of the management unit that are not timing critical "slow", meaning I added a `delayWishbone` + interconnect to break critical paths on the databus of the cpu
_Why (context, issues, etc.)_
We start getting timing violations with small changes

_Dear reviewer (anything you'd like the reviewer to pay close attention to?)_
I don't still really know if we improve timing with this.

_AI disclaimer (heads-up for more than inline autocomplete)_
No vibes here

# TODO
_~~Cross-out~~ any that do not apply_

- [ ] Write (regression) test
- [ ] Update documentation, including `docs/`
- [ ] Link to existing issue
