### PR TITLE
Finetune soft ugn demo start delays

### DIFF
--- a/firmware-binaries/demos/soft-ugn-gppe/src/main.c
+++ b/firmware-binaries/demos/soft-ugn-gppe/src/main.c
@@ -42,8 +42,12 @@ ScatterUnit su;
 #define INVALIDATE_DELAY BUFFER_SIZE
 
 // Initial offsets for scheduling events
-#define STARTING_DELAY_WRITE (BUFFER_SIZE * 1000)
-#define STARTING_DELAY_READ (BUFFER_SIZE * 1000)
+// Since RECEIVE_PERIOD is longer than SEND_PERIOD, we schedule the start of the
+// first SEND event a couple of RECEIVE_PERIODs after the first RECEIVE event to
+// increase overlap
+#define STARTING_DELAY_WRITE                                                   \
+  (125000 * 100 + (2 * RECEIVE_PERIOD))    // 100 ms at 125MHz + some delay
+#define STARTING_DELAY_READ (125000 * 100) // 100 ms at 125MHz
 
 // ============================================================================
 // Main Entry Point


### PR DESCRIPTION
_What (what did you do)_
Increase the start delay of reading and writing.

_Why (context, issues, etc.)_
We encounter single failed deadlines which fail the test. (seen in https://github.com/bittide/bittide-hardware/actions/runs/22074900114/job/63789650667)
```
Wait for "[PE] Incoming Link UGNs:", got: [PE] ========================================
Wait for "[PE] Incoming Link UGNs:", got: [PE] Protocol terminated after 1000 iterations
Wait for "[PE] Incoming Link UGNs:", got: [PE] Elapsed cycles: 7685682
Wait for "[PE] Incoming Link UGNs:", got: [PE] Deadline Statistics:
Wait for "[PE] Incoming Link UGNs:", got: [PE] --------------------
Wait for "[PE] Incoming Link UGNs:", got: [PE] SEND events:
Wait for "[PE] Incoming Link UGNs:", got: [PE]   Met deadlines: 455
Wait for "[PE] Incoming Link UGNs:", got: [PE]   Missed deadlines: 0
Wait for "[PE] Incoming Link UGNs:", got: [PE] RECEIVE events:
Wait for "[PE] Incoming Link UGNs:", got: [PE]   Met deadlines: 90
Wait for "[PE] Incoming Link UGNs:", got: [PE]   Missed deadlines: 1
Wait for "[PE] Incoming Link UGNs:", got: [PE] INVALIDATE events:
Wait for "[PE] Incoming Link UGNs:", got: [PE]   Met deadlines: 454
Wait for "[PE] Incoming Link UGNs:", got: [PE]   Missed deadlines: 0
Wait for "[PE] Incoming Link UGNs:", got: [PE] Total:
Wait for "[PE] Incoming Link UGNs:", got: [PE]   Met deadlines: 999
Wait for "[PE] Incoming Link UGNs:", got: [PE]   Missed deadlines: 1
```
_Dear reviewer (anything you'd like the reviewer to pay close attention to?)_

_AI disclaimer (heads-up for more than inline autocomplete)_

# TODO
_~~Cross-out~~ any that do not apply_

- [ ] ~Write (regression) test~
- [ ] ~Update documentation, including `docs/`~
- [ ] ~Link to existing issue~
