### PR TITLE
Route picocom through logfile to prevent log clobbering

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -698,7 +698,8 @@ jobs:
           fi
           .github/scripts/with_vivado.sh \
             shake ${{ matrix.target.top }}:test
-
+      - name: Check picocom logs for any error that was not read lazily by Haskell driver
+        run: grep "\[ERROR\]:" _build/hitl/Bittide_Demo_DUT/picocom-*.log || true
       - name: Archive HITL data
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4

--- a/bittide-instances/data/picocom/start.sh
+++ b/bittide-instances/data/picocom/start.sh
@@ -11,17 +11,24 @@
 set -e
 
 # Default stdout to /dev/null
-PICOCOM_STDOUT_LOG="${PICOCOM_STDOUT_LOG:-/dev/null}"
+PICOCOM_STDOUT_LOG="${PICOCOM_STDOUT_LOG:?PICOCOM_STDOUT_LOG should be set}"
 stdout_dir=$(dirname "${PICOCOM_STDOUT_LOG}")
 mkdir -p "${stdout_dir}"
+rm -f "$PICOCOM_STDOUT_LOG" ; touch "$PICOCOM_STDOUT_LOG"
 
 # Default stderr to /dev/null
-PICOCOM_STDERR_LOG="${PICOCOM_STDERR_LOG:-/dev/null}"
+PICOCOM_STDERR_LOG="${PICOCOM_STDERR_LOG:?PICOCOM_STDERR_LOG should be set}"
 stderr_dir=$(dirname "${PICOCOM_STDERR_LOG}")
 mkdir -p "${stderr_dir}"
+rm -f "$PICOCOM_STDERR_LOG" ; touch "$PICOCOM_STDERR_LOG"
 
 PICOCOM_BAUD="${PICOCOM_BAUD:-921600}"
+# Since picocom times out after not receiving input, define the number of ms
+# to wait for new input before timing out picocom
+PICOCOM_TIMEOUT="${PICOCOM_TIMEOUT:-$((2**32))}"
 
-exec picocom --baud "${PICOCOM_BAUD}" --imap lfcrlf --omap lfcrlf $@ \
-  > >(tee "${PICOCOM_STDOUT_LOG}") \
-  2> >(tee "${PICOCOM_STDERR_LOG}" >&2)
+picocom --baud "${PICOCOM_BAUD}" --imap lfcrlf --omap lfcrlf --exit-after "${PICOCOM_TIMEOUT}" $@ \
+  >> "${PICOCOM_STDOUT_LOG}" \
+  2>> "${PICOCOM_STDERR_LOG}" &
+
+tail -n +1 -f "${PICOCOM_STDOUT_LOG}"


### PR DESCRIPTION
_What (what did you do)_
1) Updates picocom bash script to output to a log file and have another process read from that log file, rather than having the downstream process reading directly from picocom
2) Adds ci workflow step to read all picocom logs and grep for "ERROR"

_Why (context, issues, etc.)_

https://github.com/bittide/bittide-hardware/issues/1151
https://github.com/bittide/bittide-hardware/issues/1152

_Dear reviewer (anything you'd like the reviewer to pay close attention to?)_

The bash script defaults to /dev/null for log file output, which means if the invoker does not provide a log file path, this script (and ci) will fail. Probably the best course of action is to make a more sensible default path for the log file (than /dev/null). The reviewer is welcome to propose a default path.

_AI disclaimer (heads-up for more than inline autocomplete)_

AI was used in debugging some of the darker corners of bash (but was not super helpful)

# TODO
_~~Cross-out~~ any that do not apply_

- ~~[ ] Write (regression) test~~
- ~~[ ] Update documentation, including `docs/`~~
- [x] Link to existing issue
