### PR TITLE
Build Binaries Per-Test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,7 @@ jobs:
         run: .github/scripts/check_consistent_cabal_common.py
 
   build:
-    name: Build Haskell+Rust
+    name: Build Haskell
     runs-on: [self-hosted, compute]
     defaults:
       run:
@@ -154,13 +154,10 @@ jobs:
 
       - run: .github/scripts/check_cabal_log.sh cabal_build_log
 
-      - run: ./cargo.sh fetch
-      - run: ./cargo.sh build --frozen --release
-      - run: ./cargo.sh build --frozen
+      - run: mkdir -p firmware-support/bittide-hal{/src/{shared_devices,types,hals}/,-c/generated/}
 
       - run: cache push cabal
       - run: cache push dist-newstyle
-      - run: cache push cargo
       - run: cache push build
 
   generate-control-reports:
@@ -340,6 +337,11 @@ jobs:
         run: |
           cabal run ${{ matrix.package }}:${{ matrix.test_suite }}
 
+      - name: Cache any Rust builds done in this test
+        run: |
+          cache push cargo
+          cache push build
+
 
   rust-lints:
     name: Rust Lints
@@ -400,6 +402,11 @@ jobs:
           ./run_tests.sh
         working-directory: firmware-support/bittide-hal-c/
 
+      - name: Cache any Rust builds done in this test
+        run: |
+          cache push cargo
+          cache push build
+
   firmware-limit-checks:
     name: Firmware Limit Checks
     runs-on: [self-hosted, compute]
@@ -423,13 +430,31 @@ jobs:
 
       - name: Checking firmware binary limits
         run: |
+          TOPDIR="$(git rev-parse --show-toplevel)"
+          BINDIR="${TOPDIR}/_build/cargo/firmware-binaries/riscv32imc-unknown-none-elf/release"
+          SRCDIR="${TOPDIR}/firmware-binaries/"
+          BINNAMES=("clock-control" "vexriscv-hello")
+
+          cd "${SRCDIR}"
+          for binname in ${BINNAMES[@]}
+          do
+            if [ ! -f "${BINDIR}/$binname" ]
+            then
+              cargo build --release --bin "$binname"
+            fi
+          done
+          cd -
+
+          cd "${BINDIR}"
           ~/.cargo/bin/elf-limits \
             --instruction-mem-limit 64K \
             --data-mem-limit 64K \
-            clock-control \
-            hello \
-            processing-element-test
-        working-directory: _build/cargo/firmware-binaries/riscv32imc-unknown-none-elf/release/
+            ${BINNAMES[@]}
+
+      - name: Cache any Rust builds done in this test
+        run: |
+          cache push cargo
+          cache push build
 
   bittide-instances-matrices:
     name: bittide-instances matrices generation
@@ -709,6 +734,11 @@ jobs:
             _build/hitl/*
           overwrite: true
           retention-days: 14
+
+      - name: Cache any Rust builds done in this test
+        run: |
+          cache push cargo
+          cache push build
 
   mdbook:
     name: Build and publish mdBook

--- a/bittide-instances/src/Bittide/Instances/Hitl/Driver/Si539xConfiguration.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/Driver/Si539xConfiguration.hs
@@ -17,6 +17,7 @@ import Vivado.VivadoM
 
 import Bittide.Hitl
 import Bittide.Instances.Hitl.SwitchDemo.Driver (initGdb, initPicocom, parseTapInfo)
+import Bittide.Instances.Hitl.Utils.Driver (buildRustTarget)
 import "bittide-extra" Control.Exception.Extra (brackets)
 
 import Control.Concurrent.Async (forConcurrently_, mapConcurrently_)
@@ -42,6 +43,8 @@ driverFunc _name targets = do
 
   projectDir <- liftIO $ findParentContaining "cabal.project"
   let hitlDir = projectDir </> "_build" </> "hitl"
+
+  liftIO $ buildRustTarget projectDir "clock-board" Release
 
   let
     expectedJtagIds = [0x0514C001]

--- a/bittide-instances/src/Bittide/Instances/Hitl/Driver/VexRiscv.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/Driver/VexRiscv.hs
@@ -16,6 +16,7 @@ import Vivado.Tcl (HwTarget)
 import Vivado.VivadoM
 
 import Bittide.Hitl
+import Bittide.Instances.Hitl.Utils.Driver (buildRustTarget)
 import Bittide.Instances.Hitl.Utils.Program
 
 import Control.Concurrent (threadDelay)
@@ -56,6 +57,8 @@ driverFunc _name targets = do
       pure $ ExitFailure 2
 
   projectDir <- liftIO $ findParentContaining "cabal.project"
+
+  liftIO $ buildRustTarget projectDir "vexriscv-hello" Release
 
   exitCodes <- forM (L.zip [0 ..] targets) $ \(targetIndex, (hwT, deviceInfo)) -> handle (liftIO . catchError deviceInfo) $ do
     liftIO $ putStrLn $ "Running driver for " <> deviceInfo.deviceId

--- a/bittide-instances/src/Bittide/Instances/Hitl/Driver/VexRiscvTcp.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/Driver/VexRiscvTcp.hs
@@ -7,6 +7,7 @@ module Bittide.Instances.Hitl.Driver.VexRiscvTcp where
 import Prelude
 
 import Bittide.Hitl
+import Bittide.Instances.Hitl.Utils.Driver (buildRustTarget)
 import Bittide.Instances.Hitl.Utils.Program
 
 import Control.Concurrent
@@ -69,6 +70,8 @@ driverFunc ::
   VivadoM ExitCode
 driverFunc _name [d@(_, dI)] = do
   projectDir <- liftIO $ findParentContaining "cabal.project"
+
+  liftIO $ buildRustTarget projectDir "smoltcp_client" Release
 
   let
     hitlDir = projectDir </> "_build" </> "hitl"

--- a/bittide-instances/src/Bittide/Instances/Hitl/SoftUgnDemo/Driver.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/SoftUgnDemo/Driver.hs
@@ -52,6 +52,10 @@ driver testName targets = do
   projectDir <- liftIO $ findParentContaining "cabal.project"
   let hitlDir = projectDir </> "_build/hitl" </> testName
 
+  liftIO $ buildRustTarget projectDir "switch-demo1-boot" Release
+  liftIO $ buildRustTarget projectDir "clock-control" Release
+  liftIO $ buildRustTarget projectDir "soft-ugn-mu" Release
+
   forM_ targets (assertProbe "probe_test_start")
 
   let

--- a/bittide-instances/src/Bittide/Instances/Hitl/SwitchDemo/Driver.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/SwitchDemo/Driver.hs
@@ -209,6 +209,11 @@ driver testName targets = do
 
   projectDir <- liftIO $ findParentContaining "cabal.project"
 
+  -- Build necessary binaries
+  liftIO $ buildRustTarget projectDir "clock-control" Release
+  liftIO $ buildRustTarget projectDir "switch-demo1-boot" Release
+  liftIO $ buildRustTarget projectDir "switch-demo1-mu" Release
+
   let
     hitlDir = projectDir </> "_build/hitl" </> testName
 

--- a/bittide-instances/src/Bittide/Instances/Hitl/Utils/Driver.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/Utils/Driver.hs
@@ -10,9 +10,23 @@ import Prelude
 import Bittide.Hitl
 import Bittide.Instances.Hitl.Setup (demoRigInfo)
 import Bittide.Instances.Hitl.Utils.Vivado
+import Control.Monad (unless)
 import Control.Monad.IO.Class
 import Data.Maybe (fromMaybe)
+import Data.String.Interpolate (i, __i)
 import GHC.Stack (HasCallStack)
+import Project.FilePath (CargoBuildType (..))
+import System.Environment (getEnvironment)
+import System.Exit (ExitCode (ExitSuccess))
+import System.FilePath ((</>))
+import System.IO (hGetContents)
+import System.Process (
+  CreateProcess (..),
+  StdStream (CreatePipe),
+  createProcess,
+  shell,
+  waitForProcess,
+ )
 import Vivado.Tcl (HwTarget)
 import Vivado.VivadoM
 
@@ -83,3 +97,41 @@ awaitHandshakes targets = do
         then return ()
         else inner new
   inner innerInit
+
+buildRustTarget :: FilePath -> FilePath -> CargoBuildType -> IO ()
+buildRustTarget baseDir binName build = do
+  let
+    buildArg = case build of
+      Debug -> ""
+      Release -> "--release"
+
+  currentEnv <- getEnvironment
+
+  (_rustStdin, rustStdoutH, rustStderrH, rustProc) <-
+    createProcess $
+      (shell [i|cd #{baseDir </> "firmware-binaries"}; cargo build #{buildArg} --bin="#{binName}"|])
+        { env = Just currentEnv
+        , std_in = CreatePipe
+        , std_err = CreatePipe
+        , std_out = CreatePipe
+        }
+
+  rustProcExit <- waitForProcess rustProc
+
+  unless (rustProcExit == ExitSuccess) $ do
+    rustStdout <- case rustStdoutH of
+      Just h -> hGetContents h
+      _ -> return ""
+    rustStderr <- case rustStderrH of
+      Just h -> hGetContents h
+      _ -> return ""
+    let indentString = concatMap (\c -> if c == '\n' then "\n  " else [c])
+    error
+      [__i|
+        Failed to build Rust binary!
+        exit code: #{rustProcExit}
+        stdout:
+        #{indentString rustStdout}
+        stderr:
+        #{indentString rustStderr}
+      |]

--- a/bittide-instances/src/Bittide/Instances/Pnr/Ethernet.hs
+++ b/bittide-instances/src/Bittide/Instances/Pnr/Ethernet.hs
@@ -28,6 +28,7 @@ import Bittide.Cpus.Riscv32imc (vexRiscv0)
 import Bittide.DoubleBufferedRam
 import Bittide.Ethernet.Mac
 import Bittide.Instances.Domains
+import Bittide.Instances.Hitl.Utils.Driver (buildRustTarget)
 import Bittide.ProcessingElement (PeConfig (..), processingElement)
 import Bittide.ProcessingElement.Util (vecFromElfData, vecFromElfInstr)
 import Bittide.SharedTypes (withLittleEndian)
@@ -162,7 +163,10 @@ vexRiscGmiiC SNat sysClk sysRst rxClk rxRst txClk txRst =
   peConfigSim = unsafePerformIO $ do
     root <- findParentContaining "cabal.project"
     let
-      elfPath = root </> firmwareBinariesDir "riscv32imc" Release </> "smoltcp_client"
+      binName = "smoltcp_client"
+      buildType = Release
+      runBuild = buildRustTarget root binName buildType
+      elfPath = root </> firmwareBinariesDir "riscv32imc" buildType </> "smoltcp_client"
     pure
       $ PeConfig
         { cpu = vexRiscv0
@@ -172,13 +176,15 @@ vexRiscGmiiC SNat sysClk sysRst rxClk rxRst txClk txRst =
             Just
               ( Vec
                   $ unsafePerformIO
-                  $ vecFromElfInstr @IMemWords BigEndian elfPath
+                  $ runBuild
+                  >> vecFromElfInstr @IMemWords BigEndian elfPath
               )
         , initD =
             Just
               ( Vec
                   $ unsafePerformIO
-                  $ vecFromElfData @DMemWords BigEndian elfPath
+                  $ runBuild
+                  >> vecFromElfData @DMemWords BigEndian elfPath
               )
         , iBusTimeout = d0
         , dBusTimeout = d0

--- a/bittide-instances/src/Bittide/Instances/Pnr/ProcessingElement.hs
+++ b/bittide-instances/src/Bittide/Instances/Pnr/ProcessingElement.hs
@@ -23,6 +23,7 @@ import VexRiscv
 
 import Bittide.DoubleBufferedRam
 import Bittide.Instances.Domains
+import Bittide.Instances.Hitl.Utils.Driver (buildRustTarget)
 import Bittide.ProcessingElement
 import Bittide.ProcessingElement.Util
 import Bittide.SharedTypes (withLittleEndian)
@@ -62,20 +63,25 @@ vexRiscvUartHelloC baudSnat = withLittleEndian $ circuit $ \(mm, (uartRx, jtag))
     root <- findParentContaining "cabal.project"
     maybeBinaryName <- lookupEnv "TEST_BINARY_NAME"
     let
-      elfDir = root </> firmwareBinariesDir "riscv32imc" Debug
-      elfPath = elfDir </> fromMaybe "vexrscv-hello" maybeBinaryName
+      binName = fromMaybe "vexriscv-hello" maybeBinaryName
+      buildType = Debug
+      runBuild = buildRustTarget root binName buildType
+      elfDir = root </> firmwareBinariesDir "riscv32imc" buildType
+      elfPath = elfDir </> binName
     pure
       peConfigRtl
         { initI =
             Just
               $ Vec
               $ unsafePerformIO
-              $ vecFromElfInstr @IMemWords BigEndian elfPath
+              $ runBuild
+              >> vecFromElfInstr @IMemWords BigEndian elfPath
         , initD =
             Just
               $ Vec
               $ unsafePerformIO
-              $ vecFromElfData @DMemWords BigEndian elfPath
+              $ runBuild
+              >> vecFromElfData @DMemWords BigEndian elfPath
         , depthI = SNat @IMemWords
         , depthD = SNat @DMemWords
         , includeIlaWb = False

--- a/bittide-instances/src/Bittide/Instances/Tests/AddressableBytesWb.hs
+++ b/bittide-instances/src/Bittide/Instances/Tests/AddressableBytesWb.hs
@@ -13,6 +13,7 @@ import Bittide.DoubleBufferedRam (
   wbStorage,
  )
 import Bittide.Instances.Domains (Basic50)
+import Bittide.Instances.Hitl.Utils.Driver (buildRustTarget)
 import Bittide.ProcessingElement (
   PeConfig (..),
   processingElement,
@@ -87,7 +88,10 @@ dutWithBinary binaryName =
 
   peConfig binary = unsafePerformIO $ do
     root <- findParentContaining "cabal.project"
-    let elfPath = root </> firmwareBinariesDir "riscv32imc" Release </> binary
+    let
+      buildType = Release
+      runBuild = buildRustTarget root binary buildType
+      elfPath = root </> firmwareBinariesDir "riscv32imc" buildType </> binary
     pure
       PeConfig
         { cpu = vexRiscv0
@@ -97,12 +101,14 @@ dutWithBinary binaryName =
             Just
               $ Vec
               $ unsafePerformIO
-              $ vecFromElfInstr BigEndian elfPath
+              $ runBuild
+              >> vecFromElfInstr BigEndian elfPath
         , initD =
             Just
               $ Vec
               $ unsafePerformIO
-              $ vecFromElfData BigEndian elfPath
+              $ runBuild
+              >> vecFromElfData BigEndian elfPath
         , iBusTimeout = d0 -- No timeouts on the instruction bus
         , dBusTimeout = d0 -- No timeouts on the data bus
         , includeIlaWb = False

--- a/bittide-instances/src/Bittide/Instances/Tests/ElasticBufferWb.hs
+++ b/bittide-instances/src/Bittide/Instances/Tests/ElasticBufferWb.hs
@@ -9,6 +9,7 @@ import Clash.Prelude (withClockResetEnable)
 import Bittide.Cpus.Riscv32imc (vexRiscv0)
 import Bittide.DoubleBufferedRam (ContentType (Vec))
 import Bittide.ElasticBuffer
+import Bittide.Instances.Hitl.Utils.Driver (buildRustTarget)
 import Bittide.ProcessingElement
 import Bittide.ProcessingElement.Util
 import Bittide.SharedTypes (withLittleEndian)
@@ -78,8 +79,11 @@ dut = withLittleEndian $ withClockResetEnable clockGen (resetGenN d2) enableGen 
   peConfig = unsafePerformIO $ do
     root <- findParentContaining "cabal.project"
     let
-      elfDir = root </> firmwareBinariesDir "riscv32imc" Release
-      elfPath = elfDir </> "elastic_buffer_wb_test"
+      binName = "elastic_buffer_wb_test"
+      buildType = Release
+      runBuild = buildRustTarget root binName buildType
+      elfDir = root </> firmwareBinariesDir "riscv32imc" buildType
+      elfPath = elfDir </> binName
     pure
       PeConfig
         { cpu = vexRiscv0
@@ -89,12 +93,14 @@ dut = withLittleEndian $ withClockResetEnable clockGen (resetGenN d2) enableGen 
             Just
               $ Vec @IMemWords
               $ unsafePerformIO
-              $ vecFromElfInstr BigEndian elfPath
+              $ runBuild
+              >> vecFromElfInstr BigEndian elfPath
         , initD =
             Just
               $ Vec @DMemWords
               $ unsafePerformIO
-              $ vecFromElfData BigEndian elfPath
+              $ runBuild
+              >> vecFromElfData BigEndian elfPath
         , iBusTimeout = d0 -- No timeouts on the instruction bus
         , dBusTimeout = d0 -- No timeouts on the data bus
         , includeIlaWb = False

--- a/bittide-instances/src/Bittide/Instances/Tests/NestedInterconnect.hs
+++ b/bittide-instances/src/Bittide/Instances/Tests/NestedInterconnect.hs
@@ -14,6 +14,7 @@ import Bittide.DoubleBufferedRam (
   ContentType (Vec),
  )
 import Bittide.Instances.Domains (Basic50)
+import Bittide.Instances.Hitl.Utils.Driver (buildRustTarget)
 import Bittide.ProcessingElement (
   PeConfig (..),
   processingElement,
@@ -79,7 +80,11 @@ simplePeripheral name = withName name $ circuit $ \(mm, wb) -> do
 peConfig :: PeConfig 7
 peConfig = unsafePerformIO $ do
   root <- findParentContaining "cabal.project"
-  let elfPath = root </> firmwareBinariesDir "riscv32imc" Release </> "nested_interconnect_test"
+  let
+    binName = "nested_interconnect_test"
+    buildType = Release
+    runBuild = buildRustTarget root binName buildType
+    elfPath = root </> firmwareBinariesDir "riscv32imc" buildType </> binName
   pure
     PeConfig
       { cpu = vexRiscv0
@@ -89,12 +94,14 @@ peConfig = unsafePerformIO $ do
           Just
             $ Vec @IMemWords
             $ unsafePerformIO
-            $ vecFromElfInstr BigEndian elfPath
+            $ runBuild
+            >> vecFromElfInstr BigEndian elfPath
       , initD =
           Just
             $ Vec @DMemWords
             $ unsafePerformIO
-            $ vecFromElfData BigEndian elfPath
+            $ runBuild
+            >> vecFromElfData BigEndian elfPath
       , iBusTimeout = d0
       , dBusTimeout = d0
       , includeIlaWb = False

--- a/bittide-instances/src/Bittide/Instances/Tests/RegisterWb.hs
+++ b/bittide-instances/src/Bittide/Instances/Tests/RegisterWb.hs
@@ -14,6 +14,7 @@ import Bittide.DoubleBufferedRam (
  )
 import Bittide.Extra.Maybe (orNothing)
 import Bittide.Instances.Domains (Basic50)
+import Bittide.Instances.Hitl.Utils.Driver (buildRustTarget)
 import Bittide.ProcessingElement (
   PeConfig (..),
   processingElement,
@@ -449,7 +450,10 @@ dutWithBinary binaryName =
 
   peConfig binary = unsafePerformIO $ do
     root <- findParentContaining "cabal.project"
-    let elfPath = root </> firmwareBinariesDir "riscv32imc" Release </> binary
+    let
+      buildType = Release
+      runBuild = buildRustTarget root binary buildType
+      elfPath = root </> firmwareBinariesDir "riscv32imc" buildType </> binary
     pure
       PeConfig
         { cpu = vexRiscv0
@@ -459,12 +463,14 @@ dutWithBinary binaryName =
             Just
               $ Vec @IMemWords
               $ unsafePerformIO
-              $ vecFromElfInstr BigEndian elfPath
+              $ runBuild
+              >> vecFromElfInstr BigEndian elfPath
         , initD =
             Just
               $ Vec @DMemWords
               $ unsafePerformIO
-              $ vecFromElfData BigEndian elfPath
+              $ runBuild
+              >> vecFromElfData BigEndian elfPath
         , iBusTimeout = d0 -- No timeouts on the instruction bus
         , dBusTimeout = d0 -- No timeouts on the data bus
         , includeIlaWb = False

--- a/bittide-instances/src/Bittide/Instances/Tests/ScatterGather.hs
+++ b/bittide-instances/src/Bittide/Instances/Tests/ScatterGather.hs
@@ -19,6 +19,7 @@ import VexRiscv (DumpVcd (NoDumpVcd))
 import Bittide.Calendar
 import Bittide.Cpus.Riscv32imc (vexRiscv0)
 import Bittide.DoubleBufferedRam
+import Bittide.Instances.Hitl.Utils.Driver (buildRustTarget)
 import Bittide.ProcessingElement
 import Bittide.ProcessingElement.Util
 import Bittide.ScatterGather
@@ -78,7 +79,9 @@ dutWithBinary binaryName = withLittleEndian $ circuit $ \mm -> do
   peConfig binary = unsafePerformIO $ do
     root <- findParentContaining "cabal.project"
     let
-      elfDir = root </> firmwareBinariesDir "riscv32imc" Release
+      buildType = Release
+      runBuild = buildRustTarget root binary buildType
+      elfDir = root </> firmwareBinariesDir "riscv32imc" buildType
       elfPath = elfDir </> binary
     pure
       PeConfig
@@ -89,12 +92,14 @@ dutWithBinary binaryName = withLittleEndian $ circuit $ \mm -> do
             Just
               $ Vec
               $ unsafePerformIO
-              $ vecFromElfInstr BigEndian elfPath
+              $ runBuild
+              >> vecFromElfInstr BigEndian elfPath
         , initD =
             Just
               $ Vec
               $ unsafePerformIO
-              $ vecFromElfData BigEndian elfPath
+              $ runBuild
+              >> vecFromElfData BigEndian elfPath
         , iBusTimeout = d0 -- No timeouts on the instruction bus
         , dBusTimeout = d0 -- No timeouts on the data bus
         , includeIlaWb = False

--- a/bittide-instances/src/Bittide/Instances/Tests/SwitchCalendar.hs
+++ b/bittide-instances/src/Bittide/Instances/Tests/SwitchCalendar.hs
@@ -8,6 +8,7 @@ import Bittide.DoubleBufferedRam (
   ContentType (Vec),
  )
 import Bittide.Instances.Domains (Basic200)
+import Bittide.Instances.Hitl.Utils.Driver (buildRustTarget)
 import Bittide.Instances.Pnr.Switch
 import Bittide.ProcessingElement
 import Bittide.ProcessingElement.Util (
@@ -75,7 +76,11 @@ dut =
 
   peConfig = unsafePerformIO $ do
     root <- findParentContaining "cabal.project"
-    let elfPath = root </> firmwareBinariesDir "riscv32imc" Release </> "switch_calendar_test"
+    let
+      binName = "switch_calendar_test"
+      buildType = Release
+      runBuild = buildRustTarget root binName buildType
+      elfPath = root </> firmwareBinariesDir "riscv32imc" buildType </> binName
     pure
       PeConfig
         { cpu = vexRiscv0
@@ -85,12 +90,14 @@ dut =
             Just
               $ Vec
               $ unsafePerformIO
-              $ vecFromElfInstr BigEndian elfPath
+              $ runBuild
+              >> vecFromElfInstr BigEndian elfPath
         , initD =
             Just
               $ Vec
               $ unsafePerformIO
-              $ vecFromElfData BigEndian elfPath
+              $ runBuild
+              >> vecFromElfData BigEndian elfPath
         , iBusTimeout = d0 -- No timeouts on the instruction bus
         , dBusTimeout = d0 -- No timeouts on the data bus
         , includeIlaWb = False

--- a/bittide-instances/src/Bittide/Instances/Tests/TimeWb.hs
+++ b/bittide-instances/src/Bittide/Instances/Tests/TimeWb.hs
@@ -8,6 +8,7 @@ import Clash.Prelude
 
 import Bittide.Cpus.Riscv32imc (vexRiscv0)
 import Bittide.DoubleBufferedRam hiding (registerWb)
+import Bittide.Instances.Hitl.Utils.Driver (buildRustTarget)
 import Bittide.ProcessingElement
 import Bittide.ProcessingElement.Util
 import Bittide.SharedTypes (withLittleEndian)
@@ -51,7 +52,11 @@ dutCpu = withLittleEndian $ circuit $ \mm -> do
  where
   peConfig = unsafePerformIO $ do
     root <- findParentContaining "cabal.project"
-    let elfPath = root </> firmwareBinariesDir "riscv32imc" Release </> "c_timer_wb"
+    let
+      binName = "c_timer_wb"
+      buildType = Release
+      runBuild = buildRustTarget root binName buildType
+      elfPath = root </> firmwareBinariesDir "riscv32imc" buildType </> "c_timer_wb"
     pure
       PeConfig
         { cpu = vexRiscv0
@@ -61,12 +66,14 @@ dutCpu = withLittleEndian $ circuit $ \mm -> do
             Just
               $ Vec
               $ unsafePerformIO
-              $ vecFromElfInstr BigEndian elfPath
+              $ runBuild
+              >> vecFromElfInstr BigEndian elfPath
         , initD =
             Just
               $ Vec
               $ unsafePerformIO
-              $ vecFromElfData BigEndian elfPath
+              $ runBuild
+              >> vecFromElfData BigEndian elfPath
         , iBusTimeout = d0
         , dBusTimeout = d0
         , includeIlaWb = False

--- a/bittide-instances/src/Bittide/Instances/Tests/WbToDf.hs
+++ b/bittide-instances/src/Bittide/Instances/Tests/WbToDf.hs
@@ -9,6 +9,7 @@ import Clash.Prelude (withClockResetEnable)
 import Bittide.Cpus.Riscv32imc (vexRiscv0)
 import Bittide.Df
 import Bittide.DoubleBufferedRam
+import Bittide.Instances.Hitl.Utils.Driver (buildRustTarget)
 import Bittide.ProcessingElement
 import Bittide.ProcessingElement.Util
 import Bittide.SharedTypes (withLittleEndian)
@@ -86,8 +87,11 @@ dut = withLittleEndian $ withClockResetEnable clockGen (resetGenN d2) enableGen 
   peConfig = unsafePerformIO $ do
     root <- findParentContaining "cabal.project"
     let
-      elfDir = root </> firmwareBinariesDir "riscv32imc" Release
-      elfPath = elfDir </> "wb_to_df_test"
+      binName = "wb_to_df_test"
+      buildType = Release
+      runBuild = buildRustTarget root binName buildType
+      elfDir = root </> firmwareBinariesDir "riscv32imc" buildType
+      elfPath = elfDir </> binName
     pure
       PeConfig
         { cpu = vexRiscv0
@@ -97,12 +101,14 @@ dut = withLittleEndian $ withClockResetEnable clockGen (resetGenN d2) enableGen 
             Just
               $ Vec
               $ unsafePerformIO
-              $ vecFromElfInstr BigEndian elfPath
+              $ runBuild
+              >> vecFromElfInstr BigEndian elfPath
         , initD =
             Just
               $ Vec
               $ unsafePerformIO
-              $ vecFromElfData BigEndian elfPath
+              $ runBuild
+              >> vecFromElfData BigEndian elfPath
         , iBusTimeout = d0 -- No timeouts on the instruction bus
         , dBusTimeout = d0 -- No timeouts on the data bus
         , includeIlaWb = False

--- a/bittide-instances/tests/Tests/ClockControlWb.hs
+++ b/bittide-instances/tests/Tests/ClockControlWb.hs
@@ -35,6 +35,7 @@ import Bittide.ClockControl (SpeedChange)
 import Bittide.ClockControl.Registers (clockControlWb)
 import Bittide.DoubleBufferedRam
 import Bittide.Instances.Hitl.Setup (LinkCount)
+import Bittide.Instances.Hitl.Utils.Driver (buildRustTarget)
 import Bittide.ProcessingElement
 import Bittide.ProcessingElement.Util
 import Bittide.SharedTypes (withLittleEndian)
@@ -149,16 +150,28 @@ dut =
   peConfig = unsafePerformIO $ do
     root <- findParentContaining "cabal.project"
     let
-      elfDir = root </> firmwareBinariesDir "riscv32imc" Release
-      elfPath = elfDir </> "clock-control-wb"
-    (iMem, dMem) <- vecsFromElf @IMemWords @DMemWords BigEndian elfPath Nothing
+      binName = "clock-control-wb"
+      buildType = Release
+      runBuild = buildRustTarget root binName buildType
+      elfDir = root </> firmwareBinariesDir "riscv32imc" buildType
+      elfPath = elfDir </> binName
     pure
       PeConfig
         { cpu = vexRiscv0
         , depthI = SNat @IMemWords
         , depthD = SNat @DMemWords
-        , initI = Just (Vec iMem)
-        , initD = Just (Vec dMem)
+        , initI =
+            Just
+              $ Vec
+              $ unsafePerformIO
+              $ runBuild
+              >> vecFromElfInstr BigEndian elfPath
+        , initD =
+            Just
+              $ Vec
+              $ unsafePerformIO
+              $ runBuild
+              >> vecFromElfData BigEndian elfPath
         , iBusTimeout = d0
         , dBusTimeout = d0
         , includeIlaWb = False

--- a/bittide-instances/tests/Wishbone/Axi.hs
+++ b/bittide-instances/tests/Wishbone/Axi.hs
@@ -11,6 +11,7 @@ import Clash.Prelude (withClockResetEnable)
 -- Local
 import Bittide.Axi4
 import Bittide.DoubleBufferedRam
+import Bittide.Instances.Hitl.Utils.Driver (buildRustTarget)
 import Bittide.ProcessingElement
 import Bittide.ProcessingElement.Util
 import Bittide.Wishbone
@@ -101,15 +102,28 @@ dut =
   axiProxy = Proxy @(Axi4Stream System ('Axi4StreamConfig 4 0 0) ())
   peConfig = unsafePerformIO $ do
     root <- findParentContaining "cabal.project"
-    let elfPath = root </> firmwareBinariesDir "riscv32imc" Release </> "axi_stream_self_test"
-    (iMem, dMem) <- vecsFromElf @IMemWords @DMemWords BigEndian elfPath Nothing
+    let
+      binName = "axi_stream_self_test"
+      buildType = Release
+      runBuild = buildRustTarget root binName buildType
+      elfPath = root </> firmwareBinariesDir "riscv32imc" buildType </> binName
     pure
       PeConfig
         { cpu = Riscv32imc.vexRiscv0
         , depthI = SNat @IMemWords
         , depthD = SNat @DMemWords
-        , initI = Just (Vec iMem)
-        , initD = Just (Vec dMem)
+        , initI =
+            Just
+              $ Vec
+              $ unsafePerformIO
+              $ runBuild
+              >> vecFromElfInstr BigEndian elfPath
+        , initD =
+            Just
+              $ Vec
+              $ unsafePerformIO
+              $ runBuild
+              >> vecFromElfData BigEndian elfPath
         , iBusTimeout = d0 -- No timeouts on the instruction bus
         , dBusTimeout = d0 -- No timeouts on the data bus
         , includeIlaWb = False

--- a/bittide-instances/tests/Wishbone/CaptureUgn.hs
+++ b/bittide-instances/tests/Wishbone/CaptureUgn.hs
@@ -31,6 +31,7 @@ import VexRiscv (DumpVcd (NoDumpVcd))
 import Bittide.CaptureUgn
 import qualified Bittide.Cpus.Riscv32imc as Riscv32imc
 import Bittide.DoubleBufferedRam
+import Bittide.Instances.Hitl.Utils.Driver (buildRustTarget)
 import Bittide.ProcessingElement
 import Bittide.ProcessingElement.Util
 import Bittide.SharedTypes (withLittleEndian)
@@ -104,15 +105,28 @@ dut eb localCounter = withLittleEndian $ circuit $ do
  where
   peConfig = unsafePerformIO $ do
     root <- findParentContaining "cabal.project"
-    let elfPath = root </> firmwareBinariesDir "riscv32imc" Release </> "capture_ugn_test"
-    (iMem, dMem) <- vecsFromElf @IMemWords @DMemWords BigEndian elfPath Nothing
+    let
+      binName = "capture_ugn_test"
+      buildType = Release
+      runBuild = buildRustTarget root binName buildType
+      elfPath = root </> firmwareBinariesDir "riscv32imc" buildType </> binName
     pure
       PeConfig
         { cpu = Riscv32imc.vexRiscv0
         , depthI = SNat @IMemWords
         , depthD = SNat @DMemWords
-        , initI = Just (Vec iMem)
-        , initD = Just (Vec dMem)
+        , initI =
+            Just
+              $ Vec
+              $ unsafePerformIO
+              $ runBuild
+              >> vecFromElfInstr BigEndian elfPath
+        , initD =
+            Just
+              $ Vec
+              $ unsafePerformIO
+              $ runBuild
+              >> vecFromElfData BigEndian elfPath
         , iBusTimeout = d0 -- No timeouts on the instruction bus
         , dBusTimeout = d0 -- No timeouts on the data bus
         , includeIlaWb = False

--- a/bittide-instances/tests/Wishbone/DnaPortE2.hs
+++ b/bittide-instances/tests/Wishbone/DnaPortE2.hs
@@ -26,6 +26,7 @@ import Test.Tasty.TH
 import VexRiscv (DumpVcd (NoDumpVcd))
 
 import Bittide.DoubleBufferedRam
+import Bittide.Instances.Hitl.Utils.Driver (buildRustTarget)
 import Bittide.ProcessingElement
 import Bittide.ProcessingElement.Util
 import Bittide.SharedTypes (withLittleEndian)
@@ -71,15 +72,28 @@ dut = withLittleEndian $ circuit $ \_unit -> do
  where
   peConfig = unsafePerformIO $ do
     root <- findParentContaining "cabal.project"
-    let elfPath = root </> firmwareBinariesDir "riscv32imc" Release </> "dna_port_e2_test"
-    (iMem, dMem) <- vecsFromElf @IMemWords @DMemWords BigEndian elfPath Nothing
+    let
+      binName = "dna_port_e2_test"
+      buildType = Release
+      runBuild = buildRustTarget root binName buildType
+      elfPath = root </> firmwareBinariesDir "riscv32imc" buildType </> binName
     pure
       PeConfig
         { cpu = Riscv32imc.vexRiscv0
         , depthI = SNat @IMemWords
         , depthD = SNat @DMemWords
-        , initI = Just (Vec iMem)
-        , initD = Just (Vec dMem)
+        , initI =
+            Just
+              $ Vec
+              $ unsafePerformIO
+              $ runBuild
+              >> vecFromElfInstr BigEndian elfPath
+        , initD =
+            Just
+              $ Vec
+              $ unsafePerformIO
+              $ runBuild
+              >> vecFromElfData BigEndian elfPath
         , iBusTimeout = d0 -- No timeouts on the instruction bus
         , dBusTimeout = d0 -- No timeouts on the data bus
         , includeIlaWb = False

--- a/bittide-instances/tests/Wishbone/SwitchDemoProcessingElement.hs
+++ b/bittide-instances/tests/Wishbone/SwitchDemoProcessingElement.hs
@@ -23,6 +23,7 @@ import Test.Tasty.TH
 import VexRiscv (DumpVcd (NoDumpVcd))
 
 import Bittide.DoubleBufferedRam
+import Bittide.Instances.Hitl.Utils.Driver (buildRustTarget)
 import Bittide.ProcessingElement
 import Bittide.ProcessingElement.Util
 import Bittide.SharedTypes (withLittleEndian)
@@ -103,16 +104,28 @@ dut dnaA dnaB = withLittleEndian $ circuit $ do
   peConfig = unsafePerformIO $ do
     root <- findParentContaining "cabal.project"
     let
-      elfDir = root </> firmwareBinariesDir "riscv32imc" Release
-      elfPath = elfDir </> "switch_demo_pe_test"
-    (iMem, dMem) <- vecsFromElf @IMemWords @DMemWords BigEndian elfPath Nothing
+      binName = "switch_demo_pe_test"
+      buildType = Release
+      runBuild = buildRustTarget root binName buildType
+      elfDir = root </> firmwareBinariesDir "riscv32imc" buildType
+      elfPath = elfDir </> binName
     pure
       PeConfig
         { cpu = Riscv32imc.vexRiscv0
         , depthI = SNat @IMemWords
         , depthD = SNat @DMemWords
-        , initI = Just (Vec iMem)
-        , initD = Just (Vec dMem)
+        , initI =
+            Just
+              $ Vec
+              $ unsafePerformIO
+              $ runBuild
+              >> vecFromElfInstr BigEndian elfPath
+        , initD =
+            Just
+              $ Vec
+              $ unsafePerformIO
+              $ runBuild
+              >> vecFromElfData BigEndian elfPath
         , iBusTimeout = d0 -- No timeouts on the instruction bus
         , dBusTimeout = d0 -- No timeouts on the data bus
         , includeIlaWb = False

--- a/bittide-instances/tests/Wishbone/Time.hs
+++ b/bittide-instances/tests/Wishbone/Time.hs
@@ -10,6 +10,7 @@ import Clash.Prelude
 -- Local
 import Bittide.DoubleBufferedRam
 import Bittide.Instances.Domains
+import Bittide.Instances.Hitl.Utils.Driver (buildRustTarget)
 import Bittide.ProcessingElement
 import Bittide.ProcessingElement.Util
 import Bittide.SharedTypes (withLittleEndian)
@@ -76,15 +77,28 @@ dut = withLittleEndian
  where
   peConfig = unsafePerformIO $ do
     root <- findParentContaining "cabal.project"
-    let elfPath = root </> firmwareBinariesDir "riscv32imc" Release </> "time_self_test"
-    (iMem, dMem) <- vecsFromElf @IMemWords @DMemWords BigEndian elfPath Nothing
+    let
+      binName = "time_self_test"
+      buildType = Release
+      runBuild = buildRustTarget root binName buildType
+      elfPath = root </> firmwareBinariesDir "riscv32imc" buildType </> binName
     pure
       PeConfig
         { cpu = Riscv32imc.vexRiscv0
         , depthI = SNat @IMemWords
         , depthD = SNat @DMemWords
-        , initI = Just (Vec iMem)
-        , initD = Just (Vec dMem)
+        , initI =
+            Just
+              $ Vec
+              $ unsafePerformIO
+              $ runBuild
+              >> vecFromElfInstr BigEndian elfPath
+        , initD =
+            Just
+              $ Vec
+              $ unsafePerformIO
+              $ runBuild
+              >> vecFromElfData BigEndian elfPath
         , iBusTimeout = d0 -- No timeouts on the instruction bus
         , dBusTimeout = d0 -- No timeouts on the data bus
         , includeIlaWb = False
@@ -160,15 +174,28 @@ dutC = withLittleEndian
  where
   peConfigC = unsafePerformIO $ do
     root <- findParentContaining "cabal.project"
-    let elfPath = root </> firmwareBinariesDir "riscv32imc" Release </> "c_timer_wb"
-    (iMem, dMem) <- vecsFromElf @IMemWords @DMemWords BigEndian elfPath Nothing
+    let
+      binName = "c_timer_wb"
+      buildType = Release
+      runBuild = buildRustTarget root binName buildType
+      elfPath = root </> firmwareBinariesDir "riscv32imc" buildType </> binName
     pure
       PeConfig
         { cpu = Riscv32imc.vexRiscv0
         , depthI = SNat @IMemWords
         , depthD = SNat @DMemWords
-        , initI = Just (Vec iMem)
-        , initD = Just (Vec dMem)
+        , initI =
+            Just
+              $ Vec
+              $ unsafePerformIO
+              $ runBuild
+              >> vecFromElfInstr BigEndian elfPath
+        , initD =
+            Just
+              $ Vec
+              $ unsafePerformIO
+              $ runBuild
+              >> vecFromElfData BigEndian elfPath
         , iBusTimeout = d0 -- No timeouts on the instruction bus
         , dBusTimeout = d0 -- No timeouts on the data bus
         , includeIlaWb = False

--- a/bittide-instances/tests/Wishbone/Watchdog.hs
+++ b/bittide-instances/tests/Wishbone/Watchdog.hs
@@ -12,6 +12,7 @@ import Clash.Prelude
 -- Local
 import Bittide.DoubleBufferedRam
 import Bittide.Instances.Domains
+import Bittide.Instances.Hitl.Utils.Driver (buildRustTarget)
 import Bittide.ProcessingElement
 import Bittide.ProcessingElement.Util
 import Bittide.SharedTypes (withLittleEndian)
@@ -87,16 +88,28 @@ dut = withLittleEndian
  where
   peConfig = unsafePerformIO $ do
     root <- findParentContaining "cabal.project"
-    let elfPath = root </> firmwareBinariesDir "riscv32imc" Release </> "watchdog_test"
-
-    (iMem, dMem) <- vecsFromElf @IMemWords @DMemWords BigEndian elfPath Nothing
+    let
+      binName = "watchdog_test"
+      buildType = Release
+      runBuild = buildRustTarget root binName buildType
+      elfPath = root </> firmwareBinariesDir "riscv32imc" buildType </> binName
     pure
       $ PeConfig
         { cpu = Riscv32imc.vexRiscv0
         , depthI = SNat @IMemWords
         , depthD = SNat @DMemWords
-        , initI = Just (Vec iMem)
-        , initD = Just (Vec dMem)
+        , initI =
+            Just
+              $ Vec
+              $ unsafePerformIO
+              $ runBuild
+              >> vecFromElfInstr BigEndian elfPath
+        , initD =
+            Just
+              $ Vec
+              $ unsafePerformIO
+              $ runBuild
+              >> vecFromElfData BigEndian elfPath
         , iBusTimeout = d0 -- No timeouts on the instruction bus
         , dBusTimeout = d0 -- No timeouts on the data bus
         , includeIlaWb = False

--- a/bittide-instances/tests/unittests.hs
+++ b/bittide-instances/tests/unittests.hs
@@ -9,10 +9,9 @@ import Prelude
 
 import Data.String.Interpolate (i)
 import System.Exit (ExitCode (ExitFailure, ExitSuccess))
-import System.IO.Unsafe (unsafePerformIO)
 import System.Process (cwd, proc, readCreateProcessWithExitCode, readProcess)
 import Test.Tasty
-import Test.Tasty.HUnit (assertFailure, testCase)
+import Test.Tasty.HUnit (assertFailure)
 import "extra" Data.List.Extra (trim)
 
 import qualified Df.ElasticBufferWb as ElasticBufferWb
@@ -64,11 +63,6 @@ tests =
     "bittide-instances"
     AllSucceed
     [ testGroup
-        "Build Rust crates"
-        [ testCase "release" (run "./cargo.sh" ["build", "--release"] (Just gitRoot))
-        , testCase "debug" (run "./cargo.sh" ["build"] (Just gitRoot))
-        ]
-    , testGroup
         "Unittests"
         [ AddressableBytesWb.tests
         , Axi.tests
@@ -89,8 +83,6 @@ tests =
         , WbToDf.tests
         ]
     ]
- where
-  gitRoot = unsafePerformIO getGitRoot
 
 main :: IO ()
 main = defaultMain tests


### PR DESCRIPTION
_What (what did you do)_

Tests build their own binaries to remove the need to build each one in debug and release mode separately. This should enable us to use smaller memories in a number of tests.

_Why (context, issues, etc.)_

We were starting to see some issues with timing closure because of how much block RAM we were using, so this should solve that issue for now.

_Dear reviewer (anything you'd like the reviewer to pay close attention to?)_

I have no idea what I'm doing with CI stuff, so that was just a best (uneducated) guess. If there's a better way to do it, please let me know.

_AI disclaimer (heads-up for more than inline autocomplete)_

None.

# TODO
_~~Cross-out~~ any that do not apply_

- [x] ~~Write (regression) test~~
- [x] ~~Update documentation, including `docs/`~~
- [x] ~~Link to existing issue~~
- [ ] Ensure changed CI works correctly
