### PR TITLE
Remove `ByteOrder` argument from `vecFromElf`-family

### DIFF
--- a/bittide-instances/src/Bittide/Instances/Hitl/VexRiscv.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/VexRiscv.hs
@@ -165,12 +165,12 @@ vexRiscvTestC =
             Just
               $ Vec
               $ unsafePerformIO
-              $ vecFromElfInstr @IMemWords BigEndian elfPath
+              $ vecFromElfInstr @IMemWords elfPath
         , initD =
             Just
               $ Vec
               $ unsafePerformIO
-              $ vecFromElfData @DMemWords BigEndian elfPath
+              $ vecFromElfData @DMemWords elfPath
         , includeIlaWb = False
         }
   peConfigRtl =

--- a/bittide-instances/src/Bittide/Instances/Pnr/Ethernet.hs
+++ b/bittide-instances/src/Bittide/Instances/Pnr/Ethernet.hs
@@ -32,7 +32,6 @@ import Bittide.ProcessingElement (PeConfig (..), processingElement)
 import Bittide.ProcessingElement.Util (vecFromElfData, vecFromElfInstr)
 import Bittide.SharedTypes (withLittleEndian)
 import Bittide.Wishbone
-import Clash.Class.BitPackC (ByteOrder (BigEndian))
 
 import Project.FilePath (
   CargoBuildType (Release),
@@ -172,13 +171,13 @@ vexRiscGmiiC SNat sysClk sysRst rxClk rxRst txClk txRst =
             Just
               ( Vec
                   $ unsafePerformIO
-                  $ vecFromElfInstr @IMemWords BigEndian elfPath
+                  $ vecFromElfInstr @IMemWords elfPath
               )
         , initD =
             Just
               ( Vec
                   $ unsafePerformIO
-                  $ vecFromElfData @DMemWords BigEndian elfPath
+                  $ vecFromElfData @DMemWords elfPath
               )
         , iBusTimeout = d0
         , dBusTimeout = d0

--- a/bittide-instances/src/Bittide/Instances/Pnr/ProcessingElement.hs
+++ b/bittide-instances/src/Bittide/Instances/Pnr/ProcessingElement.hs
@@ -9,7 +9,6 @@ import Clash.Prelude
 
 import Bittide.Cpus.Riscv32imc (vexRiscv0)
 import Clash.Annotations.TH
-import Clash.Class.BitPackC (ByteOrder (BigEndian))
 import Clash.Cores.UART (ValidBaud)
 import Clash.Explicit.Prelude (noReset, orReset)
 import Clash.Xilinx.ClockGen
@@ -70,12 +69,12 @@ vexRiscvUartHelloC baudSnat = withLittleEndian $ circuit $ \(mm, (uartRx, jtag))
             Just
               $ Vec
               $ unsafePerformIO
-              $ vecFromElfInstr @IMemWords BigEndian elfPath
+              $ vecFromElfInstr @IMemWords elfPath
         , initD =
             Just
               $ Vec
               $ unsafePerformIO
-              $ vecFromElfData @DMemWords BigEndian elfPath
+              $ vecFromElfData @DMemWords elfPath
         , depthI = SNat @IMemWords
         , depthD = SNat @DMemWords
         , includeIlaWb = False

--- a/bittide-instances/src/Bittide/Instances/Tests/AddressableBytesWb.hs
+++ b/bittide-instances/src/Bittide/Instances/Tests/AddressableBytesWb.hs
@@ -29,7 +29,7 @@ import Project.FilePath (
   firmwareBinariesDir,
  )
 
-import Clash.Class.BitPackC (ByteOrder (BigEndian, LittleEndian))
+import Clash.Class.BitPackC (ByteOrder (LittleEndian))
 import Data.Char (chr)
 import Data.Maybe (catMaybes)
 import Protocols
@@ -97,12 +97,12 @@ dutWithBinary binaryName =
             Just
               $ Vec
               $ unsafePerformIO
-              $ vecFromElfInstr BigEndian elfPath
+              $ vecFromElfInstr elfPath
         , initD =
             Just
               $ Vec
               $ unsafePerformIO
-              $ vecFromElfData BigEndian elfPath
+              $ vecFromElfData elfPath
         , iBusTimeout = d0 -- No timeouts on the instruction bus
         , dBusTimeout = d0 -- No timeouts on the data bus
         , includeIlaWb = False

--- a/bittide-instances/src/Bittide/Instances/Tests/ElasticBufferWb.hs
+++ b/bittide-instances/src/Bittide/Instances/Tests/ElasticBufferWb.hs
@@ -13,7 +13,6 @@ import Bittide.ProcessingElement
 import Bittide.ProcessingElement.Util
 import Bittide.SharedTypes (withLittleEndian)
 import Bittide.Wishbone
-import Clash.Class.BitPackC
 import GHC.Stack (HasCallStack)
 import Project.FilePath
 import Protocols
@@ -89,12 +88,12 @@ dut = withLittleEndian $ withClockResetEnable clockGen (resetGenN d2) enableGen 
             Just
               $ Vec @IMemWords
               $ unsafePerformIO
-              $ vecFromElfInstr BigEndian elfPath
+              $ vecFromElfInstr elfPath
         , initD =
             Just
               $ Vec @DMemWords
               $ unsafePerformIO
-              $ vecFromElfData BigEndian elfPath
+              $ vecFromElfData elfPath
         , iBusTimeout = d0 -- No timeouts on the instruction bus
         , dBusTimeout = d0 -- No timeouts on the data bus
         , includeIlaWb = False

--- a/bittide-instances/src/Bittide/Instances/Tests/NestedInterconnect.hs
+++ b/bittide-instances/src/Bittide/Instances/Tests/NestedInterconnect.hs
@@ -30,7 +30,7 @@ import Project.FilePath (
   firmwareBinariesDir,
  )
 
-import Clash.Class.BitPackC (ByteOrder (BigEndian))
+import Clash.Class.BitPackC (ByteOrder)
 import Clash.Sized.Vector.Extra
 import Data.Char (chr)
 import Data.Maybe (catMaybes)
@@ -89,12 +89,12 @@ peConfig = unsafePerformIO $ do
           Just
             $ Vec @IMemWords
             $ unsafePerformIO
-            $ vecFromElfInstr BigEndian elfPath
+            $ vecFromElfInstr elfPath
       , initD =
           Just
             $ Vec @DMemWords
             $ unsafePerformIO
-            $ vecFromElfData BigEndian elfPath
+            $ vecFromElfData elfPath
       , iBusTimeout = d0
       , dBusTimeout = d0
       , includeIlaWb = False

--- a/bittide-instances/src/Bittide/Instances/Tests/RegisterWb.hs
+++ b/bittide-instances/src/Bittide/Instances/Tests/RegisterWb.hs
@@ -30,7 +30,7 @@ import Project.FilePath (
   firmwareBinariesDir,
  )
 
-import Clash.Class.BitPackC (BitPackC, ByteOrder (BigEndian))
+import Clash.Class.BitPackC (BitPackC, ByteOrder)
 import Data.Char (chr)
 import Data.Maybe (catMaybes)
 import Protocols
@@ -459,12 +459,12 @@ dutWithBinary binaryName =
             Just
               $ Vec @IMemWords
               $ unsafePerformIO
-              $ vecFromElfInstr BigEndian elfPath
+              $ vecFromElfInstr elfPath
         , initD =
             Just
               $ Vec @DMemWords
               $ unsafePerformIO
-              $ vecFromElfData BigEndian elfPath
+              $ vecFromElfData elfPath
         , iBusTimeout = d0 -- No timeouts on the instruction bus
         , dBusTimeout = d0 -- No timeouts on the data bus
         , includeIlaWb = False

--- a/bittide-instances/src/Bittide/Instances/Tests/ScatterGather.hs
+++ b/bittide-instances/src/Bittide/Instances/Tests/ScatterGather.hs
@@ -6,7 +6,6 @@ module Bittide.Instances.Tests.ScatterGather where
 import Clash.Explicit.Prelude
 import Clash.Prelude (HiddenClockResetEnable, withClockResetEnable)
 
-import Clash.Class.BitPackC (ByteOrder (BigEndian))
 import GHC.Stack (HasCallStack)
 import Project.FilePath
 import Protocols
@@ -89,12 +88,12 @@ dutWithBinary binaryName = withLittleEndian $ circuit $ \mm -> do
             Just
               $ Vec
               $ unsafePerformIO
-              $ vecFromElfInstr BigEndian elfPath
+              $ vecFromElfInstr elfPath
         , initD =
             Just
               $ Vec
               $ unsafePerformIO
-              $ vecFromElfData BigEndian elfPath
+              $ vecFromElfData elfPath
         , iBusTimeout = d0 -- No timeouts on the instruction bus
         , dBusTimeout = d0 -- No timeouts on the data bus
         , includeIlaWb = False

--- a/bittide-instances/src/Bittide/Instances/Tests/SwitchCalendar.hs
+++ b/bittide-instances/src/Bittide/Instances/Tests/SwitchCalendar.hs
@@ -16,7 +16,6 @@ import Bittide.ProcessingElement.Util (
  )
 import Bittide.SharedTypes
 import Bittide.Wishbone hiding (MemoryMap)
-import Clash.Class.BitPackC
 import Clash.Explicit.Prelude
 import Clash.Prelude (withClockResetEnable)
 import Data.Char
@@ -85,12 +84,12 @@ dut =
             Just
               $ Vec
               $ unsafePerformIO
-              $ vecFromElfInstr BigEndian elfPath
+              $ vecFromElfInstr elfPath
         , initD =
             Just
               $ Vec
               $ unsafePerformIO
-              $ vecFromElfData BigEndian elfPath
+              $ vecFromElfData elfPath
         , iBusTimeout = d0 -- No timeouts on the instruction bus
         , dBusTimeout = d0 -- No timeouts on the data bus
         , includeIlaWb = False

--- a/bittide-instances/src/Bittide/Instances/Tests/TimeWb.hs
+++ b/bittide-instances/src/Bittide/Instances/Tests/TimeWb.hs
@@ -14,7 +14,7 @@ import Bittide.SharedTypes (withLittleEndian)
 import Bittide.Wishbone
 import Project.FilePath
 
-import Clash.Class.BitPackC (BitPackC, ByteOrder (BigEndian))
+import Clash.Class.BitPackC (BitPackC)
 import Protocols
 import Protocols.Idle
 import Protocols.MemoryMap (Mm)
@@ -61,12 +61,12 @@ dutCpu = withLittleEndian $ circuit $ \mm -> do
             Just
               $ Vec
               $ unsafePerformIO
-              $ vecFromElfInstr BigEndian elfPath
+              $ vecFromElfInstr elfPath
         , initD =
             Just
               $ Vec
               $ unsafePerformIO
-              $ vecFromElfData BigEndian elfPath
+              $ vecFromElfData elfPath
         , iBusTimeout = d0
         , dBusTimeout = d0
         , includeIlaWb = False

--- a/bittide-instances/src/Bittide/Instances/Tests/WbToDf.hs
+++ b/bittide-instances/src/Bittide/Instances/Tests/WbToDf.hs
@@ -97,12 +97,12 @@ dut = withLittleEndian $ withClockResetEnable clockGen (resetGenN d2) enableGen 
             Just
               $ Vec
               $ unsafePerformIO
-              $ vecFromElfInstr BigEndian elfPath
+              $ vecFromElfInstr elfPath
         , initD =
             Just
               $ Vec
               $ unsafePerformIO
-              $ vecFromElfData BigEndian elfPath
+              $ vecFromElfData elfPath
         , iBusTimeout = d0 -- No timeouts on the instruction bus
         , dBusTimeout = d0 -- No timeouts on the data bus
         , includeIlaWb = False

--- a/bittide-instances/tests/Tests/ClockControlWb.hs
+++ b/bittide-instances/tests/Tests/ClockControlWb.hs
@@ -11,7 +11,6 @@ import Clash.Explicit.Prelude hiding (PeriodToCycles, many)
 -- external imports
 
 import Bittide.Cpus.Riscv32imc (vexRiscv0)
-import Clash.Class.BitPackC (ByteOrder (BigEndian))
 import Clash.Signal (withClockResetEnable)
 import Data.Char (chr)
 import Data.Maybe (catMaybes)
@@ -151,7 +150,7 @@ dut =
     let
       elfDir = root </> firmwareBinariesDir "riscv32imc" Release
       elfPath = elfDir </> "clock-control-wb"
-    (iMem, dMem) <- vecsFromElf @IMemWords @DMemWords BigEndian elfPath Nothing
+    (iMem, dMem) <- vecsFromElf @IMemWords @DMemWords elfPath Nothing
     pure
       PeConfig
         { cpu = vexRiscv0

--- a/bittide-instances/tests/Wishbone/Axi.hs
+++ b/bittide-instances/tests/Wishbone/Axi.hs
@@ -18,7 +18,6 @@ import Project.FilePath
 
 -- Other
 import Bittide.SharedTypes (withLittleEndian)
-import Clash.Class.BitPackC (ByteOrder (BigEndian))
 import Control.Monad (forM_)
 import Data.Char
 import Data.Maybe
@@ -102,7 +101,7 @@ dut =
   peConfig = unsafePerformIO $ do
     root <- findParentContaining "cabal.project"
     let elfPath = root </> firmwareBinariesDir "riscv32imc" Release </> "axi_stream_self_test"
-    (iMem, dMem) <- vecsFromElf @IMemWords @DMemWords BigEndian elfPath Nothing
+    (iMem, dMem) <- vecsFromElf @IMemWords @DMemWords elfPath Nothing
     pure
       PeConfig
         { cpu = Riscv32imc.vexRiscv0

--- a/bittide-instances/tests/Wishbone/CaptureUgn.hs
+++ b/bittide-instances/tests/Wishbone/CaptureUgn.hs
@@ -12,7 +12,6 @@ import Clash.Prelude (HiddenClockResetEnable, withClockResetEnable)
 import qualified Prelude as P
 
 import Bittide.ElasticBuffer (ElasticBufferData (Data))
-import Clash.Class.BitPackC (ByteOrder (BigEndian))
 import Clash.Signal.Internal
 import Data.Char
 import Data.Maybe
@@ -105,7 +104,7 @@ dut eb localCounter = withLittleEndian $ circuit $ do
   peConfig = unsafePerformIO $ do
     root <- findParentContaining "cabal.project"
     let elfPath = root </> firmwareBinariesDir "riscv32imc" Release </> "capture_ugn_test"
-    (iMem, dMem) <- vecsFromElf @IMemWords @DMemWords BigEndian elfPath Nothing
+    (iMem, dMem) <- vecsFromElf @IMemWords @DMemWords elfPath Nothing
     pure
       PeConfig
         { cpu = Riscv32imc.vexRiscv0

--- a/bittide-instances/tests/Wishbone/DnaPortE2.hs
+++ b/bittide-instances/tests/Wishbone/DnaPortE2.hs
@@ -9,7 +9,6 @@ module Wishbone.DnaPortE2 where
 import Clash.Explicit.Prelude
 import Clash.Prelude (HiddenClockResetEnable, withClockResetEnable)
 
-import Clash.Class.BitPackC (ByteOrder (BigEndian))
 import Clash.Cores.Xilinx.Unisim.DnaPortE2
 import Data.Char
 import Data.Maybe
@@ -72,7 +71,7 @@ dut = withLittleEndian $ circuit $ \_unit -> do
   peConfig = unsafePerformIO $ do
     root <- findParentContaining "cabal.project"
     let elfPath = root </> firmwareBinariesDir "riscv32imc" Release </> "dna_port_e2_test"
-    (iMem, dMem) <- vecsFromElf @IMemWords @DMemWords BigEndian elfPath Nothing
+    (iMem, dMem) <- vecsFromElf @IMemWords @DMemWords elfPath Nothing
     pure
       PeConfig
         { cpu = Riscv32imc.vexRiscv0

--- a/bittide-instances/tests/Wishbone/SwitchDemoProcessingElement.hs
+++ b/bittide-instances/tests/Wishbone/SwitchDemoProcessingElement.hs
@@ -7,7 +7,6 @@ module Wishbone.SwitchDemoProcessingElement where
 import Clash.Explicit.Prelude
 import Clash.Prelude (HiddenClockResetEnable, withClockResetEnable)
 
-import Clash.Class.BitPackC (ByteOrder (BigEndian))
 import Data.Char (chr)
 import Data.List (isPrefixOf)
 import Data.Maybe (catMaybes)
@@ -105,7 +104,7 @@ dut dnaA dnaB = withLittleEndian $ circuit $ do
     let
       elfDir = root </> firmwareBinariesDir "riscv32imc" Release
       elfPath = elfDir </> "switch_demo_pe_test"
-    (iMem, dMem) <- vecsFromElf @IMemWords @DMemWords BigEndian elfPath Nothing
+    (iMem, dMem) <- vecsFromElf @IMemWords @DMemWords elfPath Nothing
     pure
       PeConfig
         { cpu = Riscv32imc.vexRiscv0

--- a/bittide-instances/tests/Wishbone/Time.hs
+++ b/bittide-instances/tests/Wishbone/Time.hs
@@ -17,7 +17,6 @@ import Bittide.Wishbone
 import Project.FilePath
 
 -- Other
-import Clash.Class.BitPackC (ByteOrder (BigEndian))
 import Control.Monad (forM_, when)
 import Data.Char
 import Data.List (isInfixOf)
@@ -77,7 +76,7 @@ dut = withLittleEndian
   peConfig = unsafePerformIO $ do
     root <- findParentContaining "cabal.project"
     let elfPath = root </> firmwareBinariesDir "riscv32imc" Release </> "time_self_test"
-    (iMem, dMem) <- vecsFromElf @IMemWords @DMemWords BigEndian elfPath Nothing
+    (iMem, dMem) <- vecsFromElf @IMemWords @DMemWords elfPath Nothing
     pure
       PeConfig
         { cpu = Riscv32imc.vexRiscv0
@@ -161,7 +160,7 @@ dutC = withLittleEndian
   peConfigC = unsafePerformIO $ do
     root <- findParentContaining "cabal.project"
     let elfPath = root </> firmwareBinariesDir "riscv32imc" Release </> "c_timer_wb"
-    (iMem, dMem) <- vecsFromElf @IMemWords @DMemWords BigEndian elfPath Nothing
+    (iMem, dMem) <- vecsFromElf @IMemWords @DMemWords elfPath Nothing
     pure
       PeConfig
         { cpu = Riscv32imc.vexRiscv0

--- a/bittide-instances/tests/Wishbone/Watchdog.hs
+++ b/bittide-instances/tests/Wishbone/Watchdog.hs
@@ -19,7 +19,6 @@ import Bittide.Wishbone
 import Project.FilePath
 
 -- Other
-import Clash.Class.BitPackC (ByteOrder (BigEndian))
 import Data.Char
 import Data.Maybe
 import Protocols
@@ -89,7 +88,7 @@ dut = withLittleEndian
     root <- findParentContaining "cabal.project"
     let elfPath = root </> firmwareBinariesDir "riscv32imc" Release </> "watchdog_test"
 
-    (iMem, dMem) <- vecsFromElf @IMemWords @DMemWords BigEndian elfPath Nothing
+    (iMem, dMem) <- vecsFromElf @IMemWords @DMemWords elfPath Nothing
     pure
       $ PeConfig
         { cpu = Riscv32imc.vexRiscv0

--- a/bittide/src/Bittide/ProcessingElement/Util.hs
+++ b/bittide/src/Bittide/ProcessingElement/Util.hs
@@ -11,7 +11,6 @@ import Bittide.ProcessingElement.DeviceTreeCompiler
 import Bittide.ProcessingElement.ReadElf
 import Bittide.SharedTypes
 
-import Clash.Class.BitPackC (ByteOrder (..))
 import Control.Monad (when)
 import Data.Maybe
 import GHC.Stack
@@ -46,8 +45,6 @@ padToSize name (Just s) a xs
 vecsFromElf ::
   forall nInstrWords nDataWords.
   (HasCallStack, KnownNat nDataWords, KnownNat nInstrWords) =>
-  -- | How the words should be ordered
-  ByteOrder ->
   -- | Source file, assumed to be Little Endian.
   FilePath ->
   -- | Optional tuple of starting address and filepath to a device tree.
@@ -57,11 +54,11 @@ vecsFromElf ::
     ( Vec nInstrWords (BitVector 32)
     , Vec nDataWords (BitVector 32)
     )
-vecsFromElf byteOrder elfPath maybeDeviceTree = do
+vecsFromElf elfPath maybeDeviceTree = do
   (iMemIntMap, dMemIntMap) <- getBytesMems elfPath maybeDeviceTree
   let
-    (_iStartAddr, _, iList) = extractIntMapData byteOrder iMemIntMap
-    (_dStartAddr, _, dList) = extractIntMapData byteOrder dMemIntMap
+    (_iStartAddr, _, iList) = extractIntMapData iMemIntMap
+    (_dStartAddr, _, dList) = extractIntMapData dMemIntMap
     iListPadded = padToSize "Instruction memory" (Just (natToNum @nInstrWords)) 0 iList
     dListPadded = padToSize "Data memory" (Just (natToNum @nInstrWords)) 0 dList
 
@@ -71,16 +68,14 @@ vecsFromElf byteOrder elfPath maybeDeviceTree = do
 vecFromElfData ::
   forall nWords.
   (HasCallStack, KnownNat nWords) =>
-  -- | How the words should be ordered
-  ByteOrder ->
   -- | Source file, assumed to be Little Endian.
   FilePath ->
   -- | Data memory
   IO (Vec nWords (BitVector 32))
-vecFromElfData byteOrder elfPath = do
+vecFromElfData elfPath = do
   (_iMemIntMap, dMemIntMap) <- getBytesMems elfPath Nothing
   let
-    (_dStartAddr, _, dList) = extractIntMapData byteOrder dMemIntMap
+    (_dStartAddr, _, dList) = extractIntMapData dMemIntMap
     dListPadded = padToSize "Data memory" (Just (natToNum @nWords)) 0 dList
 
   pure (unsafeFromList dListPadded)
@@ -89,16 +84,14 @@ vecFromElfData byteOrder elfPath = do
 vecFromElfInstr ::
   forall nWords.
   (HasCallStack, KnownNat nWords) =>
-  -- | How the words should be ordered
-  ByteOrder ->
   -- | Source file, assumed to be Little Endian.
   FilePath ->
   -- | Instruction memory
   IO (Vec nWords (BitVector 32))
-vecFromElfInstr byteOrder elfPath = do
+vecFromElfInstr elfPath = do
   (iMemIntMap, _dMemIntMap) <- getBytesMems elfPath Nothing
   let
-    (_iStartAddr, _, iList) = extractIntMapData byteOrder iMemIntMap
+    (_iStartAddr, _, iList) = extractIntMapData iMemIntMap
     iListPadded = padToSize "Instruction memory" (Just (natToNum @nWords)) 0 iList
 
   pure (unsafeFromList iListPadded)
@@ -143,7 +136,6 @@ if the IntMap is empty.
 -}
 extractIntMapData ::
   (HasCallStack) =>
-  ByteOrder ->
   -- | IntMap
   I.IntMap (BitVector 8) ->
   -- |
@@ -151,13 +143,9 @@ extractIntMapData ::
   -- 2. Size
   -- 3. List of words
   (BitVector 32, Int, [Bytes 4])
-extractIntMapData byteOrder dataMap =
-  (resize . bitCoerce $ startAddr, size, combineFunction content)
+extractIntMapData dataMap =
+  (resize . bitCoerce $ startAddr, size, toWords content)
  where
-  combineFunction
-    | LittleEndian <- byteOrder = toWordsLinear
-    | BigEndian <- byteOrder = toWordsSwapped
-
   (ordListHead, ordListTail) = case I.toAscList dataMap of
     [] -> error "extractIntMapData: IntMap is empty"
     (x : xs) -> (x, xs)
@@ -175,19 +163,18 @@ extractIntMapData byteOrder dataMap =
      in
       padding L.++ (val : flattenContent nextAddr vals)
 
-  toWordsLinear :: [Bytes 1] -> [Bytes 4]
-  toWordsLinear [] = []
-  toWordsLinear [!a] = [bitCoerce (a, 0 :: Bytes 3)]
-  toWordsLinear [!a, !b] = [bitCoerce (a, b, 0 :: Bytes 2)]
-  toWordsLinear [!a, !b, !c] = [bitCoerce (a, b, c, 0 :: Bytes 1)]
-  toWordsLinear ((!a) : (!b) : (!c) : (!d) : rest) = bitCoerce (a, b, c, d) : toWordsLinear rest
-
-  toWordsSwapped :: [Bytes 1] -> [Bytes 4]
-  toWordsSwapped [] = []
-  toWordsSwapped [!a] = [bitCoerce (a, 0 :: Bytes 3)]
-  toWordsSwapped [!a, !b] = [bitCoerce (b, a, 0 :: Bytes 2)]
-  toWordsSwapped [!a, !b, !c] = [bitCoerce (c, b, a, 0 :: Bytes 1)]
-  toWordsSwapped ((!a) : (!b) : (!c) : (!d) : rest) = bitCoerce (d, c, b, a) : toWordsSwapped rest
+  toWords :: [Bytes 1] -> [Bytes 4]
+  toWords [] = []
+  toWords [a] = toWords [a, 0, 0, 0]
+  toWords [a, b] = toWords [a, b, 0, 0]
+  toWords [a, b, c] = toWords [a, b, c, 0]
+  toWords (a : b : c : d : rest) =
+    -- Note the way we pack: this might seem counterintuitive, but it makes sure that the
+    -- lower addresses are packed into the lower bits.
+    let
+      !packed = pack (d, c, b, a)
+     in
+      packed : toWords rest
 
 -- | Given the filepath to a device tree, return the divce tree as list of `Byte`.
 readDeviceTree :: FilePath -> IO [Byte]


### PR DESCRIPTION
The bytes in the `ByteString` yielded by the `elf` package are address ordered. This means that the first byte of the `ByteString` corresponds to the first address -- relative to the section's starting position. There is therefore no need to account for endianness, as that is only relevant for the interpretation of the data.

Fixes #1240

# TODO
- [X] ~~Write (regression) test~~
- [X] Update documentation, including `docs/`
- [X] Link to existing issue
