### PR TITLE
Add `increaseBuswidth` utility for `Wishbone`

### DIFF
--- a/bittide-extra/src/Protocols/Wishbone/Extra.hs
+++ b/bittide-extra/src/Protocols/Wishbone/Extra.hs
@@ -2,7 +2,7 @@
 --
 -- SPDX-License-Identifier: Apache-2.0
 
-module Protocols.Wishbone.Extra (delayWishbone, xpmCdcHandshakeWb) where
+module Protocols.Wishbone.Extra (delayWishbone, xpmCdcHandshakeWb, increaseBuswidth) where
 
 import Clash.Cores.Xilinx.Xpm.Cdc.Extra (xpmCdcHandshakeDf)
 import Clash.Prelude
@@ -218,3 +218,36 @@ xpmCdcHandshakeWb clkM rstM clkS rstS =
     state
       | ackIn = HwsForwarding
       | otherwise = HwsResponding s2mIn
+
+{- | Converts a bus of `width` bytes wide to bus of `(2 ^ power * width) based on the lower
+`power` bits of the address. For example, with `power = 1`, a 32-bit bus becomes a 64-bit bus,
+where even addresses access the lower 32 bits and odd addresses access the upper 32 bits.
+-}
+increaseBuswidth ::
+  forall dom mode aw width power.
+  (HiddenClockResetEnable dom, KnownNat aw, KnownNat width, KnownNat power, power <= aw) =>
+  SNat power ->
+  Circuit
+    (Wishbone dom mode aw width)
+    (Wishbone dom mode (aw - power) (2 ^ power * width))
+increaseBuswidth SNat = Circuit (unbundle . fmap go . bundle)
+ where
+  go (m2sLeft, s2mRight) = (s2mLeft, m2sRight)
+   where
+    m2sRight =
+      m2sLeft
+        { addr = newAddr
+        , writeData = newWriteData
+        , busSelect = newBusSelect
+        }
+    s2mLeft =
+      s2mRight
+        { readData = newReadData
+        }
+
+    newAddr = addrMsbs
+    bitShift = natToNum @width * fromIntegral addrLsbs -- `shiftL` takes an `Int`
+    (addrMsbs, addrLsbs :: BitVector power) = bitCoerce (m2sLeft.addr)
+    newWriteData = pack (repeat m2sLeft.writeData)
+    newBusSelect = shiftL (resize m2sLeft.busSelect) bitShift
+    newReadData = resize (shiftR (s2mRight.readData) (8 * bitShift))

--- a/bittide/tests/Tests/Clash/Protocols/Wishbone/Extra.hs
+++ b/bittide/tests/Tests/Clash/Protocols/Wishbone/Extra.hs
@@ -11,6 +11,7 @@ import Bittide.DoubleBufferedRam (
   ContentType (Vec),
   wbStorage,
  )
+import Clash.Hedgehog.Sized.BitVector (genDefinedBitVector)
 import Clash.Prelude (withClockResetEnable)
 import Data.Map (Map)
 import Data.String.Interpolate (i)
@@ -19,7 +20,7 @@ import Protocols
 import Protocols.Hedgehog (ExpectOptions (eoResetCycles), defExpectOptions, eoSampleMax)
 import Protocols.MemoryMap (unMemmap)
 import Protocols.Wishbone
-import Protocols.Wishbone.Extra (xpmCdcHandshakeWb)
+import Protocols.Wishbone.Extra (increaseBuswidth, xpmCdcHandshakeWb)
 import Protocols.Wishbone.Standard.Hedgehog (
   WishboneMasterRequest (Read, Write),
   wishbonePropWithModel,
@@ -28,12 +29,25 @@ import Test.Tasty (TestTree)
 import Test.Tasty.Hedgehog (testProperty)
 import Test.Tasty.TH (testGroupGenerator)
 
+import qualified Clash.Prelude as C
 import qualified Data.List as L
 import qualified Data.Map as Map
+import qualified Hedgehog as H
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
 
 type AddressWidth = 4
+
+genWishboneTransfer ::
+  (KnownNat aw, KnownNat nBytes) =>
+  Gen (BitVector aw) ->
+  Gen (WishboneMasterRequest aw nBytes)
+genWishboneTransfer genAddr =
+  Gen.choice
+    [ Read <$> genAddr <*> pure maxBound
+    , Write <$> genAddr <*> pure maxBound <*> genDefinedBitVector
+    ]
+
 mergeWithMask ::
   forall n m.
   (KnownNat n, KnownNat m) =>
@@ -122,6 +136,79 @@ prop_xpmCdcHandshakeWb = property $ do
   genBoundedIntegral :: forall a. (Integral a, Bounded a) => Gen a
   genBoundedIntegral = Gen.integral Range.constantBounded
 
+testIncreaseBuswidth ::
+  forall power nBytes.
+  -- \| We are restricted by our 4 byte wide `wbStorage` backend.
+  (KnownNat power, (2 ^ power) * nBytes ~ 4, nBytes ~ 4 `DivRU` (2 ^ power)) =>
+  SNat power ->
+  Property
+testIncreaseBuswidth power = property $ do
+  let
+    eOpts = defExpectOptions
+
+    -- Depth is half the number of addresses to also tests error on out-of-range accesses.
+    depth = SNat @(2 ^ (AddressWidth - 2))
+    lastAddress = snatToNum $ predSNat depth
+    lastAddressSmall = lastAddress * (natToNum @(2 ^ power))
+    genAddr = Gen.integral (Range.linear 0 lastAddressSmall)
+    genInputs = Gen.list (Range.linear 1 10) (genWishboneTransfer genAddr)
+
+    dutMem :: Circuit (Wishbone System 'Standard AddressWidth 4) ()
+    dutMem =
+      withClockResetEnable clk rst ena
+        $ unMemmap
+        $ wbStorage "test" depth (Just (Vec (repeat 0)))
+
+    dut :: Circuit (Wishbone System 'Standard (AddressWidth + power) nBytes) ()
+    dut = withClockResetEnable clk rst ena (increaseBuswidth power |> dutMem)
+
+  H.footnote [i| Depth: #{snatToInteger depth}, Last Address: #{lastAddress}|]
+
+  withClockResetEnable clk rst ena
+    $ wishbonePropWithModel
+      @System
+      eOpts
+      (memoryModel (fromIntegral lastAddressSmall))
+      dut
+      genInputs
+      (Map.fromList (L.zip [0 .. lastAddressSmall] (L.repeat 0)))
+ where
+  clk = clockGen
+  rst = noReset
+  ena = enableGen
+
+prop_increaseBuswidth_0 :: Property
+prop_increaseBuswidth_0 = testIncreaseBuswidth d0
+
+prop_increaseBuswidth_1 :: Property
+prop_increaseBuswidth_1 = testIncreaseBuswidth d1
+
+prop_increaseBuswidth_2 :: Property
+prop_increaseBuswidth_2 = testIncreaseBuswidth d2
+
+prop_memoryModel :: Property
+prop_memoryModel = property $ do
+  let
+    eOpts = defExpectOptions
+    dut :: (C.HiddenClockResetEnable System) => Circuit (Wishbone System 'Standard AddressWidth 4) ()
+    dut =
+      unMemmap (wbStorage "test" d8 (Just (Vec (repeat 0))))
+
+  withClockResetEnable clk rst ena
+    $ wishbonePropWithModel
+      @System
+      eOpts
+      (memoryModel 16)
+      dut
+      genInputs
+      (Map.fromList (L.zip [0 .. lastAddress] (L.repeat 0)))
+ where
+  clk = clockGen
+  rst = noReset
+  ena = enableGen
+  lastAddress = natToNum @(2 ^ (AddressWidth - 1)) -- Less elements to also test error propagation.
+  genAddr = Gen.integral (Range.linear 0 (lastAddress * 2))
+  genInputs = Gen.list (Range.linear 1 10) (genWishboneTransfer genAddr)
 
 tests :: TestTree
 tests = $(testGroupGenerator)

--- a/bittide/tests/Tests/Clash/Protocols/Wishbone/Extra.hs
+++ b/bittide/tests/Tests/Clash/Protocols/Wishbone/Extra.hs
@@ -13,9 +13,8 @@ import Bittide.DoubleBufferedRam (
  )
 import Clash.Prelude (withClockResetEnable)
 import Data.Map (Map)
-import Data.Maybe (fromMaybe)
-import Hedgehog (Gen, Property)
-import Hedgehog.Internal.Property (property)
+import Data.String.Interpolate (i)
+import Hedgehog (Gen, Property, property)
 import Protocols
 import Protocols.Hedgehog (ExpectOptions (eoResetCycles), defExpectOptions, eoSampleMax)
 import Protocols.MemoryMap (unMemmap)
@@ -25,28 +24,61 @@ import Protocols.Wishbone.Standard.Hedgehog (
   WishboneMasterRequest (Read, Write),
   wishbonePropWithModel,
  )
-import Test.Tasty (TestTree, testGroup)
-import Test.Tasty.Hedgehog (testPropertyNamed)
+import Test.Tasty (TestTree)
+import Test.Tasty.Hedgehog (testProperty)
+import Test.Tasty.TH (testGroupGenerator)
 
+import qualified Data.List as L
 import qualified Data.Map as Map
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
 
 type AddressWidth = 4
-
-tests :: TestTree
-tests =
-  testGroup
-    "Tests.Clash.Protocols.Wishbone.Extra"
-    [ testPropertyNamed
-        "xpmCdcHandshakeWb preserves wishbone transactions"
-        "xpmCdcHandshakeWb"
-        prop_xpmCdcHandshakeWb
-    ]
-
-mergeWithMask :: BitVector 32 -> BitVector 32 -> BitVector 4 -> BitVector 32
+mergeWithMask ::
+  forall n m.
+  (KnownNat n, KnownNat m) =>
+  BitVector (n * m) ->
+  BitVector (n * m) ->
+  BitVector n ->
+  BitVector (n * m)
 mergeWithMask (unpack -> old) (unpack -> new) (unpack -> mask) =
-  pack (mux @(Vec 4) @(BitVector 8) mask new old)
+  pack (mux @(Vec n) @(BitVector m) mask new old)
+
+-- | Generic memory model for a Wishbone slave.
+memoryModel ::
+  forall aw dw.
+  (KnownNat aw, KnownNat dw) =>
+  Int ->
+  WishboneMasterRequest aw dw ->
+  WishboneS2M dw ->
+  Map (BitVector aw) (BitVector (dw * 8)) ->
+  Either String (Map (BitVector aw) (BitVector (dw * 8)))
+memoryModel maxAddr req@(Write addr mask dat) resp mem
+  | addrInt <= maxAddr && resp.acknowledge = Right newMem
+  | resp.acknowledge = Left [i|Received acknowledge for out-of-range address #{(req, resp)}|]
+  | maxAddr > addrRange = Left [i|Supplied depth #{maxAddr} exceeds addressable range #{addrRange}|]
+  | resp.err = Right mem
+  | otherwise = Left [i|Expected acknowledge for valid write #{(req, resp)}|]
+ where
+  addrInt = fromIntegral addr
+  addrRange :: Int
+  addrRange = fromIntegral (maxBound :: BitVector aw)
+  oldData = mem Map.! addr
+  newData = mergeWithMask oldData dat mask
+  newMem = Map.insert addr newData mem
+memoryModel maxAddr req@(Read addr mask) resp mem
+  | addrInt <= maxAddr && resp.acknowledge && match = Right mem
+  | addrInt <= maxAddr && resp.acknowledge = Left "Data mismatch"
+  | resp.acknowledge = Left [i|Received acknowledge for out-of-range address #{(req, resp)}|]
+  | maxAddr > addrRange = Left [i|Supplied depth #{maxAddr} exceeds addressable range #{addrRange}|]
+  | resp.err = Right mem
+  | otherwise = Left [i|Expected acknowledge for valid read #{(req, resp)}|]
+ where
+  addrInt = fromIntegral addr
+  addrRange :: Int
+  addrRange = fromIntegral (maxBound :: BitVector aw)
+  match = mergeWithMask 0 (resp.readData) mask == mergeWithMask 0 memData mask
+  memData = mem Map.! addr
 
 {- | Test that xpmCdcHandshakeWb correctly transfers Wishbone transactions
 between clock domains without data corruption. The test connects the CDC
@@ -55,41 +87,29 @@ work correctly.
 -}
 prop_xpmCdcHandshakeWb :: Property
 prop_xpmCdcHandshakeWb = property $ do
+  let
+    dut :: Circuit (Wishbone System 'Standard AddressWidth 4) ()
+    dut = xpmCdcHandshakeWb clk rst clk rst |> dutMem
+
+    dutMem :: Circuit (Wishbone System 'Standard AddressWidth 4) ()
+    dutMem =
+      withClockResetEnable clk rst ena
+        $ unMemmap
+        $ wbStorage "test" (SNat @(2 ^ (AddressWidth - 1))) (Just (Vec (repeat 0)))
+
   withClockResetEnable clk rst ena
     $ wishbonePropWithModel
       @System
       defExpectOptions{eoSampleMax = 10_000, eoResetCycles = 0}
-      model
+      (memoryModel 7)
       dut
       genInputs
-      Map.empty
+      (Map.fromList (L.zip [0 .. lastAddress] (L.repeat 0)))
  where
+  lastAddress = natToNum @(2 ^ (AddressWidth - 1)) -- Less elements to also test error propagation.
   clk = clockGen
   rst = noReset
   ena = enableGen
-
-  -- Behavioral model: track memory state
-  model ::
-    WishboneMasterRequest AddressWidth 4 ->
-    WishboneS2M 4 ->
-    Map (BitVector AddressWidth) (BitVector 32) ->
-    Either String (Map (BitVector AddressWidth) (BitVector 32))
-  model _ resp _mem | resp.err = Left "Unexpected bus error"
-  --
-  model (Read addr _mask) resp mem
-    | resp.acknowledge =
-        let expected = fromMaybe 0 (Map.lookup addr mem)
-         in if resp.readData == expected then Right mem else Left "Data mismatch"
-  --
-  model (Write addr mask dat) resp mem
-    | resp.acknowledge =
-        let
-          old = fromMaybe 0 (Map.lookup addr mem)
-          new = mergeWithMask old dat mask
-         in
-          Right (Map.insert addr new mem)
-  --
-  model _ _ mem = Right mem
 
   -- Generate wishbone requests
   genInputs :: Gen [WishboneMasterRequest AddressWidth 4]
@@ -102,11 +122,6 @@ prop_xpmCdcHandshakeWb = property $ do
   genBoundedIntegral :: forall a. (Integral a, Bounded a) => Gen a
   genBoundedIntegral = Gen.integral Range.constantBounded
 
-  dut :: Circuit (Wishbone System 'Standard AddressWidth 4) ()
-  dut = xpmCdcHandshakeWb clk rst clk rst |> dutMem
 
-  dutMem :: Circuit (Wishbone System 'Standard AddressWidth 4) ()
-  dutMem =
-    withClockResetEnable clk rst ena
-      $ unMemmap
-      $ wbStorage "test" (SNat @(2 ^ AddressWidth)) (Just (Vec (repeat 0)))
+tests :: TestTree
+tests = $(testGroupGenerator)


### PR DESCRIPTION
_What (what did you do)_
Add a utility to increase the buswidth of a wishbone bus.

This also added a new memory model that is compliant with `wbStorage` to more easily test wishbone peripherals.

_Why (context, issues, etc.)_
Increasing the buswidth is required for the transmitbuffer and receivebuffer.

_Dear reviewer (anything you'd like the reviewer to pay close attention to?)_

_AI disclaimer (heads-up for more than inline autocomplete)_
No AI here

# TODO
_~~Cross-out~~ any that do not apply_

- [x] ~Write (regression) test~
- [ ] ~Update documentation, including `docs/`~
- [ ] ~Link to existing issue~
