### PR TITLE
Add Df based wrappers for `tdpBram`

### DIFF
--- a/bittide-extra/bittide-extra.cabal
+++ b/bittide-extra/bittide-extra.cabal
@@ -200,10 +200,12 @@ test-suite unittests
   build-depends:
     base,
     bittide-extra,
+    clash-cores,
     clash-prelude,
     clash-prelude-hedgehog,
     clash-protocols,
     containers,
+    deepseq,
     hedgehog,
     string-interpolate,
     tasty,

--- a/bittide-extra/src/Protocols/Df/Extra.hs
+++ b/bittide-extra/src/Protocols/Df/Extra.hs
@@ -160,30 +160,38 @@ fromDualPortedBramWithMask prim clkA clkB = Circuit goS
     (rightOpAck, rightOp1, rightDat1) = goChannel clkB (rightOp0, rightDat0, rightDatAck)
     (leftDat0, rightDat0) = prim leftOp1 rightOp1
 
-  goChannel clk = E.mealyB clk E.noReset enableGen goT RamNoOp
+  goChannel clk = E.mealyB clk E.noReset enableGen goT Nothing
 
-  goT lastOp (maybeOp, ramData, Ack ack) = (op1, (Ack opAck, op1, dat1))
+  goT lastRead (maybeOp, ramData, Ack ack) = (nextState, (Ack opAck, outgoingOp, dat1))
    where
     -- Construct rhs data from previous cycle's operation
     dat1
-      | isRead lastOp = Just ramData
+      | isJust lastRead = Just ramData
       | otherwise = Nothing
 
     -- Determine if we receive backpressure
     stall = isJust dat1 && not ack
 
     -- If we receive backpressure on our rhs, we have to reissue our ramop.
-    op1
-      | stall = lastOp
+    outgoingOp
+      | stall = addrToOp lastRead
       | otherwise = fromMaybe RamNoOp maybeOp
 
-    -- Determine if we ack our lhs
-    opAck = isWrite op1 || isNothing dat1 || ack
+    nextState
+      | isRead outgoingOp = ramAddr outgoingOp
+      | otherwise = Nothing
 
-  isWrite (RamWrite _ _) = True
-  isWrite _ = False
+    -- Determine if we ack our lhs
+    opAck = isNothing lastRead || ack
+
   isRead (RamRead _) = True
   isRead _ = False
+  addrToOp (Just addr) = RamRead addr
+  addrToOp Nothing = RamNoOp
+  ramAddr :: RamOp addr a -> Maybe (Index addr)
+  ramAddr (RamRead addr) = Just addr
+  ramAddr (RamWrite addr _) = Just addr
+  ramAddr _ = Nothing
 
 {- | Creates a `Df` wrapper around a block RAM primitive that supports byte enables for
 its write channel. Writes are always acked immediately, reads receive backpressure

--- a/bittide-extra/src/Protocols/Df/Extra.hs
+++ b/bittide-extra/src/Protocols/Df/Extra.hs
@@ -156,29 +156,29 @@ fromDualPortedBramWithMask prim clkA clkB = Circuit goS
  where
   goS ((leftOp0, rightOp0), (leftDatAck, rightDatAck)) = ((leftOpAck, rightOpAck), (leftDat1, rightDat1))
    where
-    (leftOpAck, leftOp1, leftDat1) = goChannel clkA leftOp0 leftDat0 leftDatAck
-    (rightOpAck, rightOp1, rightDat1) = goChannel clkB rightOp0 rightDat0 rightDatAck
+    (leftOpAck, leftOp1, leftDat1) = goChannel clkA (leftOp0, leftDat0, leftDatAck)
+    (rightOpAck, rightOp1, rightDat1) = goChannel clkB (rightOp0, rightDat0, rightDatAck)
     (leftDat0, rightDat0) = prim leftOp1 rightOp1
 
-  goChannel clk op0 dat0 datAck0 = (fmap Ack opAck, op1, dat1)
-   where
-    datAck1 = fmap (\(Ack a) -> a) datAck0
+  goChannel clk = E.mealyB clk E.noReset enableGen goT RamNoOp
 
-    -- Store last RamOp
-    opReg = E.register clk E.noReset enableGen RamNoOp op1
+  goT lastOp (maybeOp, ramData, Ack ack) = (op1, (Ack opAck, op1, dat1))
+   where
+    -- Construct rhs data from previous cycle's operation
+    dat1
+      | isRead lastOp = Just ramData
+      | otherwise = Nothing
 
     -- Determine if we receive backpressure
-    stall = fmap isJust dat1 .&&. fmap not datAck1
+    stall = isJust dat1 && not ack
 
     -- If we receive backpressure on our rhs, we have to reissue our ramop.
-    op1 = mux stall opReg $ fmap (fromMaybe RamNoOp) op0
+    op1
+      | stall = lastOp
+      | otherwise = fromMaybe RamNoOp maybeOp
 
     -- Determine if we ack our lhs
-    opAck = fmap isWrite op1 .||. fmap isNothing dat1 .||. datAck1
-
-    -- Actually construct rhs data
-    valid1 = E.register clk E.noReset enableGen False (fmap isRead op1)
-    dat1 = mux valid1 (fmap Just dat0) (pure Nothing)
+    opAck = isWrite op1 || isNothing dat1 || ack
 
   isWrite (RamWrite _ _) = True
   isWrite _ = False

--- a/bittide-extra/src/Protocols/Df/Extra.hs
+++ b/bittide-extra/src/Protocols/Df/Extra.hs
@@ -76,7 +76,7 @@ skid = Circuit go
 ackWhen :: Signal dom Bool -> Circuit (Df dom a) ()
 ackWhen canDrop = Circuit $ \_ -> (Ack <$> canDrop, ())
 
--- | Creates a wrapper around `tdpbram` to make it work on `RamOp
+-- | Creates a wrapper around 'tdpbram' to make it work on 'RamOp'
 tdpbramRamOp ::
   forall nAddrs domA domB nBytes a.
   ( HasCallStack
@@ -132,8 +132,8 @@ tdpbramRamOp prim clkA clkB ramOpA ramOpB =
   toAddr (RamRead addr) = addr
   toAddr _ = deepErrorX "Read address undefined when idle"
 
-{- | Given a true dualported blockram implementation that operates on `RamOp`.
-Creates a `Df` compatible Circuit version.
+{- | Given a true dualported blockram implementation that operates on 'RamOp'.
+Creates a 'Df' compatible Circuit version.
 -}
 fromDualPortedBramWithMask ::
   (KnownDomain domA, HiddenClock domB, KnownNat n, KnownNat nBytes, NFDataX a) =>
@@ -170,7 +170,7 @@ fromDualPortedBramWithMask prim clkA clkB = Circuit goS
       | otherwise = Nothing
 
     -- Determine if we receive backpressure
-    stall = isJust dat1 && not ack
+    stall = isJust lastRead && not ack
 
     -- If we receive backpressure on our rhs, we have to reissue our ramop.
     outgoingOp
@@ -193,9 +193,9 @@ fromDualPortedBramWithMask prim clkA clkB = Circuit goS
   ramAddr (RamWrite addr _) = Just addr
   ramAddr _ = Nothing
 
-{- | Creates a `Df` wrapper around a block RAM primitive that supports byte enables for
+{- | Creates a 'Df' wrapper around a block RAM primitive that supports byte enables for
 its write channel. Writes are always acked immediately, reads receive backpressure
-based on the outgoing `Df` channel.
+based on the outgoing 'Df' channel.
 -}
 fromBlockRamWithMask ::
   (KnownDomain dom, HiddenClock dom, HiddenReset dom, Num addr, NFDataX addr, KnownNat words) =>
@@ -227,7 +227,7 @@ fromBlockRam primitive = circuit $ \(r, w) -> do
   let primitiveD ena readD = ED.fromBlockRam (primitive ena) readD write
   fromDSignal hasClock hasReset primitiveD <| forceResetSanity -< r
 
--- | Converts a delay annotated circuit with enable port into a `Df` circuit.
+-- | Converts a delay annotated circuit with enable port into a 'Df' circuit.
 fromDSignal ::
   forall dom a b n.
   ( KnownDomain dom
@@ -353,9 +353,9 @@ bypassFifo SNat fifoCircuit = circuit $ \inp -> do
          in
           (nextState, ((inpAck, fifoOutAck), (out, fifoIn)))
 
-{- | Will stall the next incoming transaction until the `Bool` is `True`. If it becomes `False`
+{- | Will stall the next incoming transaction until the 'Bool' is 'True'. If it becomes 'False'
  while a transaction is being processed it will not be affected, but the next transaction will
-be blocked until it is `True` again.
+be blocked until it is 'True' again.
 -}
 stallNext ::
   forall dom a.
@@ -386,7 +386,7 @@ stallNext rdyS = circuit $ \req -> do
 
     ackOut = Ack (passThrough && ackIn)
 
-{- | `Df` version of `traceShowId`, introduces no state or logic of any form. Only prints when
+{- | 'Df' version of 'traceShowId', introduces no state or logic of any form. Only prints when
 there is data available on the input side. Prints available data, clock cycle count in the
 relevant domain, and the corresponding Ack.
 -}
@@ -402,7 +402,7 @@ trace msg =
    where
     s2m' = Debug.trace [i| Df.Trace #{msg} | #{cnt}: #{showX m2s}, #{showX s2m}|] s2m
 
--- | `Df` version of `Clash.Debug.traceSignal`. names forward signal (name_fwd) and backward signal (name_bwd)
+-- | 'Df' version of 'Clash.Debug.traceSignal'. names forward signal (name_fwd) and backward signal (name_bwd)
 traceSignal ::
   (KnownDomain dom, ShowX a, NFDataX a, BitPack a, Typeable a) =>
   String ->

--- a/bittide-extra/src/Protocols/Df/Extra.hs
+++ b/bittide-extra/src/Protocols/Df/Extra.hs
@@ -174,24 +174,15 @@ fromDualPortedBramWithMask prim clkA clkB = Circuit goS
 
     -- If we receive backpressure on our rhs, we have to reissue our ramop.
     outgoingOp
-      | stall = addrToOp lastRead
+      | stall, Just addr <- lastRead = RamRead addr
       | otherwise = fromMaybe RamNoOp maybeOp
 
     nextState
-      | isRead outgoingOp = ramAddr outgoingOp
+      | RamRead addr <- outgoingOp = Just addr
       | otherwise = Nothing
 
     -- Determine if we ack our lhs
     opAck = isNothing lastRead || ack
-
-  isRead (RamRead _) = True
-  isRead _ = False
-  addrToOp (Just addr) = RamRead addr
-  addrToOp Nothing = RamNoOp
-  ramAddr :: RamOp addr a -> Maybe (Index addr)
-  ramAddr (RamRead addr) = Just addr
-  ramAddr (RamWrite addr _) = Just addr
-  ramAddr _ = Nothing
 
 {- | Creates a 'Df' wrapper around a block RAM primitive that supports byte enables for
 its write channel. Writes are always acked immediately, reads receive backpressure

--- a/bittide-extra/src/Protocols/Df/Extra.hs
+++ b/bittide-extra/src/Protocols/Df/Extra.hs
@@ -9,6 +9,7 @@ import Data.Bifunctor (Bifunctor (..))
 import Data.Maybe
 import Data.String.Interpolate (i)
 import Data.Typeable (Typeable)
+import GHC.Stack (HasCallStack)
 import Protocols
 import Protocols.Df (forceResetSanity)
 
@@ -74,6 +75,115 @@ skid = Circuit go
 
 ackWhen :: Signal dom Bool -> Circuit (Df dom a) ()
 ackWhen canDrop = Circuit $ \_ -> (Ack <$> canDrop, ())
+
+-- | Creates a wrapper around `tdpbram` to make it work on `RamOp
+tdpbramRamOp ::
+  forall nAddrs domA domB nBytes a.
+  ( HasCallStack
+  , KnownNat nAddrs
+  , KnownDomain domA
+  , KnownDomain domB
+  , KnownNat nBytes
+  , BitSize a ~ (8 * nBytes)
+  , NFDataX a
+  , BitPack a
+  ) =>
+  -- | Primitive
+  ( Clock domA ->
+    Enable domA ->
+    Signal domA (Index nAddrs) ->
+    Signal domA (BitVector nBytes) ->
+    Signal domA a ->
+    Clock domB ->
+    Enable domB ->
+    Signal domB (Index nAddrs) ->
+    Signal domB (BitVector nBytes) ->
+    Signal domB a ->
+    ( Signal domA a
+    , Signal domB a
+    )
+  ) ->
+  -- | Result
+  ( Clock domA ->
+    Clock domB ->
+    Signal domA (RamOp nAddrs (BitVector nBytes, a)) ->
+    Signal domB (RamOp nAddrs (BitVector nBytes, a)) ->
+    (Signal domA a, Signal domB a)
+  )
+tdpbramRamOp prim clkA clkB ramOpA ramOpB =
+  prim clkA enA addrA byteEnaA datA clkB enB addrB byteEnaB datB
+ where
+  byteEnaA = fmap toByteEna ramOpA
+  byteEnaB = fmap toByteEna ramOpB
+  datA = fmap toDat ramOpA
+  datB = fmap toDat ramOpB
+  addrA = fmap toAddr ramOpA
+  addrB = fmap toAddr ramOpB
+  enA = enableGen
+  enB = enableGen
+
+  toByteEna (RamWrite _ (bv, _)) = bv
+  toByteEna _ = 0
+
+  toDat (RamWrite _ (_, dat)) = dat
+  toDat _ = deepErrorX "Data undefined when not writing"
+
+  toAddr (RamWrite addr _) = addr
+  toAddr (RamRead addr) = addr
+  toAddr _ = deepErrorX "Read address undefined when idle"
+
+{- | Given a true dualported blockram implementation that operates on `RamOp`.
+Creates a `Df` compatible Circuit version.
+-}
+fromDualPortedBramWithMask ::
+  (KnownDomain domA, HiddenClock domB, KnownNat n, KnownNat nBytes, NFDataX a) =>
+  ( Signal domA (RamOp n (BitVector nBytes, a)) ->
+    -- \^ RAM operation for port A
+    Signal domB (RamOp n (BitVector nBytes, a)) ->
+    -- \^ RAM operation for port B
+    (Signal domA a, Signal domB a)
+  ) ->
+  Clock domA ->
+  Clock domB ->
+  Circuit
+    ( Df domA (RamOp n (BitVector nBytes, a))
+    , Df domB (RamOp n (BitVector nBytes, a))
+    )
+    ( Df domA a
+    , Df domB a
+    )
+fromDualPortedBramWithMask prim clkA clkB = Circuit goS
+ where
+  goS ((leftOp0, rightOp0), (leftDatAck, rightDatAck)) = ((leftOpAck, rightOpAck), (leftDat1, rightDat1))
+   where
+    (leftOpAck, leftOp1, leftDat1) = goChannel clkA leftOp0 leftDat0 leftDatAck
+    (rightOpAck, rightOp1, rightDat1) = goChannel clkB rightOp0 rightDat0 rightDatAck
+    (leftDat0, rightDat0) = prim leftOp1 rightOp1
+
+  goChannel clk op0 dat0 datAck0 = (fmap Ack opAck, op1, dat1)
+   where
+    datAck1 = fmap (\(Ack a) -> a) datAck0
+
+    -- Store last RamOp
+    opReg = E.register clk E.noReset enableGen RamNoOp op1
+
+    -- Determine if we receive backpressure
+    stall = fmap isJust dat1 .&&. fmap not datAck1
+
+    -- If we receive backpressure on our rhs, we have to reissue our ramop.
+    op1 = mux stall opReg $ fmap (fromMaybe RamNoOp) op0
+
+    -- Determine if we ack our lhs
+    opAck = fmap isWrite op1 .||. fmap isNothing dat1 .||. datAck1
+
+    -- Actually construct rhs data
+    valid1 = E.register clk E.noReset enableGen False (fmap isRead op1)
+    dat1 = mux valid1 (fmap Just dat0) (pure Nothing)
+
+  isWrite (RamWrite _ _) = True
+  isWrite _ = False
+  isRead (RamRead _) = True
+  isRead _ = False
 
 {- | Creates a `Df` wrapper around a block RAM primitive that supports byte enables for
 its write channel. Writes are always acked immediately, reads receive backpressure

--- a/bittide-extra/tests/unittests/Tests/Protocols/Df/Extra.hs
+++ b/bittide-extra/tests/unittests/Tests/Protocols/Df/Extra.hs
@@ -2,19 +2,23 @@
 --
 -- SPDX-License-Identifier: Apache-2.0
 {-# LANGUAGE OverloadedStrings #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Tests.Protocols.Df.Extra where
 
 import Clash.Prelude
 
+import Clash.Cores.Xilinx.BlockRam (tdpbram)
 import Clash.Hedgehog.Sized.BitVector
+import Clash.Hedgehog.Sized.Index
 import Clash.Hedgehog.Sized.Unsigned
 import Clash.Hedgehog.Sized.Vector
+import Control.DeepSeq (NFData)
 import Data.Maybe
 import Data.String.Interpolate (i)
 import Hedgehog (Gen, Property, Range, assert, cover, footnote, forAll, (===))
 import Protocols
-import Protocols.Df.Extra (skid)
+import Protocols.Df.Extra (skid, tdpbramRamOp)
 import Protocols.Hedgehog (
   ExpectOptions (..),
   defExpectOptions,
@@ -307,6 +311,68 @@ splitWriteInBytes (Just (addr, writeData)) byteSelect =
 splitWriteInBytes Nothing _ = repeat Nothing
 
 -- End of shamelessly copied code from bittide
+
+deriving instance (NFData a) => NFData (RamOp addr a)
+deriving instance (ShowX a) => ShowX (RamOp addr a)
+deriving instance (Eq a) => Eq (RamOp addr a)
+
+-- | A helper function to extract the address from a 'RamOp'
+ramAddr :: RamOp addr a -> Maybe (Index addr)
+ramAddr (RamRead addr) = Just addr
+ramAddr (RamWrite addr _) = Just addr
+ramAddr _ = Nothing
+
+{- | Writes new memory contents to the blockram with byte enables, then reads it back
+uses even addresses on the left port and odd addresses on the right port to verify that both
+ports are working correctly.
+-}
+prop_fromDualPortedBramWithMask_writeRead :: Property
+prop_fromDualPortedBramWithMask_writeRead = H.property $ do
+  newValues <- forAll $ genVec @16 (genDefinedBitVector @32)
+  masks <- forAll $ genVec genDefinedBitVector
+  nWrites <- forAll $ genIndex Range.linearBounded
+  let
+    oldMem = repeat 0
+    newMem = zipWith3 mergeWithMask oldMem newValues masks
+    addresses = [0 .. nWrites]
+
+    -- First write old memory with full masks, then write new values with given masks
+    writeOps =
+      L.zipWith3
+        (\addr m d -> RamWrite addr (m, d))
+        (addresses <> addresses)
+        (L.replicate (L.length addresses) maxBound <> toList masks)
+        (L.replicate (L.length addresses) 0 <> toList newValues)
+
+    readOps = fmap RamRead addresses
+
+    -- Partition reads and writes based on address parity to ensure both ports are used.
+    (writeOpsLeft, writeOpsRight) = L.partition (even . fromJust . ramAddr) writeOps
+    (readOpsLeft, readOpsRight) = L.partition (even . fromJust . ramAddr) readOps
+    getReadResults (RamRead a : rest) = newMem !! a : getReadResults rest
+    getReadResults (_ : rest) = getReadResults rest
+    getReadResults [] = []
+    model (lefts, rights) = (getReadResults lefts, getReadResults rights)
+
+    dut ::
+      forall dom.
+      (HiddenClockResetEnable dom) =>
+      Circuit
+        (Df dom (RamOp 16 (BitVector 4, BitVector 32)), Df dom (RamOp 16 (BitVector 4, BitVector 32)))
+        (Df dom (BitVector 32), Df dom (BitVector 32))
+    dut =
+      Df.fromDualPortedBramWithMask
+        (tdpbramRamOp tdpbram hasClock hasClock)
+        hasClock
+        hasClock
+
+    top = exposeClockResetEnable @System dut
+
+  idWithModelSingleDomainT @System
+    defExpectOptions
+    (pure $ (writeOpsLeft <> readOpsLeft, writeOpsRight <> readOpsRight))
+    (\_ _ _ -> model)
+    top
 
 tests :: TestTree
 tests = $(testGroupGenerator)


### PR DESCRIPTION
_What (what did you do)_
Adds Df based wrappers for `tdpBram` compatible true dual ported blockRams.

_Why (context, issues, etc.)_
The CPU needs both read and write access to the transmit buffer to calculate the checksum. (and we need to be able to continuously read content from the same buffer.

_Dear reviewer (anything you'd like the reviewer to pay close attention to?)_
Am I missing relevant test coverage of the wrapper?

_AI disclaimer (heads-up for more than inline autocomplete)_
Rewrite as mealy mostly done by AI

# TODO
_~~Cross-out~~ any that do not apply_

- [x] ~Write (regression) test~
- [ ] ~Update documentation, including `docs/`~
- [ ] ~Link to existing issue~
