### PR TITLE
Introduce typeclasses for vendored CDC primitives

### DIFF
--- a/bittide-extra/bittide-extra.cabal
+++ b/bittide-extra/bittide-extra.cabal
@@ -165,6 +165,8 @@ library
   exposed-modules:
     Bittide.Extra.Maybe
     Bittide.Extra.Wishbone
+    Clash.Class.Cdc
+    Clash.Cores.Xilinx
     Clash.Cores.Xilinx.Xpm.Cdc.Extra
     Clash.Explicit.Signal.Delayed.Extra
     Clash.Explicit.Signal.Extra

--- a/bittide-extra/src/Clash/Class/Cdc.hs
+++ b/bittide-extra/src/Clash/Class/Cdc.hs
@@ -1,0 +1,755 @@
+-- SPDX-FileCopyrightText: 2026 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE UndecidableSuperClasses #-}
+
+{- | This module introduces typeclasses, instances, and some helper functions + type aliases for
+writing components that require CDC crossings, but it may not be desirable to use a specific CDC
+crossing. This enables the designer to write functions that are general over the many parameters
+of CDC crossings as well, including what type the input signal contains, the particular clock
+domains, and the number of stages in the CDC primitive. The goal of this is then that the
+designer is able to write another file with orphaned instances containing the primitives for a
+given vendor, which may then be used to specialize more general components.
+
+To be more concrete, a designer may want to be able to write a component that requires a gray CDC
+primitive and synthesize for both Xilinx and Intel FPGAs. In this case, the designer can write that
+component with the constraint @Gray vendor InnerType SrcDomain DstDomain@ and provide the vendor
+later through the 'withVendor' or 'withVendorI' functions.
+
+N.B.: this module is written with qualified use in mind. Generally it should only be imported as
+@import qualified Clash.Class.Cdc as Cdc@ or similar.
+-}
+module Clash.Class.Cdc where
+
+import Clash.Prelude hiding (Bit, isRising, regEn)
+
+import Bittide.Extra.Maybe (orNothing)
+import Clash.Explicit.Prelude (isRising, noReset, regEn)
+import Data.Data (Proxy (Proxy))
+import Data.Maybe (fromMaybe, isJust, isNothing)
+import GHC.Stack (HasCallStack)
+
+{- | Guarantees the existence of a CDC primitive for a fixed-width array of independent bits for a
+given vendor
+-}
+class IndependentBits (vendor :: Symbol) where
+  -- | Additional constraints on the independent bits CDC primitive with a custom configuration
+  type
+    IndependentBitsWithConstraints vendor (stages :: Nat) (a :: Type) (src :: Domain) (dst :: Domain) ::
+      Constraint
+
+  -- | Configuration type for an independent bits CDC primitive
+  type IndependentBitsConfig vendor (stages :: Nat) (a :: Type) (src :: Domain) (dst :: Domain) :: Type
+
+  -- | Independent bits CDC primitive with a custom configuration
+  independentBitsWith ::
+    forall stages a src dst.
+    ( KnownDomain src
+    , KnownDomain dst
+    , HasCallStack
+    , NFDataX a
+    , BitPack a
+    , IndependentBitsWithConstraints vendor stages a src dst
+    ) =>
+    IndependentBitsConfig vendor stages a src dst ->
+    Clock src ->
+    Clock dst ->
+    Signal src a ->
+    Signal dst a
+
+  -- | Additional constraints on the independent bits CDC primitive with the default configuration
+  type IndependentBitsConstraints vendor (a :: Type) (src :: Domain) (dst :: Domain) :: Constraint
+
+  -- | Default number of stages in an independent bits CDC primitive
+  type IndependentBitsDefaultStages vendor (a :: Type) (src :: Domain) (dst :: Domain) :: Nat
+
+  -- | Default configuration for an independent bits CDC primitive
+  defaultIndependentBitsConfig ::
+    forall a src dst.
+    (KnownDomain src, KnownDomain dst) =>
+    Proxy src ->
+    Proxy dst ->
+    Proxy a ->
+    IndependentBitsConfig vendor (IndependentBitsDefaultStages vendor a src dst) a src dst
+
+  -- | Independent bits CDC primitive with the default configuration
+  independentBits ::
+    forall a src dst.
+    ( KnownDomain src
+    , KnownDomain dst
+    , HasCallStack
+    , NFDataX a
+    , BitPack a
+    , IndependentBitsConstraints vendor a src dst
+    ) =>
+    Clock src ->
+    Clock dst ->
+    Signal src a ->
+    Signal dst a
+  default independentBits ::
+    ( KnownDomain src
+    , KnownDomain dst
+    , NFDataX a
+    , BitPack a
+    , IndependentBitsWithConstraints vendor (IndependentBitsDefaultStages vendor a src dst) a src dst
+    ) =>
+    Clock src ->
+    Clock dst ->
+    Signal src a ->
+    Signal dst a
+  independentBits (srcClk :: Clock src) (dstClk :: Clock dst) (input :: Signal src a) =
+    independentBitsWith @vendor @(IndependentBitsDefaultStages vendor a src dst) @a @src @dst
+      (defaultIndependentBitsConfig @vendor @a @src @dst Proxy Proxy Proxy)
+      srcClk
+      dstClk
+      input
+
+-- | Helper typeclass for bringing in the primitive typeclass and additional constraints
+class
+  (IndependentBits vendor, IndependentBitsConstraints vendor a src dst) =>
+  ValidIndependentBits (vendor :: Symbol) (a :: Type) (src :: Domain) (dst :: Domain)
+
+instance
+  (IndependentBits vendor, IndependentBitsConstraints vendor a src dst) =>
+  ValidIndependentBits (vendor :: Symbol) (a :: Type) (src :: Domain) (dst :: Domain)
+
+-- | Helper typeclass for bringing in the primitive typeclass and additional constraints
+class
+  (IndependentBits vendor, IndependentBitsWithConstraints vendor stages a src dst) =>
+  ValidIndependentBitsWith
+    (vendor :: Symbol)
+    (stages :: Nat)
+    (a :: Type)
+    (src :: Domain)
+    (dst :: Domain)
+
+instance
+  (IndependentBits vendor, IndependentBitsWithConstraints vendor stages a src dst) =>
+  ValidIndependentBitsWith
+    (vendor :: Symbol)
+    (stages :: Nat)
+    (a :: Type)
+    (src :: Domain)
+    (dst :: Domain)
+
+-- | Guarantees the existence of a gray CDC primitive for a given vendor
+class Gray (vendor :: Symbol) where
+  -- | Additional constraints on the gray CDC primtive with a custom configuration
+  type GrayWithConstraints vendor (stages :: Nat) (n :: Nat) (src :: Domain) (dst :: Domain) :: Constraint
+
+  -- | Configuration type for a gray CDC primitive
+  type GrayConfig vendor (stages :: Nat) (n :: Nat) (src :: Domain) (dst :: Domain) :: Type
+
+  -- | Gray CDC primitive with a custom configuration
+  grayWith ::
+    forall stages n src dst.
+    ( KnownDomain src
+    , KnownDomain dst
+    , HasCallStack
+    , KnownNat n
+    , GrayWithConstraints vendor stages n src dst
+    ) =>
+    GrayConfig vendor stages n src dst ->
+    Clock src ->
+    Clock dst ->
+    Signal src (Unsigned n) ->
+    Signal dst (Unsigned n)
+
+  -- | Additional constraints on the gray CDC primtive with the default configuration
+  type GrayConstraints vendor (n :: Nat) (src :: Domain) (dst :: Domain) :: Constraint
+
+  -- | Default number of stages in a gray CDC
+  type GrayDefaultStages vendor (n :: Nat) (src :: Domain) (dst :: Domain) :: Nat
+
+  -- | Default configuration for a gray CDC primitive
+  defaultGrayConfig ::
+    forall n src dst.
+    (KnownDomain src, KnownDomain dst) =>
+    Proxy src ->
+    Proxy dst ->
+    Proxy n ->
+    GrayConfig vendor (GrayDefaultStages vendor n src dst) n src dst
+
+  -- | Gray CDC primitive with the default configuration
+  gray ::
+    forall n src dst.
+    ( KnownDomain src
+    , KnownDomain dst
+    , KnownNat n
+    , HasCallStack
+    , GrayConstraints vendor n src dst
+    ) =>
+    Clock src ->
+    Clock dst ->
+    Signal src (Unsigned n) ->
+    Signal dst (Unsigned n)
+  default gray ::
+    ( KnownDomain src
+    , KnownDomain dst
+    , KnownNat n
+    , HasCallStack
+    , GrayWithConstraints vendor (GrayDefaultStages vendor n src dst) n src dst
+    ) =>
+    Clock src ->
+    Clock dst ->
+    Signal src (Unsigned n) ->
+    Signal dst (Unsigned n)
+  gray (srcClk :: Clock src) (dstClk :: Clock dst) (input :: Signal src (Unsigned n)) =
+    grayWith @vendor @(GrayDefaultStages vendor n src dst) @n @src @dst
+      (defaultGrayConfig @vendor @n @src @dst Proxy Proxy Proxy)
+      srcClk
+      dstClk
+      input
+
+-- | Helper typeclass for bringing in the primitive typeclass and additional constraints
+class
+  (Gray vendor, GrayConstraints vendor n src dst) =>
+  ValidGray (vendor :: Symbol) (n :: Nat) (src :: Domain) (dst :: Symbol)
+
+instance
+  (Gray vendor, GrayConstraints vendor n src dst) =>
+  ValidGray (vendor :: Symbol) (n :: Nat) (src :: Domain) (dst :: Symbol)
+
+-- | Helper typeclass for bringing in the primitive typeclass and additional constraints
+class
+  (Gray vendor, GrayWithConstraints vendor stages n src dst) =>
+  ValidGrayWith (vendor :: Symbol) (stages :: Nat) (n :: Nat) (src :: Domain) (dst :: Symbol)
+
+instance
+  (Gray vendor, GrayWithConstraints vendor stages n src dst) =>
+  ValidGrayWith (vendor :: Symbol) (stages :: Nat) (n :: Nat) (src :: Domain) (dst :: Symbol)
+
+-- | Guarantees the existence of a handshake CDC primitive for a given vendor
+class Handshake (vendor :: Symbol) where
+  -- | Additional constraints on the handshake CDC primitive with a custom configuration
+  type
+    HandshakeWithConstraints
+      vendor
+      (srcStages :: Nat)
+      (dstStages :: Nat)
+      (a :: Type)
+      (src :: Domain)
+      (dst :: Domain) ::
+      Constraint
+
+  -- | Configuration type for a handshake CDC primitive
+  type
+    HandshakeConfig
+      vendor
+      (srcStages :: Nat)
+      (dstStages :: Nat)
+      (a :: Type)
+      (src :: Domain)
+      (dst :: Domain) ::
+      Type
+
+  -- | Handshake CDC primitive with a custom configuration
+  handshakeWith ::
+    forall srcStages dstStages a src dst.
+    ( KnownDomain src
+    , KnownDomain dst
+    , HasCallStack
+    , BitPack a
+    , NFDataX a
+    , HandshakeWithConstraints vendor srcStages dstStages a src dst
+    ) =>
+    HandshakeConfig vendor srcStages dstStages a src dst ->
+    Clock src ->
+    Clock dst ->
+    {- | Word to synchronize to destination domain. This value should not change when @src_send@ is
+    asserted.
+    -}
+    "src_in" ::: Signal src a ->
+    {- | Assertion of this signal allows the @src_in@ bus to be synchronized to the destination
+    clock domain. This signal should only be asserted when @src_rcv@ is deasserted, indicating
+    that the previous data transfer is complete. This signal should only be deasserted once
+    @src_rcv@ is asserted, acknowledging that the @src_in@ has been received by the destination
+    logic.
+    -}
+    "src_send" ::: Signal src Bool ->
+    -- Destination ack receive signal. Asserting this signal indicates that data on the output
+    -- signal has been captured by the destination logic. This signal should be deasserted once the
+    -- destination request signal is deasserted, completing the handshake on the destination clock
+    -- domain and indicating that the destination logic is ready for a new transfer.
+    "dst_ack" ::: Signal dst Bool ->
+    {- | @dest_req@ indicates that @dest_out@ contains valid data. It can be acknowledged by
+    asserting @dst_ack@. @src_rcv@ indicates that the destination domain has acknowledged a data
+    transfer.
+    -}
+    ( "dest_out" ::: Signal dst a
+    , "dest_req" ::: Signal dst Bool
+    , "src_rcv" ::: Signal src Bool
+    )
+
+  -- | Additional constraints on the handshake CDC primitive with the default configuration
+  type HandshakeConstraints vendor (a :: Type) (src :: Domain) (dst :: Domain) :: Constraint
+
+  -- | Default number of stages in the source domain in a handshake CDC primitive
+  type HandshakeDefaultSrcStages vendor (a :: Type) (src :: Domain) (dst :: Domain) :: Nat
+
+  -- | Default number of stages in the destination domain in a handshake CDC primitive
+  type HandshakeDefaultDstStages vendor (a :: Type) (src :: Domain) (dst :: Domain) :: Nat
+
+  -- | Default configuration for a handshake CDC primitive
+  defaultHandshakeConfig ::
+    forall a src dst.
+    (KnownDomain src, KnownDomain dst) =>
+    Proxy src ->
+    Proxy dst ->
+    Proxy a ->
+    HandshakeConfig
+      vendor
+      (HandshakeDefaultSrcStages vendor a src dst)
+      (HandshakeDefaultDstStages vendor a src dst)
+      a
+      src
+      dst
+
+  -- | Handshake CDC primitive with the default configuration
+  handshake ::
+    forall a src dst.
+    ( KnownDomain src
+    , KnownDomain dst
+    , BitPack a
+    , NFDataX a
+    , HasCallStack
+    , HandshakeConstraints vendor a src dst
+    ) =>
+    Clock src ->
+    Clock dst ->
+    Signal src a ->
+    Signal src Bool ->
+    Signal dst Bool ->
+    (Signal dst a, Signal dst Bool, Signal src Bool)
+  default handshake ::
+    ( KnownDomain src
+    , KnownDomain dst
+    , BitPack a
+    , NFDataX a
+    , HasCallStack
+    , HandshakeWithConstraints
+        vendor
+        (HandshakeDefaultSrcStages vendor a src dst)
+        (HandshakeDefaultDstStages vendor a src dst)
+        a
+        src
+        dst
+    ) =>
+    Clock src ->
+    Clock dst ->
+    Signal src a ->
+    Signal src Bool ->
+    Signal dst Bool ->
+    ( Signal dst a
+    , Signal dst Bool
+    , Signal src Bool
+    )
+  handshake
+    (srcClk :: Clock src)
+    (dstClk :: Clock dst)
+    (input :: Signal src a)
+    (srcSend :: Signal src Bool)
+    (dstAck :: Signal dst Bool) =
+      handshakeWith
+        @vendor
+        @(HandshakeDefaultSrcStages vendor a src dst)
+        @(HandshakeDefaultDstStages vendor a src dst)
+        @a
+        @src
+        @dst
+        (defaultHandshakeConfig @vendor @a @src @dst Proxy Proxy Proxy)
+        srcClk
+        dstClk
+        input
+        srcSend
+        dstAck
+
+-- | Helper typeclass for bringing in the primitive typeclass and additional constraints
+class
+  (Handshake vendor, HandshakeConstraints vendor a src dst) =>
+  ValidHandshake (vendor :: Symbol) (a :: Type) (src :: Domain) (dst :: Domain)
+
+instance
+  (Handshake vendor, HandshakeConstraints vendor a src dst) =>
+  ValidHandshake (vendor :: Symbol) (a :: Type) (src :: Domain) (dst :: Domain)
+
+-- | Helper typeclass for bringing in the primitive typeclass and additional constraints
+class
+  (Handshake vendor, HandshakeWithConstraints vendor srcStages dstStages a src dst) =>
+  ValidHandshakeWith
+    (vendor :: Symbol)
+    (srcStages :: Nat)
+    (dstStages :: Nat)
+    (a :: Type)
+    (src :: Domain)
+    (dst :: Domain)
+
+instance
+  (Handshake vendor, HandshakeWithConstraints vendor srcStages dstStages a src dst) =>
+  ValidHandshakeWith
+    (vendor :: Symbol)
+    (srcStages :: Nat)
+    (dstStages :: Nat)
+    (a :: Type)
+    (src :: Domain)
+    (dst :: Domain)
+
+-- | Guarantees the existence of a pulse CDC primitive for a given vendor
+class Pulse (vendor :: Symbol) where
+  -- | Additional constraints on the pulse CDC primitive with a custom configuration
+  type
+    PulseWithConstraints vendor (stages :: Nat) (a :: Type) (src :: Domain) (dst :: Domain) ::
+      Constraint
+
+  -- | Configuration type for a pulse CDC primitive
+  type PulseConfig vendor (stages :: Nat) (a :: Type) (src :: Domain) (dst :: Domain) :: Type
+
+  -- | Pulse CDC primitive with a custom configuration
+  pulseWith ::
+    forall stages a src dst.
+    ( KnownDomain src
+    , KnownDomain dst
+    , HasCallStack
+    , Bits a
+    , NFDataX a
+    , BitPack a
+    , PulseWithConstraints vendor stages a src dst
+    ) =>
+    PulseConfig vendor stages a src dst ->
+    Clock src ->
+    Reset src ->
+    Clock dst ->
+    Reset dst ->
+    Signal src a ->
+    Signal dst a
+
+  -- | Additional constraints on the pulse CDC primitive with the default configuration
+  type PulseConstraints vendor (a :: Type) (src :: Domain) (dst :: Domain) :: Constraint
+
+  -- | Default number of stages in a pulse CDC primitive
+  type PulseDefaultStages vendor (a :: Type) (src :: Domain) (dst :: Domain) :: Nat
+
+  -- | Default configuration for a pulse CDC primitive
+  defaultPulseConfig ::
+    forall a src dst.
+    (KnownDomain src, KnownDomain dst) =>
+    Proxy src ->
+    Proxy dst ->
+    Proxy a ->
+    PulseConfig vendor (PulseDefaultStages vendor a src dst) a src dst
+
+  -- | Pulse CDC primitive with the default configuration
+  pulse ::
+    forall a src dst.
+    ( KnownDomain src
+    , KnownDomain dst
+    , HasCallStack
+    , Bits a
+    , NFDataX a
+    , BitPack a
+    , PulseConstraints vendor a src dst
+    ) =>
+    Clock src ->
+    Clock dst ->
+    Signal src a ->
+    Signal dst a
+  default pulse ::
+    ( KnownDomain src
+    , KnownDomain dst
+    , HasCallStack
+    , Bits a
+    , NFDataX a
+    , BitPack a
+    , PulseWithConstraints vendor (PulseDefaultStages vendor a src dst) a src dst
+    ) =>
+    Clock src ->
+    Clock dst ->
+    Signal src a ->
+    Signal dst a
+  pulse
+    (srcClk :: Clock src)
+    (dstClk :: Clock dst)
+    (input :: Signal src a) =
+      pulseWith
+        @vendor
+        @(PulseDefaultStages vendor a src dst)
+        @a
+        @src
+        @dst
+        (defaultPulseConfig @vendor @a @src @dst Proxy Proxy Proxy)
+        srcClk
+        (errorX "src: no reset")
+        dstClk
+        (errorX "dst: no reset")
+        input
+
+-- | Helper typeclass for bringing in the primitive typeclass and additional constraints
+class
+  (Pulse vendor, PulseConstraints vendor a src dst) =>
+  ValidPulse (vendor :: Symbol) (a :: Type) (src :: Domain) (dst :: Domain)
+
+instance
+  (Pulse vendor, PulseConstraints vendor a src dst) =>
+  ValidPulse (vendor :: Symbol) (a :: Type) (src :: Domain) (dst :: Domain)
+
+-- | Helper typeclass for bringing in the primitive typeclass and additional constraints
+class
+  (Pulse vendor, PulseWithConstraints vendor stages a src dst) =>
+  ValidPulseWith (vendor :: Symbol) (stages :: Nat) (a :: Type) (src :: Domain) (dst :: Domain)
+
+instance
+  (Pulse vendor, PulseWithConstraints vendor stages a src dst) =>
+  ValidPulseWith (vendor :: Symbol) (stages :: Nat) (a :: Type) (src :: Domain) (dst :: Domain)
+
+-- | Guarantees the existence of a single bit CDC primitive for a given vendor
+class Bit (vendor :: Symbol) where
+  -- | Additional constraints on the single bit CDC primitive with a custom configuration
+  type BitWithConstraints vendor (stages :: Nat) (a :: Type) (src :: Domain) (dst :: Domain) :: Constraint
+
+  -- | Configuration type for a single bit CDC primitive
+  type BitConfig vendor (stages :: Nat) (a :: Type) (src :: Domain) (dst :: Domain) :: Type
+
+  -- | Single bit CDC primitive with a custom configuration
+  bitWith ::
+    forall stages a src dst.
+    ( KnownDomain src
+    , KnownDomain dst
+    , HasCallStack
+    , NFDataX a
+    , BitPack a
+    , BitWithConstraints vendor stages a src dst
+    ) =>
+    BitConfig vendor stages a src dst ->
+    Clock src ->
+    Clock dst ->
+    Signal src a ->
+    Signal dst a
+
+  -- | Additional constraints on the single bit CDC primitive with the default configuration
+  type BitConstraints vendor (a :: Type) (src :: Domain) (dst :: Domain) :: Constraint
+
+  -- | Default number of stages in a single bit CDC primitive
+  type BitDefaultStages vendor (a :: Type) (src :: Domain) (dst :: Domain) :: Nat
+
+  -- | Default configuration for a single bit CDC primitive
+  defaultBitConfig ::
+    forall a src dst.
+    (KnownDomain src, KnownDomain dst) =>
+    Proxy src ->
+    Proxy dst ->
+    Proxy a ->
+    BitConfig vendor (BitDefaultStages vendor a src dst) a src dst
+
+  -- | Single bit CDC primitive with the default configuration
+  bit ::
+    forall a src dst.
+    ( KnownDomain src
+    , KnownDomain dst
+    , HasCallStack
+    , NFDataX a
+    , BitPack a
+    , BitConstraints vendor a src dst
+    ) =>
+    Clock src ->
+    Clock dst ->
+    Signal src a ->
+    Signal dst a
+  default bit ::
+    ( KnownDomain src
+    , KnownDomain dst
+    , NFDataX a
+    , BitPack a
+    , BitWithConstraints vendor (BitDefaultStages vendor a src dst) a src dst
+    ) =>
+    Clock src ->
+    Clock dst ->
+    Signal src a ->
+    Signal dst a
+  bit (srcClk :: Clock src) (dstClk :: Clock dst) (input :: Signal src a) =
+    bitWith @vendor @(BitDefaultStages vendor a src dst) @a @src @dst
+      (defaultBitConfig @vendor @a @src @dst Proxy Proxy Proxy)
+      srcClk
+      dstClk
+      input
+
+-- | Helper typeclass for bringing in the primitive typeclass and additional constraints
+class
+  (Bit vendor, BitConstraints vendor a src dst) =>
+  ValidBit (vendor :: Symbol) (a :: Type) (src :: Domain) (dst :: Domain)
+
+instance
+  (Bit vendor, BitConstraints vendor a src dst) =>
+  ValidBit (vendor :: Symbol) (a :: Type) (src :: Domain) (dst :: Domain)
+
+-- | Helper typeclass for bringing in the primitive typeclass and additional constraints
+class
+  (Bit vendor, BitWithConstraints vendor stages a src dst) =>
+  ValidBitWith (vendor :: Symbol) (stages :: Nat) (a :: Type) (src :: Domain) (dst :: Domain)
+
+instance
+  (Bit vendor, BitWithConstraints vendor stages a src dst) =>
+  ValidBitWith (vendor :: Symbol) (stages :: Nat) (a :: Type) (src :: Domain) (dst :: Domain)
+
+-- | Guarantees the existence of a sync reset CDC primitive for a given vendor
+class SyncRst vendor where
+  -- | Additional constraints on the sync reset CDC primitive with a custom configuration
+  type SyncRstWithConstraints vendor (stages :: Nat) (src :: Domain) (dst :: Domain) :: Constraint
+
+  -- | Configuration type for a sync reset CDC primitive
+  type SyncRstConfig vendor (stages :: Nat) (src :: Domain) (dst :: Domain) :: Type
+
+  -- | Sync reset CDC primitive with a custom configuration
+  syncRstWith ::
+    forall stages src dst.
+    ( KnownDomain src
+    , KnownDomain dst
+    , HasCallStack
+    , SyncRstWithConstraints vendor stages src dst
+    ) =>
+    SyncRstConfig vendor stages src dst ->
+    Clock src ->
+    Clock dst ->
+    Reset src ->
+    Reset dst
+
+  -- | Additional constraints on the sync reset primitive with the default configuration
+  type SyncRstConstraints vendor (src :: Domain) (dst :: Domain) :: Constraint
+
+  -- | Reset assertion type
+  type ResetAssert vendor :: Type
+
+  -- | Provides the default reset assert for @ResetAssert vendor@
+  defaultAssert :: ResetAssert vendor
+
+  -- | Provides the asserted form of @ResetAssert vendor@
+  asserted :: ResetAssert vendor
+
+  -- | Provides the deasserted form of @ResetAssert vendor@
+  deasserted :: ResetAssert vendor
+
+  -- | Default number of stages in a sync reset CDC primitive
+  type SyncRstDefaultStages vendor (src :: Domain) (dst :: Domain) :: Nat
+
+  -- | Default configuration for a sync reset CDC primitive
+  defaultSyncRstConfig ::
+    forall src dst.
+    (KnownDomain src, KnownDomain dst) =>
+    ResetAssert vendor ->
+    Proxy src ->
+    Proxy dst ->
+    SyncRstConfig vendor (SyncRstDefaultStages vendor src dst) src dst
+
+  -- | Sync reset CDC primitive with the default configuration
+  syncRst ::
+    forall src dst.
+    ( KnownDomain src
+    , KnownDomain dst
+    , HasCallStack
+    , SyncRstConstraints vendor src dst
+    ) =>
+    ResetAssert vendor ->
+    Clock src ->
+    Clock dst ->
+    Reset src ->
+    Reset dst
+  default syncRst ::
+    ( KnownDomain src
+    , KnownDomain dst
+    , HasCallStack
+    , SyncRstWithConstraints vendor (SyncRstDefaultStages vendor src dst) src dst
+    ) =>
+    ResetAssert vendor ->
+    Clock src ->
+    Clock dst ->
+    Reset src ->
+    Reset dst
+  syncRst resetAssert (srcClk :: Clock src) (dstClk :: Clock dst) (srcRst :: Reset src) =
+    syncRstWith @vendor @(SyncRstDefaultStages vendor src dst) @src @dst
+      (defaultSyncRstConfig @vendor @src @dst resetAssert Proxy Proxy)
+      srcClk
+      dstClk
+      srcRst
+
+-- | Helper typeclass for bringing in the primitive typeclass and additional constraints
+class
+  (SyncRst vendor, SyncRstConstraints vendor src dst) =>
+  ValidSyncRst (vendor :: Symbol) (src :: Domain) (dst :: Domain)
+
+instance
+  (SyncRst vendor, SyncRstConstraints vendor src dst) =>
+  ValidSyncRst (vendor :: Symbol) (src :: Domain) (dst :: Domain)
+
+-- | Helper typeclass for bringing in the primitive typeclass and additional constraints
+class
+  (SyncRst vendor, SyncRstWithConstraints vendor stages src dst) =>
+  ValidSyncRstWith (vendor :: Symbol) (stages :: Nat) (src :: Domain) (dst :: Domain)
+
+instance
+  (SyncRst vendor, SyncRstWithConstraints vendor stages src dst) =>
+  ValidSyncRstWith (vendor :: Symbol) (stages :: Nat) (src :: Domain) (dst :: Domain)
+
+type HiddenVendor (vendor :: Symbol) = (KnownSymbol vendor, ?vendorName :: SSymbol vendor)
+
+-- | Alias for @let ?vendorName = ssym in f@
+withVendor ::
+  forall vendor r. (KnownSymbol vendor) => SSymbol vendor -> ((HiddenVendor vendor) => r) -> r
+withVendor ssym f = let ?vendorName = ssym in f
+
+-- | Implicitly creates the @SSymbol vendor@ used to call 'withVendor'
+withVendorI :: forall vendor r. (KnownSymbol vendor) => ((HiddenVendor vendor) => r) -> r
+withVendorI = withVendor (SSymbol @vendor)
+
+-- | `Maybe a` based version of `handshake`.
+handshakeMaybe ::
+  forall a src dst vendor.
+  ( KnownDomain src
+  , KnownDomain dst
+  , BitPack a
+  , NFDataX a
+  , HiddenVendor vendor
+  , ValidHandshake vendor a src dst
+  ) =>
+  Clock src ->
+  Clock dst ->
+  Signal src (Maybe a) ->
+  Signal dst Bool ->
+  (Signal src Bool, Signal dst (Maybe a))
+handshakeMaybe clkSrc clkDst srcIn dstAck = (srcRcv, orNothing <$> dstReq <*> dstOut)
+ where
+  (dstOut, dstReq, srcRcv) =
+    handshake @vendor clkSrc clkDst (fromMaybe (unpack 0) <$> srcIn) (isJust <$> srcIn) dstAck
+
+{- | Reliable CDC component based on 'handshakeMaybe' without backpressure and with limited
+throughput. Data will be lost if the `src` domain provides more inputs than the circuit can handle.
+Useful for low granularity synchronization.
+-}
+maybeLossy ::
+  forall a src dst vendor.
+  ( KnownDomain src
+  , KnownDomain dst
+  , BitPack a
+  , NFDataX a
+  , HiddenVendor vendor
+  , ValidHandshake vendor a src dst
+  ) =>
+  Clock src ->
+  Clock dst ->
+  Signal src (Maybe a) ->
+  Signal dst (Maybe a)
+maybeLossy clkSrc clkDst maybeInp =
+  mux (isRising clkDst noReset enableGen False dstAck) dstOut (pure Nothing)
+ where
+  srcReg =
+    regEn
+      clkSrc
+      noReset
+      enableGen
+      Nothing
+      (srcRcv .||. srcRegEmpty)
+      $ mux (srcRegEmpty .&&. fmap not srcRcv) maybeInp (pure Nothing)
+
+  srcRegEmpty = isNothing <$> srcReg
+  (srcRcv, dstOut) = handshakeMaybe @a @src @dst @vendor clkSrc clkDst srcReg (isJust <$> dstOut)
+  dstAck = isJust <$> dstOut

--- a/bittide-extra/src/Clash/Cores/Xilinx.hs
+++ b/bittide-extra/src/Clash/Cores/Xilinx.hs
@@ -1,0 +1,147 @@
+-- SPDX-FileCopyrightText: 2026 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+{-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+{- | This module contains instances of the various CDC primitive typeclasses for Xilinx. For help
+with choosing primitives, please consult Xilinx's documentation:
+<https://docs.amd.com/r/en-US/ug949-vivado-design-methodology/Single-Bit-CDC>
+-}
+module Clash.Cores.Xilinx where
+
+import Clash.Prelude
+
+import Clash.Cores.Xilinx.Xpm.Cdc.ArraySingle (XpmCdcArraySingleConfig (..), xpmCdcArraySingleWith)
+import Clash.Cores.Xilinx.Xpm.Cdc.Gray (XpmCdcGrayConfig (..), xpmCdcGrayWith)
+import Clash.Cores.Xilinx.Xpm.Cdc.Handshake (XpmCdcHandshakeConfig (..), xpmCdcHandshakeWith)
+import Clash.Cores.Xilinx.Xpm.Cdc.Pulse (XpmCdcPulseConfig (..), xpmCdcPulseWith)
+import Clash.Cores.Xilinx.Xpm.Cdc.Single (XpmCdcSingleConfig (..), xpmCdcSingleWith)
+import Clash.Cores.Xilinx.Xpm.Cdc.SyncRst (
+  Asserted (..),
+  XpmCdcSyncRstConfig (..),
+  xpmCdcSyncRstWith,
+ )
+import Data.Data (Proxy (Proxy))
+
+import qualified Clash.Class.Cdc as Cdc
+
+type Xilinx = "Xilinx"
+
+withXilinx :: forall r. ((Cdc.HiddenVendor Xilinx) => r) -> r
+withXilinx = Cdc.withVendorI @Xilinx
+
+genInitialValues ::
+  forall src dst. (KnownDomain src, KnownDomain dst) => Proxy src -> Proxy dst -> String -> Bool
+genInitialValues (_ :: Proxy src) (_ :: Proxy dst) compName =
+  case (initBehavior @src, initBehavior @dst) of
+    (SDefined, SDefined) -> True
+    (SUnknown, SUnknown) -> False
+    _ ->
+      clashCompileError
+        $ compName
+        <> ": domains need to agree on initial value "
+        <> "behavior. To set initial value usage explicitly, "
+        <> "consider using '"
+        <> compName
+        <> "With'."
+
+instance Cdc.IndependentBits Xilinx where
+  type
+    IndependentBitsWithConstraints Xilinx stages a src dst =
+      ( 2 <= stages
+      , stages <= 10
+      , 1 <= BitSize a
+      , BitSize a <= 1024
+      )
+  type IndependentBitsConfig Xilinx stages a src dst = XpmCdcArraySingleConfig stages
+  independentBitsWith = xpmCdcArraySingleWith
+  type IndependentBitsConstraints Xilinx a src dst = (1 <= BitSize a, BitSize a <= 1024)
+  type IndependentBitsDefaultStages Xilinx a src dst = 4
+  defaultIndependentBitsConfig (_ :: Proxy src) (_ :: Proxy dst) (_ :: Proxy a) =
+    XpmCdcArraySingleConfig
+      { stages = SNat
+      , initialValues = genInitialValues @src @dst Proxy Proxy "xpmCdcArraySingle"
+      , registerInput = True
+      }
+
+instance Cdc.Gray Xilinx where
+  type GrayWithConstraints Xilinx stages n src dst = (2 <= stages, stages <= 10, 2 <= n, n <= 32)
+  type GrayConfig Xilinx stages n src dst = XpmCdcGrayConfig stages
+  grayWith = xpmCdcGrayWith
+  type GrayConstraints Xilinx n src dst = (2 <= n, n <= 32)
+  type GrayDefaultStages Xilinx n src dst = 4
+  defaultGrayConfig (_ :: Proxy src) (_ :: Proxy dst) (_ :: Proxy n) =
+    XpmCdcGrayConfig
+      { stages = SNat
+      , initialValues = genInitialValues @src @dst Proxy Proxy "xpmCdcGray"
+      }
+
+instance Cdc.Handshake Xilinx where
+  type
+    HandshakeWithConstraints Xilinx srcStages dstStages a src dst =
+      ( 2 <= srcStages
+      , srcStages <= 10
+      , 2 <= dstStages
+      , dstStages <= 10
+      , 1 <= BitSize a
+      , BitSize a <= 1024
+      )
+  type
+    HandshakeConfig Xilinx srcStages dstStages a src dst =
+      XpmCdcHandshakeConfig srcStages dstStages
+  handshakeWith = xpmCdcHandshakeWith
+  type HandshakeConstraints Xilinx a src dst = (1 <= BitSize a, BitSize a <= 1024)
+  type HandshakeDefaultSrcStages Xilinx a src dst = 4
+  type HandshakeDefaultDstStages Xilinx a src dst = 4
+  defaultHandshakeConfig (_ :: Proxy src) (_ :: Proxy dst) (_ :: Proxy a) =
+    XpmCdcHandshakeConfig
+      { srcStages = SNat
+      , dstStages = SNat
+      , initialValues = genInitialValues @src @dst Proxy Proxy "xpmCdcHandshake"
+      }
+
+instance Cdc.Pulse Xilinx where
+  type PulseWithConstraints Xilinx stages a src dst = (2 <= stages, stages <= 10, BitSize a ~ 1)
+  type PulseConfig Xilinx stages a src dst = XpmCdcPulseConfig stages
+  pulseWith = xpmCdcPulseWith
+  type PulseConstraints Xilinx a src dst = (BitSize a ~ 1)
+  type PulseDefaultStages Xilinx a src dst = 4
+  defaultPulseConfig (_ :: Proxy src) (_ :: Proxy dst) (_ :: Proxy a) =
+    XpmCdcPulseConfig
+      { stages = SNat
+      , initialValues = genInitialValues @src @dst Proxy Proxy "xpmCdcPulse"
+      , registerOutput = True
+      , resetUsed = False
+      }
+
+instance Cdc.Bit Xilinx where
+  type BitWithConstraints Xilinx stages a src dst = (2 <= stages, stages <= 10, BitSize a ~ 1)
+  type BitConfig Xilinx stages a src dst = XpmCdcSingleConfig stages
+  bitWith = xpmCdcSingleWith
+  type BitConstraints Xilinx a src dst = (BitSize a ~ 1)
+  type BitDefaultStages Xilinx a src dst = 4
+  defaultBitConfig (_ :: Proxy src) (_ :: Proxy dst) (_ :: Proxy a) =
+    XpmCdcSingleConfig
+      { stages = SNat
+      , initialValues = genInitialValues @src @dst Proxy Proxy "xpmCdcSingle"
+      , registerInput = True
+      }
+
+instance Cdc.SyncRst Xilinx where
+  type SyncRstWithConstraints Xilinx stages src dst = (2 <= stages, stages <= 10)
+  type SyncRstConfig Xilinx stages src dst = XpmCdcSyncRstConfig stages
+  syncRstWith = xpmCdcSyncRstWith
+  type SyncRstConstraints Xilinx src dst = ()
+  type ResetAssert Xilinx = Asserted
+  defaultAssert = Cdc.asserted @Xilinx
+  asserted = Asserted
+  deasserted = Deasserted
+  type SyncRstDefaultStages Xilinx src dst = 4
+  defaultSyncRstConfig resetAsserted (_ :: Proxy src) (_ :: Proxy dst) =
+    XpmCdcSyncRstConfig
+      { stages = SNat
+      , initialValues = case initBehavior @dst of
+          SDefined -> Just resetAsserted
+          SUnknown -> Nothing
+      }

--- a/bittide-instances/src/Bittide/Instances/Hitl/FincFdec.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/FincFdec.hs
@@ -9,6 +9,7 @@ FINC and FDEC pins.
 module Bittide.Instances.Hitl.FincFdec where
 
 import Clash.Annotations.TH (makeTopEntity)
+import Clash.Cores.Xilinx (withXilinx)
 import Clash.Explicit.Prelude
 import Clash.Prelude (withClockResetEnable)
 import Clash.Xilinx.ClockGen (clockWizardDifferential)
@@ -108,7 +109,7 @@ goFincFdecTests clk rst clkControlled testSelect spiS2M =
       -- reset much earlier than 'rstTest'. Doing it the "proper" way would
       -- therefore introduce extra complexity, without adding to the test's
       -- coverage.
-      domainDiffCounter clkControlled rstControlled clk rstTest
+      (withXilinx domainDiffCounter) clkControlled rstControlled clk rstTest
 
   fIncDec = unbundle $ speedChangeToFincFdec clk rstTest fIncDecRequest
 

--- a/bittide-instances/src/Bittide/Instances/Hitl/Si539xConfiguration.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/Si539xConfiguration.hs
@@ -38,6 +38,7 @@ import Bittide.Wishbone (timeWb, uartBytes, uartDf, uartInterfaceWb)
 #ifdef SIM_BAUD_RATE
 import Clash.Cores.UART.Extra
 #endif
+import Clash.Cores.Xilinx (withXilinx)
 
 import Bittide.Instances.Domains
 
@@ -114,7 +115,7 @@ dut ::
     , "SPI_DONE" ::: CSignal free Bool
     , Spi free
     )
-dut freeClk freeRst skyClk = withLittleEndian $ circuit $ \(mm, jtag) -> do
+dut freeClk freeRst skyClk = withXilinx $ withLittleEndian $ circuit $ \(mm, jtag) -> do
   [siBus, timeBus, uartBus, dcBus] <-
     withClockResetEnable freeClk freeRst enableGen
       $ processingElement NoDumpVcd peConfig

--- a/bittide-instances/src/Bittide/Instances/Hitl/SoftUgnDemo/Core.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/SoftUgnDemo/Core.hs
@@ -33,6 +33,7 @@ import Bittide.SharedTypes (Bitbone, BitboneMm)
 import Bittide.Sync (Sync)
 import Bittide.Wishbone (readDnaPortE2WbWorker, timeWb, uartBytes, uartInterfaceWb)
 import Clash.Class.BitPackC (ByteOrder)
+import Clash.Cores.Xilinx (withXilinx)
 import Clash.Cores.Xilinx.Unisim.DnaPortE2 (readDnaPortE2, simDna2)
 import Protocols.Extra
 import Protocols.Idle (idleSink)
@@ -163,8 +164,9 @@ core ::
     , "UARTS" ::: Vec InternalCpuCount (Df Bittide (BitVector 8))
     , "MU_TRANSCEIVER" ::: (BitboneMm Bittide NmuRemBusWidth)
     )
-core (refClk, refRst) (bitClk, bitRst, bitEna) rxClocks rxResets =
-  circuit $ \(memoryMaps, jtag, mask, linksSuitableForCc, Fwd rxs0) -> do
+core (refClk, refRst) (bitClk, bitRst, bitEna) rxClocks rxResets = withXilinx
+  $ circuit
+  $ \(memoryMaps, jtag, mask, linksSuitableForCc, Fwd rxs0) -> do
     [muMm, ccMm] <- idC -< memoryMaps
 
     [muJtag, ccJtag] <- jtagChain -< jtag
@@ -237,8 +239,7 @@ core (refClk, refRst) (bitClk, bitRst, bitEna) rxClocks rxResets =
           ]
       ) <-
       withBittideClockResetEnable
-        $ callistoSwClockControlC
-          @LinkCount
+        $ callistoSwClockControlC @LinkCount
           refClk
           refRst
           rxClocks

--- a/bittide-instances/src/Bittide/Instances/Hitl/SwitchDemo/Core.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/SwitchDemo/Core.hs
@@ -37,6 +37,7 @@ import Bittide.SwitchDemoProcessingElement (switchDemoPeWb)
 import Bittide.Sync (Sync)
 import Bittide.Wishbone (readDnaPortE2WbWorker, timeWb, uartBytes, uartInterfaceWb)
 import Clash.Class.BitPackC (ByteOrder)
+import Clash.Cores.Xilinx (withXilinx)
 import Clash.Cores.Xilinx.Unisim.DnaPortE2 (readDnaPortE2, simDna2)
 import Protocols.Extra
 import Protocols.MemoryMap (Mm)
@@ -195,8 +196,9 @@ core ::
     , "UARTS" ::: Vec InternalCpuCount (Df Bittide (BitVector 8))
     , "MU_TRANSCEIVER" ::: (BitboneMm Bittide NmuRemBusWidth)
     )
-core (refClk, refRst) (bitClk, bitRst, bitEna) rxClocks rxResets =
-  circuit $ \(memoryMaps, jtag, mask, linksSuitableForCc, Fwd rxs0) -> do
+core (refClk, refRst) (bitClk, bitRst, bitEna) rxClocks rxResets = withXilinx
+  $ circuit
+  $ \(memoryMaps, jtag, mask, linksSuitableForCc, Fwd rxs0) -> do
     [muMm, ccMm] <- idC -< memoryMaps
 
     [muJtag, ccJtag] <- jtagChain -< jtag

--- a/bittide-instances/src/Bittide/Instances/Hitl/SwitchDemoGppe/Core.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/SwitchDemoGppe/Core.hs
@@ -37,6 +37,7 @@ import Bittide.Switch (switchC)
 import Bittide.Sync (Sync)
 import Bittide.Wishbone (readDnaPortE2WbWorker, timeWb, uartBytes, uartInterfaceWb)
 import Clash.Class.BitPackC (ByteOrder)
+import Clash.Cores.Xilinx (withXilinx)
 import Clash.Cores.Xilinx.Unisim.DnaPortE2 (readDnaPortE2, simDna2)
 import Protocols.Extra
 import Protocols.MemoryMap (Mm)
@@ -259,8 +260,9 @@ core ::
     , "UARTS" ::: Vec InternalCpuCount (Df Bittide (BitVector 8))
     , "MU_TRANSCEIVER" ::: (BitboneMm Bittide NmuRemBusWidth)
     )
-core (refClk, refRst) (bitClk, bitRst, bitEna) rxClocks rxResets =
-  circuit $ \(memoryMaps, jtag, mask, linksSuitableForCc, Fwd rxs0) -> do
+core (refClk, refRst) (bitClk, bitRst, bitEna) rxClocks rxResets = withXilinx
+  $ circuit
+  $ \(memoryMaps, jtag, mask, linksSuitableForCc, Fwd rxs0) -> do
     [muMm, ccMm, gppeMm] <- idC -< memoryMaps
 
     [muJtag, ccJtag, gppeJtag] <- jtagChain -< jtag

--- a/bittide-instances/src/Bittide/Instances/Hitl/WireDemo/Core.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/WireDemo/Core.hs
@@ -32,6 +32,7 @@ import Bittide.Sync (Sync)
 import Bittide.WireDemoProcessingElement (wireDemoPe, wireDemoPeConfig)
 import Bittide.Wishbone (readDnaPortE2WbWorker, timeWb, uartBytes, uartInterfaceWb)
 import Clash.Class.BitPackC (ByteOrder)
+import Clash.Cores.Xilinx (withXilinx)
 import Clash.Cores.Xilinx.Unisim.DnaPortE2 (readDnaPortE2, simDna2)
 import Protocols.Extra
 import Protocols.Idle (idleSink)
@@ -265,6 +266,7 @@ core (refClk, refRst) (bitClk, bitRst, bitEna) rxClocks rxResets =
           ]
       ) <-
       withBittideClockResetEnable
+        $ withXilinx
         $ callistoSwClockControlC
           @LinkCount
           refClk

--- a/bittide-instances/src/Bittide/Instances/Pnr/Counter.hs
+++ b/bittide-instances/src/Bittide/Instances/Pnr/Counter.hs
@@ -10,6 +10,7 @@ import Clash.Prelude (withClock)
 import Bittide.Counter
 import Bittide.Instances.Domains
 import Bittide.Instances.Hacks
+import Clash.Cores.Xilinx (withXilinx)
 
 counter ::
   Clock Basic200 ->
@@ -18,8 +19,7 @@ counter ::
   Reset Basic200 ->
   Signal Basic200 () ->
   Signal Basic200 (Signed 32, Bool)
-counter clk0 rst0 clk1 rst1 _ =
-  domainDiffCounter clk0 rst0 clk1 rst1
+counter clk0 rst0 clk1 rst1 _ = withXilinx $ domainDiffCounter clk0 rst0 clk1 rst1
 
 counterReducedPins :: Clock Basic200 -> Signal Basic200 Bit
 counterReducedPins clk =

--- a/bittide/src/Bittide/ClockControl/CallistoSw.hs
+++ b/bittide/src/Bittide/ClockControl/CallistoSw.hs
@@ -1,6 +1,7 @@
 -- SPDX-FileCopyrightText: 2024 Google LLC
 --
 -- SPDX-License-Identifier: Apache-2.0
+{-# LANGUAGE ImplicitParams #-}
 
 module Bittide.ClockControl.CallistoSw (
   callistoSwClockControlC,
@@ -27,6 +28,7 @@ import Protocols.Extra
 import Protocols.MemoryMap
 import Protocols.Wishbone.Extra (delayWishbone)
 
+import qualified Clash.Class.Cdc as Cdc
 import qualified Protocols.Vec as Vec
 
 -- | Configuration type for software clock control.
@@ -44,7 +46,7 @@ type SwcccRemBusWidth n = 30 - PrefixWidth (n + SwcccInternalBusses)
 -- TODO: Make this the primary Callisto function once the reset logic is fixed
 -- and Callisto is detached from the ILA plotting mechanisms.
 callistoSwClockControlC ::
-  forall nLinks dom free rx otherWb otherWbMu.
+  forall nLinks dom free rx otherWb otherWbMu vendor.
   ( HiddenClockResetEnable dom
   , KnownNat nLinks
   , KnownNat otherWb
@@ -57,6 +59,10 @@ callistoSwClockControlC ::
   , 1 <= DomainPeriod dom
   , ?byteOrder :: ByteOrder
   , 4 <= SwcccRemBusWidth otherWb
+  , Cdc.HiddenVendor vendor
+  , Cdc.ValidGray vendor 8 rx dom
+  , Cdc.ValidBit vendor Bool dom dom
+  , Cdc.ValidSyncRst vendor dom free
   ) =>
   {- | Clock of an uncontrolled domain, e.g. the free-running clock. This is
   used to generate the SYNC_OUT signal.

--- a/bittide/src/Bittide/Counter.hs
+++ b/bittide/src/Bittide/Counter.hs
@@ -1,6 +1,7 @@
 -- SPDX-FileCopyrightText: 2022 Google LLC
 --
 -- SPDX-License-Identifier: Apache-2.0
+{-# LANGUAGE ImplicitParams #-}
 
 module Bittide.Counter (
   Active,
@@ -13,7 +14,6 @@ import Protocols
 
 import Bittide.SharedTypes (BitboneMm)
 import Clash.Class.BitPackC (ByteOrder)
-import Clash.Cores.Xilinx.Xpm (xpmCdcGray)
 import Clash.Functor.Extra ((<<$>>))
 import Clash.Sized.Extra (concatUnsigneds, unsignedToSigned)
 import GHC.Stack (HasCallStack)
@@ -26,6 +26,8 @@ import Protocols.MemoryMap.Registers.WishboneStandard (
   registerWb,
   registerWb_,
  )
+
+import qualified Clash.Class.Cdc as Cdc
 
 -- | State of 'domainDiffCounter'
 data DdcState
@@ -75,9 +77,11 @@ __N.B.__:
       zero ever so often.
 -}
 domainDiffCounter ::
-  forall src dst.
+  forall src dst vendor.
   ( KnownDomain src
   , KnownDomain dst
+  , Cdc.HiddenVendor vendor
+  , Cdc.ValidGray vendor 8 src dst
   ) =>
   Clock src ->
   Reset src ->
@@ -89,7 +93,7 @@ domainDiffCounter clkSrc rstSrc clkDst rstDst =
   mealy clkDst rstDst enableGen go DdcInReset counter
  where
   -- 64 bits is enough for approximately 3 millenia @ 200 MHz
-  counter = synchronizedSuccCounter @64 clkSrc rstSrc clkDst rstDst
+  counter = Cdc.withVendor ?vendorName $ synchronizedSuccCounter @64 clkSrc rstSrc clkDst rstDst
 
   go :: DdcState -> Unsigned 64 -> (DdcState, (Signed 32, Bool))
   go DdcInReset c1
@@ -106,8 +110,9 @@ only be read from. See 'domainDiffCounter' for more information on domain
 difference counters in general.
 -}
 domainDiffCountersWbC ::
-  forall src dst n addrW.
-  ( HasCallStack
+  forall src dst n addrW vendor.
+  ( Cdc.GrayConstraints vendor 8 src dst
+  , HasCallStack
   , KnownDomain src
   , KnownDomain dst
   , HasSynchronousReset src
@@ -115,6 +120,8 @@ domainDiffCountersWbC ::
   , KnownNat n
   , KnownNat addrW
   , ?byteOrder :: ByteOrder
+  , Cdc.HiddenVendor vendor
+  , Cdc.ValidGray vendor 8 src dst
   ) =>
   Vec n (Clock src) ->
   Vec n (Reset src) ->
@@ -123,7 +130,7 @@ domainDiffCountersWbC ::
   Circuit
     (BitboneMm dst addrW)
     (CSignal dst (Vec n (Signed 32, Active)))
-domainDiffCountersWbC srcClocks srcResets clk rst = circuit $ \bus -> do
+domainDiffCountersWbC srcClocks srcResets clk rst = Cdc.withVendor ?vendorName $ circuit $ \bus -> do
   [enableWb, countersWb, activesWb] <- deviceWb clk rst (deviceConfig "DomainDiffCounters") -< bus
 
   (Fwd enables, _a) <-
@@ -166,11 +173,14 @@ __N.B.__: This function uses an 8-bit Gray counter internally, and will therefor
           only work properly if both clock speeds are pretty close to one another.
 -}
 synchronizedSuccCounter ::
-  forall n src dst.
+  forall n src dst vendor.
   ( KnownDomain src
   , KnownDomain dst
   , KnownNat n
   , 8 <= n
+  , Cdc.HiddenVendor vendor
+  , Cdc.Gray vendor
+  , Cdc.GrayConstraints vendor 8 src dst
   ) =>
   Clock src ->
   Reset src ->
@@ -179,7 +189,8 @@ synchronizedSuccCounter ::
   Signal dst (Unsigned n)
 synchronizedSuccCounter clkSrc rstSrc clkDst rstDst =
   extendSuccCounter @8 @(n - 8) clkDst rstDst
-    $ xpmCdcGray @8 clkSrc clkDst counter
+    $ Cdc.withVendor ?vendorName
+    $ Cdc.gray @vendor @8 @src @dst clkSrc clkDst counter
  where
   counter :: Signal src (Unsigned 8)
   counter = register clkSrc rstSrc enableGen 0 (counter + 1)

--- a/bittide/src/Bittide/Sync.hs
+++ b/bittide/src/Bittide/Sync.hs
@@ -43,8 +43,7 @@ import Bittide.Arithmetic.Time (PeriodToCycles)
 import Bittide.SharedTypes (BitboneMm)
 import Clash.Class.BitPackC (ByteOrder)
 import Clash.Class.Counter (Counter (countSuccOverflow))
-import Clash.Cores.Xilinx.Xpm (xpmCdcSingle, xpmCdcSyncRst)
-import Clash.Cores.Xilinx.Xpm.Cdc.SyncRst (Asserted (..))
+
 import Clash.Explicit.Signal.Extra (changepoints)
 import GHC.Stack (HasCallStack)
 import Protocols.MemoryMap.Registers.WishboneStandard (
@@ -53,6 +52,8 @@ import Protocols.MemoryMap.Registers.WishboneStandard (
   registerConfig,
   registerWb,
  )
+
+import qualified Clash.Class.Cdc as Cdc
 
 type SyncOutGeneratorHalfPeriod = Milliseconds 5
 
@@ -78,11 +79,13 @@ filtered and synchronized to the clock domain of the circuit. The glitch filter
 is hardcoded to 128 clock cycles.
 -}
 syncInCounterC ::
-  forall n dom.
+  forall n dom vendor.
   ( KnownDomain dom
   , HasSynchronousReset dom
   , KnownNat n
   , DomainInitBehavior dom ~ 'Defined
+  , Cdc.HiddenVendor vendor
+  , Cdc.ValidBit vendor Bool dom dom
   ) =>
   Clock dom ->
   Reset dom ->
@@ -99,7 +102,7 @@ syncInCounterC clk rst = Circuit go
       unsafeToActiveLow
         $ resetGlitchFilter (SNat @128) clk
         $ unsafeFromActiveLow
-        $ xpmCdcSingle clk clk
+        $ Cdc.bit @vendor @Bool @dom @dom clk clk
         $ fmap bitToBool syncIn
     syncInChange = changepoints clk rst enableGen syncInFiltered
     syncInChangeRst = unsafeFromActiveHigh syncInChange
@@ -128,13 +131,15 @@ is a registered output, i.e., it can directly be connected to a pin. On the
 wishbone bus, a single register is exposed: whether this component is active.
 -}
 syncOutGenerateWbC ::
-  forall dom counterDom aw.
+  forall dom counterDom aw vendor.
   ( KnownDomain dom
   , HasSynchronousReset dom
   , HasSynchronousReset counterDom
   , HasCallStack
   , KnownNat aw
   , ?byteOrder :: ByteOrder
+  , Cdc.HiddenVendor vendor
+  , Cdc.ValidSyncRst vendor dom counterDom
   ) =>
   -- | Clock domain of the wishbone bus, typically the controlled domain.
   Clock dom ->
@@ -150,7 +155,9 @@ syncOutGenerateWbC clk rst counterClk counterRst = circuit $ \(mm, wb) -> do
   (Fwd active, _activity) <- registerWb clk rst config False -< (activeWb, Fwd noWrite)
   let
     syncOutRst0 = rst `orReset` unsafeFromActiveLow active
-    syncOutRst1 = counterRst `orReset` xpmCdcSyncRst Asserted clk counterClk syncOutRst0
+    syncOutRst1 =
+      orReset counterRst
+        $ Cdc.syncRst @vendor (Cdc.defaultAssert @vendor) clk counterClk syncOutRst0
   syncOut <- syncOutGeneratorC counterClk syncOutRst1
   idC -< syncOut
  where

--- a/bittide/src/Clash/Cores/Xilinx/Xpm/Cdc/Handshake/Extra.hs
+++ b/bittide/src/Clash/Cores/Xilinx/Xpm/Cdc/Handshake/Extra.hs
@@ -5,23 +5,17 @@ module Clash.Cores.Xilinx.Xpm.Cdc.Handshake.Extra where
 
 import Clash.Explicit.Prelude
 
-import Clash.Cores.Xilinx.Xpm
-import Data.Maybe
+import Clash.Cores.Xilinx (Xilinx, withXilinx)
 
-import Bittide.Extra.Maybe
+import qualified Clash.Class.Cdc as Cdc
 
-{- | Reliable CDC component based on `xpmCdcHandshakeMaybe` without backpressure and
-with limited throughput. Data will be lost if the `src` domain provides more inputs
-than the circuit can handle. Useful for low granularity synchronization,
-in our case: synchronizing datacounts.
--}
+-- | Xilinx-specialized version of 'maybeLossy'
 xpmCdcMaybeLossy ::
   ( KnownDomain src
   , KnownDomain dst
   , BitPack a
   , NFDataX a
-  , 1 <= BitSize a
-  , BitSize a <= 1024
+  , Cdc.ValidHandshake Xilinx a src dst
   ) =>
   -- | Source clock
   Clock src ->
@@ -31,29 +25,15 @@ xpmCdcMaybeLossy ::
   Signal src (Maybe a) ->
   -- | Data in the destination domain
   Signal dst (Maybe a)
-xpmCdcMaybeLossy clkSrc clkDst maybeInp = mux (isRising clkDst noReset enableGen False dstAck) dstOut (pure Nothing)
- where
-  srcReg =
-    regEn
-      clkSrc
-      noReset
-      enableGen
-      Nothing
-      (srcRcv .||. srcRegEmpty)
-      $ mux (srcRegEmpty .&&. fmap not srcRcv) maybeInp (pure Nothing)
+xpmCdcMaybeLossy = withXilinx Cdc.maybeLossy
 
-  srcRegEmpty = isNothing <$> srcReg
-  (srcRcv, dstOut) = xpmCdcHandshakeMaybe clkSrc clkDst srcReg (isJust <$> dstOut)
-  dstAck = isJust <$> dstOut
-
--- | `Maybe a` based version of `xpmCdcHandshake`.
+-- | Xilinx-specialized version of 'handshake
 xpmCdcHandshakeMaybe ::
   ( KnownDomain src
   , KnownDomain dst
   , BitPack a
   , NFDataX a
-  , 1 <= BitSize a
-  , BitSize a <= 1024
+  , Cdc.ValidHandshake Xilinx a src dst
   ) =>
   -- | Source clock
   Clock src ->
@@ -68,7 +48,4 @@ xpmCdcHandshakeMaybe ::
   2. Data in the destination domain.
   -}
   (Signal src Bool, Signal dst (Maybe a))
-xpmCdcHandshakeMaybe clkSrc clkDst srcIn dstAck = (srcRcv, orNothing <$> dstReq <*> dstOut)
- where
-  (dstOut, dstReq, srcRcv) =
-    xpmCdcHandshake clkSrc clkDst (fromMaybe (unpack 0) <$> srcIn) (isJust <$> srcIn) dstAck
+xpmCdcHandshakeMaybe = withXilinx Cdc.handshakeMaybe

--- a/bittide/tests/Tests/Counter.hs
+++ b/bittide/tests/Tests/Counter.hs
@@ -1,6 +1,7 @@
 -- SPDX-FileCopyrightText: 2022 Google LLC
 --
 -- SPDX-License-Identifier: Apache-2.0
+{-# LANGUAGE ImplicitParams #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Tests.Counter where
@@ -8,6 +9,7 @@ module Tests.Counter where
 import Clash.Explicit.Prelude
 import qualified Prelude as P
 
+import Clash.Cores.Xilinx (Xilinx)
 import Control.Monad (forM_)
 
 import Test.Tasty
@@ -15,6 +17,8 @@ import Test.Tasty.HUnit
 import Test.Tasty.TH
 
 import Bittide.Counter (domainDiffCounter)
+
+import qualified Clash.Class.Cdc as Cdc
 
 createDomain vXilinxSystem{vName = "D10", vPeriod = hzToPeriod 100e6}
 createDomain vXilinxSystem{vName = "D17", vPeriod = hzToPeriod 170e6}
@@ -33,11 +37,15 @@ top ::
   forall src dst.
   ( KnownDomain src
   , KnownDomain dst
+  , Cdc.ValidGray Xilinx 8 src dst
   ) =>
   Reset src ->
   Reset dst ->
   Signal dst (Signed 32)
-top rstSrc rstDst = fst <$> domainDiffCounter clockGen rstSrc clockGen rstDst
+top rstSrc rstDst =
+  Cdc.withVendorI @Xilinx
+    $ fst
+    <$> (domainDiffCounter @_ @_ @Xilinx) clockGen rstSrc clockGen rstDst
 
 -- | 'domainDiffCounter' should continuously emit zeros when applied to the same domain
 case_zeroSameDomain :: Assertion


### PR DESCRIPTION
_What (what did you do)_
This should implement (most of?) the desired changes as per #1222.

_Why (context, issues, etc.)_
See issue for context.

_Dear reviewer (anything you'd like the reviewer to pay close attention to?)_
I think there's a GHC bug to be found in here. If in `Clash.Cores.Xilinx` I write
```hs
withXilinxI :: forall r. (forall vendor. (VendorCdcImplicit vendor) => r) -> r
withXilinxI = withVendorI @Xilinx
```
and then replace all `withVendorI @Xilinx` with `withXilinxI` calls, I suddenly get a bunch of compilation errors. If it's somehow possible to get this to work though, I'd appreciate a review comment (:

_AI disclaimer (heads-up for more than inline autocomplete)_

None.

# TODO
_~~Cross-out~~ any that do not apply_

- [ ] ~~Write (regression) test~~
- [ ] Update documentation, including `docs/`
- [x] Link to existing issue
