### PR TITLE
Add `TraceC` typeclass for debugging `Circuit`

### DIFF
--- a/bittide-extra/bittide-extra.cabal
+++ b/bittide-extra/bittide-extra.cabal
@@ -158,6 +158,7 @@ library
     shockwaves,
     string-interpolate,
     tasty-hunit,
+    template-haskell,
     time,
     word8,
 
@@ -178,8 +179,12 @@ library
     Protocols.BiDf
     Protocols.Df.Extra
     Protocols.Extra
+    Protocols.Extra.TH
+    Protocols.Internal.TH.Extra
+    Protocols.Internal.Types.Extra
     Protocols.ReqResp
     Protocols.Spi
+    Protocols.TraceC
     Protocols.Wishbone.Extra
     System.Timeout.Extra
 
@@ -195,6 +200,7 @@ test-suite unittests
     Tests.Numeric.Extra
     Tests.Protocols.BiDf
     Tests.Protocols.Df.Extra
+    Tests.Protocols.Extra
     Tests.Protocols.ReqResp
 
   build-depends:
@@ -207,10 +213,13 @@ test-suite unittests
     containers,
     deepseq,
     hedgehog,
+    shockwaves,
     string-interpolate,
     tasty,
     tasty-hedgehog,
+    tasty-hunit,
     tasty-th,
+    text,
 
 test-suite doctests
   type: exitcode-stdio-1.0

--- a/bittide-extra/src/Protocols/BiDf.hs
+++ b/bittide-extra/src/Protocols/BiDf.hs
@@ -26,14 +26,9 @@ module Protocols.BiDf (
   -- * Memories
   fromBlockRam,
   fromBlockRamWithMask,
-
-  -- * Debugging
-  trace,
-  traceSignal,
 ) where
 
-import Clash.Prelude hiding (map, traceSignal)
-import Data.Typeable (Typeable)
+import Clash.Prelude hiding (map)
 import Protocols
 
 import qualified Protocols.Df as Df
@@ -224,35 +219,3 @@ fromBlockRam primitive = circuit $ \(bidf, writeData) -> do
   readAddress <- toDfs -< (bidf, readData)
   readData <- Df.fromBlockRam primitive -< (readAddress, writeData)
   idC -< ()
-
-{- | `BiDf` version of `traceShowId`, introduces no state or logic of any form. Only prints when
-there is data available on the input side. Prints available data, clock cycle count in the
-relevant domain, and the corresponding Ack.
--}
-trace ::
-  (KnownDomain dom, ShowX req, NFDataX req, ShowX resp, NFDataX resp) =>
-  String ->
-  Circuit (BiDf dom req resp) (BiDf dom req resp)
-trace msg = map (Df.trace (msg <> "_request")) (Df.trace (msg <> "_response"))
-
-{- | `BiDf` version of `Clash.Debug.traceSignal` based on `Df.traceSignal`.
-Signal names:
-- left request forward: name_request_fwd
-- left request backward: name_request_bwd
-- right response forward: name_response_fwd
-- right response backward: name_response_bwd
--}
-traceSignal ::
-  ( KnownDomain dom
-  , ShowX req
-  , NFDataX req
-  , BitPack req
-  , Typeable req
-  , ShowX resp
-  , NFDataX resp
-  , BitPack resp
-  , Typeable resp
-  ) =>
-  String ->
-  Circuit (BiDf dom req resp) (BiDf dom req resp)
-traceSignal name = map (Df.traceSignal (name <> "_request")) (Df.traceSignal (name <> "_response"))

--- a/bittide-extra/src/Protocols/Df/Extra.hs
+++ b/bittide-extra/src/Protocols/Df/Extra.hs
@@ -7,8 +7,6 @@ module Protocols.Df.Extra where
 import Clash.Prelude hiding (traceSignal)
 import Data.Bifunctor (Bifunctor (..))
 import Data.Maybe
-import Data.String.Interpolate (i)
-import Data.Typeable (Typeable)
 import GHC.Stack (HasCallStack)
 import Protocols
 import Protocols.Df (forceResetSanity)
@@ -18,7 +16,6 @@ import qualified Clash.Explicit.Signal.Delayed as ED
 import qualified Clash.Explicit.Signal.Delayed.Extra as ED
 import qualified Clash.Signal.Delayed as D
 import qualified Data.Maybe as Maybe
-import qualified Debug.Trace as Debug
 import qualified Protocols.Df as Df
 
 andAck :: forall dom a. Signal dom Bool -> Circuit (Df dom a) (Df dom a)
@@ -376,28 +373,3 @@ stallNext rdyS = circuit $ \req -> do
       | otherwise = False
 
     ackOut = Ack (passThrough && ackIn)
-
-{- | 'Df' version of 'traceShowId', introduces no state or logic of any form. Only prints when
-there is data available on the input side. Prints available data, clock cycle count in the
-relevant domain, and the corresponding Ack.
--}
-trace ::
-  (KnownDomain dom, ShowX a, NFDataX a) =>
-  String ->
-  Circuit (Df dom a) (Df dom a)
-trace msg =
-  Circuit
-    (unbundle . withClockResetEnable clockGen resetGen enableGen mealy go (0 :: Int) . bundle)
- where
-  go cnt ~(m2s, s2m) = (cnt + 1, (s2m', m2s))
-   where
-    s2m' = Debug.trace [i| Df.Trace #{msg} | #{cnt}: #{showX m2s}, #{showX s2m}|] s2m
-
--- | 'Df' version of 'Clash.Debug.traceSignal'. names forward signal (name_fwd) and backward signal (name_bwd)
-traceSignal ::
-  (KnownDomain dom, ShowX a, NFDataX a, BitPack a, Typeable a) =>
-  String ->
-  Circuit (Df dom a) (Df dom a)
-traceSignal name = Circuit go
- where
-  go ~(fwd, bwd) = (E.traceSignal (name <> "_bwd") bwd, E.traceSignal (name <> "_fwd") fwd)

--- a/bittide-extra/src/Protocols/Extra.hs
+++ b/bittide-extra/src/Protocols/Extra.hs
@@ -1,6 +1,8 @@
 -- SPDX-FileCopyrightText: 2025 Google LLC
 --
 -- SPDX-License-Identifier: Apache-2.0
+{-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 {- | Many of these functions should be added to `clash-protocols`, there is a PR
 for this: https://github.com/clash-lang/clash-protocols/pull/116
@@ -9,7 +11,7 @@ https://github.com/bittide/bittide-hardware/issues/645
 -}
 module Protocols.Extra where
 
-import Clash.Prelude
+import Clash.Prelude hiding (traceSignal)
 
 import Protocols
 

--- a/bittide-extra/src/Protocols/Extra/TH.hs
+++ b/bittide-extra/src/Protocols/Extra/TH.hs
@@ -1,0 +1,103 @@
+-- SPDX-FileCopyrightText: 2025 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+
+module Protocols.Extra.TH (traceCTupleInstances) where
+
+import Control.Monad (zipWithM)
+import Control.Monad.Extra (concatMapM)
+import Data.Proxy
+import Language.Haskell.TH
+import Protocols.Internal.Types.Extra (TraceC (..))
+import qualified Protocols.Internal.Types.Extra as Trace (TraceC (..))
+import Protocols.Plugin (Circuit (..))
+import Prelude
+
+{- | Generate 'TraceC' instances for tuple sizes @n@ through @m@ (inclusive).
+
+Usage:
+
+> $(traceCTupleInstances 3 12)
+-}
+traceCTupleInstances :: Int -> Int -> DecsQ
+traceCTupleInstances n m = concatMapM traceCTupleInstance [n .. m]
+
+traceCTupleInstance :: Int -> DecsQ
+traceCTupleInstance n =
+  [d|
+    instance ($instCtx) => TraceC $instTy where
+      shock $(varP nameN) = $mkShockExpr
+      signal $(varP nameN) = $mkSignalExpr
+      names $(varP proxyN) $(varP nameN) = $mkSignalNamesExpr
+      trace $(varP nameN) = $mkExpr
+    |]
+ where
+  nameN = mkName "name"
+  proxyN = mkName "_proxy"
+  circTys = map (\i -> varT $ mkName $ "p" <> show i) [1 .. n]
+  instCtx = foldl appT (tupleT n) $ map (\ty -> [t|TraceC $ty|]) circTys
+  instTy = foldl appT (tupleT n) circTys
+
+  suffixes = map show [0 .. n - 1]
+  mkSuffix s = litE $ stringL $ "_" <> s
+
+  fwdPat = tupP $ map (\i -> varP $ mkName $ "fwd" <> show i) [1 .. n]
+  bwdPat = tupP $ map (\i -> varP $ mkName $ "bwd" <> show i) [1 .. n]
+  fwdExprs' = map (\i -> varE $ mkName $ "fwd" <> show i <> "'") [1 .. n] :: [ExpQ]
+  bwdExprs' = map (\i -> varE $ mkName $ "bwd" <> show i <> "'") [1 .. n] :: [ExpQ]
+
+  -- Generate:
+  --   Circuit $ \(~(fwd1, ..., fwdN), ~(bwd1, ..., bwdN)) ->
+  --     let Circuit traced1 = method @(p1) (name <> "_0")
+  --         ...
+  --         (bwd1', fwd1') = traced1 (fwd1, bwd1)
+  --         ...
+  --     in ((bwd1', ..., bwdN'), (fwd1', ..., fwdN'))
+  mkCircuitExpr mkMethodExpr = do
+    circuitDecs <-
+      concat <$> zipWithM (\i ty -> mkCircuitDec (mkMethodExpr ty) i) [1 .. n] circTys
+    resultDecs <-
+      concatMapM mkResultDec [1 .. n]
+    LetE (circuitDecs <> resultDecs)
+      <$> [e|($(tupE bwdExprs'), $(tupE fwdExprs'))|]
+
+  mkCircuitDec methodExpr i =
+    [d|
+      $[p|Circuit $(varP $ mkName $ "traced" <> show i)|] =
+        $methodExpr ($(varE nameN) <> $(mkSuffix (suffixes !! (i - 1))))
+      |]
+
+  mkResultDec i =
+    [d|
+      $[p|
+        ( $(varP $ mkName $ "bwd" <> show i <> "'")
+          , $(varP $ mkName $ "fwd" <> show i <> "'")
+          )
+        |] =
+          $(varE $ mkName $ "traced" <> show i)
+            ( $(varE $ mkName $ "fwd" <> show i)
+            , $(varE $ mkName $ "bwd" <> show i)
+            )
+      |]
+
+  mkShockExpr =
+    [e|
+      Circuit $ \($(tildeP fwdPat), $(tildeP bwdPat)) -> $(mkCircuitExpr (\ty -> appTypeE (varE 'Trace.shock) ty))
+      |]
+  mkSignalExpr =
+    [e|
+      Circuit $ \($(tildeP fwdPat), $(tildeP bwdPat)) -> $(mkCircuitExpr (\ty -> appTypeE (varE 'Trace.signal) ty))
+      |]
+  mkExpr =
+    [e|
+      Circuit $ \($(tildeP fwdPat), $(tildeP bwdPat)) -> $(mkCircuitExpr (\ty -> appTypeE (varE 'Trace.trace) ty))
+      |]
+
+  mkSignalNamesExpr =
+    foldl1
+      (\a b -> [e|$a <> $b|])
+      ( zipWith
+          (\ty s -> [e|$(appTypeE (varE 'Trace.names) ty) Proxy ($(varE nameN) <> $(mkSuffix s))|])
+          circTys
+          suffixes
+      )

--- a/bittide-extra/src/Protocols/Internal/TH/Extra.hs
+++ b/bittide-extra/src/Protocols/Internal/TH/Extra.hs
@@ -1,0 +1,100 @@
+-- SPDX-FileCopyrightText: 2025 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+
+module Protocols.Internal.TH.Extra (traceCTupleInstances) where
+
+import Control.Monad (zipWithM)
+import Control.Monad.Extra (concatMapM)
+import Data.Proxy
+import Language.Haskell.TH
+import Protocols.Internal.Types.Extra (TraceC (..))
+import Protocols.Plugin (Circuit (..))
+import Prelude
+
+{- | Generate 'TraceC' instances for tuple sizes @n@ through @m@ (inclusive).
+
+Usage:
+
+> $(traceCTupleInstances 3 12)
+-}
+traceCTupleInstances :: Int -> Int -> DecsQ
+traceCTupleInstances n m = concatMapM traceCTupleInstance [n .. m]
+
+traceCTupleInstance :: Int -> DecsQ
+traceCTupleInstance n =
+  [d|
+    instance ($instCtx) => TraceC $instTy where
+      shock $(varP nameN) = $mkTraceShockExpr
+      signal $(varP nameN) = $mkTraceSignalExpr
+      names $(varP proxyN) $(varP nameN) = $mkSignalNamesExpr
+      trace $(varP nameN) = $mkTraceExpr
+    |]
+ where
+  nameN = mkName "name"
+  proxyN = mkName "_proxy"
+  circTys = map (\i -> varT $ mkName $ "p" <> show i) [1 .. n]
+  instCtx = foldl appT (tupleT n) $ map (\ty -> [t|TraceC $ty|]) circTys
+  instTy = foldl appT (tupleT n) circTys
+
+  suffixes = map show [0 .. n - 1]
+  mkSuffix s = litE $ stringL $ "_" <> s
+
+  fwdPat = tupP $ map (\i -> varP $ mkName $ "fwd" <> show i) [1 .. n]
+  bwdPat = tupP $ map (\i -> varP $ mkName $ "bwd" <> show i) [1 .. n]
+  fwdExprs' = map (\i -> varE $ mkName $ "fwd" <> show i <> "'") [1 .. n] :: [ExpQ]
+  bwdExprs' = map (\i -> varE $ mkName $ "bwd" <> show i <> "'") [1 .. n] :: [ExpQ]
+
+  -- Generate:
+  --   Circuit $ \(~(fwd1, ..., fwdN), ~(bwd1, ..., bwdN)) ->
+  --     let Circuit traced1 = method @(p1) (name <> "_0")
+  --         ...
+  --         (bwd1', fwd1') = traced1 (fwd1, bwd1)
+  --         ...
+  --     in ((bwd1', ..., bwdN'), (fwd1', ..., fwdN'))
+  mkCircuitExpr mkMethodExpr = do
+    circuitDecs <-
+      concat <$> zipWithM (\i ty -> mkCircuitDec (mkMethodExpr ty) i) [1 .. n] circTys
+    resultDecs <-
+      concatMapM mkResultDec [1 .. n]
+    LetE (circuitDecs <> resultDecs)
+      <$> [e|($(tupE bwdExprs'), $(tupE fwdExprs'))|]
+
+  mkCircuitDec methodExpr i =
+    [d|
+      $[p|Circuit $(varP $ mkName $ "traced" <> show i)|] =
+        $methodExpr ($(varE nameN) <> $(mkSuffix (suffixes !! (i - 1))))
+      |]
+
+  mkResultDec i =
+    [d|
+      $[p|
+        ( $(varP $ mkName $ "bwd" <> show i <> "'")
+          , $(varP $ mkName $ "fwd" <> show i <> "'")
+          )
+        |] =
+          $(varE $ mkName $ "traced" <> show i)
+            ( $(varE $ mkName $ "fwd" <> show i)
+            , $(varE $ mkName $ "bwd" <> show i)
+            )
+      |]
+
+  mkTraceShockExpr =
+    [e|
+      Circuit $ \($(tildeP fwdPat), $(tildeP bwdPat)) -> $(mkCircuitExpr (\ty -> [e|traceShock @($ty)|]))
+      |]
+  mkTraceSignalExpr =
+    [e|
+      Circuit $ \($(tildeP fwdPat), $(tildeP bwdPat)) -> $(mkCircuitExpr (\ty -> [e|traceSignal @($ty)|]))
+      |]
+  mkTraceExpr =
+    [e|Circuit $ \($(tildeP fwdPat), $(tildeP bwdPat)) -> $(mkCircuitExpr (\ty -> [e|trace @($ty)|]))|]
+
+  mkSignalNamesExpr =
+    foldl1
+      (\a b -> [e|$a <> $b|])
+      ( zipWith
+          (\ty s -> [e|(signalNames (Proxy @($ty)) ($(varE nameN) <> $(mkSuffix s)))|])
+          circTys
+          suffixes
+      )

--- a/bittide-extra/src/Protocols/Internal/Types/Extra.hs
+++ b/bittide-extra/src/Protocols/Internal/Types/Extra.hs
@@ -1,0 +1,24 @@
+-- SPDX-FileCopyrightText: 2026 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+module Protocols.Internal.Types.Extra where
+
+import Clash.Prelude hiding (traceSignal)
+import Data.Data (Proxy (..))
+import Protocols
+
+-- | Typeclass used for tracing circuits either with 'clash-shockwaves', 'Clash.Prelude.traceSignal', or 'Debug.Trace.trace'.
+class TraceC p where
+  -- | Tracing function that uses 'traceSignal' from the 'clash-shockwaves' package to
+  -- create waveforms with ADTs.
+  shock :: String -> Circuit p p
+
+  -- | Tracing function that uses 'Clash.Prelude.traceSignal' to add signals to normal waveforms.
+  signal :: String -> Circuit p p
+
+  -- | Returns a list of signal names that will be added to the HDL when using 'shock'.
+  -- useful in combination with 'dumpVCD' and friends.
+  names :: Proxy p -> String -> [String]
+
+  -- | Tracing function that uses 'Debug.Trace.trace' to print values to the console.
+  trace :: String -> Circuit p p

--- a/bittide-extra/src/Protocols/Spi.hs
+++ b/bittide-extra/src/Protocols/Spi.hs
@@ -6,6 +6,8 @@ module Protocols.Spi where
 import Clash.Prelude
 import Protocols
 
+import qualified Clash.Shockwaves as Shock
+
 data Spi (dom :: Domain)
 
 -- | SPI data that flows from the manager to the subordinate.
@@ -18,13 +20,13 @@ data M2S = M2S
   -- ^ Active-low chip select signal from manager to enable communication with a
   -- specific subordinate device
   }
-  deriving (Show, Generic, NFDataX, Eq)
+  deriving (Show, ShowX, BitPack, Shock.Waveform, Generic, NFDataX, Eq)
 
 data S2M = S2M
   { miso :: "MISO" ::: Bit
   -- ^ Serial data output from the subordinate to the manager
   }
-  deriving (Show, Generic, NFDataX, Eq)
+  deriving (Show, ShowX, BitPack, Shock.Waveform, Generic, NFDataX, Eq)
 
 instance Protocol (Spi dom) where
   type Fwd (Spi dom) = Signal dom M2S

--- a/bittide-extra/src/Protocols/TraceC.hs
+++ b/bittide-extra/src/Protocols/TraceC.hs
@@ -1,0 +1,530 @@
+-- SPDX-FileCopyrightText: 2025 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+{-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+{- | Many of these functions should be added to `clash-protocols`, there is a PR
+for this: https://github.com/clash-lang/clash-protocols/pull/116
+And a bittide-hardware issue:
+https://github.com/bittide/bittide-hardware/issues/645
+-}
+module Protocols.TraceC (TraceC (..)) where
+
+import Clash.Prelude
+
+import Data.Data (Proxy (..))
+import Data.Either (isLeft)
+import Data.Maybe (isJust)
+import Data.String.Interpolate (i)
+import Data.Typeable (Typeable)
+import Protocols
+import Protocols.Axi4.ReadAddress (
+  Axi4ReadAddress,
+  KnownAxi4ReadAddressConfig,
+  M2S_ReadAddress (..),
+ )
+import Protocols.Axi4.ReadData (Axi4ReadData, KnownAxi4ReadDataConfig, S2M_ReadData (..))
+import Protocols.Axi4.Stream (Axi4Stream, Axi4StreamM2S, Axi4StreamS2M, KnownAxi4StreamConfig)
+import Protocols.Axi4.WriteAddress (
+  Axi4WriteAddress,
+  KnownAxi4WriteAddressConfig,
+  M2S_WriteAddress (..),
+ )
+import Protocols.Axi4.WriteData (
+  Axi4WriteData,
+  KnownAxi4WriteDataConfig,
+  M2S_WriteData (..),
+  S2M_WriteData,
+ )
+import Protocols.Axi4.WriteResponse (
+  Axi4WriteResponse,
+  KnownAxi4WriteResponseConfig,
+  S2M_WriteResponse (..),
+ )
+import Protocols.Extra.TH
+import Protocols.Internal (reverseCircuit)
+import Protocols.Internal.Types.Extra (TraceC)
+import Protocols.PacketStream (PacketStream, PacketStreamM2S, PacketStreamS2M)
+import Protocols.ReqResp (ReqResp)
+import Protocols.Spi (Spi)
+import Protocols.Vec (vecCircuits)
+import Protocols.Wishbone
+
+import qualified Clash.Prelude as C
+import qualified Clash.Shockwaves as Shock
+import qualified Clash.Shockwaves.Trace.CRE as Shock
+import qualified Debug.Trace as Debug
+import qualified Protocols.Axi4.Common as Axi4
+import qualified Protocols.Axi4.ReadAddress as Axi4
+import qualified Protocols.Axi4.ReadData as Axi4
+import qualified Protocols.Axi4.WriteAddress as Axi4
+import qualified Protocols.Axi4.WriteData as Axi4
+import qualified Protocols.Axi4.WriteResponse as Axi4
+import qualified Protocols.Internal.Types.Extra as Trace (TraceC (..))
+
+instance TraceC () where
+  shock _ = idC
+  signal _ = idC
+  names _ _ = []
+  trace _ = idC
+
+instance (TraceC a, TraceC b) => TraceC (a, b) where
+  shock name = circuit $ \(a, b) -> do
+    a' <- Trace.shock (name <> "_0") -< a
+    b' <- Trace.shock (name <> "_1") -< b
+    idC -< (a', b')
+  signal name = circuit $ \(a, b) -> do
+    a' <- Trace.signal (name <> "_0") -< a
+    b' <- Trace.signal (name <> "_1") -< b
+    idC -< (a', b')
+  names _ name =
+    (Trace.names (Proxy @a) (name <> "_0"))
+      <> (Trace.names (Proxy @b) (name <> "_1"))
+  trace name = circuit $ \(a, b) -> do
+    a' <- Trace.trace (name <> "_0") -< a
+    b' <- Trace.trace (name <> "_1") -< b
+    idC -< (a', b')
+
+$(traceCTupleInstances 3 3)
+
+instance (KnownNat n, TraceC p) => TraceC (Vec n p) where
+  shock name = vecCircuits (fmap (\n -> Trace.shock (name <> "_" <> show n)) indicesI)
+  signal name = vecCircuits (fmap (\n -> Trace.signal (name <> "_" <> show n)) indicesI)
+  names _ name = fmap (<> "n") (Trace.names (Proxy @p) name)
+  trace name = vecCircuits (fmap (\n -> Trace.trace (name <> "_" <> show n)) indicesI)
+
+instance (KnownDomain dom, NFDataX a, Shock.Waveform a) => TraceC (CSignal dom a) where
+  shock name = applyC (Shock.traceSignal name) id
+  signal name = applyC (C.traceSignal name) id
+  names _ name = [name]
+  trace name = applyC (Debug.trace name) id
+
+instance (KnownDomain dom) => TraceC (Clock dom) where
+  shock name = applyC (Shock.traceClock name) id
+  signal name = error (name <> ": Tracing clocks with Trace.signal is not supported, use Trace.shock instead.")
+  names _ name = [name]
+  trace name = error (name <> ": Clocks are only used for wiring and can not be traced with Debug.Trace.trace")
+
+instance (KnownDomain dom) => TraceC (Reset dom) where
+  shock name = applyC (Shock.traceReset name) id
+  signal name = applyC (C.unsafeToReset . C.traceSignal name . C.unsafeFromReset) id
+  names _ name = [name]
+  trace name = applyC (C.unsafeFromActiveHigh . fmap printMsg . C.unsafeToActiveHigh) id
+   where
+    printMsg r = Debug.trace [i|#{name}: #{resolveReset r}|] r
+    resolveReset r
+      | isLeft $ hasX r = "Undefined"
+      | r = "Asserted"
+      | otherwise = "Deasserted"
+
+instance (KnownDomain dom) => TraceC (Enable dom) where
+  shock name = applyC (Shock.traceEnable name) id
+  signal name = applyC (C.toEnable . C.traceSignal name . C.fromEnable) id
+  names _ name = [name]
+  trace name = applyC (C.toEnable . fmap printMsg . C.fromEnable) id
+   where
+    printMsg e = Debug.trace [i|#{name}: #{resolveEnable e}|] e
+    resolveEnable e
+      | isLeft $ hasX e = "Undefined"
+      | e = "Enabled"
+      | otherwise = "Disabled"
+
+instance (TraceC a) => TraceC (Reverse a) where
+  shock name = reverseCircuit (Trace.shock name)
+  signal name = reverseCircuit (Trace.signal name)
+  names _ name = Trace.names (Proxy @a) name
+  trace name = reverseCircuit (Trace.trace name)
+
+-- Df derivations
+deriving newtype instance Shock.Waveform Ack
+
+-- Wishbone derivations
+deriving anyclass instance Shock.Waveform (CycleTypeIdentifier)
+deriving anyclass instance Shock.Waveform (BurstTypeExtension)
+deriving anyclass instance (KnownNat nBytes, KnownNat aw) => Shock.Waveform (WishboneM2S aw nBytes)
+deriving anyclass instance (KnownNat nBytes) => Shock.Waveform (WishboneS2M nBytes)
+
+-- Packetstream derivations
+deriving anyclass instance (KnownNat w, BitPack meta) => BitPack (PacketStreamM2S w meta)
+deriving anyclass instance BitPack PacketStreamS2M
+deriving anyclass instance
+  (KnownNat w, BitPack meta, Shock.Waveform meta) => Shock.Waveform (PacketStreamM2S w meta)
+deriving anyclass instance Shock.Waveform (PacketStreamS2M)
+
+-- AXI4 derivations
+deriving anyclass instance
+  (KnownAxi4StreamConfig conf, BitPack userType) => BitPack (Axi4StreamM2S conf userType)
+deriving anyclass instance
+  ( KnownAxi4StreamConfig conf
+  , Typeable conf
+  , BitPack userType
+  , Shock.Waveform userType
+  , Typeable userType
+  ) =>
+  Shock.Waveform (Axi4StreamM2S conf userType)
+deriving anyclass instance BitPack Axi4StreamS2M
+deriving anyclass instance Shock.Waveform Axi4StreamS2M
+deriving anyclass instance
+  (KnownAxi4ReadDataConfig conf, BitPack dataType, BitPack userType) =>
+  BitPack (S2M_ReadData conf userType dataType)
+deriving anyclass instance ShowX (S2M_WriteData)
+deriving instance (Typeable (Proxy a), BitPack (Proxy a)) => Shock.Waveform (Proxy a)
+deriving anyclass instance Shock.Waveform Axi4.S2M_ReadAddress
+deriving anyclass instance Shock.Waveform Axi4.S2M_WriteAddress
+deriving anyclass instance Shock.Waveform Axi4.M2S_ReadData
+deriving anyclass instance Shock.Waveform Axi4.S2M_WriteData
+deriving anyclass instance Shock.Waveform Axi4.M2S_WriteResponse
+
+instance
+  ( KnownDomain dom
+  , NFDataX a
+  , ShowX a
+  , Shock.Waveform a
+  , Shock.Waveform (Maybe a)
+  , Typeable a
+  , BitPack a
+  ) =>
+  TraceC (Df dom a)
+  where
+  shock name =
+    Circuit $ \(fwd, bwd) ->
+      (Shock.traceSignal (name <> "_ack") bwd, Shock.traceSignal (name <> "_dat") fwd)
+  signal name =
+    Circuit $ \(fwd, bwd) ->
+      (C.traceSignal (name <> "_ack") bwd, C.traceSignal (name <> "_dat") fwd)
+  names _ name = [name <> "_dat", name <> "_ack"]
+  trace name = Circuit (unbundle . fmap go . bundle)
+   where
+    go ~(m2s, s2m0)
+      | isJust m2s =
+          let msg = [i| #{name}: #{showX m2s}, #{showX s2m0}|]
+              s2m1 = Debug.trace msg s2m0
+           in (s2m1, m2s)
+      | otherwise = (s2m0, m2s)
+
+instance (KnownDomain dom, KnownNat nBytes, KnownNat aw) => TraceC (Wishbone dom mode aw nBytes) where
+  shock name = applyC (Shock.traceSignal (name <> "_m2s")) (Shock.traceSignal (name <> "_s2m"))
+  signal name = applyC (C.traceSignal (name <> "_m2s")) (C.traceSignal (name <> "_s2m"))
+  names _ name = [name <> "_m2s", name <> "_s2m"]
+  trace name = Circuit (unbundle . fmap go . bundle)
+   where
+    go ~(m2s, s2m)
+      | m2s.busCycle && m2s.strobe =
+          (Debug.trace ([i| #{name}: #{showX m2s}, #{showX s2m} |]) s2m, m2s)
+      | otherwise = (s2m, m2s)
+
+instance
+  ( KnownDomain dom
+  , NFDataX req
+  , NFDataX resp
+  , ShowX req
+  , ShowX resp
+  , Shock.Waveform (Maybe req)
+  , Shock.Waveform (Maybe resp)
+  , Typeable req
+  , Typeable resp
+  , BitPack req
+  , BitPack resp
+  ) =>
+  TraceC (ReqResp dom req resp)
+  where
+  shock name =
+    Circuit $ \(fwd, bwd) ->
+      (Shock.traceSignal (name <> "_resp") bwd, Shock.traceSignal (name <> "_req") fwd)
+  signal name =
+    Circuit $ \(fwd, bwd) ->
+      (C.traceSignal (name <> "_resp") bwd, C.traceSignal (name <> "_req") fwd)
+  names _ name = [name <> "_req", name <> "_resp"]
+  trace name = Circuit (unbundle . fmap go . bundle)
+   where
+    go ~(m2s0, s2m)
+      | isJust m2s0 =
+          let msg = [i| #{name}: req = #{showX m2s0}, resp = #{showX s2m}|]
+              m2s1 = Debug.trace msg m2s0
+           in (s2m, m2s1)
+      | otherwise = (s2m, m2s0)
+
+instance (KnownDomain dom) => TraceC (Spi dom) where
+  -- Unique names for request and response signals are needed to distinguish them for the
+  -- tracing infastructure.
+  shock name =
+    Circuit $ \(fwd, bwd) ->
+      (Shock.traceSignal (name <> "_s2m") bwd, Shock.traceSignal (name <> "_m2s") fwd)
+  signal name =
+    Circuit $ \(fwd, bwd) ->
+      (C.traceSignal (name <> "_s2m") bwd, C.traceSignal (name <> "_m2s") fwd)
+  names _ name = [name <> "_m2s", name <> "_s2m"]
+  trace name = Circuit (unbundle . fmap go . bundle)
+   where
+    go ~(m2s, s2m) = (s2m, Debug.trace ([i| #{name}: #{showX m2s}, #{showX s2m} |]) m2s)
+
+instance
+  ( KnownDomain dom
+  , KnownNat w
+  , Shock.Waveform meta
+  , BitPack meta
+  , NFDataX meta
+  , Typeable meta
+  , ShowX meta
+  ) =>
+  TraceC (PacketStream dom w meta)
+  where
+  shock name =
+    Circuit $ \(fwd, bwd) ->
+      (Shock.traceSignal (name <> "_bwd") bwd, Shock.traceSignal (name <> "_fwd") fwd)
+  signal name =
+    Circuit $ \(fwd, bwd) ->
+      (C.traceSignal (name <> "_bwd") bwd, C.traceSignal (name <> "_fwd") fwd)
+  names _ name = [name <> "_fwd", name <> "_bwd"]
+  trace name = Circuit (unbundle . fmap go . bundle)
+   where
+    go ~(m2s0, s2m)
+      | isJust m2s0 =
+          let msg = [i| #{name}: #{showX m2s0}, #{showX s2m}|]
+              m2s1 = Debug.trace msg m2s0
+           in (s2m, m2s1)
+      | otherwise = (s2m, m2s0)
+
+-- Axi4Stream
+instance
+  ( KnownDomain dom
+  , KnownAxi4StreamConfig conf
+  , Typeable conf
+  , Shock.Waveform userType
+  , BitPack userType
+  , NFDataX userType
+  , Typeable userType
+  , ShowX userType
+  ) =>
+  TraceC (Axi4Stream dom conf userType)
+  where
+  shock name =
+    Circuit $ \(fwd, bwd) ->
+      (Shock.traceSignal (name <> "_bwd") bwd, Shock.traceSignal (name <> "_fwd") fwd)
+  signal name =
+    Circuit $ \(fwd, bwd) ->
+      (C.traceSignal (name <> "_bwd") bwd, C.traceSignal (name <> "_fwd") fwd)
+  names _ name = [name <> "_fwd", name <> "_bwd"]
+  trace name = Circuit (unbundle . fmap go . bundle)
+   where
+    go ~(m2s0, s2m)
+      | isJust m2s0 =
+          let msg = [i| #{name}: #{showX m2s0}, #{showX s2m}|]
+              m2s1 = Debug.trace msg m2s0
+           in (s2m, m2s1)
+      | otherwise = (s2m, m2s0)
+
+deriving instance
+  ( KnownAxi4ReadAddressConfig conf
+  , Typeable conf
+  , Shock.Waveform userType
+  , Shock.Waveform (Axi4.RegionType (Axi4.ARKeepRegion conf))
+  , Shock.Waveform (Axi4.BurstLengthType (Axi4.ARKeepBurstLength conf))
+  , Shock.Waveform (Axi4.SizeType (Axi4.ARKeepSize conf))
+  , Shock.Waveform (Axi4.BurstType (Axi4.ARKeepBurst conf))
+  , Shock.Waveform (Axi4.LockType (Axi4.ARKeepLock conf))
+  , Shock.Waveform (Axi4.ArCacheType (Axi4.ARKeepCache conf))
+  , Shock.Waveform (Axi4.PermissionsType (Axi4.ARKeepPermissions conf))
+  , Shock.Waveform (Axi4.QosType (Axi4.ARKeepQos conf))
+  ) =>
+  Shock.Waveform (M2S_ReadAddress conf userType)
+
+deriving instance
+  ( KnownAxi4WriteAddressConfig conf
+  , Typeable conf
+  , Shock.Waveform userType
+  , Shock.Waveform (Axi4.RegionType (Axi4.AWKeepRegion conf))
+  , Shock.Waveform (Axi4.BurstLengthType (Axi4.AWKeepBurstLength conf))
+  , Shock.Waveform (Axi4.SizeType (Axi4.AWKeepSize conf))
+  , Shock.Waveform (Axi4.BurstType (Axi4.AWKeepBurst conf))
+  , Shock.Waveform (Axi4.LockType (Axi4.AWKeepLock conf))
+  , Shock.Waveform (Axi4.AwCacheType (Axi4.AWKeepCache conf))
+  , Shock.Waveform (Axi4.PermissionsType (Axi4.AWKeepPermissions conf))
+  , Shock.Waveform (Axi4.QosType (Axi4.AWKeepQos conf))
+  ) =>
+  Shock.Waveform (M2S_WriteAddress conf userType)
+
+deriving instance
+  ( KnownAxi4ReadDataConfig conf
+  , Typeable conf
+  , Shock.Waveform userType
+  , Shock.Waveform dataType
+  , Shock.Waveform (Axi4.ResponseType (Axi4.RKeepResponse conf))
+  ) =>
+  Shock.Waveform (S2M_ReadData conf userType dataType)
+
+deriving instance
+  ( KnownAxi4WriteDataConfig conf
+  , Typeable conf
+  , Shock.Waveform userType
+  , Shock.Waveform (Axi4.StrobeDataType (Axi4.WKeepStrobe conf))
+  ) =>
+  Shock.Waveform (M2S_WriteData conf userType)
+
+deriving instance
+  ( KnownAxi4WriteResponseConfig conf
+  , Typeable conf
+  , Shock.Waveform userType
+  , Shock.Waveform (Axi4.ResponseType (Axi4.BKeepResponse conf))
+  ) =>
+  Shock.Waveform (S2M_WriteResponse conf userType)
+
+-- Axi4ReadAddress
+instance
+  ( KnownDomain dom
+  , KnownAxi4ReadAddressConfig conf
+  , NFDataX userType
+  , ShowX userType
+  , BitPack userType
+  , Typeable userType
+  , Typeable conf
+  , Shock.Waveform userType
+  , Shock.Waveform (Axi4.RegionType (Axi4.ARKeepRegion conf))
+  , Shock.Waveform (Axi4.BurstLengthType (Axi4.ARKeepBurstLength conf))
+  , Shock.Waveform (Axi4.SizeType (Axi4.ARKeepSize conf))
+  , Shock.Waveform (Axi4.BurstType (Axi4.ARKeepBurst conf))
+  , Shock.Waveform (Axi4.LockType (Axi4.ARKeepLock conf))
+  , Shock.Waveform (Axi4.ArCacheType (Axi4.ARKeepCache conf))
+  , Shock.Waveform (Axi4.PermissionsType (Axi4.ARKeepPermissions conf))
+  , Shock.Waveform (Axi4.QosType (Axi4.ARKeepQos conf))
+  ) =>
+  TraceC (Axi4ReadAddress dom conf userType)
+  where
+  shock name =
+    Circuit $ \(fwd, bwd) ->
+      (Shock.traceSignal (name <> "_bwd") bwd, Shock.traceSignal (name <> "_fwd") fwd)
+  signal name =
+    Circuit $ \(fwd, bwd) ->
+      (C.traceSignal (name <> "_bwd") bwd, C.traceSignal (name <> "_fwd") fwd)
+  names _ name = [name <> "_fwd", name <> "_bwd"]
+  trace name = Circuit (unbundle . fmap go . bundle)
+   where
+    go ~(m2s, s2m) = case m2s of
+      M2S_NoReadAddress -> (s2m, m2s)
+      M2S_ReadAddress{} ->
+        (Debug.trace ([i| #{name}: #{showX m2s}, #{showX s2m}|]) s2m, m2s)
+
+-- Axi4WriteAddress
+instance
+  ( KnownDomain dom
+  , KnownAxi4WriteAddressConfig conf
+  , NFDataX userType
+  , ShowX userType
+  , BitPack userType
+  , Typeable userType
+  , Typeable conf
+  , Shock.Waveform userType
+  , Shock.Waveform (Axi4.RegionType (Axi4.AWKeepRegion conf))
+  , Shock.Waveform (Axi4.BurstLengthType (Axi4.AWKeepBurstLength conf))
+  , Shock.Waveform (Axi4.SizeType (Axi4.AWKeepSize conf))
+  , Shock.Waveform (Axi4.BurstType (Axi4.AWKeepBurst conf))
+  , Shock.Waveform (Axi4.LockType (Axi4.AWKeepLock conf))
+  , Shock.Waveform (Axi4.AwCacheType (Axi4.AWKeepCache conf))
+  , Shock.Waveform (Axi4.PermissionsType (Axi4.AWKeepPermissions conf))
+  , Shock.Waveform (Axi4.QosType (Axi4.AWKeepQos conf))
+  ) =>
+  TraceC (Axi4WriteAddress dom conf userType)
+  where
+  shock name =
+    Circuit $ \(fwd, bwd) ->
+      (Shock.traceSignal (name <> "_bwd") bwd, Shock.traceSignal (name <> "_fwd") fwd)
+  signal name =
+    Circuit $ \(fwd, bwd) ->
+      (C.traceSignal (name <> "_bwd") bwd, C.traceSignal (name <> "_fwd") fwd)
+  names _ name = [name <> "_fwd", name <> "_bwd"]
+  trace name = Circuit (unbundle . fmap go . bundle)
+   where
+    go ~(m2s, s2m) = case m2s of
+      M2S_NoWriteAddress -> (s2m, m2s)
+      M2S_WriteAddress{} ->
+        (Debug.trace ([i| #{name}: #{showX m2s}, #{showX s2m}|]) s2m, m2s)
+
+-- Axi4ReadData (reversed: Fwd = S2M_ReadData, Bwd = M2S_ReadData)
+instance
+  ( KnownDomain dom
+  , KnownAxi4ReadDataConfig conf
+  , NFDataX userType
+  , NFDataX dataType
+  , ShowX userType
+  , ShowX dataType
+  , BitPack dataType
+  , BitPack userType
+  , Typeable userType
+  , Typeable dataType
+  , Typeable conf
+  , Shock.Waveform userType
+  , Shock.Waveform dataType
+  , Shock.Waveform (Axi4.ResponseType (Axi4.RKeepResponse conf))
+  ) =>
+  TraceC (Axi4ReadData dom conf userType dataType)
+  where
+  shock name =
+    Circuit $ \(fwd, bwd) ->
+      (Shock.traceSignal (name <> "_bwd") bwd, Shock.traceSignal (name <> "_fwd") fwd)
+  signal name =
+    Circuit $ \(fwd, bwd) ->
+      (C.traceSignal (name <> "_bwd") bwd, C.traceSignal (name <> "_fwd") fwd)
+  names _ name = [name <> "_fwd", name <> "_bwd"]
+  trace name = Circuit (unbundle . fmap go . bundle)
+   where
+    go ~(s2m, m2s) = case s2m of
+      S2M_NoReadData -> (m2s, s2m)
+      S2M_ReadData{} ->
+        (Debug.trace ([i| #{name}: #{showX s2m}, #{showX m2s}|]) m2s, s2m)
+
+-- Axi4WriteData
+instance
+  ( KnownDomain dom
+  , KnownAxi4WriteDataConfig conf
+  , NFDataX userType
+  , ShowX userType
+  , BitPack userType
+  , Typeable userType
+  , Typeable conf
+  , Shock.Waveform userType
+  , Shock.Waveform (Axi4.StrobeDataType (Axi4.WKeepStrobe conf))
+  ) =>
+  TraceC (Axi4WriteData dom conf userType)
+  where
+  shock name =
+    Circuit $ \(fwd, bwd) ->
+      (Shock.traceSignal (name <> "_bwd") bwd, Shock.traceSignal (name <> "_fwd") fwd)
+  signal name =
+    Circuit $ \(fwd, bwd) ->
+      (C.traceSignal (name <> "_bwd") bwd, C.traceSignal (name <> "_fwd") fwd)
+  names _ name = [name <> "_fwd", name <> "_bwd"]
+  trace name = Circuit (unbundle . fmap go . bundle)
+   where
+    go ~(m2s, s2m) = case m2s of
+      M2S_NoWriteData -> (s2m, m2s)
+      M2S_WriteData{} ->
+        (Debug.trace ([i| #{name}: #{showX m2s}, #{showX s2m}|]) s2m, m2s)
+
+-- Axi4WriteResponse (reversed: Fwd = S2M_WriteResponse, Bwd = M2S_WriteResponse)
+instance
+  ( KnownDomain dom
+  , KnownAxi4WriteResponseConfig conf
+  , NFDataX userType
+  , ShowX userType
+  , BitPack userType
+  , Typeable userType
+  , Typeable conf
+  , Shock.Waveform userType
+  , Shock.Waveform (Axi4.ResponseType (Axi4.BKeepResponse conf))
+  ) =>
+  TraceC (Axi4WriteResponse dom conf userType)
+  where
+  shock name =
+    Circuit $ \(fwd, bwd) ->
+      (Shock.traceSignal (name <> "_bwd") bwd, Shock.traceSignal (name <> "_fwd") fwd)
+  signal name =
+    Circuit $ \(fwd, bwd) ->
+      (C.traceSignal (name <> "_bwd") bwd, C.traceSignal (name <> "_fwd") fwd)
+  names _ name = [name <> "_fwd", name <> "_bwd"]
+  trace name = Circuit (unbundle . fmap go . bundle)
+   where
+    go ~(s2m, m2s) = case s2m of
+      S2M_NoWriteResponse -> (m2s, s2m)
+      S2M_WriteResponse{} ->
+        (Debug.trace ([i| #{name}: #{showX s2m}, #{showX m2s}|]) m2s, s2m)

--- a/bittide-extra/tests/unittests/Main.hs
+++ b/bittide-extra/tests/unittests/Main.hs
@@ -14,6 +14,7 @@ import qualified Tests.Clash.Cores.Xilinx.Xpm.Cdc.Extra
 import qualified Tests.Numeric.Extra
 import qualified Tests.Protocols.BiDf
 import qualified Tests.Protocols.Df.Extra
+import qualified Tests.Protocols.Extra
 import qualified Tests.Protocols.ReqResp
 
 setDefaultHedgehogTestLimit :: HedgehogTestLimit -> HedgehogTestLimit
@@ -28,6 +29,7 @@ tests =
     , Tests.Clash.Cores.Xilinx.Xpm.Cdc.Extra.tests
     , Tests.Protocols.BiDf.tests
     , Tests.Protocols.Df.Extra.tests
+    , Tests.Protocols.Extra.tests
     , Tests.Protocols.ReqResp.tests
     ]
 

--- a/bittide-extra/tests/unittests/Tests/Protocols/Extra.hs
+++ b/bittide-extra/tests/unittests/Tests/Protocols/Extra.hs
@@ -1,0 +1,509 @@
+-- SPDX-FileCopyrightText: 2025 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+
+module Tests.Protocols.Extra (tests) where
+
+import Clash.Prelude
+
+import Data.Data (Proxy (..))
+import Data.Either (isRight)
+import Data.List (isInfixOf)
+import Protocols
+import Protocols.Extra ()
+import Test.Tasty (DependencyType (..), TestTree, dependentTestGroup)
+import Test.Tasty.HUnit (assertBool, testCase, (@?=))
+
+import qualified Clash.Prelude as C
+import qualified Clash.Shockwaves.Trace as Shock
+import qualified Clash.Signal.Trace as Trace
+import qualified Data.Text as Text
+import qualified Protocols.TraceC as Trace
+import qualified Prelude as P
+
+import Protocols.Axi4.ReadAddress (
+  Axi4ReadAddress,
+  Axi4ReadAddressConfig (..),
+  M2S_ReadAddress (..),
+  S2M_ReadAddress (..),
+ )
+import Protocols.Axi4.ReadData (
+  Axi4ReadData,
+  Axi4ReadDataConfig (..),
+  M2S_ReadData (..),
+  S2M_ReadData (..),
+ )
+import Protocols.Axi4.Stream (
+  Axi4Stream,
+  Axi4StreamConfig (..),
+  Axi4StreamM2S (..),
+  Axi4StreamS2M (..),
+ )
+import Protocols.Axi4.WriteAddress (
+  Axi4WriteAddress,
+  Axi4WriteAddressConfig (..),
+  M2S_WriteAddress (..),
+  S2M_WriteAddress (..),
+ )
+import Protocols.Axi4.WriteData (
+  Axi4WriteData,
+  Axi4WriteDataConfig (..),
+  M2S_WriteData (..),
+  S2M_WriteData (..),
+ )
+import Protocols.Axi4.WriteResponse (
+  Axi4WriteResponse,
+  Axi4WriteResponseConfig (..),
+  M2S_WriteResponse (..),
+  S2M_WriteResponse (..),
+ )
+import Protocols.BiDf (BiDf)
+import Protocols.Df ()
+import Protocols.PacketStream (PacketStream, PacketStreamM2S (..), PacketStreamS2M (..))
+import Protocols.Spi (Spi)
+import qualified Protocols.Spi as Spi
+import Protocols.Wishbone
+
+-- * Helpers
+
+nCycles :: Int
+nCycles = 100
+
+-- | Check that a Shock VCD text contains all the given signal names.
+assertVcdContains :: Either String (Text.Text, a) -> [String] -> IO ()
+assertVcdContains result names = do
+  assertBool "dumpVCD succeeded" (isRight result)
+  case result of
+    Right (vcdText, _) ->
+      let vcd = Text.unpack vcdText
+       in P.mapM_ (\n -> assertBool ("VCD contains " <> n) (n `isInfixOf` vcd)) names
+    Left _ -> error "Expected Right from dumpVCD"
+
+-- | Check that a Clash VCD text contains all the given signal names.
+assertClashVcdContains :: Either String Text.Text -> [String] -> IO ()
+assertClashVcdContains result names = do
+  assertBool "dumpVCD succeeded" (isRight result)
+  case result of
+    Right vcdText ->
+      let vcd = Text.unpack vcdText
+       in P.mapM_ (\n -> assertBool ("VCD contains " <> n) (n `isInfixOf` vcd)) names
+    Left _ -> error "Expected Right from dumpVCD"
+
+-- * Type aliases for concrete AXI4 configs
+
+type SimpleAxi4StreamConf = 'Axi4StreamConfig 1 0 0
+
+type SimpleAxi4ReadAddrConf =
+  'Axi4ReadAddressConfig
+    'False
+    'False
+    0
+    8
+    'False
+    'False
+    'False
+    'False
+    'False
+    'False
+
+type SimpleAxi4WriteAddrConf =
+  'Axi4WriteAddressConfig
+    'False
+    'False
+    0
+    8
+    'False
+    'False
+    'False
+    'False
+    'False
+    'False
+
+type SimpleAxi4ReadDataConf = 'Axi4ReadDataConfig 'False 0
+type SimpleAxi4WriteDataConf = 'Axi4WriteDataConfig 'False 1
+type SimpleAxi4WriteRespConf = 'Axi4WriteResponseConfig 'False 0
+
+type TestBiDf = BiDf System (Unsigned 8) (Unsigned 8)
+type TestTriple = (Df System (Unsigned 8), Spi System, PacketStream System 1 ())
+-- * Tests
+
+-- ** Trace.names tests
+
+case_names :: IO ()
+case_names = do
+  Trace.names (Proxy @(Wishbone System Standard 8 4)) "wb" @?= ["wb_m2s", "wb_s2m"]
+  Trace.names (Proxy @(Df System (Unsigned 8))) "df" @?= ["df_dat", "df_ack"]
+  Trace.names (Proxy @(Spi System)) "spi" @?= ["spi_m2s", "spi_s2m"]
+  Trace.names (Proxy @(PacketStream System 1 ())) "ps" @?= ["ps_fwd", "ps_bwd"]
+  Trace.names (Proxy @(Axi4Stream System SimpleAxi4StreamConf ())) "as" @?= ["as_fwd", "as_bwd"]
+  Trace.names (Proxy @(Axi4ReadAddress System SimpleAxi4ReadAddrConf ())) "ar"
+    @?= ["ar_fwd", "ar_bwd"]
+  Trace.names (Proxy @(Axi4WriteAddress System SimpleAxi4WriteAddrConf ())) "aw"
+    @?= ["aw_fwd", "aw_bwd"]
+  Trace.names (Proxy @(Axi4ReadData System SimpleAxi4ReadDataConf () (BitVector 8))) "rd"
+    @?= ["rd_fwd", "rd_bwd"]
+  Trace.names (Proxy @(Axi4WriteData System SimpleAxi4WriteDataConf ())) "wd" @?= ["wd_fwd", "wd_bwd"]
+  Trace.names (Proxy @(Axi4WriteResponse System SimpleAxi4WriteRespConf ())) "wr"
+    @?= ["wr_fwd", "wr_bwd"]
+  Trace.names (Proxy @TestBiDf) "bd"
+    @?= ["bd_0_dat", "bd_0_ack", "bd_1_dat", "bd_1_ack"]
+  Trace.names (Proxy @TestTriple) "t3"
+    @?= [ "t3_0_dat"
+        , "t3_0_ack"
+        , "t3_1_m2s"
+        , "t3_1_s2m"
+        , "t3_2_fwd"
+        , "t3_2_bwd"
+        ]
+
+-- ** Trace.shock tests
+
+-- For protocols that support Trace.shock: simulate, dump VCD, check signal names appear.
+
+case_shock_wishbone :: IO ()
+case_shock_wishbone = do
+  let names = Trace.names (Proxy @(Wishbone System Standard 8 4)) "wb"
+      fwd = C.fromList (P.repeat (emptyWishboneM2S @8 @4))
+      bwd = C.fromList (P.repeat emptyWishboneS2M)
+      ckt = Trace.shock @(Wishbone System Standard 8 4) "wb"
+      (bwdOut, fwdOut) = toSignals ckt (fwd, bwd)
+      combined = C.bundle (fwdOut, bwdOut)
+  result <- Shock.dumpVCD (0, nCycles) combined names
+  assertVcdContains result names
+
+case_shock_df :: IO ()
+case_shock_df = do
+  let names = Trace.names (Proxy @(Df System (Unsigned 8))) "df"
+      fwd = C.fromList (P.repeat (Just (1 :: Unsigned 8)))
+      bwd = C.fromList (P.repeat (Ack True))
+      ckt = Trace.shock @(Df System (Unsigned 8)) "df"
+      (bwdOut, fwdOut) = toSignals ckt (fwd, bwd)
+      combined = C.bundle (fwdOut, bwdOut)
+  result <- Shock.dumpVCD (0, nCycles) combined names
+  assertVcdContains result names
+
+case_shock_spi :: IO ()
+case_shock_spi = do
+  let names = Trace.names (Proxy @(Spi System)) "spi"
+      fwd = C.fromList (P.repeat (Spi.M2S False 0 True))
+      bwd = C.fromList (P.repeat (Spi.S2M 0))
+      ckt = Trace.shock @(Spi System) "spi"
+      (bwdOut, fwdOut) = toSignals ckt (fwd, bwd)
+      combined = C.bundle (fwdOut, bwdOut)
+  result <- Shock.dumpVCD (0, nCycles) combined names
+  assertVcdContains result names
+
+case_shock_packetstream :: IO ()
+case_shock_packetstream = do
+  let names = Trace.names (Proxy @(PacketStream System 1 ())) "ps"
+      fwd = C.fromList (P.repeat (Just (PacketStreamM2S (0 :> Nil) Nothing () False)))
+      bwd = C.fromList (P.repeat (PacketStreamS2M True))
+      ckt = Trace.shock @(PacketStream System 1 ()) "ps"
+      (bwdOut, fwdOut) = toSignals ckt (fwd, bwd)
+      combined = C.bundle (fwdOut, bwdOut)
+  result <- Shock.dumpVCD (0, nCycles) combined names
+  assertVcdContains result names
+
+case_shock_axi4stream :: IO ()
+case_shock_axi4stream = do
+  let names = Trace.names (Proxy @(Axi4Stream System SimpleAxi4StreamConf ())) "as"
+      m2s = Axi4StreamM2S (0 :> Nil) (True :> Nil) (True :> Nil) False 0 0 ()
+      fwd = C.fromList (P.repeat (Just m2s))
+      bwd = C.fromList (P.repeat (Axi4StreamS2M True))
+      ckt = Trace.shock @(Axi4Stream System SimpleAxi4StreamConf ()) "as"
+      (bwdOut, fwdOut) = toSignals ckt (fwd, bwd)
+      combined = C.bundle (fwdOut, bwdOut)
+  result <- Shock.dumpVCD (0, nCycles) combined names
+  assertVcdContains result names
+
+case_shock_axi4readaddress :: IO ()
+case_shock_axi4readaddress = do
+  let names = Trace.names (Proxy @(Axi4ReadAddress System SimpleAxi4ReadAddrConf ())) "ar"
+      fwd = C.fromList (P.repeat M2S_NoReadAddress)
+      bwd = C.fromList (P.repeat (S2M_ReadAddress True))
+      ckt = Trace.shock @(Axi4ReadAddress System SimpleAxi4ReadAddrConf ()) "ar"
+      (bwdOut, fwdOut) = toSignals ckt (fwd, bwd)
+      combined = C.bundle (fwdOut, bwdOut)
+  result <- Shock.dumpVCD (0, nCycles) combined names
+  assertVcdContains result names
+
+case_shock_axi4writeaddress :: IO ()
+case_shock_axi4writeaddress = do
+  let names = Trace.names (Proxy @(Axi4WriteAddress System SimpleAxi4WriteAddrConf ())) "aw"
+      fwd = C.fromList (P.repeat M2S_NoWriteAddress)
+      bwd = C.fromList (P.repeat (S2M_WriteAddress True))
+      ckt = Trace.shock @(Axi4WriteAddress System SimpleAxi4WriteAddrConf ()) "aw"
+      (bwdOut, fwdOut) = toSignals ckt (fwd, bwd)
+      combined = C.bundle (fwdOut, bwdOut)
+  result <- Shock.dumpVCD (0, nCycles) combined names
+  assertVcdContains result names
+
+case_shock_axi4readdata :: IO ()
+case_shock_axi4readdata = do
+  let names = Trace.names (Proxy @(Axi4ReadData System SimpleAxi4ReadDataConf () (BitVector 8))) "rd"
+      fwd = C.fromList (P.repeat (S2M_NoReadData @SimpleAxi4ReadDataConf @() @(BitVector 8)))
+      bwd = C.fromList (P.repeat (M2S_ReadData True))
+      ckt = Trace.shock @(Axi4ReadData System SimpleAxi4ReadDataConf () (BitVector 8)) "rd"
+      (bwdOut, fwdOut) = toSignals ckt (fwd, bwd)
+      combined = C.bundle (fwdOut, bwdOut)
+  result <- Shock.dumpVCD (0, nCycles) combined names
+  assertVcdContains result names
+
+case_shock_axi4writedata :: IO ()
+case_shock_axi4writedata = do
+  let names = Trace.names (Proxy @(Axi4WriteData System SimpleAxi4WriteDataConf ())) "wd"
+      fwd = C.fromList (P.repeat (M2S_NoWriteData @SimpleAxi4WriteDataConf @()))
+      bwd = C.fromList (P.repeat (S2M_WriteData True))
+      ckt = Trace.shock @(Axi4WriteData System SimpleAxi4WriteDataConf ()) "wd"
+      (bwdOut, fwdOut) = toSignals ckt (fwd, bwd)
+      combined = C.bundle (fwdOut, bwdOut)
+  result <- Shock.dumpVCD (0, nCycles) combined names
+  assertVcdContains result names
+
+case_shock_axi4writeresponse :: IO ()
+case_shock_axi4writeresponse = do
+  let names = Trace.names (Proxy @(Axi4WriteResponse System SimpleAxi4WriteRespConf ())) "wr"
+      fwd = C.fromList (P.repeat (S2M_NoWriteResponse @SimpleAxi4WriteRespConf @()))
+      bwd = C.fromList (P.repeat (M2S_WriteResponse True))
+      ckt = Trace.shock @(Axi4WriteResponse System SimpleAxi4WriteRespConf ()) "wr"
+      (bwdOut, fwdOut) = toSignals ckt (fwd, bwd)
+      combined = C.bundle (fwdOut, bwdOut)
+  result <- Shock.dumpVCD (0, nCycles) combined names
+  assertVcdContains result names
+
+-- ** traceSignal tests
+
+-- Same pattern as Trace.shock but using Clash's built-in VCD dump.
+
+case_traceSignal_wishbone :: IO ()
+case_traceSignal_wishbone = do
+  let names = Trace.names (Proxy @(Wishbone System Standard 8 4)) "wb_s"
+      fwd = C.fromList (P.repeat (emptyWishboneM2S @8 @4))
+      bwd = C.fromList (P.repeat emptyWishboneS2M)
+      ckt = Trace.signal @(Wishbone System Standard 8 4) "wb_s"
+      (bwdOut, fwdOut) = toSignals ckt (fwd, bwd)
+      combined = C.bundle (fwdOut, bwdOut)
+  result <- Trace.dumpVCD (0, nCycles) combined names
+  assertClashVcdContains result names
+
+case_traceSignal_df :: IO ()
+case_traceSignal_df = do
+  let names = Trace.names (Proxy @(Df System (Unsigned 8))) "df_s"
+      fwd = C.fromList (P.repeat (Just (1 :: Unsigned 8)))
+      bwd = C.fromList (P.repeat (Ack True))
+      ckt = Trace.signal @(Df System (Unsigned 8)) "df_s"
+      (bwdOut, fwdOut) = toSignals ckt (fwd, bwd)
+      combined = C.bundle (fwdOut, bwdOut)
+  result <- Trace.dumpVCD (0, nCycles) combined names
+  assertClashVcdContains result names
+
+case_traceSignal_spi :: IO ()
+case_traceSignal_spi = do
+  let names = Trace.names (Proxy @(Spi System)) "spi_s"
+      fwd = C.fromList (P.repeat (Spi.M2S False 0 True))
+      bwd = C.fromList (P.repeat (Spi.S2M 0))
+      ckt = Trace.signal @(Spi System) "spi_s"
+      (bwdOut, fwdOut) = toSignals ckt (fwd, bwd)
+      combined = C.bundle (fwdOut, bwdOut)
+  result <- Trace.dumpVCD (0, nCycles) combined names
+  assertClashVcdContains result names
+
+case_traceSignal_packetstream :: IO ()
+case_traceSignal_packetstream = do
+  let names = Trace.names (Proxy @(PacketStream System 1 ())) "ps_s"
+      fwd = C.fromList (P.repeat (Just (PacketStreamM2S (0 :> Nil) Nothing () False)))
+      bwd = C.fromList (P.repeat (PacketStreamS2M True))
+      ckt = Trace.signal @(PacketStream System 1 ()) "ps_s"
+      (bwdOut, fwdOut) = toSignals ckt (fwd, bwd)
+      combined = C.bundle (fwdOut, bwdOut)
+  result <- Trace.dumpVCD (0, nCycles) combined names
+  assertClashVcdContains result names
+
+case_traceSignal_axi4stream :: IO ()
+case_traceSignal_axi4stream = do
+  let names = Trace.names (Proxy @(Axi4Stream System SimpleAxi4StreamConf ())) "as_s"
+      m2s = Axi4StreamM2S (0 :> Nil) (True :> Nil) (True :> Nil) False 0 0 ()
+      fwd = C.fromList (P.repeat (Just m2s))
+      bwd = C.fromList (P.repeat (Axi4StreamS2M True))
+      ckt = Trace.signal @(Axi4Stream System SimpleAxi4StreamConf ()) "as_s"
+      (bwdOut, fwdOut) = toSignals ckt (fwd, bwd)
+      combined = C.bundle (fwdOut, bwdOut)
+  result <- Trace.dumpVCD (0, nCycles) combined names
+  assertClashVcdContains result names
+
+case_traceSignal_axi4readaddress :: IO ()
+case_traceSignal_axi4readaddress = do
+  let names = Trace.names (Proxy @(Axi4ReadAddress System SimpleAxi4ReadAddrConf ())) "ar_s"
+      fwd = C.fromList (P.repeat M2S_NoReadAddress)
+      bwd = C.fromList (P.repeat (S2M_ReadAddress True))
+      ckt = Trace.signal @(Axi4ReadAddress System SimpleAxi4ReadAddrConf ()) "ar_s"
+      (bwdOut, fwdOut) = toSignals ckt (fwd, bwd)
+      combined = C.bundle (fwdOut, bwdOut)
+  result <- Trace.dumpVCD (0, nCycles) combined names
+  assertClashVcdContains result names
+
+case_traceSignal_axi4writeaddress :: IO ()
+case_traceSignal_axi4writeaddress = do
+  let names = Trace.names (Proxy @(Axi4WriteAddress System SimpleAxi4WriteAddrConf ())) "aw_s"
+      fwd = C.fromList (P.repeat M2S_NoWriteAddress)
+      bwd = C.fromList (P.repeat (S2M_WriteAddress True))
+      ckt = Trace.signal @(Axi4WriteAddress System SimpleAxi4WriteAddrConf ()) "aw_s"
+      (bwdOut, fwdOut) = toSignals ckt (fwd, bwd)
+      combined = C.bundle (fwdOut, bwdOut)
+  result <- Trace.dumpVCD (0, nCycles) combined names
+  assertClashVcdContains result names
+
+case_traceSignal_axi4readdata :: IO ()
+case_traceSignal_axi4readdata = do
+  let names = Trace.names (Proxy @(Axi4ReadData System SimpleAxi4ReadDataConf () (BitVector 8))) "rd_s"
+      fwd = C.fromList (P.repeat (S2M_NoReadData @SimpleAxi4ReadDataConf @() @(BitVector 8)))
+      bwd = C.fromList (P.repeat (M2S_ReadData True))
+      ckt = Trace.signal @(Axi4ReadData System SimpleAxi4ReadDataConf () (BitVector 8)) "rd_s"
+      (bwdOut, fwdOut) = toSignals ckt (fwd, bwd)
+      combined = C.bundle (fwdOut, bwdOut)
+  result <- Trace.dumpVCD (0, nCycles) combined names
+  assertClashVcdContains result names
+
+case_traceSignal_axi4writedata :: IO ()
+case_traceSignal_axi4writedata = do
+  let names = Trace.names (Proxy @(Axi4WriteData System SimpleAxi4WriteDataConf ())) "wd_s"
+      fwd = C.fromList (P.repeat (M2S_NoWriteData @SimpleAxi4WriteDataConf @()))
+      bwd = C.fromList (P.repeat (S2M_WriteData True))
+      ckt = Trace.signal @(Axi4WriteData System SimpleAxi4WriteDataConf ()) "wd_s"
+      (bwdOut, fwdOut) = toSignals ckt (fwd, bwd)
+      combined = C.bundle (fwdOut, bwdOut)
+  result <- Trace.dumpVCD (0, nCycles) combined names
+  assertClashVcdContains result names
+
+case_traceSignal_axi4writeresponse :: IO ()
+case_traceSignal_axi4writeresponse = do
+  let names = Trace.names (Proxy @(Axi4WriteResponse System SimpleAxi4WriteRespConf ())) "wr_s"
+      fwd = C.fromList (P.repeat (S2M_NoWriteResponse @SimpleAxi4WriteRespConf @()))
+      bwd = C.fromList (P.repeat (M2S_WriteResponse True))
+      ckt = Trace.signal @(Axi4WriteResponse System SimpleAxi4WriteRespConf ()) "wr_s"
+      (bwdOut, fwdOut) = toSignals ckt (fwd, bwd)
+      combined = C.bundle (fwdOut, bwdOut)
+  result <- Trace.dumpVCD (0, nCycles) combined names
+  assertClashVcdContains result names
+
+-- ** BiDf (2-tuple) tests
+
+case_shock_bidf :: IO ()
+case_shock_bidf = do
+  let names = Trace.names (Proxy @TestBiDf) "bd"
+      fwd =
+        ( C.fromList (P.repeat (Just (1 :: Unsigned 8)))
+        , C.fromList (P.repeat (Ack True))
+        )
+      bwd =
+        ( C.fromList (P.repeat (Ack True))
+        , C.fromList (P.repeat (Just (2 :: Unsigned 8)))
+        )
+      ckt = Trace.shock @TestBiDf "bd"
+      (bwdOut, fwdOut) = toSignals ckt (fwd, bwd)
+      combined = C.bundle (C.bundle fwdOut, C.bundle bwdOut)
+  result <- Shock.dumpVCD (0, nCycles) combined ["bd_0_dat"]
+  assertVcdContains result names
+
+case_traceSignal_bidf :: IO ()
+case_traceSignal_bidf = do
+  let names = Trace.names (Proxy @TestBiDf) "bd_s"
+      fwd =
+        ( C.fromList (P.repeat (Just (1 :: Unsigned 8)))
+        , C.fromList (P.repeat (Ack True))
+        )
+      bwd =
+        ( C.fromList (P.repeat (Ack True))
+        , C.fromList (P.repeat (Just (2 :: Unsigned 8)))
+        )
+      ckt = Trace.signal @TestBiDf "bd_s"
+      (bwdOut, fwdOut) = toSignals ckt (fwd, bwd)
+      combined = C.bundle (C.bundle fwdOut, C.bundle bwdOut)
+  result <- Trace.dumpVCD (0, nCycles) combined names
+  assertClashVcdContains result names
+
+-- ** 3-tuple tests (exercises TH-generated instances)
+
+case_shock_triple :: IO ()
+case_shock_triple = do
+  let names = Trace.names (Proxy @TestTriple) "t3"
+      fwd =
+        ( C.fromList (P.repeat (Just (1 :: Unsigned 8)))
+        , C.fromList (P.repeat (Spi.M2S False 0 True))
+        , C.fromList (P.repeat (Just (PacketStreamM2S (0 :> Nil) Nothing () False)))
+        )
+      bwd =
+        ( C.fromList (P.repeat (Ack True))
+        , C.fromList (P.repeat (Spi.S2M 0))
+        , C.fromList (P.repeat (PacketStreamS2M True))
+        )
+      ckt = Trace.shock @TestTriple "t3"
+      (bwdOut, fwdOut) = toSignals ckt (fwd, bwd)
+      combined = C.bundle (C.bundle fwdOut, C.bundle bwdOut)
+  result <- Shock.dumpVCD (0, nCycles) combined names
+  assertVcdContains result names
+
+case_traceSignal_triple :: IO ()
+case_traceSignal_triple = do
+  let names = Trace.names (Proxy @TestTriple) "t3_s"
+      fwd =
+        ( C.fromList (P.repeat (Just (1 :: Unsigned 8)))
+        , C.fromList (P.repeat (Spi.M2S False 0 True))
+        , C.fromList (P.repeat (Just (PacketStreamM2S (0 :> Nil) Nothing () False)))
+        )
+      bwd =
+        ( C.fromList (P.repeat (Ack True))
+        , C.fromList (P.repeat (Spi.S2M 0))
+        , C.fromList (P.repeat (PacketStreamS2M True))
+        )
+      ckt = Trace.signal @TestTriple "t3_s"
+      (bwdOut, fwdOut) = toSignals ckt (fwd, bwd)
+      combined = C.bundle (C.bundle fwdOut, C.bundle bwdOut)
+  result <- Trace.dumpVCD (0, nCycles) combined names
+  assertClashVcdContains result names
+
+-- * Test tree
+
+tests :: TestTree
+tests =
+  dependentTestGroup
+    "Protocols.Extra"
+    AllSucceed
+    [ dependentTestGroup
+        "Trace.names"
+        AllSucceed
+        [ testCase "Trace.names" case_names
+        ]
+    , dependentTestGroup
+        "Trace.shock"
+        AllSucceed
+        [ testCase "Wishbone" case_shock_wishbone
+        , testCase "Df" case_shock_df
+        , testCase "Spi" case_shock_spi
+        , testCase "PacketStream" case_shock_packetstream
+        , testCase "Axi4Stream" case_shock_axi4stream
+        , testCase "Axi4ReadAddress" case_shock_axi4readaddress
+        , testCase "Axi4WriteAddress" case_shock_axi4writeaddress
+        , testCase "Axi4ReadData" case_shock_axi4readdata
+        , testCase "Axi4WriteData" case_shock_axi4writedata
+        , testCase "Axi4WriteResponse" case_shock_axi4writeresponse
+        , testCase "BiDf" case_shock_bidf
+        , testCase "3-tuple" case_shock_triple
+        ]
+    , dependentTestGroup
+        "traceSignal"
+        AllSucceed
+        [ testCase "Wishbone" case_traceSignal_wishbone
+        , testCase "Df" case_traceSignal_df
+        , testCase "Spi" case_traceSignal_spi
+        , testCase "PacketStream" case_traceSignal_packetstream
+        , testCase "Axi4Stream" case_traceSignal_axi4stream
+        , testCase "Axi4ReadAddress" case_traceSignal_axi4readaddress
+        , testCase "Axi4WriteAddress" case_traceSignal_axi4writeaddress
+        , testCase "Axi4ReadData" case_traceSignal_axi4readdata
+        , testCase "Axi4WriteData" case_traceSignal_axi4writedata
+        , testCase "Axi4WriteResponse" case_traceSignal_axi4writeresponse
+        , testCase "BiDf" case_traceSignal_bidf
+        , testCase "3-tuple" case_traceSignal_triple
+        ]
+    ]


### PR DESCRIPTION
_What (what did you do)_
Add a `TraceC` typeclass that contains useful functions for debugging your circuit.

_Why (context, issues, etc.)_
I've found myself needing these kinds of functions many times and had to rewrite them each time for the protocol I was debugging.

_Dear reviewer (anything you'd like the reviewer to pay close attention to?)_
I have not yet used this specific typeclass, but it seems useful and I would guess it to be uncontroversial. It contains some orphan instances for common typeclasses (ShowX, Typeable etc) that I intend to upstream to `clash-protocols`.

_AI disclaimer (heads-up for more than inline autocomplete)_
I used Opus 4.6 to generate the test suite, I wanted to be sure that at least I could create the VCDs which contain the names indicated by `signalNames`.

I also used Opus 4.6 to generate the function to generate tuple instances.

# TODO
_~~Cross-out~~ any that do not apply_

- [X] Write test
- [ ] ~Update documentation, including `docs/`~
- [ ] ~Link to existing issue~
