### PR TITLE
Add wire demo

### DIFF
--- a/.github/synthesis/all.json
+++ b/.github/synthesis/all.json
@@ -28,5 +28,6 @@
   {"top": "syncInSyncOut",                 "stage": "test",  "cc_report": false},
   {"top": "temperatureMonitor",            "stage": "test",  "cc_report": false},
   {"top": "transceiversUpTest",            "stage": "test",  "cc_report": false},
-  {"top": "vexRiscvTest",                  "stage": "test",  "cc_report": false}
+  {"top": "vexRiscvTest",                  "stage": "test",  "cc_report": false},
+  {"top": "wireDemoTest",                  "stage": "test",  "cc_report": true}
 ]

--- a/.github/synthesis/main.json
+++ b/.github/synthesis/main.json
@@ -1,6 +1,5 @@
 [
   {"top": "safeDffSynchronizer",   "stage": "hdl" , "cc_report": false},
 
-  {"top": "switchDemoGppeTest",    "stage": "test", "cc_report": true},
-  {"top": "switchDemoTest",        "stage": "test", "cc_report": true}
+  {"top": "wireDemoTest",          "stage": "test", "cc_report": true}
 ]

--- a/bittide-instances/bittide-instances.cabal
+++ b/bittide-instances/bittide-instances.cabal
@@ -211,6 +211,11 @@ library
     Bittide.Instances.Hitl.Utils.Ugn
     Bittide.Instances.Hitl.Utils.Vivado
     Bittide.Instances.Hitl.VexRiscv
+    Bittide.Instances.Hitl.WireDemo.BringUp
+    Bittide.Instances.Hitl.WireDemo.Core
+    Bittide.Instances.Hitl.WireDemo.Driver
+    Bittide.Instances.Hitl.WireDemo.MemoryMaps
+    Bittide.Instances.Hitl.WireDemo.TopEntity
     Bittide.Instances.MemoryMaps
     Bittide.Instances.Pnr.AsciiDebugMux
     Bittide.Instances.Pnr.Counter

--- a/bittide-instances/src/Bittide/Instances/Hitl/SoftUgnDemo/BringUp.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/SoftUgnDemo/BringUp.hs
@@ -3,13 +3,6 @@
 -- SPDX-License-Identifier: Apache-2.0
 {-# LANGUAGE CPP #-}
 
-{- | Switch demo for a Bittide system. In concert with its driver file, this device under
-test should demonstrate the predictability of a Bittide system once it has achieved logical
-synchronicity.
-
-For more details, see [QBayLogic's presentation](https://docs.google.com/presentation/d/1AGbAJQ1zhTPtrekKnQcthd0TUPyQs-zowQpV1ux4k-Y)
-on the topic.
--}
 module Bittide.Instances.Hitl.SoftUgnDemo.BringUp (bringUp) where
 
 import Clash.Explicit.Prelude
@@ -51,6 +44,7 @@ import qualified Protocols.Vec as Vec
 
 #ifdef SIM_BAUD_RATE
 type Baud = MaxBaudRate Basic125
+import Clash.Cores.UART.Extra
 #else
 type Baud = 921_600
 #endif

--- a/bittide-instances/src/Bittide/Instances/Hitl/SoftUgnDemo/Core.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/SoftUgnDemo/Core.hs
@@ -1,6 +1,11 @@
 -- SPDX-FileCopyrightText: 2025 Google LLC
 --
 -- SPDX-License-Identifier: Apache-2.0
+
+{- | Demo for a bittide system which demonstrates we can capture UGNs in software without
+communicating with a host PC. The accompanying driver function is still used program the
+CPUs and checks that the software and hardware captured UGNs match.
+-}
 module Bittide.Instances.Hitl.SoftUgnDemo.Core (InternalCpuCount, core) where
 
 import Clash.Explicit.Prelude

--- a/bittide-instances/src/Bittide/Instances/Hitl/SwitchDemo/BringUp.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/SwitchDemo/BringUp.hs
@@ -3,13 +3,6 @@
 -- SPDX-License-Identifier: Apache-2.0
 {-# LANGUAGE CPP #-}
 
-{- | Switch demo for a Bittide system. In concert with its driver file, this device under
-test should demonstrate the predictability of a Bittide system once it has achieved logical
-synchronicity.
-
-For more details, see [QBayLogic's presentation](https://docs.google.com/presentation/d/1AGbAJQ1zhTPtrekKnQcthd0TUPyQs-zowQpV1ux4k-Y)
-on the topic.
--}
 module Bittide.Instances.Hitl.SwitchDemo.BringUp (bringUp) where
 
 import Clash.Explicit.Prelude

--- a/bittide-instances/src/Bittide/Instances/Hitl/SwitchDemo/Core.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/SwitchDemo/Core.hs
@@ -1,6 +1,14 @@
 -- SPDX-FileCopyrightText: 2025 Google LLC
 --
 -- SPDX-License-Identifier: Apache-2.0
+
+{- | Switch demo for a Bittide system. In concert with its driver file, this device under
+test should demonstrate the predictability of a Bittide system once it has achieved logical
+synchronicity.
+
+For more details, see [QBayLogic's presentation](https://docs.google.com/presentation/d/1AGbAJQ1zhTPtrekKnQcthd0TUPyQs-zowQpV1ux4k-Y)
+on the topic.
+-}
 module Bittide.Instances.Hitl.SwitchDemo.Core (InternalCpuCount, core) where
 
 import Clash.Explicit.Prelude

--- a/bittide-instances/src/Bittide/Instances/Hitl/SwitchDemo/Driver.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/SwitchDemo/Driver.hs
@@ -32,6 +32,7 @@ import Numeric (showHex)
 import Project.Chan
 import Project.FilePath
 import Project.Handle (assertEither, expectRight)
+import Protocols.MemoryMap (MemoryMap)
 import System.Exit
 import System.FilePath
 import System.IO
@@ -84,12 +85,14 @@ muSwitchDemoPeBuffer =
         TH.runIO $ expectRight $ getPathAddress @Integer MemoryMaps.mu ["0", "SwitchDemoPE", "buffer"]
       lift val
    )
+
 sampleMemoryBase :: Integer
 sampleMemoryBase =
   $( do
       val <- TH.runIO $ expectRight $ getPathAddress @Integer MemoryMaps.cc ["0", "SampleMemory", "data"]
       lift val
    )
+
 dumpCcSamples :: (HasCallStack) => FilePath -> CcConf Topology -> [Gdb] -> IO ()
 dumpCcSamples hitlDir ccConf ccGdbs = do
   mapConcurrently_ Gdb.interrupt ccGdbs
@@ -196,6 +199,48 @@ parseTapInfo expectedJtagIds initOcd =
           error [i|Parsed JTAG IDs do not match expected IDs!|]
       | otherwise -> tapInfos
 
+{- | Read the current time in clock cycles from the given target/device using the given
+GDB connection. Requires the CPU to be halted.
+-}
+readCurrentTime :: (HasCallStack) => MemoryMap -> (HwTarget, DeviceInfo) -> Gdb -> IO (Unsigned 64)
+readCurrentTime mm (_, d) gdb = do
+  putStrLn $ "Getting current time from device " <> d.deviceId
+  commandAddress <- expectRight $ getPathAddress mm ["0", "Timer", "command"]
+  scratchAddress <- expectRight $ getPathAddress mm ["0", "Timer", "scratchpad"]
+  Gdb.writeLe gdb commandAddress Capture
+  Gdb.readLe gdb scratchAddress
+
+{- | Read the hardware UGNs of the given device using the given GDB connection. Requires
+the CPU to be halted.
+-}
+readHardwareUgns :: MemoryMap -> (HwTarget, DeviceInfo) -> Gdb -> IO [(Unsigned 64, Unsigned 64)]
+readHardwareUgns mm (_, d) gdb = do
+  let
+    captureUgnPrefixed :: Int -> String -> [String]
+    captureUgnPrefixed linkNr reg = ["0", "CaptureUgn" <> show linkNr, reg]
+
+    readUgnMmio :: Int -> IO (Unsigned 64, Unsigned 64, Signed 32)
+    readUgnMmio linkNr = do
+      let getUgnRegister = expectRight . getPathAddress mm . captureUgnPrefixed linkNr
+      counterAddresses <- mapM getUgnRegister ["local_counter", "remote_counter"]
+      [localCounter, remoteCounter] <- mapM (Gdb.readLe gdb) counterAddresses
+      delta <- Gdb.readLe gdb =<< getUgnRegister "elastic_buffer_delta"
+      pure (localCounter, remoteCounter, delta)
+
+    -- Adjust the local counter for the frames added/removed from the elastic
+    -- buffer after capturing the UGN. Leaves the remote counter untouched.
+    adjustLocalCounter :: (Unsigned 64, Unsigned 64, Signed 32) -> (Unsigned 64, Unsigned 64)
+    adjustLocalCounter (localCounter, remoteCounter, delta) =
+      (addSigned localCounter delta, remoteCounter)
+     where
+      addSigned :: Unsigned 64 -> Signed 32 -> Unsigned 64
+      addSigned u s = checkedFromIntegral (toInteger u + toInteger s)
+
+  liftIO $ putStrLn $ "Getting UGNs for device " <> d.deviceId
+  ugnTriples <- mapM readUgnMmio [0 .. natToNum @(LinkCount - 1)]
+  liftIO $ forM_ ugnTriples $ \triple -> putStrLn $ "Raw UGN triple: " <> show triple
+  pure $ adjustLocalCounter <$> ugnTriples
+
 driver ::
   (HasCallStack) =>
   String ->
@@ -212,34 +257,6 @@ driver testName targets = do
   let
     hitlDir = projectDir </> "_build/hitl" </> testName
 
-    muGetUgns :: (HwTarget, DeviceInfo) -> Gdb -> IO [(Unsigned 64, Unsigned 64)]
-    muGetUgns (_, d) gdb = do
-      let
-        captureUgnPrefixed :: Int -> String -> [String]
-        captureUgnPrefixed linkNr reg = ["0", "CaptureUgn" <> show linkNr, reg]
-
-        readUgnMmio :: Int -> IO (Unsigned 64, Unsigned 64, Signed 32)
-        readUgnMmio linkNr = do
-          let getUgnRegister = expectRight . getPathAddress MemoryMaps.mu . captureUgnPrefixed linkNr
-          counterAddresses <- mapM getUgnRegister ["local_counter", "remote_counter"]
-          [localCounter, remoteCounter] <- mapM (Gdb.readLe gdb) counterAddresses
-          delta <- Gdb.readLe gdb =<< getUgnRegister "elastic_buffer_delta"
-          pure (localCounter, remoteCounter, delta)
-
-        -- Adjust the local counter for the frames added/removed from the elastic
-        -- buffer after capturing the UGN. Leaves the remote counter untouched.
-        adjustLocalCounter :: (Unsigned 64, Unsigned 64, Signed 32) -> (Unsigned 64, Unsigned 64)
-        adjustLocalCounter (localCounter, remoteCounter, delta) =
-          (addSigned localCounter delta, remoteCounter)
-         where
-          addSigned :: Unsigned 64 -> Signed 32 -> Unsigned 64
-          addSigned u s = checkedFromIntegral (toInteger u + toInteger s)
-
-      liftIO $ putStrLn $ "Getting UGNs for device " <> d.deviceId
-      ugnTriples <- mapM readUgnMmio [0 .. natToNum @(LinkCount - 1)]
-      liftIO $ forM_ ugnTriples $ \triple -> putStrLn $ "Raw UGN triple: " <> show triple
-      pure $ adjustLocalCounter <$> ugnTriples
-
     muReadPeBuffer :: (HasCallStack) => (HwTarget, DeviceInfo) -> Gdb -> IO ()
     muReadPeBuffer (_, d) gdb = do
       putStrLn $ "Reading PE buffer from device " <> d.deviceId
@@ -249,14 +266,6 @@ driver testName targets = do
       output <-
         Gdb.readCommandRaw gdb [i|x/#{bufferSize}xg #{showHex32 muSwitchDemoPeBuffer}|]
       putStrLn [i|PE buffer readout:\n#{output}|]
-
-    muGetCurrentTime :: (HasCallStack) => (HwTarget, DeviceInfo) -> Gdb -> IO (Unsigned 64)
-    muGetCurrentTime (_, d) gdb = do
-      putStrLn $ "Getting current time from device " <> d.deviceId
-      commandAddress <- expectRight $ getPathAddress MemoryMaps.mu ["0", "Timer", "command"]
-      scratchAddress <- expectRight $ getPathAddress MemoryMaps.mu ["0", "Timer", "scratchpad"]
-      Gdb.writeLe gdb commandAddress Capture
-      Gdb.readLe gdb scratchAddress
 
     -- \| Read the elastic buffer under and overflow flags and verify they are clear
     checkElasticBufferFlags :: (HasCallStack) => (HwTarget, DeviceInfo) -> Gdb -> IO Bool
@@ -431,14 +440,14 @@ driver testName targets = do
 
           liftIO $ putStrLn "Getting UGNs for all targets"
           liftIO $ mapConcurrently_ Gdb.interrupt muGdbs
-          ugnPairsTable <- liftIO $ zipWithConcurrently muGetUgns targets muGdbs
+          ugnPairsTable <- liftIO $ zipWithConcurrently (readHardwareUgns MemoryMaps.mu) targets muGdbs
           let
             ugnPairsTableV = fromJust . V.fromList $ fromJust . V.fromList <$> ugnPairsTable
           liftIO $ do
             putStrLn "Calculating IGNs for all targets"
             Calc.printAllIgns ugnPairsTableV fpgaSetup
             mapM_ print ugnPairsTableV
-          currentTime <- liftIO $ muGetCurrentTime (L.head targets) (L.head muGdbs)
+          currentTime <- liftIO $ readCurrentTime MemoryMaps.mu (L.head targets) (L.head muGdbs)
           let
             startOffset = currentTime + natToNum @(PeriodToCycles GthTx (Seconds StartDelay))
             metaChainConfig ::
@@ -468,7 +477,7 @@ driver testName targets = do
             threadDelay delayMicros
             liftIO $ mapConcurrently_ Gdb.interrupt muGdbs
             putStrLn [i|Slept for: #{delayMicros}μs|]
-            newCurrentTime <- muGetCurrentTime (L.head targets) (L.head muGdbs)
+            newCurrentTime <- readCurrentTime MemoryMaps.mu (L.head targets) (L.head muGdbs)
             putStrLn [i|Clock is now: #{newCurrentTime}|]
 
           _ <- liftIO $ sequenceA $ L.zipWith muReadPeBuffer targets muGdbs

--- a/bittide-instances/src/Bittide/Instances/Hitl/SwitchDemoGppe/BringUp.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/SwitchDemoGppe/BringUp.hs
@@ -3,13 +3,6 @@
 -- SPDX-License-Identifier: Apache-2.0
 {-# LANGUAGE CPP #-}
 
-{- | Switch demo for a Bittide system. In concert with its driver file, this device under
-test should demonstrate the predictability of a Bittide system once it has achieved logical
-synchronicity.
-
-For more details, see [QBayLogic's presentation](https://docs.google.com/presentation/d/1AGbAJQ1zhTPtrekKnQcthd0TUPyQs-zowQpV1ux4k-Y)
-on the topic.
--}
 module Bittide.Instances.Hitl.SwitchDemoGppe.BringUp (bringUp) where
 
 import Clash.Explicit.Prelude
@@ -51,6 +44,7 @@ import qualified Protocols.Vec as Vec
 
 #ifdef SIM_BAUD_RATE
 type Baud = MaxBaudRate Basic125
+import Clash.Cores.UART.Extra
 #else
 type Baud = 921_600
 #endif

--- a/bittide-instances/src/Bittide/Instances/Hitl/SwitchDemoGppe/Core.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/SwitchDemoGppe/Core.hs
@@ -1,6 +1,14 @@
 -- SPDX-FileCopyrightText: 2025 Google LLC
 --
 -- SPDX-License-Identifier: Apache-2.0
+
+{- | Switch demo for a Bittide system. In concert with its driver file, this device under
+test should demonstrate the predictability of a Bittide system once it has achieved logical
+synchronicity.
+
+For more details, see [QBayLogic's presentation](https://docs.google.com/presentation/d/1AGbAJQ1zhTPtrekKnQcthd0TUPyQs-zowQpV1ux4k-Y)
+on the topic.
+-}
 module Bittide.Instances.Hitl.SwitchDemoGppe.Core (InternalCpuCount, core) where
 
 import Clash.Explicit.Prelude

--- a/bittide-instances/src/Bittide/Instances/Hitl/Tests.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/Tests.hs
@@ -34,6 +34,7 @@ import qualified Bittide.Instances.Hitl.SyncInSyncOut as SyncInSyncOut
 import qualified Bittide.Instances.Hitl.TemperatureMonitor as TemperatureMonitor
 import qualified Bittide.Instances.Hitl.Transceivers as Transceivers
 import qualified Bittide.Instances.Hitl.VexRiscv as VexRiscv
+import qualified Bittide.Instances.Hitl.WireDemo.TopEntity as WireDemo
 
 hitlTests :: [HitlTestGroup]
 hitlTests =
@@ -53,3 +54,4 @@ hitlTests =
     <> [TemperatureMonitor.tests]
     <> [Transceivers.tests]
     <> [VexRiscv.tests]
+    <> [WireDemo.tests]

--- a/bittide-instances/src/Bittide/Instances/Hitl/WireDemo/BringUp.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/WireDemo/BringUp.hs
@@ -1,0 +1,182 @@
+-- SPDX-FileCopyrightText: 2025 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+{-# LANGUAGE CPP #-}
+
+module Bittide.Instances.Hitl.WireDemo.BringUp (bringUp) where
+
+import Clash.Explicit.Prelude
+import Clash.Prelude (HiddenClockResetEnable, withClockResetEnable)
+import Protocols
+
+import Bittide.BootPe (BootPeBusses, bootPe)
+import Bittide.CaptureUgn (sendUgnC)
+import Bittide.ClockControl
+import Bittide.Df (asciiDebugMux)
+import Bittide.Instances.Domains (
+  Basic125,
+  Bittide,
+  Ext200,
+  GthRx,
+  GthRxS,
+  GthTxS,
+ )
+import Bittide.Instances.Hitl.Setup (LinkCount)
+import Bittide.Instances.Hitl.WireDemo.Core (InternalCpuCount, core)
+import Bittide.Jtag (jtagChain, unsafeJtagSynchronizer)
+import Bittide.ProcessingElement (PeConfig (..))
+import Bittide.SharedTypes (Byte, withLittleEndian)
+import Bittide.Sync (Sync)
+import Bittide.Wishbone (arbiterMm, extendAddressWidthWb, uartDf)
+import Clash.Cores.Xilinx.DcFifo (dcFifoDf)
+import Data.Char (ord)
+import Protocols.Extra
+import Protocols.MemoryMap (Mm)
+import Protocols.Spi (Spi)
+import Protocols.Wishbone.Extra (xpmCdcHandshakeWb)
+import VexRiscv (Jtag)
+
+import qualified Bittide.Cpus.Riscv32imc as Riscv32imc
+import qualified Bittide.Transceiver as Transceiver
+import qualified Bittide.Transceiver.Wishbone as Transceiver
+import qualified Clash.Cores.Xilinx.Gth as Gth
+import qualified Protocols.Vec as Vec
+
+#ifdef SIM_BAUD_RATE
+type Baud = MaxBaudRate Basic125
+import Clash.Cores.UART.Extra
+#else
+type Baud = 921_600
+#endif
+
+baud :: SNat Baud
+baud = SNat
+
+uartLabels :: Vec 3 (Vec 2 Byte)
+uartLabels =
+  fmap (fromIntegral . ord)
+    <$> ( $(listToVecTH "BT")
+            :> $(listToVecTH "MU")
+            :> $(listToVecTH "CC")
+            :> Nil
+        )
+
+bootPeConfig :: PeConfig BootPeBusses
+bootPeConfig =
+  PeConfig
+    { cpu = Riscv32imc.vexRiscv0
+    , depthI = SNat @(Div (4 * 1024) 4)
+    , depthD = SNat @(Div (16 * 1024) 4)
+    , initI = Nothing
+    , initD = Nothing
+    , iBusTimeout = d0
+    , dBusTimeout = d0
+    , includeIlaWb = False
+    }
+
+{- | See 'Bittide.Instances.Hitl.SwitchDemo.BringUp.bringUp'
+
+TODO: Deduplicate
+-}
+bringUp ::
+  "REFCLK" ::: Clock Basic125 ->
+  "TEST_RST" ::: Reset Basic125 ->
+  Circuit
+    ( Vec (InternalCpuCount + 1) (ToConstBwd Mm)
+    , Jtag Basic125
+    , Gth.Gths GthRx GthRxS Bittide GthTxS Ext200 LinkCount
+    )
+    ( Spi Basic125
+    , Sync Bittide Basic125
+    , "UART_TX" ::: CSignal Basic125 Bit
+    , "FINC_FDEC" ::: CSignal Bittide (FINC, FDEC)
+    )
+bringUp refClk refRst = withLittleEndian $ circuit $ \(memoryMaps, jtag, gths) -> do
+  ([bootMm], coreMemoryMaps) <- Vec.split -< memoryMaps
+
+  [bootJtag, otherJtag] <- jtagChain -< jtag
+  otherJtagBittide <- unsafeJtagSynchronizer refClk bittideClk -< otherJtag
+
+  transceiverWb <- withRefClockResetEnable arbiterMm -< [muTransceiverWb, bootTransceiverWb]
+  muTransceiverWb <-
+    fmapC (extendAddressWidthWb <| xpmCdcHandshakeWb bittideClk bittideRst refClk refRst)
+      -< muTransceiverWbBittide
+
+  -- Start boot PE
+  (bootUartBytes, _spiDone, spi, bootTransceiverWb) <-
+    withRefClockResetEnable
+      $ bootPe bootPeConfig
+      -< (bootMm, bootJtag)
+  -- Stop boot PE
+
+  -- Start UART multiplexing
+  uartTxBytes <-
+    withRefClockResetEnable
+      $ asciiDebugMux d1024 uartLabels
+      <| Vec.append
+      -< ([bootUartBytes], uartBytes)
+  (_uartInBytes, uartTx) <- withRefClockResetEnable $ uartDf baud -< (uartTxBytes, Fwd 0)
+
+  uartBytes <- fmapC $ dcFifoDf d5 bittideClk bittideRst refClk refRst -< uartBytesBittide
+  -- Stop UART multiplexing
+
+  Fwd tOutputs <-
+    Transceiver.transceiverPrbsNWb @Bittide @GthRx @Ext200 @Basic125 @GthTxS @GthRxS
+      refClk
+      refRst
+      Transceiver.defConfig
+      -< (transceiverWb, gths, Fwd (bundle switchDataOutOrLocalCounters))
+
+  -- Send local counter the very first "user" cycle for UGN computation. Should
+  -- this be handled in 'core'?
+  Fwd switchDataOutOrLocalCounters <-
+    withBittideClockResetEnable
+      $ sendUgnC localCounter tOutputs.txSamplings
+      -< switchDataOut
+
+  ( Fwd speedChanges
+    , Fwd localCounter
+    , switchDataOut
+    , sync
+    , uartBytesBittide
+    , muTransceiverWbBittide
+    ) <-
+    core
+      (refClk, refRst)
+      (bittideClk, bittideRst, enableGen)
+      tOutputs.rxClocks
+      (unsafeFromActiveLow <$> tOutputs.handshakesDone)
+      -< ( coreMemoryMaps
+         , otherJtagBittide
+         , Fwd (pure maxBound)
+         , Fwd linksSuitableForCc
+         , Fwd tOutputs.rxDatas
+         )
+
+  let
+    withRefClockResetEnable :: forall r. ((HiddenClockResetEnable Basic125) => r) -> r
+    withRefClockResetEnable = withClockResetEnable refClk refRst enableGen
+
+    withBittideClockResetEnable :: forall r. ((HiddenClockResetEnable Bittide) => r) -> r
+    withBittideClockResetEnable = withClockResetEnable bittideClk bittideRst enableGen
+
+    bittideClk :: Clock Bittide
+    bittideClk = tOutputs.txClock
+
+    bittideRst :: Reset Bittide
+    bittideRst = tOutputs.txReset
+
+    linksSuitableForCc :: Signal Bittide (BitVector LinkCount)
+    linksSuitableForCc = fmap pack (bundle tOutputs.handshakesDoneTx)
+
+    frequencyAdjustments :: Signal Bittide (FINC, FDEC)
+    frequencyAdjustments =
+      delay bittideClk enableGen minBound
+        $ speedChangeToStickyPins
+          bittideClk
+          bittideRst
+          enableGen
+          (SNat @Si539xHoldTime)
+          speedChanges
+
+  idC -< (spi, sync, uartTx, Fwd frequencyAdjustments)

--- a/bittide-instances/src/Bittide/Instances/Hitl/WireDemo/Core.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/WireDemo/Core.hs
@@ -6,7 +6,7 @@
 module Bittide.Instances.Hitl.WireDemo.Core (InternalCpuCount, core) where
 
 import Clash.Explicit.Prelude
-import Clash.Prelude (HiddenClockResetEnable, withClockResetEnable)
+import Clash.Prelude (HiddenClockResetEnable, withClock, withClockResetEnable)
 import Protocols
 
 import Bittide.Calendar (CalendarConfig (..), ValidEntry (..))
@@ -25,9 +25,11 @@ import Bittide.ProcessingElement (
   RemainingBusWidth,
   processingElement,
  )
+import Bittide.ProgrammableMux (programmableMux)
 import Bittide.ScatterGather
 import Bittide.SharedTypes (Bitbone, BitboneMm)
 import Bittide.Sync (Sync)
+import Bittide.WireDemoProcessingElement (wireDemoPe, wireDemoPeConfig)
 import Bittide.Wishbone (readDnaPortE2WbWorker, timeWb, uartBytes, uartInterfaceWb)
 import Clash.Class.BitPackC (ByteOrder)
 import Clash.Cores.Xilinx.Unisim.DnaPortE2 (readDnaPortE2, simDna2)
@@ -68,8 +70,10 @@ type PeripheralsPerLink = 6
 {- External busses:
     - Transceivers
     - Callisto
+    - Programmable mux
+    - PE config
 -}
-type NmuExternalBusses = 2 + (LinkCount * PeripheralsPerLink)
+type NmuExternalBusses = 4 + (LinkCount * PeripheralsPerLink)
 type NmuRemBusWidth = RemainingBusWidth (NmuExternalBusses + NmuInternalBusses)
 
 muConfig ::
@@ -178,7 +182,12 @@ core (refClk, refRst) (bitClk, bitRst, bitEna) rxClocks rxResets =
     (ebWbs, muWbs2) <- Vec.split -< muWbs1
     (scatterBusses, scatterCalendarBusses, muWbs3) <- Vec.split3 -< muWbs2
     (gatherBusses, gatherCalendarBusses, muWbs4) <- Vec.split3 -< muWbs3
-    [muTransceiverBus, muCallistoBus] <- idC -< muWbs4
+    [ muTransceiverBus
+      , muCallistoBus
+      , muProgrammableMuxBus
+      , peConfigBus
+      ] <-
+      idC -< muWbs4
     -- Stop management unit
 
     -- Start internal links
@@ -221,11 +230,30 @@ core (refClk, refRst) (bitClk, bitRst, bitEna) rxClocks rxResets =
       <| Vec.vecCircuits (fmap (withBittideClockResetEnable (scatterUnitWbC scatterConfig)) rxs2)
       <| Vec.zip
       -< (scatterBusses, scatterCalendarBussesDelayed)
-    Fwd txs <-
+    Fwd txsMu <-
       repeatC (withBittideClockResetEnable (gatherUnitWbC gatherConfig))
         <| Vec.zip
         -< (gatherBusses, gatherCalendarBussesDelayed)
     -- Stop ringbuffers
+
+    -- Start business logic
+    (readLinkI, writeLinkI) <-
+      withBittideClockResetEnable wireDemoPeConfig -< (peConfigBus, peWrittenData)
+    (Fwd txsBl, peWrittenData) <-
+      withClock bitClk
+        $ wireDemoPe businessLogicReset maybeDna
+        -< (Fwd rxs2, readLinkI, writeLinkI)
+    -- Stop business logic
+
+    -- Start programmable mux
+    (Fwd businessLogicReset, Fwd txs) <-
+      withBittideClockResetEnable
+        $ programmableMux localCounter
+        -< ( muProgrammableMuxBus
+           , (Fwd (bundle txsMu))
+           , (Fwd (bundle txsBl))
+           )
+    -- Stop programmable mux
 
     -- Start clock control
     ( sync
@@ -275,7 +303,7 @@ core (refClk, refRst) (bitClk, bitRst, bitEna) rxClocks rxResets =
     idC
       -< ( Fwd swCcOut1
          , Fwd localCounter
-         , Fwd (dflipflop bitClk <$> txs)
+         , Fwd (dflipflop bitClk <$> (unbundle txs))
          , sync
          , [muUartBytesBittide, ccUartBytesBittide]
          , muTransceiverBus

--- a/bittide-instances/src/Bittide/Instances/Hitl/WireDemo/Core.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/WireDemo/Core.hs
@@ -215,7 +215,10 @@ core (refClk, refRst) (bitClk, bitRst, bitEna) rxClocks rxResets =
 
     -- Start ringbuffers
     let
-      maxCalDepth = SNat @4000
+      -- This demo only has the scatter/gather units to have an alternative source of the
+      -- links next to the PE. The depth is reduced compared to the Soft UGN Demo to reduce
+      -- blockram usage (and thus to simplify placement).
+      maxCalDepth = SNat @200
       scatterConfig = ScatterConfig maxCalDepth (CalendarConfig maxCalDepth repetitionBits sgCal sgCal)
       gatherConfig = GatherConfig maxCalDepth (CalendarConfig maxCalDepth repetitionBits sgCal sgCal)
       repetitionBits = d16

--- a/bittide-instances/src/Bittide/Instances/Hitl/WireDemo/Core.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/WireDemo/Core.hs
@@ -1,0 +1,295 @@
+-- SPDX-FileCopyrightText: 2025 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+
+-- | Wire demo for a bittide system, similar to the switch demo but without a switch.
+module Bittide.Instances.Hitl.WireDemo.Core (InternalCpuCount, core) where
+
+import Clash.Explicit.Prelude
+import Clash.Prelude (HiddenClockResetEnable, withClockResetEnable)
+import Protocols
+
+import Bittide.Calendar (CalendarConfig (..), ValidEntry (..))
+import Bittide.CaptureUgn (captureUgn)
+import Bittide.ClockControl (SpeedChange)
+import Bittide.ClockControl.CallistoSw (SwcccInternalBusses, callistoSwClockControlC)
+import Bittide.DoubleBufferedRam (wbStorage)
+import Bittide.ElasticBuffer (xilinxElasticBufferWb)
+import Bittide.Instances.Domains (Basic125, Bittide, GthRx)
+import Bittide.Instances.Hitl.Setup (LinkCount)
+import Bittide.Jtag (jtagChain)
+import Bittide.ProcessingElement (
+  PeConfig (..),
+  PeInternalBusses,
+  PrefixWidth,
+  RemainingBusWidth,
+  processingElement,
+ )
+import Bittide.ScatterGather
+import Bittide.SharedTypes (Bitbone, BitboneMm)
+import Bittide.Sync (Sync)
+import Bittide.Wishbone (readDnaPortE2WbWorker, timeWb, uartBytes, uartInterfaceWb)
+import Clash.Class.BitPackC (ByteOrder)
+import Clash.Cores.Xilinx.Unisim.DnaPortE2 (readDnaPortE2, simDna2)
+import Protocols.Extra
+import Protocols.Idle (idleSink)
+import Protocols.MemoryMap (Mm)
+import Protocols.Wishbone.Extra (delayWishbone)
+import VexRiscv (DumpVcd (..), Jtag)
+
+import qualified Bittide.Cpus.Riscv32imc as Riscv32imc
+import qualified Protocols.MemoryMap as Mm
+import qualified Protocols.Vec as Vec
+
+-- | The number of CPUs in 'core'
+type InternalCpuCount = 2
+
+type FifoSize = 5 -- = 2^5 = 32
+
+{- Internal busses:
+    - Instruction memory
+    - Data memory
+    - `timeWb`
+    - DNA
+    - UART
+-}
+type NmuInternalBusses = 3 + PeInternalBusses
+
+{- Busses per link:
+    - UGN component
+    - Elastic buffer
+    - Scatter unit
+    - Scatter calendar
+    - Gather unit
+    - Gather calendar
+-}
+type PeripheralsPerLink = 6
+
+{- External busses:
+    - Transceivers
+    - Callisto
+-}
+type NmuExternalBusses = 2 + (LinkCount * PeripheralsPerLink)
+type NmuRemBusWidth = RemainingBusWidth (NmuExternalBusses + NmuInternalBusses)
+
+muConfig ::
+  ( KnownNat n
+  , PrefixWidth (n + NmuInternalBusses) <= 30
+  ) =>
+  PeConfig (n + NmuInternalBusses)
+muConfig =
+  PeConfig
+    { cpu = Riscv32imc.vexRiscv1
+    , depthI = SNat @(Div (16 * 1024) 4)
+    , depthD = SNat @(Div (16 * 1024) 4)
+    , initI = Nothing
+    , initD = Nothing
+    , iBusTimeout = d0
+    , dBusTimeout = d0
+    , includeIlaWb = False
+    }
+
+ccConfig ::
+  ( KnownNat n
+  , PrefixWidth (n + SwcccInternalBusses) <= 30
+  ) =>
+  PeConfig (n + SwcccInternalBusses)
+ccConfig =
+  PeConfig
+    { cpu = Riscv32imc.vexRiscv2
+    , depthI = SNat @(Div (8 * 1024) 4)
+    , depthD = SNat @(Div (16 * 1024) 4)
+    , initI = Nothing
+    , initD = Nothing
+    , iBusTimeout = d0
+    , dBusTimeout = d0
+    , includeIlaWb = False
+    }
+
+managementUnit ::
+  forall dom.
+  ( HiddenClockResetEnable dom
+  , ?byteOrder :: ByteOrder
+  , 1 <= DomainPeriod dom
+  ) =>
+  -- | External counter
+  Signal dom (Unsigned 64) ->
+  -- | DNA value
+  Signal dom (Maybe (BitVector 96)) ->
+  Circuit
+    (ToConstBwd Mm.Mm, Jtag dom)
+    ( Df dom (BitVector 8)
+    , Vec
+        NmuExternalBusses
+        ( ToConstBwd Mm.Mm
+        , Bitbone dom NmuRemBusWidth
+        )
+    )
+managementUnit externalCounter maybeDna =
+  circuit $ \(mm, jtag) -> do
+    -- Core and interconnect
+    allBusses <- processingElement NoDumpVcd muConfig -< (mm, jtag)
+    ([timeBus, uartBus, dnaBus], restBusses) <- Vec.split -< allBusses
+
+    -- Peripherals
+    _localCounter <- timeWb (Just externalCounter) -< timeBus
+    (uartOut, _uartStatus) <-
+      uartInterfaceWb d16 d16 uartBytes -< (uartBus, Fwd (pure Nothing))
+    readDnaPortE2WbWorker maybeDna -< dnaBus
+
+    -- Output
+    idC -< (uartOut, restBusses)
+
+core ::
+  ( ?byteOrder :: ByteOrder
+  ) =>
+  (Clock Basic125, Reset Basic125) ->
+  (Clock Bittide, Reset Bittide, Enable Bittide) ->
+  Vec LinkCount (Clock GthRx) ->
+  Vec LinkCount (Reset GthRx) ->
+  Circuit
+    ( Vec InternalCpuCount (ToConstBwd Mm)
+    , Jtag Bittide
+    , "MASK" ::: CSignal Bittide (BitVector LinkCount)
+    , "CC_SUITABLE" ::: CSignal Bittide (BitVector LinkCount)
+    , "RXS" ::: Vec LinkCount (CSignal GthRx (Maybe (BitVector 64)))
+    )
+    ( CSignal Bittide (Maybe SpeedChange)
+    , "LOCAL_COUNTER" ::: CSignal Bittide (Unsigned 64)
+    , "TXS" ::: Vec LinkCount (CSignal Bittide (BitVector 64))
+    , Sync Bittide Basic125
+    , "UARTS" ::: Vec InternalCpuCount (Df Bittide (BitVector 8))
+    , "MU_TRANSCEIVER" ::: (BitboneMm Bittide NmuRemBusWidth)
+    )
+core (refClk, refRst) (bitClk, bitRst, bitEna) rxClocks rxResets =
+  circuit $ \(memoryMaps, jtag, mask, linksSuitableForCc, Fwd rxs0) -> do
+    [muMm, ccMm] <- idC -< memoryMaps
+
+    [muJtag, ccJtag] <- jtagChain -< jtag
+
+    let
+      maybeDna = readDnaPortE2 bitClk bitRst bitEna simDna2
+      localCounter = register bitClk bitRst bitEna 0 (localCounter + 1)
+
+    -- Start management unit
+    (muUartBytesBittide, muWbAll) <-
+      withBittideClockResetEnable managementUnit localCounter maybeDna -< (muMm, muJtag)
+    (ugnWbs, muWbs1) <- Vec.split -< muWbAll
+    (ebWbs, muWbs2) <- Vec.split -< muWbs1
+    (scatterBusses, scatterCalendarBusses, muWbs3) <- Vec.split3 -< muWbs2
+    (gatherBusses, gatherCalendarBusses, muWbs4) <- Vec.split3 -< muWbs3
+    [muTransceiverBus, muCallistoBus] <- idC -< muWbs4
+    -- Stop management unit
+
+    -- Start internal links
+    (_relDatCount, _underflow, _overflow, Fwd rxs1) <-
+      unzip4Vec
+        <| ( Vec.vecCircuits
+              $ xilinxElasticBufferWb
+                bitClk
+                bitRst
+                (SNat @FifoSize)
+                localCounter
+              <$> rxClocks
+              <*> rxs0
+           )
+        <| repeatC (fmapC $ withBittideClockResetEnable delayWishbone)
+        -< ebWbs
+
+    -- Use of `dflipflop` to add pipelining should be replaced by
+    -- https://github.com/bittide/bittide-hardware/pull/1134
+    Fwd rxs2 <-
+      withBittideClockResetEnable
+        $ Vec.vecCircuits ((captureUgn localCounter . dflipflop bitClk) <$> rxs1)
+        -< ugnWbs
+    -- Stop internal links
+
+    -- Start ringbuffers
+    let
+      maxCalDepth = SNat @4000
+      scatterConfig = ScatterConfig maxCalDepth (CalendarConfig maxCalDepth repetitionBits sgCal sgCal)
+      gatherConfig = GatherConfig maxCalDepth (CalendarConfig maxCalDepth repetitionBits sgCal sgCal)
+      repetitionBits = d16
+      sgCal = ValidEntry 0 (snatToNum maxCalDepth - 1) :> Nil
+
+    scatterCalendarBussesDelayed <-
+      repeatC (fmapC $ withBittideClockResetEnable delayWishbone) -< scatterCalendarBusses
+    gatherCalendarBussesDelayed <-
+      repeatC (fmapC $ withBittideClockResetEnable delayWishbone) -< gatherCalendarBusses
+
+    idleSink
+      <| Vec.vecCircuits (fmap (withBittideClockResetEnable (scatterUnitWbC scatterConfig)) rxs2)
+      <| Vec.zip
+      -< (scatterBusses, scatterCalendarBussesDelayed)
+    Fwd txs <-
+      repeatC (withBittideClockResetEnable (gatherUnitWbC gatherConfig))
+        <| Vec.zip
+        -< (gatherBusses, gatherCalendarBussesDelayed)
+    -- Stop ringbuffers
+
+    -- Start clock control
+    ( sync
+      , Fwd swCcOut0
+      , [ ccUartBus
+          , ccSampleMemoryBus
+          ]
+      ) <-
+      withBittideClockResetEnable
+        $ callistoSwClockControlC
+          @LinkCount
+          refClk
+          refRst
+          rxClocks
+          rxResets
+          NoDumpVcd
+          ccConfig
+        -< (ccMm, muCallistoBus, (ccJtag, mask, linksSuitableForCc))
+
+    withBittideClockResetEnable
+      (wbStorage "SampleMemory" (SNat @36_000))
+      Nothing
+      -< ccSampleMemoryBus
+
+    (ccUartBytesBittide, _uartStatus) <-
+      withBittideClockResetEnable
+        $ uartInterfaceWb d16 d16 uartBytes
+        -< (ccUartBus, Fwd (pure Nothing))
+
+    let
+      swCcOut1 =
+        if clashSimulation
+          then
+            let
+              -- Should all clock control steps be run in simulation?
+              -- False means that clock control will always immediately be done.
+              simulateCc = False
+             in
+              if simulateCc
+                then swCcOut0
+                else pure Nothing
+          else swCcOut0
+    -- Stop clock control
+
+    -- Use of `dflipflop` to add pipelining should be replaced by
+    -- https://github.com/bittide/bittide-hardware/pull/1134
+    idC
+      -< ( Fwd swCcOut1
+         , Fwd localCounter
+         , Fwd (dflipflop bitClk <$> txs)
+         , sync
+         , [muUartBytesBittide, ccUartBytesBittide]
+         , muTransceiverBus
+         )
+ where
+  withBittideClockResetEnable :: forall r. ((HiddenClockResetEnable Bittide) => r) -> r
+  withBittideClockResetEnable = withClockResetEnable bitClk bitRst bitEna
+
+uncurry4 ::
+  (a -> b -> c -> d -> e) ->
+  (a, b, c, d) ->
+  e
+uncurry4 fn (a, b, c, d) = fn a b c d
+
+unzip4Vec ::
+  Circuit (Vec n (a, b, c, d)) (Vec n a, Vec n b, Vec n c, Vec n d)
+unzip4Vec = applyC unzip4 (uncurry4 zip4)

--- a/bittide-instances/src/Bittide/Instances/Hitl/WireDemo/Core.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/WireDemo/Core.hs
@@ -244,7 +244,7 @@ core (refClk, refRst) (bitClk, bitRst, bitEna) rxClocks rxResets =
       withBittideClockResetEnable wireDemoPeConfig -< (peConfigBus, peWrittenData)
     (Fwd txsBl, peWrittenData) <-
       withClock bitClk
-        $ wireDemoPe businessLogicReset maybeDna
+        $ wireDemoPe businessLogicReset maybeDna localCounter
         -< (Fwd rxs2, readLinkI, writeLinkI)
     -- Stop business logic
 

--- a/bittide-instances/src/Bittide/Instances/Hitl/WireDemo/Driver.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/WireDemo/Driver.hs
@@ -2,6 +2,8 @@
 --
 -- SPDX-License-Identifier: Apache-2.0
 {-# LANGUAGE PackageImports #-}
+-- TODO: Remove use of partial functions
+{-# OPTIONS_GHC -Wno-x-partial #-}
 
 module Bittide.Instances.Hitl.WireDemo.Driver where
 
@@ -9,34 +11,182 @@ import Clash.Prelude
 
 import Bittide.ClockControl.Config (defCcConf)
 import Bittide.Hitl
-import Bittide.Instances.Hitl.Setup (FpgaCount)
+import Bittide.Instances.Domains (GthTx)
+import Bittide.Instances.Hitl.Setup (FpgaCount, demoRigInfo, fpgaSetup)
 import Bittide.Instances.Hitl.SwitchDemo.Driver (
   dumpCcSamples,
   initGdb,
   initPicocom,
   parseBootTapInfo,
   parseTapInfo,
+  readCurrentTime,
+  readHardwareUgns,
  )
 import Bittide.Instances.Hitl.Utils.Driver
-import Bittide.Instances.Hitl.Utils.Ugn
-import Control.Concurrent.Async (forConcurrently_, mapConcurrently, mapConcurrently_)
-import Control.Concurrent.Async.Extra (zipWithConcurrently3_)
-import Control.Monad (forM_)
+import Bittide.Instances.Hitl.Utils.MemoryMap (getPathAddress)
+import Control.Concurrent (threadDelay)
+import Control.Concurrent.Async (forConcurrently_, mapConcurrently_)
+import Control.Concurrent.Async.Extra (zipWithConcurrently, zipWithConcurrently3_)
+import Control.Monad (forM_, unless)
 import Control.Monad.IO.Class
+import Data.Bifunctor (Bifunctor (bimap))
+import Data.Maybe (fromJust)
+import Data.String.Interpolate (i)
 import Data.Vector.Internal.Check (HasCallStack)
+import Gdb (Gdb)
+import Numeric (showHex)
 import Project.Chan
 import Project.FilePath
-import Project.Handle (assertEither)
+import Project.Handle (assertEither, expectRight)
 import System.Exit
 import System.FilePath
 import Vivado.Tcl (HwTarget)
 import Vivado.VivadoM (VivadoM)
 import "bittide-extra" Control.Exception.Extra (brackets)
 
+import qualified Bittide.Calculator as Calc
 import qualified Bittide.Instances.Hitl.Utils.OpenOcd as Ocd
+import qualified Bittide.Instances.Hitl.WireDemo.MemoryMaps as MemoryMaps
+import qualified Clash.Sized.Vector as V
 import qualified Data.List as L
+import qualified Data.Map as Map
 import qualified Gdb
 import qualified System.Timeout.Extra as T
+
+type StartDelay = 10 -- seconds
+
+{- | The delay in clock cycles between 2 PEs which is not accounted for by the
+`captureUgn` component.
+-}
+type InternalDelay = 0
+
+{- | Collect the configuration for the 'wireDemoPeConfig' and the 'programmableMux' in
+a single data structure for easier schedule generation.
+-}
+data NodeConfig linkCount = NodeConfig
+  { firstBCycle :: Unsigned 64
+  , readLink :: Maybe (Index linkCount)
+  , writeLink :: Maybe (Index linkCount)
+  }
+  deriving (Show)
+
+{- | Generate a schedule for the wire demo, which consists of a configuration for the PE
+and the programmable mux for each node.
+
+First generates an 'absolute' schedule with only a few rules:
+  - 'firstBCycle' is always 1 cycle after the previous node's 'firstBCycle'
+  - 'readLink' is always the previous node, except for the first node
+  - 'writeLink' is always the next node, except for the last node
+
+In this absolute schedule the links are FPGA indexed (not link indexed) and all
+`firstBCycle`s are relative to the first node's `firstBCycle`.
+
+Next, this absolute schedule is converted to a 'relative' schedule by:
+  - Converting 'firstBCycle' to account for the counter mapping between the nodes
+  - Converting FPGA indexed links to link indices based on the FPGA setup
+This process should be done in a chain-like manner, similar to the calculator for the
+switch demo.
+-}
+generateSchedule ::
+  forall nodeCount.
+  ( KnownNat nodeCount
+  , 1 <= nodeCount
+  ) =>
+  Vec nodeCount (FpgaId, Vec (nodeCount - 1) (Index nodeCount)) ->
+  Vec nodeCount (Vec (nodeCount - 1) (Unsigned 64, Unsigned 64)) ->
+  Unsigned 64 ->
+  Vec nodeCount (NodeConfig (nodeCount - 1))
+generateSchedule fpgaTable ugnParts startCycle = genConfig <$> iterateI nextState (0, startCycle)
+ where
+  -- Map a clock cycle in the source domain to the destination domain. Goes through integer
+  -- because the mapping can be negative. If the result would be negative, return maxBound
+  -- to indicate that the event will not happen within the timespan of this test.
+  mapCycle :: Unsigned 64 -> Index nodeCount -> Index nodeCount -> Unsigned 64
+  mapCycle srcCycle src dst = if dstCycleI < 0 then maxBound else fromInteger dstCycleI
+   where
+    dstCycleI = srcCycleI + counterMap !! src Map.! dst
+    srcCycleI = toInteger srcCycle
+
+    ugnPartsI = map (map (bimap toInteger toInteger)) ugnParts
+    counterMap = Calc.toCounterMap (SNat @InternalDelay) (Calc.toFpgaIndexed fpgaTable ugnPartsI)
+
+  nextState (fpgaIndex, firstBCycle) = (fpgaIndex + 1, nextFirstBCycle)
+   where
+    nextFirstBCycle = mapCycle (firstBCycle + 1) fpgaIndex (fpgaIndex + 1)
+
+  genConfig (fpgaIndex, firstBCycle) =
+    NodeConfig
+      { firstBCycle
+      , readLink = toLinkIndex fpgaIndex <$> readFpgaIdx
+      , writeLink = toLinkIndex fpgaIndex <$> writeFpgaIdx
+      }
+   where
+    readFpgaIdx = if fpgaIndex == 0 then Nothing else Just (fpgaIndex - 1)
+    writeFpgaIdx = if fpgaIndex == maxBound then Nothing else Just (fpgaIndex + 1)
+
+    toLinkIndex currentFpga targetFpga =
+      let links = snd (fpgaTable !! currentFpga)
+       in fromJust $ elemIndex targetFpga links
+
+writePeConfig ::
+  ( HasCallStack
+  , KnownNat linkCount
+  , 1 <= linkCount
+  ) =>
+  (HwTarget, DeviceInfo) ->
+  Gdb ->
+  NodeConfig linkCount ->
+  VivadoM ()
+writePeConfig (_, d) gdb nodeConfig = do
+  let getPeConfigRegister reg = expectRight $ getPathAddress MemoryMaps.mu ["0", "WireDemoPeConfig", reg]
+  liftIO $ do
+    putStrLn $ "Writing PE config for target " <> d.deviceId
+    addresses <- mapM getPeConfigRegister ["read_link", "write_link"]
+    let values = [nodeConfig.readLink, nodeConfig.writeLink]
+    _ <- sequence $ L.zipWith (Gdb.writeLe gdb) addresses values
+    pure ()
+
+writeProgrammableMuxConfig ::
+  (HasCallStack, KnownNat linkCount) =>
+  (HwTarget, DeviceInfo) ->
+  Gdb ->
+  NodeConfig linkCount ->
+  VivadoM ()
+writeProgrammableMuxConfig (_, d) gdb nodeConfig = do
+  let getMuxRegister reg = expectRight $ getPathAddress MemoryMaps.mu ["0", "ProgrammableMux", reg]
+  liftIO $ do
+    putStrLn $ "Writing programmable mux config for target " <> d.deviceId
+    firstBCycleAddress <- getMuxRegister "first_b_cycle"
+    armAddress <- getMuxRegister "arm"
+    Gdb.writeLe gdb firstBCycleAddress nodeConfig.firstBCycle
+    Gdb.writeLe gdb armAddress True
+    pure ()
+
+{- | Check that a node has the expected DNA and that the PE has written the expected data
+to the next node.
+-}
+verifyWrittenData ::
+  (HasCallStack) =>
+  (HwTarget, DeviceInfo) ->
+  Gdb ->
+  BitVector 96 ->
+  BitVector 64 ->
+  IO Bool
+verifyWrittenData (_, d) gdb expectedDna expectedData = do
+  putStrLn $ "Reading PE written data for target " <> d.deviceId
+  dnaBaseAddr <- expectRight $ getPathAddress @Integer MemoryMaps.mu ["0", "Dna", "maybe_dna"]
+  peConfigAddress <-
+    expectRight $ getPathAddress MemoryMaps.mu ["0", "WireDemoPeConfig", "written_data"]
+  maybeDna <- Gdb.readLe @(Maybe (BitVector 96)) gdb dnaBaseAddr
+  writtenData <- Gdb.readLe gdb peConfigAddress
+
+  let dna = fromJust maybeDna
+  putStrLn $ "  Expected device DNA:      " <> showHex expectedDna ""
+  putStrLn $ "  Actual device DNA:        " <> showHex dna ""
+  putStrLn $ "  Expected PE written data: " <> showHex expectedData ""
+  putStrLn $ "  Actual PE written data:   " <> showHex writtenData ""
+
+  pure $ dna == expectedDna && writtenData == expectedData
 
 driver ::
   (HasCallStack) =>
@@ -114,30 +264,55 @@ driver testName targets = do
           liftIO $ mapConcurrently_ Gdb.continue ccGdbs
           liftIO $ mapConcurrently_ Gdb.continue muGdbs
 
-          hardwareCaptureCounters <-
-            liftIO
-              $ T.tryWithTimeoutOn
-                T.PrintActionTime
-                "Waiting for hardware UGNs"
-                (3 * 60_000_000)
-                goDumpCcSamples
-              $ mapConcurrently parseCaptureCounters picocoms
-          let
-            hardwareUgns =
-              L.zipWith
-                (\i ccs -> (timingOracleToUgnEdge . counterCaptureToTimingOracle i) <$> ccs)
-                [0 ..]
-                hardwareCaptureCounters
-            hardwareRoundtrips = calculateRoundtripLatencies $ L.concat hardwareUgns
-          _ <- liftIO $ do
-            putStrLn "\n=== Hardware UGN Roundtrip Latencies ==="
-            mapM print hardwareRoundtrips
+          liftIO
+            $ T.tryWithTimeoutOn
+              T.PrintActionTime
+              "Waiting for captured UGNs"
+              60_000_000
+              goDumpCcSamples
+            $ forConcurrently_ picocoms
+            $ \pico ->
+              waitForLine pico "[MU] Printed all hardware UGNs"
 
-          -- TODO: Calculate `firstBCycle` for every programmable mux
-          -- TODO: Write `firstBCycle` to all programmable mux registers and arm them
-          -- TODO: Write 'readIndex' and `writeIndex' to all wireDemoProcessingElementConfigs
-          -- TODO: Do something to verify the result (probably change wireDemoPe to also store read data)
+          liftIO $ putStrLn "Getting UGNs for all targets"
+          liftIO $ mapConcurrently_ Gdb.interrupt muGdbs
+          ugnPairsTable <- liftIO $ zipWithConcurrently (readHardwareUgns MemoryMaps.mu) targets muGdbs
+          let
+            ugnPairsTableV = fromJust . V.fromList $ fromJust . V.fromList <$> ugnPairsTable
+          liftIO $ do
+            putStrLn "Calculating IGNs for all targets"
+            Calc.printAllIgns ugnPairsTableV fpgaSetup
+            putStrLn "UGN pairs table:"
+            mapM_ print ugnPairsTableV
+
+          -- Calculate schedule and write configurations
+          currentTime <- liftIO $ readCurrentTime MemoryMaps.mu (L.head targets) (L.head muGdbs)
+          let
+            startOffset = currentTime + natToNum @(PeriodToCycles GthTx (Seconds StartDelay))
+            schedule = generateSchedule fpgaSetup ugnPairsTableV startOffset
+          liftIO $ do
+            putStrLn "Generated schedule:"
+            mapM_ print schedule
+          liftIO $ putStrLn [i|Starting clock cycle: #{startOffset}|]
+          _ <- sequenceA $ L.zipWith3 writePeConfig targets muGdbs (toList schedule)
+          _ <- sequenceA $ L.zipWith3 writeProgrammableMuxConfig targets muGdbs (toList schedule)
+
+          -- Wait for test completion
+          liftIO $ do
+            let delayMicros = natToNum @((StartDelay + 1) * 1_000_000)
+            putStrLn [i|Sleeping for: #{delayMicros}μs ...|]
+            threadDelay delayMicros
+            newCurrentTime <- readCurrentTime MemoryMaps.mu (L.head targets) (L.head muGdbs)
+            putStrLn [i|Clock is now: #{newCurrentTime}|]
+
+          -- Verify test results
+          let
+            dnas = L.map (.dna) demoRigInfo
+            expectedWrittenDatas = L.tail $ L.scanl xor 0 $ L.map resize dnas
+          checks <- liftIO $ sequenceA $ L.zipWith4 verifyWrittenData targets muGdbs dnas expectedWrittenDatas
 
           liftIO goDumpCcSamples
+
+          unless (L.and checks) $ fail "Some PE buffer did not write the expected data"
 
           pure ExitSuccess

--- a/bittide-instances/src/Bittide/Instances/Hitl/WireDemo/Driver.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/WireDemo/Driver.hs
@@ -1,0 +1,224 @@
+-- SPDX-FileCopyrightText: 2025 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+{-# LANGUAGE PackageImports #-}
+
+module Bittide.Instances.Hitl.WireDemo.Driver where
+
+import Clash.Prelude
+
+import Bittide.ClockControl.Config (defCcConf)
+import Bittide.Hitl
+import Bittide.Instances.Hitl.Setup (FpgaCount)
+import Bittide.Instances.Hitl.SwitchDemo.Driver (
+  dumpCcSamples,
+  initGdb,
+  initPicocom,
+  parseBootTapInfo,
+  parseTapInfo,
+ )
+import Bittide.Instances.Hitl.Utils.Driver
+import Bittide.Instances.Hitl.Utils.Ugn
+import Control.Concurrent.Async (forConcurrently_, mapConcurrently, mapConcurrently_)
+import Control.Concurrent.Async.Extra (zipWithConcurrently3_)
+import Control.Monad (forM_, unless, when)
+import Control.Monad.IO.Class
+import Data.Vector.Internal.Check (HasCallStack)
+import Project.Chan
+import Project.FilePath
+import Project.Handle (assertEither)
+import System.Exit
+import System.FilePath
+import Vivado.Tcl (HwTarget)
+import Vivado.VivadoM (VivadoM)
+import "bittide-extra" Control.Exception.Extra (brackets)
+
+import qualified Bittide.Instances.Hitl.Utils.OpenOcd as Ocd
+import qualified Data.List as L
+import qualified Gdb
+import qualified System.Timeout.Extra as T
+
+driver ::
+  (HasCallStack) =>
+  String ->
+  [(HwTarget, DeviceInfo)] ->
+  VivadoM ExitCode
+driver testName targets = do
+  liftIO
+    . putStrLn
+    $ "Running driver function for targets "
+    <> show ((\(_, info) -> info.deviceId) <$> targets)
+
+  projectDir <- liftIO $ findParentContaining "cabal.project"
+  let hitlDir = projectDir </> "_build/hitl" </> testName
+
+  forM_ targets (assertProbe "probe_test_start")
+
+  let
+    -- BOOT / MU / CC IDs
+    expectedJtagIds = [0x0514C001, 0x1514C001, 0x2514C001]
+    toInitArgs (_, deviceInfo) targetIndex =
+      Ocd.InitOpenOcdArgs{deviceInfo, expectedJtagIds, hitlDir, targetIndex}
+    initArgs = L.zipWith toInitArgs targets [0 ..]
+    optionalBootInitArgs = L.repeat def{Ocd.logPrefix = "boot-", Ocd.initTcl = "vexriscv_boot_init.tcl"}
+    openOcdBootStarts = liftIO <$> L.zipWith Ocd.initOpenOcd initArgs optionalBootInitArgs
+
+  let picocomStarts = liftIO <$> L.zipWith (initPicocom hitlDir) targets [0 ..]
+  brackets picocomStarts (liftIO . snd) $ \(L.map fst -> picocoms) -> do
+    -- Start OpenOCD that will program the boot CPU
+    brackets openOcdBootStarts (liftIO . (.cleanup)) $ \initOcdsData -> do
+      let bootTapInfos = parseBootTapInfo <$> initOcdsData
+
+      Gdb.withGdbs (L.length targets) $ \bootGdbs -> do
+        liftIO
+          $ zipWithConcurrently3_ (initGdb hitlDir "switch-demo1-boot") bootGdbs bootTapInfos targets
+        liftIO $ mapConcurrently_ ((assertEither =<<) . Gdb.loadBinary) bootGdbs
+        liftIO $ mapConcurrently_ Gdb.continue bootGdbs
+        liftIO
+          $ T.tryWithTimeout T.PrintActionTime "Waiting for done" 60_000_000
+          $ forConcurrently_ picocoms
+          $ \pico ->
+            waitForLine pico "[BT] Going into infinite loop.."
+
+  let
+    optionalInitArgs = L.repeat def
+    openOcdStarts = liftIO <$> L.zipWith Ocd.initOpenOcd initArgs optionalInitArgs
+
+  -- Start OpenOCD instances for all CPUs
+  brackets openOcdStarts (liftIO . (.cleanup)) $ \initOcdsData -> do
+    let
+      allTapInfos = parseTapInfo expectedJtagIds <$> initOcdsData
+
+      _bootTapInfos, muTapInfos, ccTapInfos :: [Ocd.TapInfo]
+      (_bootTapInfos, muTapInfos, ccTapInfos)
+        | all (== L.length expectedJtagIds) (L.length <$> allTapInfos)
+        , [boots, mus, ccs] <- L.transpose allTapInfos =
+            (boots, mus, ccs)
+        | otherwise =
+            error
+              $ "Unexpected number of OpenOCD taps initialized. Expected: "
+              <> show (L.length expectedJtagIds)
+              <> ", but got: "
+              <> show (L.length <$> allTapInfos)
+
+    Gdb.withGdbs (L.length targets) $ \ccGdbs -> do
+      liftIO $ zipWithConcurrently3_ (initGdb hitlDir "clock-control") ccGdbs ccTapInfos targets
+      liftIO $ mapConcurrently_ ((assertEither =<<) . Gdb.loadBinary) ccGdbs
+
+      Gdb.withGdbs (L.length targets) $ \muGdbs -> do
+        liftIO $ zipWithConcurrently3_ (initGdb hitlDir "soft-ugn-mu") muGdbs muTapInfos targets
+        liftIO $ mapConcurrently_ ((assertEither =<<) . Gdb.loadBinary) muGdbs
+
+        brackets picocomStarts (liftIO . snd) $ \(L.map fst -> picocoms) -> do
+          let goDumpCcSamples = dumpCcSamples hitlDir (defCcConf (natToNum @FpgaCount)) ccGdbs
+          liftIO $ mapConcurrently_ Gdb.continue ccGdbs
+          liftIO $ mapConcurrently_ Gdb.continue muGdbs
+
+          hardwareCaptureCounters <-
+            liftIO
+              $ T.tryWithTimeoutOn
+                T.PrintActionTime
+                "Waiting for hardware UGNs"
+                (3 * 60_000_000)
+                goDumpCcSamples
+              $ mapConcurrently parseCaptureCounters picocoms
+          let
+            hardwareUgns =
+              L.zipWith
+                (\i ccs -> (timingOracleToUgnEdge . counterCaptureToTimingOracle i) <$> ccs)
+                [0 ..]
+                hardwareCaptureCounters
+            hardwareRoundtrips = calculateRoundtripLatencies $ L.concat hardwareUgns
+          _ <- liftIO $ do
+            putStrLn "\n=== Hardware UGN Roundtrip Latencies ==="
+            mapM print hardwareRoundtrips
+          liftIO
+            $ T.tryWithTimeoutOn
+              T.PrintActionTime
+              "Waiting for calendar initialization"
+              (30_000_000)
+              goDumpCcSamples
+            $ forConcurrently_ picocoms
+            $ \pico ->
+              waitForLine pico "[MU] All calendars initialized"
+
+          softwareUgnsPerNode <-
+            liftIO
+              $ T.tryWithTimeoutOn
+                T.PrintActionTime
+                "Waiting for software UGNs"
+                (60_000_000)
+                goDumpCcSamples
+              $ mapConcurrently parseSoftwareUgns picocoms
+
+          liftIO $ do
+            putStrLn "\n=== Hardware UGNs ==="
+            forM_ (L.zip hardwareUgns [0 :: Int ..]) $ \(hw, idx) ->
+              putStrLn $ "Node " <> show idx <> ": " <> show (L.length hw) <> " edges"
+
+            putStrLn "\n=== Software UGNs ==="
+            forM_ (L.zip softwareUgnsPerNode [0 :: Int ..]) $ \((swIn, swOut), idx) ->
+              putStrLn
+                $ "Node "
+                <> show idx
+                <> ": "
+                <> show (L.length swIn + L.length swOut)
+                <> " edges"
+
+            -- Process UGN edges and calculate roundtrip latencies
+            let hardwareUgnsFlat = postProcessHardwareUgns hardwareUgns
+            softwareUgnsFlat <- postProcessSoftwareUgns softwareUgnsPerNode
+
+            let
+              swExtraLatency = 2 -- gather read latency + extra link registers
+              mismatchedUgns =
+                findMismatchedUgnEdges
+                  (fmap (addLatencyEdge swExtraLatency) hardwareUgnsFlat)
+                  softwareUgnsFlat
+              softwareRoundtrips = calculateRoundtripLatencies softwareUgnsFlat
+            unless (L.null mismatchedUgns) $ do
+              putStrLn "\n=== Mismatched UGN Edges ==="
+              forM_ mismatchedUgns $ \(hw, sw) -> do
+                putStrLn $ "Hardware: " <> show hw
+                putStrLn $ "Software: " <> show sw
+
+            putStrLn "\n=== Software Roundtrip Latencies ==="
+            mapM_ print softwareRoundtrips
+
+            -- Compare roundtrip latencies
+            matched <-
+              compareRoundtripLatencies
+                (fmap (adjustLatencyRoundTrip (2 * swExtraLatency)) hardwareRoundtrips)
+                softwareRoundtrips
+
+            unless matched $ do
+              putStrLn "\n=== Per-Node Details ==="
+              forM_ (L.zip3 hardwareUgns softwareUgnsPerNode [0 :: Int ..]) $ \(hw, (swIn, swOut), idx) -> do
+                let sw = swIn L.++ swOut
+                when (L.length hw /= L.length sw) $ do
+                  putStrLn $ "\nNode " <> show idx <> " edge count differs:"
+                  putStrLn $ "  Hardware: " <> show (L.length hw) <> " edges"
+                  putStrLn
+                    $ "  Software: "
+                    <> show (L.length sw)
+                    <> " edges ("
+                    <> show (L.length swIn)
+                    <> " in + "
+                    <> show (L.length swOut)
+                    <> " out)"
+              error "Roundtrip latencies did not match between hardware and software"
+            when (not $ L.null mismatchedUgns) $ error "Some UGN edges did not match!"
+
+            liftIO
+              $ T.tryWithTimeoutOn
+                T.PrintActionTime
+                "Waiting for CPU test status"
+                (1_000_000)
+                goDumpCcSamples
+              $ forConcurrently_ picocoms
+              $ \pico ->
+                waitForLine pico "[MU] Test status: Success"
+
+          liftIO goDumpCcSamples
+
+          pure ExitSuccess

--- a/bittide-instances/src/Bittide/Instances/Hitl/WireDemo/Driver.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/WireDemo/Driver.hs
@@ -57,8 +57,12 @@ type StartDelay = 10 -- seconds
 
 {- | The delay in clock cycles between 2 PEs which is not accounted for by the
 `captureUgn` component.
+
+For the wire demo this delay is 1 cycle, caused by the 'dflipflop' at the output of
+'core', which is _before_ the 'sendUgn' component and therefore not accounted for in the
+captured UGN.
 -}
-type InternalDelay = 0
+type InternalDelay = 1
 
 {- | Collect the configuration for the 'wireDemoPeConfig' and the 'programmableMux' in
 a single data structure for easier schedule generation.

--- a/bittide-instances/src/Bittide/Instances/Hitl/WireDemo/Driver.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/WireDemo/Driver.hs
@@ -21,7 +21,7 @@ import Bittide.Instances.Hitl.Utils.Driver
 import Bittide.Instances.Hitl.Utils.Ugn
 import Control.Concurrent.Async (forConcurrently_, mapConcurrently, mapConcurrently_)
 import Control.Concurrent.Async.Extra (zipWithConcurrently3_)
-import Control.Monad (forM_, unless, when)
+import Control.Monad (forM_)
 import Control.Monad.IO.Class
 import Data.Vector.Internal.Check (HasCallStack)
 import Project.Chan
@@ -106,7 +106,7 @@ driver testName targets = do
       liftIO $ mapConcurrently_ ((assertEither =<<) . Gdb.loadBinary) ccGdbs
 
       Gdb.withGdbs (L.length targets) $ \muGdbs -> do
-        liftIO $ zipWithConcurrently3_ (initGdb hitlDir "soft-ugn-mu") muGdbs muTapInfos targets
+        liftIO $ zipWithConcurrently3_ (initGdb hitlDir "wire-demo-mu") muGdbs muTapInfos targets
         liftIO $ mapConcurrently_ ((assertEither =<<) . Gdb.loadBinary) muGdbs
 
         brackets picocomStarts (liftIO . snd) $ \(L.map fst -> picocoms) -> do
@@ -132,92 +132,11 @@ driver testName targets = do
           _ <- liftIO $ do
             putStrLn "\n=== Hardware UGN Roundtrip Latencies ==="
             mapM print hardwareRoundtrips
-          liftIO
-            $ T.tryWithTimeoutOn
-              T.PrintActionTime
-              "Waiting for calendar initialization"
-              (30_000_000)
-              goDumpCcSamples
-            $ forConcurrently_ picocoms
-            $ \pico ->
-              waitForLine pico "[MU] All calendars initialized"
 
-          softwareUgnsPerNode <-
-            liftIO
-              $ T.tryWithTimeoutOn
-                T.PrintActionTime
-                "Waiting for software UGNs"
-                (60_000_000)
-                goDumpCcSamples
-              $ mapConcurrently parseSoftwareUgns picocoms
-
-          liftIO $ do
-            putStrLn "\n=== Hardware UGNs ==="
-            forM_ (L.zip hardwareUgns [0 :: Int ..]) $ \(hw, idx) ->
-              putStrLn $ "Node " <> show idx <> ": " <> show (L.length hw) <> " edges"
-
-            putStrLn "\n=== Software UGNs ==="
-            forM_ (L.zip softwareUgnsPerNode [0 :: Int ..]) $ \((swIn, swOut), idx) ->
-              putStrLn
-                $ "Node "
-                <> show idx
-                <> ": "
-                <> show (L.length swIn + L.length swOut)
-                <> " edges"
-
-            -- Process UGN edges and calculate roundtrip latencies
-            let hardwareUgnsFlat = postProcessHardwareUgns hardwareUgns
-            softwareUgnsFlat <- postProcessSoftwareUgns softwareUgnsPerNode
-
-            let
-              swExtraLatency = 2 -- gather read latency + extra link registers
-              mismatchedUgns =
-                findMismatchedUgnEdges
-                  (fmap (addLatencyEdge swExtraLatency) hardwareUgnsFlat)
-                  softwareUgnsFlat
-              softwareRoundtrips = calculateRoundtripLatencies softwareUgnsFlat
-            unless (L.null mismatchedUgns) $ do
-              putStrLn "\n=== Mismatched UGN Edges ==="
-              forM_ mismatchedUgns $ \(hw, sw) -> do
-                putStrLn $ "Hardware: " <> show hw
-                putStrLn $ "Software: " <> show sw
-
-            putStrLn "\n=== Software Roundtrip Latencies ==="
-            mapM_ print softwareRoundtrips
-
-            -- Compare roundtrip latencies
-            matched <-
-              compareRoundtripLatencies
-                (fmap (adjustLatencyRoundTrip (2 * swExtraLatency)) hardwareRoundtrips)
-                softwareRoundtrips
-
-            unless matched $ do
-              putStrLn "\n=== Per-Node Details ==="
-              forM_ (L.zip3 hardwareUgns softwareUgnsPerNode [0 :: Int ..]) $ \(hw, (swIn, swOut), idx) -> do
-                let sw = swIn L.++ swOut
-                when (L.length hw /= L.length sw) $ do
-                  putStrLn $ "\nNode " <> show idx <> " edge count differs:"
-                  putStrLn $ "  Hardware: " <> show (L.length hw) <> " edges"
-                  putStrLn
-                    $ "  Software: "
-                    <> show (L.length sw)
-                    <> " edges ("
-                    <> show (L.length swIn)
-                    <> " in + "
-                    <> show (L.length swOut)
-                    <> " out)"
-              error "Roundtrip latencies did not match between hardware and software"
-            when (not $ L.null mismatchedUgns) $ error "Some UGN edges did not match!"
-
-            liftIO
-              $ T.tryWithTimeoutOn
-                T.PrintActionTime
-                "Waiting for CPU test status"
-                (1_000_000)
-                goDumpCcSamples
-              $ forConcurrently_ picocoms
-              $ \pico ->
-                waitForLine pico "[MU] Test status: Success"
+          -- TODO: Calculate `firstBCycle` for every programmable mux
+          -- TODO: Write `firstBCycle` to all programmable mux registers and arm them
+          -- TODO: Write 'readIndex' and `writeIndex' to all wireDemoProcessingElementConfigs
+          -- TODO: Do something to verify the result (probably change wireDemoPe to also store read data)
 
           liftIO goDumpCcSamples
 

--- a/bittide-instances/src/Bittide/Instances/Hitl/WireDemo/MemoryMaps.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/WireDemo/MemoryMaps.hs
@@ -1,0 +1,38 @@
+-- SPDX-FileCopyrightText: 2025 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+
+module Bittide.Instances.Hitl.WireDemo.MemoryMaps where
+
+import Clash.Explicit.Prelude
+import Protocols
+
+import Bittide.Instances.Hitl.WireDemo.BringUp (bringUp)
+import Bittide.SharedTypes (withLittleEndian)
+import Clash.Sized.Vector.ToTuple (vecToTuple)
+import Protocols.MemoryMap (MemoryMap)
+import VexRiscv (JtagIn (..))
+
+import qualified Protocols.Spi as Spi
+
+boot, mu, cc :: MemoryMap
+(boot, mu, cc) = (bootMm, muMm, ccMm)
+ where
+  Circuit circuitFn = withLittleEndian $ bringUp clockGen noReset
+
+  (SimOnly bootMm, SimOnly muMm, SimOnly ccMm) = vecToTuple memoryMaps
+
+  ((memoryMaps, _, _), _) =
+    circuitFn
+      (
+        ( repeat ()
+        , pure (JtagIn 0 0 0)
+        , (clockGen, SimOnly (repeat 0), 0, 0, repeat "", repeat "")
+        )
+      ,
+        ( pure (Spi.S2M low)
+        , pure low
+        , ()
+        , ()
+        )
+      )

--- a/bittide-instances/src/Bittide/Instances/Hitl/WireDemo/TopEntity.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/WireDemo/TopEntity.hs
@@ -1,0 +1,119 @@
+-- SPDX-FileCopyrightText: 2025 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+
+module Bittide.Instances.Hitl.WireDemo.TopEntity where
+
+import Clash.Explicit.Prelude
+import Protocols
+
+import Bittide.Hitl (
+  HitlTestCase (..),
+  HitlTestGroup (..),
+  hitlVioBool,
+  paramForHwTargets,
+ )
+import Bittide.Instances.Domains (
+  Basic125,
+  Bittide,
+  Ext125,
+  Ext200,
+  GthRx,
+  GthRxS,
+  GthTxS,
+ )
+import Bittide.Instances.Hitl.Setup (LinkCount, allHwTargets, channelNames, clockPaths)
+import Bittide.Instances.Hitl.WireDemo.BringUp (bringUp)
+import Clash.Annotations.TH (makeTopEntity)
+import Clash.Xilinx.ClockGen (clockWizardDifferential)
+import System.FilePath ((</>))
+import VexRiscv (JtagIn (..), JtagOut (..))
+
+import qualified Bittide.Instances.Hitl.WireDemo.Driver as Driver
+import qualified Clash.Cores.Xilinx.Gth as Gth
+import qualified Protocols.Spi as Spi
+
+wireDemoTest ::
+  "SMA_MGT_REFCLK_C" ::: DiffClock Ext200 ->
+  "SYSCLK_125" ::: DiffClock Ext125 ->
+  "GTH_RX_S" ::: Gth.SimWires GthRx LinkCount ->
+  "GTH_RX_NS" ::: Gth.Wires GthRxS LinkCount ->
+  "GTH_RX_PS" ::: Gth.Wires GthRxS LinkCount ->
+  Signal Basic125 Spi.S2M ->
+  "JTAG" ::: Signal Basic125 JtagIn ->
+  "USB_UART_TXD" ::: Signal Basic125 Bit ->
+  "SYNC_IN" ::: Signal Bittide Bit ->
+  ( "GTH_TX_S" ::: Gth.SimWires Bittide LinkCount
+  , "GTH_TX_NS" ::: Gth.Wires GthTxS LinkCount
+  , "GTH_TX_PS" ::: Gth.Wires GthTxS LinkCount
+  , ""
+      ::: ( "FINC" ::: Signal Bittide Bool
+          , "FDEC" ::: Signal Bittide Bool
+          )
+  , "" ::: Signal Basic125 Spi.M2S
+  , "JTAG" ::: Signal Basic125 JtagOut
+  , "USB_UART_RXD" ::: Signal Basic125 Bit
+  , "SYNC_OUT" ::: Signal Basic125 Bit
+  )
+wireDemoTest boardClkDiff refClkDiff rxs rxns rxps spiS2M jtagIn _uartRx syncIn =
+  ( txs
+  , txns
+  , txps
+  , unbundle swFincFdecs
+  , spiM2S
+  , jtagOut
+  , uartTx
+  , syncOut
+  )
+ where
+  boardClk :: Clock Ext200
+  (boardClk, _) = Gth.ibufds_gte3 boardClkDiff
+
+  refClk :: Clock Basic125
+  refRst :: Reset Basic125
+  (refClk, refRst) = clockWizardDifferential refClkDiff noReset
+
+  testStart :: Signal Basic125 Bool
+  testStart = hitlVioBool refClk testStart (pure True)
+
+  testReset :: Reset Basic125
+  testReset = unsafeFromActiveLow testStart `orReset` refRst
+
+  ( (_memoryMaps, jtagOut, (txs, txns, txps))
+    , ( spiM2S
+        , syncOut
+        , uartTx
+        , swFincFdecs
+        )
+    ) =
+      toSignals
+        (bringUp refClk testReset)
+        ( (repeat (), jtagIn, (boardClk, rxs, rxns, rxps, channelNames, clockPaths))
+        , (spiS2M, syncIn, (), ())
+        )
+{-# OPAQUE wireDemoTest #-}
+makeTopEntity 'wireDemoTest
+
+tests :: HitlTestGroup
+tests =
+  HitlTestGroup
+    { topEntity = 'wireDemoTest
+    , targetXdcs =
+        [ "switchDemoTest.xdc"
+        , "jtag" </> "config.xdc"
+        , "jtag" </> "pmod1.xdc"
+        , "uart" </> "pmod1.xdc"
+        , "si539x" </> "fincfdec.xdc"
+        , "si539x" </> "spi.xdc"
+        ]
+    , externalHdl = []
+    , testCases =
+        [ HitlTestCase
+            { name = "Bittide_Demo_DUT"
+            , parameters = paramForHwTargets allHwTargets ()
+            , postProcData = ()
+            }
+        ]
+    , mDriverProc = Just Driver.driver
+    , mPostProc = Nothing
+    }

--- a/bittide-instances/src/Bittide/Instances/MemoryMaps.hs
+++ b/bittide-instances/src/Bittide/Instances/MemoryMaps.hs
@@ -25,6 +25,7 @@ import qualified Bittide.Instances.Hitl.Si539xConfiguration as Si539xConfigurati
 import qualified Bittide.Instances.Hitl.SoftUgnDemo.MemoryMaps as SoftUgnDemo
 import qualified Bittide.Instances.Hitl.SwitchDemo.MemoryMaps as SwitchDemo
 import qualified Bittide.Instances.Hitl.SwitchDemoGppe.MemoryMaps as SwitchDemoGppe
+import qualified Bittide.Instances.Hitl.WireDemo.MemoryMaps as WireDemo
 import qualified Bittide.Instances.Tests.AddressableBytesWb as AddressableBytesWb
 import qualified Bittide.Instances.Tests.ElasticBufferWb as ElasticBufferWb
 import qualified Bittide.Instances.Tests.NestedInterconnect as NestedInterconnect
@@ -65,6 +66,9 @@ $( do
           , ("SwitchDemoGppeGppe", SwitchDemoGppe.gppe)
           , ("TimeWb", TimeWb.timeWbMm)
           , ("WbToDfTest", WbToDf.dutMM)
+          , ("WireDemoBoot", WireDemo.boot)
+          , ("WireDemoMu", WireDemo.mu)
+          , ("WireDemoCc", WireDemo.cc)
           , ("VexRiscv", vexRiscvTestMM)
           ]
 

--- a/bittide/bittide.cabal
+++ b/bittide/bittide.cabal
@@ -237,6 +237,7 @@ library
     Bittide.Transceiver.ResetManager
     Bittide.Transceiver.Wishbone
     Bittide.Transceiver.WordAlign
+    Bittide.WireDemoProcessingElement
     Bittide.Wishbone
     Clash.Cores.Extra
     Clash.Cores.UART.Extra
@@ -315,6 +316,7 @@ test-suite unittests
     Tests.Transceiver
     Tests.Transceiver.Prbs
     Tests.Transceiver.WordAlign
+    Tests.WireDemoProcessingElement
     Tests.Wishbone
     Tests.Wishbone.Arbiter
     Tests.Wishbone.Utils

--- a/bittide/src/Bittide/Calculator.hs
+++ b/bittide/src/Bittide/Calculator.hs
@@ -23,15 +23,17 @@ import qualified Data.Map as Map
 
 type FpgaId = String
 
--- TODO: find a way to derive this 4 from the code instead of using a magic number.
---
--- This is currently '4', because we traverse two switches and each switch has registered
--- inputs and outputs.
-iNTERNAL_SWITCH_DELAY :: (Num a) => a
-iNTERNAL_SWITCH_DELAY = 4
+{- | The delay in clock cycles between 2 PEs. This delay is not included in the UGNs when
+captured by the 'captureUgn' component, because that component is placed before the
+switch. For the switch demo the delay is 4 cycles, because the data traverses two switches
+and each switch has registered inputs and outputs.
 
-dELAY_CROSSBAR_TO_PE :: (Num a) => a
-dELAY_CROSSBAR_TO_PE = 1
+TODO: find a way to derive this 4 from the code instead of using a magic number.
+-}
+type InternalSwitchDelay = 4
+
+-- | The delay in clock cycles between the crossbar and the PE
+type DelayCrossbarToPe = 1
 
 {- | Convert a table (fpga_nr x link_nr) to a vector of maps mapping an fpga index
 (instead of a link index) to the value.
@@ -53,12 +55,13 @@ convert it into a table that represents the mapping from an FPGA's local counter
 to another FPGA's counter.
 -}
 toCounterMap ::
-  forall nNodes a.
+  forall nNodes a internalDelay.
   (HasCallStack, Num a, KnownNat nNodes, 1 <= nNodes) =>
+  SNat internalDelay ->
   Vec nNodes (Map (Index nNodes) (a, a)) ->
   -- | n -> m: c
   Vec nNodes (Map (Index nNodes) a)
-toCounterMap fpgaIndexed = goSrc <$> indicesI
+toCounterMap SNat fpgaIndexed = goSrc <$> indicesI
  where
   goSrc ::
     (HasCallStack) =>
@@ -74,7 +77,7 @@ toCounterMap fpgaIndexed = goSrc <$> indicesI
   goSrcDst src dst | src == dst = Nothing
   goSrcDst src dst =
     let (srcCycle, dstCycle) = fpgaIndexed !! dst Map.! src
-     in Just (dst, srcCycle - dstCycle + iNTERNAL_SWITCH_DELAY)
+     in Just (dst, srcCycle - dstCycle + natToNum @internalDelay)
 
 uncons :: Vec (n + 1) a -> (a, Vec n a)
 uncons (x :> xs) = (x, xs)
@@ -418,7 +421,7 @@ chainConfigurationWorker _ fpgaConfig ugnParts writeOffset =
   metacycleLength = natToNum @(MetacycleLength nNodes cyclesPerWrite padding reps)
 
   counterMap :: Vec nNodes (Map (Index nNodes) Integer)
-  counterMap = toCounterMap (toFpgaIndexed fpgaConfig ugnParts)
+  counterMap = toCounterMap (SNat @InternalSwitchDelay) (toFpgaIndexed fpgaConfig ugnParts)
 
   mkLink ::
     (Integer, Integer) ->
@@ -465,7 +468,7 @@ chainConfigurationWorker _ fpgaConfig ugnParts writeOffset =
     -- https://docs.google.com/presentation/d/1JryWl8EjcWlwOW7OO24nXui5wx_WPlDJOtp1Jlf_fmE
     linkSelectOffset0 = offsetsByFpga !! dst Map.! src
     linkSelectOffset1 = linkSelectOffset0 + windowCycles
-    crossbarDstCycle = mapCycle (srcCycle - dELAY_CROSSBAR_TO_PE) src dst
+    crossbarDstCycle = mapCycle (srcCycle - natToNum @DelayCrossbarToPe) src dst
     offsetInDstMetacycle = rem crossbarDstCycle metacycleLength
 
   offsets :: (KnownNat nNodes, 1 <= nNodes) => Vec nNodes (Vec (nNodes - 1) Integer)

--- a/bittide/src/Bittide/WireDemoProcessingElement.hs
+++ b/bittide/src/Bittide/WireDemoProcessingElement.hs
@@ -1,0 +1,136 @@
+-- SPDX-FileCopyrightText: 2024 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+
+module Bittide.WireDemoProcessingElement (
+  wireDemoPe,
+  wireDemoPeConfig,
+) where
+
+import Clash.Prelude
+import Protocols
+
+import Clash.Class.BitPackC (ByteOrder)
+import Data.Maybe (fromMaybe)
+import GHC.Stack (HasCallStack)
+import Protocols.MemoryMap (Access (ReadOnly, ReadWrite), Mm)
+import Protocols.MemoryMap.Registers.WishboneStandard (
+  RegisterConfig (access, description),
+  deviceConfig,
+  deviceWbI,
+  registerConfig,
+  registerWbI,
+  registerWbI_,
+ )
+import Protocols.Wishbone (Wishbone, WishboneMode (Standard))
+
+wireDemoPeConfig ::
+  forall dom addrW nBytes linkCount linkWidth.
+  ( HasCallStack
+  , HiddenClockResetEnable dom
+  , KnownNat addrW
+  , KnownNat nBytes
+  , 1 <= nBytes
+  , KnownNat linkCount
+  , 1 <= linkCount
+  , KnownNat linkWidth
+  , ?byteOrder :: ByteOrder
+  ) =>
+  Circuit
+    ( (ToConstBwd Mm, Wishbone dom 'Standard addrW nBytes)
+    , "WRITTEN_DATA" ::: CSignal dom (Maybe (BitVector linkWidth))
+    )
+    ( "READ_LINK" ::: CSignal dom (Maybe (Index linkCount))
+    , "WRITE_LINK" ::: CSignal dom (Maybe (Index linkCount))
+    )
+wireDemoPeConfig = circuit $ \(bus, writtenData) -> do
+  [wbReadLink, wbWriteLink, wbWrittenData] <-
+    deviceWbI (deviceConfig "WireDemoPeConfig") -< bus
+
+  (Fwd readLink, _readLinkActivity) <-
+    registerWbI
+      (registerConfig "read_link")
+        { access = ReadWrite
+        , description = "Index of the link to read from."
+        }
+      Nothing
+      -< (wbReadLink, Fwd (pure Nothing))
+
+  (Fwd writeLink, _writeLinkActivity) <-
+    registerWbI
+      (registerConfig "write_link")
+        { access = ReadWrite
+        , description = "Index of the link to write to."
+        }
+      Nothing
+      -< (wbWriteLink, Fwd (pure Nothing))
+
+  registerWbI_
+    (registerConfig "written_data")
+      { access = ReadOnly
+      , description =
+          "The data written by the wireDemoPe in the second cycle after reset."
+      }
+    0
+    -< (wbWrittenData, writtenData)
+
+  idC -< Fwd (readLink, writeLink)
+
+data PeState linkCount linkWidth = Read | Write (Index linkCount) (BitVector linkWidth) | Idle
+  deriving (Eq, Show, Generic, NFDataX)
+
+{- | The wireDemoPe is active for two cycles after reset. In the first cycle
+it samples from the link indicated by the config (or sources static 'dna'). In the second cycle,
+it writes 'value_read_in_first_cycle XOR fpga_dna_lsbs' to the link indicated by the config
+(or writes to link '0').
+-}
+wireDemoPe ::
+  forall dom linkCount linkWidth.
+  ( HasCallStack
+  , HiddenClock dom
+  , KnownNat linkCount
+  , 1 <= linkCount
+  , KnownNat linkWidth
+  ) =>
+  Reset dom ->
+  -- | DNA value
+  Signal dom (Maybe (BitVector 96)) ->
+  Circuit
+    ( "LINKS_IN" ::: Vec linkCount (CSignal dom (BitVector linkWidth))
+    , "READ_INDEX" ::: CSignal dom (Maybe (Index linkCount))
+    , "WRITE_INDEX" ::: CSignal dom (Maybe (Index linkCount))
+    )
+    ( "LINKS_OUT" ::: Vec linkCount (CSignal dom (BitVector linkWidth))
+    , "WRITTEN_DATA" ::: CSignal dom (Maybe (BitVector linkWidth))
+    )
+wireDemoPe rst maybeDna = Circuit go
+ where
+  go ((linksIn, readIndex_, writeIndex_), _) = ((repeat (), (), ()), (unbundle linksOut, writtenData))
+   where
+    (linksOut, writtenData) =
+      withClockResetEnable hasClock rst enableGen
+        $ mealyB goMealy Read (bundle linksIn, readIndex_, writeIndex_, dnaLsbs)
+    -- TODO: Do the `fromMaybe` at top level, so all components use the same default DNA value.
+    dnaLsbs = resize . fromMaybe 0xDEADBEEF <$> maybeDna
+
+    goMealy ::
+      PeState linkCount linkWidth ->
+      ( Vec linkCount (BitVector linkWidth)
+      , Maybe (Index linkCount)
+      , Maybe (Index linkCount)
+      , BitVector linkWidth
+      ) ->
+      ( PeState linkCount linkWidth
+      , ( Vec linkCount (BitVector linkWidth)
+        , Maybe (BitVector linkWidth)
+        )
+      )
+    goMealy Read (links, readIndex, writeIndex, dna) =
+      let nextState = case readIndex of
+            Just rdIdx -> Write (fromMaybe 0 writeIndex) (links !! rdIdx `xor` dna)
+            Nothing -> Write (fromMaybe 0 writeIndex) dna
+       in (nextState, (repeat 0, Nothing))
+    goMealy (Write writeIndex value) _ =
+      (Idle, (replace writeIndex value (repeat 0), Just value))
+    goMealy Idle _ =
+      (Idle, (repeat 0, Nothing))

--- a/bittide/src/Bittide/WireDemoProcessingElement.hs
+++ b/bittide/src/Bittide/WireDemoProcessingElement.hs
@@ -83,6 +83,7 @@ data PeState linkCount linkWidth = Read | Write (Index linkCount) (BitVector lin
 it samples from the link indicated by the config (or sources static 'dna'). In the second cycle,
 it writes 'value_read_in_first_cycle XOR fpga_dna_lsbs' to the link indicated by the config
 (or writes to link '0').
+Writes the local counter to all links by default, which is useful when debugging.
 -}
 wireDemoPe ::
   forall dom linkCount linkWidth.
@@ -95,6 +96,8 @@ wireDemoPe ::
   Reset dom ->
   -- | DNA value
   Signal dom (Maybe (BitVector 96)) ->
+  -- | Local counter
+  Signal dom (Unsigned 64) ->
   Circuit
     ( "LINKS_IN" ::: Vec linkCount (CSignal dom (BitVector linkWidth))
     , "READ_INDEX" ::: CSignal dom (Maybe (Index linkCount))
@@ -103,13 +106,13 @@ wireDemoPe ::
     ( "LINKS_OUT" ::: Vec linkCount (CSignal dom (BitVector linkWidth))
     , "WRITTEN_DATA" ::: CSignal dom (Maybe (BitVector linkWidth))
     )
-wireDemoPe rst maybeDna = Circuit go
+wireDemoPe rst maybeDna localCounter = Circuit go
  where
   go ((linksIn, readIndex_, writeIndex_), _) = ((repeat (), (), ()), (unbundle linksOut, writtenData))
    where
     (linksOut, writtenData) =
       withClockResetEnable hasClock rst enableGen
-        $ mealyB goMealy Read (bundle linksIn, readIndex_, writeIndex_, dnaLsbs)
+        $ mealyB goMealy Read (bundle linksIn, readIndex_, writeIndex_, dnaLsbs, localCounter)
     -- TODO: Do the `fromMaybe` at top level, so all components use the same default DNA value.
     dnaLsbs = resize . fromMaybe 0xDEADBEEF <$> maybeDna
 
@@ -119,18 +122,19 @@ wireDemoPe rst maybeDna = Circuit go
       , Maybe (Index linkCount)
       , Maybe (Index linkCount)
       , BitVector linkWidth
+      , Unsigned 64
       ) ->
       ( PeState linkCount linkWidth
       , ( Vec linkCount (BitVector linkWidth)
         , Maybe (BitVector linkWidth)
         )
       )
-    goMealy Read (links, readIndex, writeIndex, dna) =
+    goMealy Read (links, readIndex, writeIndex, dna, counter) =
       let nextState = case readIndex of
             Just rdIdx -> Write (fromMaybe 0 writeIndex) (links !! rdIdx `xor` dna)
             Nothing -> Write (fromMaybe 0 writeIndex) dna
-       in (nextState, (repeat 0, Nothing))
-    goMealy (Write writeIndex value) _ =
-      (Idle, (replace writeIndex value (repeat 0), Just value))
-    goMealy Idle _ =
-      (Idle, (repeat 0, Nothing))
+       in (nextState, (repeat (resize (pack counter)), Nothing))
+    goMealy (Write writeIndex value) (_, _, _, _, counter) =
+      (Idle, (replace writeIndex value (repeat (resize (pack counter))), Just value))
+    goMealy Idle (_, _, _, _, counter) =
+      (Idle, (repeat (resize (pack counter)), Nothing))

--- a/bittide/tests/Tests/SwitchDemoProcessingElement/Calculator.hs
+++ b/bittide/tests/Tests/SwitchDemoProcessingElement/Calculator.hs
@@ -45,7 +45,8 @@ case_toFpgaIndexed = toFpgaIndexed fpgaSetup indices @?= expected
   expected = [(1, 0), (2, 1)] :> [(2, 2), (0, 3)] :> [(0, 4), (1, 5)] :> Nil
 
 case_toCounterMap :: Assertion
-case_toCounterMap = toCounterMap (toFpgaIndexed fpgaSetup parts) @?= expected
+case_toCounterMap =
+  toCounterMap (SNat @InternalSwitchDelay) (toFpgaIndexed fpgaSetup parts) @?= expected
  where
   expected = [(1, 2), (2, 7)] :> [(0, 5), (2, 1)] :> [(0, 3), (1, 6)] :> Nil
 

--- a/bittide/tests/Tests/WireDemoProcessingElement.hs
+++ b/bittide/tests/Tests/WireDemoProcessingElement.hs
@@ -1,0 +1,90 @@
+-- SPDX-FileCopyrightText: 2026 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+{-# LANGUAGE OverloadedStrings #-}
+
+module Tests.WireDemoProcessingElement where
+
+import Clash.Prelude
+import Protocols
+
+import Bittide.WireDemoProcessingElement (wireDemoPe)
+
+import Clash.Hedgehog.Sized.BitVector (genDefinedBitVector)
+import Clash.Hedgehog.Sized.Unsigned (genUnsigned)
+import Hedgehog (Property)
+import Test.Tasty (TestTree)
+import Test.Tasty.Hedgehog (testProperty)
+import Test.Tasty.TH (testGroupGenerator)
+
+import qualified Data.List as L
+import qualified Data.String.Interpolate as Str
+import qualified Hedgehog as H
+import qualified Hedgehog.Range as Range
+
+splitAtIndex :: Int -> [a] -> ([a], a, [a])
+splitAtIndex n xs =
+  let (before, rest) = L.splitAt n xs
+   in case rest of
+        (x : after) -> (before, x, after)
+        [] -> error "Index out of bounds"
+
+prop_WireDemoPe :: Property
+prop_WireDemoPe = H.property $ do
+  peResetCycle <- H.forAll $ genUnsigned (Range.linear 0 90)
+  dna <- H.forAll $ genDefinedBitVector
+
+  let
+    dut ::
+      Circuit
+        (CSignal System (BitVector 64))
+        (CSignal System (BitVector 64), CSignal System (Maybe (BitVector 64)))
+    dut =
+      withClock clockGen
+        $ circuit
+        $ \cntr -> do
+          let
+            maybeDna = pure (Just dna)
+            readIndex = pure (Just 0)
+            writeIndex = pure (Just 0)
+            peReset = unsafeFromActiveHigh $ (pure peResetCycle) .>. (unpack <$> c)
+
+          Fwd c <- idC -< cntr
+          (Fwd linksOut, writtenData) <-
+            wireDemoPe @_ @1 peReset maybeDna
+              -< (Fwd (repeat c), Fwd readIndex, Fwd writeIndex)
+          -- Since 'linkCount' is 1 there is only one link in the vector
+          idC -< (Fwd (head linksOut), writtenData)
+
+    counter = L.iterate (+ 1) 0
+    (outLink, writtenData) = sampleC conf $ dut <| driveC conf counter
+
+    readCycle = peResetCycle
+    writeCycle = peResetCycle + 1
+    expectedOutput = resize dna `xor` (pack readCycle)
+
+    (linkBeforeActive, linkAtWriteCycle, linkAfterActive) = splitAtIndex (fromIntegral writeCycle) outLink
+    (wDataBeforeActive, wDataAtWriteCycle, wDataAfterActive) = splitAtIndex (fromIntegral writeCycle) writtenData
+
+    interestingCycles :: [Unsigned 64]
+    interestingCycles = L.map unpack $ L.take 10 (L.drop (fromIntegral writeCycle - 5) outLink)
+
+    firstNonZeroIndex = L.findIndex (/= 0) outLink
+
+  H.footnote [Str.i|Interesting cycles (around reset): #{interestingCycles}|]
+  H.footnote [Str.i|Expected output at cycle #{writeCycle}, but got it at cycle #{firstNonZeroIndex}|]
+
+  H.assert (L.all (== 0) linkBeforeActive)
+  linkAtWriteCycle H.=== expectedOutput
+  H.assert (L.all (== 0) linkAfterActive)
+
+  H.assert (L.all (== Nothing) wDataBeforeActive)
+  wDataAtWriteCycle H.=== Just expectedOutput
+  H.assert (L.all (== Nothing) wDataAfterActive)
+ where
+  simLength = 100
+  -- We set the reset inside 'dut' based on the input counter so we don't use it here
+  conf = def{timeoutAfter = simLength, resetCycles = 0}
+
+tests :: TestTree
+tests = $(testGroupGenerator)

--- a/bittide/tests/Tests/WireDemoProcessingElement.hs
+++ b/bittide/tests/Tests/WireDemoProcessingElement.hs
@@ -51,7 +51,7 @@ prop_WireDemoPe = H.property $ do
 
           Fwd c <- idC -< cntr
           (Fwd linksOut, writtenData) <-
-            wireDemoPe @_ @1 peReset maybeDna
+            wireDemoPe @_ @1 peReset maybeDna (pure 0)
               -< (Fwd (repeat c), Fwd readIndex, Fwd writeIndex)
           -- Since 'linkCount' is 1 there is only one link in the vector
           idC -< (Fwd (head linksOut), writtenData)

--- a/bittide/tests/UnitTests.hs
+++ b/bittide/tests/UnitTests.hs
@@ -32,6 +32,7 @@ import qualified Tests.SwitchDemoProcessingElement.Calculator
 import qualified Tests.Transceiver
 import qualified Tests.Transceiver.Prbs
 import qualified Tests.Transceiver.WordAlign
+import qualified Tests.WireDemoProcessingElement
 import qualified Tests.Wishbone
 import qualified Tests.Wishbone.Arbiter
 
@@ -62,6 +63,7 @@ tests =
     , Tests.Transceiver.Prbs.tests
     , Tests.Transceiver.tests
     , Tests.Transceiver.WordAlign.tests
+    , Tests.WireDemoProcessingElement.tests
     , Tests.Wishbone.tests
     , Tests.Wishbone.Arbiter.tests
     ]

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -19,5 +19,6 @@ SPDX-License-Identifier: Apache-2.0
   - [Soft UGN Demo](sections/demos/soft-ugn-demo.md)
   - [Switch Demo with ASIC](sections/demos/switch-demo-asic.md)
   - [Switch Demo with GPPE](sections/demos/switch-demo-gppe.md)
+  - [Wire Demo](sections/demos/wire-demo.md)
 - [Ringbuffer alignment](sections/ringbuffer-alignment.md)
 - [Asynchronous communication](sections/asynchronous-communication.md)

--- a/docs/diagrams/wireDemo.drawio
+++ b/docs/diagrams/wireDemo.drawio
@@ -1,0 +1,294 @@
+<mxfile host="65bd71144e">
+    <diagram id="-eBjuuXd_3k9EE6LEn2m" name="Page-1">
+        <mxGraphModel dx="-1828" dy="-158" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="850" pageHeight="1100" math="0" shadow="0">
+            <root>
+                <mxCell id="0"/>
+                <mxCell id="1" parent="0"/>
+                <mxCell id="2" value="" style="rounded=0;whiteSpace=wrap;html=1;movable=0;resizable=0;rotatable=0;deletable=0;editable=0;locked=1;connectable=0;labelPosition=left;verticalLabelPosition=top;align=right;verticalAlign=bottom;" vertex="1" parent="1">
+                    <mxGeometry x="3050" y="1940" width="480" height="490" as="geometry"/>
+                </mxCell>
+                <mxCell id="3" value="EB1" style="rounded=0;whiteSpace=wrap;html=1;rotation=90;" vertex="1" parent="1">
+                    <mxGeometry x="3050" y="1980" width="80" height="40" as="geometry"/>
+                </mxCell>
+                <mxCell id="4" value="" style="endArrow=classic;html=1;rounded=0;fillColor=#dae8fc;strokeColor=#6c8ebf;" edge="1" parent="1">
+                    <mxGeometry width="50" height="50" relative="1" as="geometry">
+                        <mxPoint x="3100" y="1920" as="sourcePoint"/>
+                        <mxPoint x="3100" y="1960" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="5" value="" style="endArrow=classic;html=1;rounded=0;fillColor=#ffe6cc;strokeColor=#d79b00;" edge="1" parent="1">
+                    <mxGeometry width="50" height="50" relative="1" as="geometry">
+                        <mxPoint x="3080" y="1960" as="sourcePoint"/>
+                        <mxPoint x="3080" y="1920" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="6" value="" style="endArrow=classic;html=1;rounded=0;fillColor=#d5e8d4;strokeColor=#82b366;" edge="1" parent="1">
+                    <mxGeometry width="50" height="50" relative="1" as="geometry">
+                        <mxPoint x="3149.44" y="1920" as="sourcePoint"/>
+                        <mxPoint x="3149.44" y="1960" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="7" value="" style="endArrow=classic;html=1;rounded=0;fillColor=#ffe6cc;strokeColor=#d79b00;" edge="1" parent="1">
+                    <mxGeometry width="50" height="50" relative="1" as="geometry">
+                        <mxPoint x="3129.44" y="1960" as="sourcePoint"/>
+                        <mxPoint x="3129.44" y="1920" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="8" value="" style="endArrow=classic;html=1;rounded=0;fillColor=#f8cecc;strokeColor=#b85450;" edge="1" parent="1">
+                    <mxGeometry width="50" height="50" relative="1" as="geometry">
+                        <mxPoint x="3199.44" y="1920" as="sourcePoint"/>
+                        <mxPoint x="3199.44" y="1960" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="9" value="" style="endArrow=classic;html=1;rounded=0;fillColor=#ffe6cc;strokeColor=#d79b00;" edge="1" parent="1">
+                    <mxGeometry width="50" height="50" relative="1" as="geometry">
+                        <mxPoint x="3179.44" y="1960" as="sourcePoint"/>
+                        <mxPoint x="3179.44" y="1920" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="10" value="EB2" style="rounded=0;whiteSpace=wrap;html=1;rotation=90;" vertex="1" parent="1">
+                    <mxGeometry x="3100" y="1980" width="80" height="40" as="geometry"/>
+                </mxCell>
+                <mxCell id="11" value="EB3" style="rounded=0;whiteSpace=wrap;html=1;rotation=90;" vertex="1" parent="1">
+                    <mxGeometry x="3150" y="1980" width="80" height="40" as="geometry"/>
+                </mxCell>
+                <mxCell id="12" value="&lt;div&gt;Management Unit&lt;/div&gt;&lt;div&gt;(RISC-V / VexRiscV)&lt;br&gt;&lt;/div&gt;" style="rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="1">
+                    <mxGeometry x="3070" y="2290.75" width="210" height="120" as="geometry"/>
+                </mxCell>
+                <mxCell id="13" value="" style="group;rotation=-90;" connectable="0" vertex="1" parent="1">
+                    <mxGeometry x="3290" y="2380" width="10" height="35" as="geometry"/>
+                </mxCell>
+                <mxCell id="14" value="" style="endArrow=classic;html=1;rounded=0;fillColor=#ffe6cc;strokeColor=#d79b00;startArrow=classic;startFill=1;" edge="1" parent="13">
+                    <mxGeometry width="50" height="50" relative="1" as="geometry">
+                        <mxPoint x="-13" y="17" as="sourcePoint"/>
+                        <mxPoint x="22" y="18" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="15" value="" style="endArrow=none;html=1;rounded=0;fillColor=#ffe6cc;strokeColor=#d79b00;" edge="1" parent="13">
+                    <mxGeometry width="50" height="50" relative="1" as="geometry">
+                        <mxPoint x="11" y="23" as="sourcePoint"/>
+                        <mxPoint x="1" y="12" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="16" value="" style="endArrow=none;html=1;rounded=0;fillColor=#ffe6cc;strokeColor=#d79b00;" edge="1" parent="13">
+                    <mxGeometry width="50" height="50" relative="1" as="geometry">
+                        <mxPoint x="9" y="23" as="sourcePoint"/>
+                        <mxPoint x="-1" y="12" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="17" value="PE" style="rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="1">
+                    <mxGeometry x="3390" y="2000" width="120" height="131" as="geometry"/>
+                </mxCell>
+                <mxCell id="18" value="" style="endArrow=classic;html=1;rounded=0;exitX=1;exitY=0.75;exitDx=0;exitDy=0;entryX=0.517;entryY=-0.015;entryDx=0;entryDy=0;entryPerimeter=0;" edge="1" parent="1" source="11" target="12">
+                    <mxGeometry width="50" height="50" relative="1" as="geometry">
+                        <mxPoint x="3239.44" y="2160" as="sourcePoint"/>
+                        <mxPoint x="3239.44" y="2520" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="19" value="" style="endArrow=classic;html=1;rounded=0;" edge="1" parent="1">
+                    <mxGeometry width="50" height="50" relative="1" as="geometry">
+                        <mxPoint x="3080" y="2040" as="sourcePoint"/>
+                        <mxPoint x="3080" y="2290" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="20" value="" style="endArrow=classic;html=1;rounded=0;entryX=0.285;entryY=-0.007;entryDx=0;entryDy=0;entryPerimeter=0;" edge="1" parent="1" target="12">
+                    <mxGeometry width="50" height="50" relative="1" as="geometry">
+                        <mxPoint x="3130" y="2040" as="sourcePoint"/>
+                        <mxPoint x="3130" y="2520" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="21" value="programmable mux" style="whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="1">
+                    <mxGeometry x="3230" y="2150" width="90" height="90" as="geometry"/>
+                </mxCell>
+                <mxCell id="22" value="" style="endArrow=classic;html=1;rounded=0;exitX=1.004;exitY=0.32;exitDx=0;exitDy=0;exitPerimeter=0;" edge="1" parent="1" source="21">
+                    <mxGeometry width="50" height="50" relative="1" as="geometry">
+                        <Array as="points">
+                            <mxPoint x="3410" y="2180"/>
+                        </Array>
+                        <mxPoint x="3360" y="2180" as="sourcePoint"/>
+                        <mxPoint x="3410" y="2130" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="23" value="rst" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" connectable="0" vertex="1" parent="22">
+                    <mxGeometry x="0.7231" relative="1" as="geometry">
+                        <mxPoint as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="24" value="" style="endArrow=classic;html=1;rounded=0;" edge="1" parent="1">
+                    <mxGeometry width="50" height="50" relative="1" as="geometry">
+                        <mxPoint x="3250" y="2290" as="sourcePoint"/>
+                        <mxPoint x="3250" y="2240" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="25" value="" style="endArrow=classic;html=1;rounded=0;" edge="1" parent="1">
+                    <mxGeometry width="50" height="50" relative="1" as="geometry">
+                        <mxPoint x="3260" y="2290" as="sourcePoint"/>
+                        <mxPoint x="3260" y="2240" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="26" value="" style="endArrow=classic;html=1;rounded=0;" edge="1" parent="1">
+                    <mxGeometry width="50" height="50" relative="1" as="geometry">
+                        <mxPoint x="3270" y="2290" as="sourcePoint"/>
+                        <mxPoint x="3270" y="2240" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="27" value="" style="endArrow=classic;html=1;rounded=0;" edge="1" parent="1">
+                    <mxGeometry width="50" height="50" relative="1" as="geometry">
+                        <mxPoint x="3440" y="2200" as="sourcePoint"/>
+                        <mxPoint x="3320" y="2200" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="28" value="" style="endArrow=classic;html=1;rounded=0;" edge="1" parent="1">
+                    <mxGeometry width="50" height="50" relative="1" as="geometry">
+                        <mxPoint x="3450" y="2210" as="sourcePoint"/>
+                        <mxPoint x="3320" y="2210" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="29" value="" style="endArrow=classic;html=1;rounded=0;" edge="1" parent="1">
+                    <mxGeometry width="50" height="50" relative="1" as="geometry">
+                        <mxPoint x="3460" y="2220" as="sourcePoint"/>
+                        <mxPoint x="3320" y="2220" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="30" value="" style="endArrow=none;html=1;rounded=0;" edge="1" parent="1">
+                    <mxGeometry width="50" height="50" relative="1" as="geometry">
+                        <mxPoint x="3440" y="2200" as="sourcePoint"/>
+                        <mxPoint x="3440" y="2130" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="31" value="" style="endArrow=none;html=1;rounded=0;entryX=0.5;entryY=1;entryDx=0;entryDy=0;" edge="1" parent="1" target="17">
+                    <mxGeometry width="50" height="50" relative="1" as="geometry">
+                        <mxPoint x="3450" y="2210" as="sourcePoint"/>
+                        <mxPoint x="3500" y="2160" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="32" value="" style="endArrow=none;html=1;rounded=0;entryX=0.583;entryY=0.992;entryDx=0;entryDy=0;entryPerimeter=0;" edge="1" parent="1" target="17">
+                    <mxGeometry width="50" height="50" relative="1" as="geometry">
+                        <mxPoint x="3460" y="2219" as="sourcePoint"/>
+                        <mxPoint x="3460" y="2140" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="33" value="" style="endArrow=classic;html=1;rounded=0;" edge="1" parent="1">
+                    <mxGeometry width="50" height="50" relative="1" as="geometry">
+                        <mxPoint x="3100" y="2180" as="sourcePoint"/>
+                        <mxPoint x="3100" y="2040" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="34" value="" style="endArrow=classic;html=1;rounded=0;jumpStyle=arc;" edge="1" parent="1">
+                    <mxGeometry width="50" height="50" relative="1" as="geometry">
+                        <mxPoint x="3150" y="2170" as="sourcePoint"/>
+                        <mxPoint x="3150" y="2040" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="35" value="" style="endArrow=classic;html=1;rounded=0;" edge="1" parent="1">
+                    <mxGeometry width="50" height="50" relative="1" as="geometry">
+                        <mxPoint x="3199" y="2160" as="sourcePoint"/>
+                        <mxPoint x="3199" y="2040" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="36" value="" style="endArrow=none;html=1;rounded=0;jumpStyle=arc;" edge="1" parent="1">
+                    <mxGeometry width="50" height="50" relative="1" as="geometry">
+                        <mxPoint x="3100" y="2180" as="sourcePoint"/>
+                        <mxPoint x="3230" y="2180" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="37" value="" style="endArrow=none;html=1;rounded=0;" edge="1" parent="1">
+                    <mxGeometry width="50" height="50" relative="1" as="geometry">
+                        <mxPoint x="3200" y="2160" as="sourcePoint"/>
+                        <mxPoint x="3230" y="2160" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="38" value="ringbufs" style="rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="1">
+                    <mxGeometry x="3230" y="2260" width="60" height="20" as="geometry"/>
+                </mxCell>
+                <mxCell id="39" value="ringbufs" style="rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="1">
+                    <mxGeometry x="3070" y="2250" width="120" height="20" as="geometry"/>
+                </mxCell>
+                <mxCell id="40" value="PE config" style="whiteSpace=wrap;html=1;aspect=fixed;" vertex="1" parent="1">
+                    <mxGeometry x="3389.5" y="2289.25" width="121" height="121" as="geometry"/>
+                </mxCell>
+                <mxCell id="41" value="" style="endArrow=classic;html=1;rounded=0;" edge="1" parent="1">
+                    <mxGeometry width="50" height="50" relative="1" as="geometry">
+                        <mxPoint x="3500" y="2290.75" as="sourcePoint"/>
+                        <mxPoint x="3500" y="2130.75" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="42" value="" style="endArrow=classic;html=1;rounded=0;" edge="1" parent="1">
+                    <mxGeometry width="50" height="50" relative="1" as="geometry">
+                        <mxPoint x="3490" y="2291" as="sourcePoint"/>
+                        <mxPoint x="3490" y="2131" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="43" value="" style="group;rotation=-90;" connectable="0" vertex="1" parent="1">
+                    <mxGeometry x="3370" y="2380" width="10" height="35" as="geometry"/>
+                </mxCell>
+                <mxCell id="44" value="" style="endArrow=classic;html=1;rounded=0;fillColor=#ffe6cc;strokeColor=#d79b00;startArrow=classic;startFill=1;" edge="1" parent="43">
+                    <mxGeometry width="50" height="50" relative="1" as="geometry">
+                        <mxPoint x="-13" y="17" as="sourcePoint"/>
+                        <mxPoint x="22" y="18" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="45" value="" style="endArrow=none;html=1;rounded=0;fillColor=#ffe6cc;strokeColor=#d79b00;" edge="1" parent="43">
+                    <mxGeometry width="50" height="50" relative="1" as="geometry">
+                        <mxPoint x="11" y="23" as="sourcePoint"/>
+                        <mxPoint x="1" y="12" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="46" value="" style="endArrow=none;html=1;rounded=0;fillColor=#ffe6cc;strokeColor=#d79b00;" edge="1" parent="43">
+                    <mxGeometry width="50" height="50" relative="1" as="geometry">
+                        <mxPoint x="9" y="23" as="sourcePoint"/>
+                        <mxPoint x="-1" y="12" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="47" value="" style="group;rotation=0;" connectable="0" vertex="1" parent="1">
+                    <mxGeometry x="3300" y="2240" width="10" height="35" as="geometry"/>
+                </mxCell>
+                <mxCell id="48" value="" style="endArrow=classic;html=1;rounded=0;fillColor=#ffe6cc;strokeColor=#d79b00;startArrow=classic;startFill=1;" edge="1" parent="47">
+                    <mxGeometry width="50" height="50" relative="1" as="geometry">
+                        <mxPoint x="5" as="sourcePoint"/>
+                        <mxPoint x="5" y="35" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="49" value="" style="endArrow=none;html=1;rounded=0;fillColor=#ffe6cc;strokeColor=#d79b00;" edge="1" parent="47">
+                    <mxGeometry width="50" height="50" relative="1" as="geometry">
+                        <mxPoint y="24" as="sourcePoint"/>
+                        <mxPoint x="11" y="14" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="50" value="" style="endArrow=none;html=1;rounded=0;fillColor=#ffe6cc;strokeColor=#d79b00;" edge="1" parent="47">
+                    <mxGeometry width="50" height="50" relative="1" as="geometry">
+                        <mxPoint y="22" as="sourcePoint"/>
+                        <mxPoint x="11" y="12" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="51" value="" style="endArrow=classic;html=1;rounded=0;jumpStyle=arc;" edge="1" parent="1">
+                    <mxGeometry width="50" height="50" relative="1" as="geometry">
+                        <mxPoint x="3080" y="2100" as="sourcePoint"/>
+                        <mxPoint x="3390" y="2100" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="52" value="" style="endArrow=classic;html=1;rounded=0;jumpStyle=arc;" edge="1" parent="1">
+                    <mxGeometry width="50" height="50" relative="1" as="geometry">
+                        <mxPoint x="3130" y="2110" as="sourcePoint"/>
+                        <mxPoint x="3390" y="2110" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="53" value="" style="endArrow=classic;html=1;rounded=0;jumpStyle=arc;" edge="1" parent="1">
+                    <mxGeometry width="50" height="50" relative="1" as="geometry">
+                        <mxPoint x="3180" y="2120" as="sourcePoint"/>
+                        <mxPoint x="3390" y="2120" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="54" value="" style="endArrow=none;html=1;rounded=0;jumpStyle=arc;" edge="1" parent="1">
+                    <mxGeometry width="50" height="50" relative="1" as="geometry">
+                        <mxPoint x="3150" y="2170" as="sourcePoint"/>
+                        <mxPoint x="3230" y="2170" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="57" value="&lt;b&gt;Demo, simplified 2025Q4 (example 4 nodes)&lt;br&gt;&lt;/b&gt;" style="text;html=1;align=right;verticalAlign=middle;whiteSpace=wrap;rounded=0;" vertex="1" parent="1">
+                    <mxGeometry x="3170" y="1910" width="360" height="30" as="geometry"/>
+                </mxCell>
+            </root>
+        </mxGraphModel>
+    </diagram>
+</mxfile>

--- a/docs/diagrams/wireDemo.drawio.license
+++ b/docs/diagrams/wireDemo.drawio.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2026 Google LLC
+
+SPDX-License-Identifier: CC0-1.0

--- a/docs/sections/demos/wire-demo.md
+++ b/docs/sections/demos/wire-demo.md
@@ -1,0 +1,121 @@
+<!--
+SPDX-FileCopyrightText: 2026 Google LLC
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Wire Demo
+The [switch demo](switch-demo-asic.md) shows that we could use the bittide mechanism to thread a path through an 8-node network, all statically scheduled. To simplify things, we programmed a static calendar and used a calculator to produce the exact clock cycles at which the PE should send and receive data. For more details, see [this presentation](https://docs.google.com/presentation/d/1AGbAJQ1zhTPtrekKnQcthd0TUPyQs-zowQpV1ux4k-Y/edit?usp=sharing).
+
+While talking to potential users of bittide we've found that they're not interested in this switching behavior (yet). Instead, they're more interested in the "wire" behavior of bittide and would simply like to be kept away from anything else.
+
+The idea is still the same: thread a path through a bunch of nodes/FPGAs (in our case 8). The implementation is much simpler than the previous iteration though: instead of using calendars to do time multiplexing on every link, the links are connected to the PE through a single mux. This mux can either be set to serve the MU or the PE.
+
+
+## Architecture
+{{#drawio path="diagrams/wireDemo.drawio" page=0}}
+
+### Initialization sequence
+1. "Boot" CPU
+    1. Gets programmed by the host
+    2. Programs the clock boards
+    3. Gets transceiver block out of reset (enabling the bittide domain / other CPUs)
+    4. Activates each transceiver channel and waits until they've negotiated a link with their neighbors.
+    5. Prints "all done" message to UART.
+2. Clock control CPU
+    1. Gets programmed by the host
+    2. Calibrates clocks
+    3. Prints "all done" message to UART.
+    4. (Keeps calibrating clocks.)
+3. Management unit CPU
+    1. Gets programmed by the host
+    2. Sets the channels to "user" mode. This makes the channels accept data from the outside world instead of their negotiation state machinery.
+    3. Waits for hardware UGN to be captured
+    4. Start auto-centering elastic buffers
+    5. Waits for clocks to be considered stable
+    6. Stops auto-centering the elastic buffers
+    7. Prints UGNs captured by hardware component to UART.
+
+
+### Domain related
+Components:
+- Boot CPU (BOOT)
+- Transceivers
+- Domain difference counters
+- Clock control (CC)
+- Elastic buffers (one per incoming transceiver link)
+- Hardware UGN capture (for comparison)
+
+### Node related
+Components:
+- Management unit (MU)
+- 7 [scatter](../components/scatter-unit.md) and [gather](../components/gather-unit.md) units, one of each per elastic buffer
+- Programmable mux
+- WireDemoPe, a processing elemenent specific for this demo
+- WireDemoPeConfig, a bus accessible device with a writable configuration for the processing element
+
+### Management unit
+Connected components:
+- Timer
+- UART (for debugging)
+- FPGA DNA register
+
+The management unit has access to and is responsible for all [scatter](../components/scatter-unit.md)/[gather](../components/gather-unit.md) [calendars](../components/calendar.md) in the node. In this demo these calendars are not used.
+
+To change the binary run on this CPU, one may either:
+- Edit `bittide-instances/src/bittide/Instances/Hitl/WireDemo/Driver.hs`, line 215 (at
+  time of writing) to use another binary instead of `wire-demo-mu`
+- Edit the source files in `firmware-binaries/wire-demo-mu/` to change the binary
+  pre-selected by the driver function
+
+### Wire Demo processing element
+#### PE (`wireDemoPe`)
+Takes two configuration values (from "PE config"):
+- What link to read from
+- What link to write to
+
+The PE is active for two cycles after reset:
+- First cycle: read from link indicated by config (or source static "0").
+- Second cycle: write value_read_in_first_cycle XOR fpga_dna_lsbs to link indicated by config (or do nothing)
+
+#### PE Config (`wireDemoPeConfig`)
+Has 3 bus accessible registers:
+- `read_link :: Maybe (Index 7)`
+- `write_link :: Maybe (Index 7)`
+- `written_data :: Maybe (BitVector 64)`
+
+The first 2 registers are used to configure the PE. The third register stores the data written by the PE over the configured link. This is used to verify the demo works. The data in the last PE Config should be the XOR of all DNAs.
+
+### Debugging related
+- UART arbiter
+- JTAG interconnect
+- Integrated logic analyzers
+- `SYNC_IN`/`SYNC_OUT`
+
+## Running tests
+One may specifically run the software UGN demo test by making a
+`.github/synthesis/debug.json` with the following contents:
+
+```json
+[
+  {"top": "wireDemoTest",       "stage": "test", "cc_report": true}
+]
+```
+
+At the time of writing, the clock control CPU stabilizes system. The driver running
+on the host (`bittide-instances/src/bittide/Instances/Hitl/WireDemo/Driver.hs`)
+then releases the reset of the management unit CPU. In turn, this CPU will center
+the elastic buffers and print out the UGNs captured using the hardware UGN capture component over UART.
+
+The host driver then calculates the a schedule to thread a path through all nodes and programs all PE Configs and programmable muxes. After waiting for a static time the host driver reads the `written_data` register in each PE Config device and verifies it is equal to the XOR of all device DNAs up to that node. The last node should therefore have stored the XOR of all device DNAs.
+
+Tests are configured to run the following binaries on the system's CPUs:
+- Boot CPU: `switch-demo1-boot` (`firmware-binaries/demos/switch-demo1-boot`)
+- Clock control CPU: `clock-control` (`firmware-binaries/demos/clock-control`)
+- Management unit: `wire-demo-mu` (`firmware-binaries/demos/wrie-demo-mu`)
+
+One may change this by either:
+1. Changing the driver function so that it loads different binaries onto the CPUs. This
+   may be accomplished by changing which binary name is used with each of the `initGdb`
+   function calls.
+2. Changing the source code for the binaries. The locations for them are listed above.

--- a/firmware-binaries/Cargo.lock
+++ b/firmware-binaries/Cargo.lock
@@ -900,3 +900,14 @@ dependencies = [
  "riscv-rt 0.11.0",
  "ufmt",
 ]
+
+[[package]]
+name = "wire-demo-mu"
+version = "0.1.0"
+dependencies = [
+ "bittide-hal",
+ "bittide-sys",
+ "memmap-generate",
+ "riscv-rt 0.11.0",
+ "ufmt",
+]

--- a/firmware-binaries/Cargo.toml
+++ b/firmware-binaries/Cargo.toml
@@ -51,5 +51,6 @@ members = [
   "demos/switch-demo1-mu",
   "demos/switch-demo2-mu",
   "demos/switch-demo2-gppe",
+  "demos/wire-demo-mu",
 ]
 resolver = "2"

--- a/firmware-binaries/demos/wire-demo-mu/Cargo.toml
+++ b/firmware-binaries/demos/wire-demo-mu/Cargo.toml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2025 Google LLC
+#
+# SPDX-License-Identifier: CC0-1.0
+
+[package]
+name = "wire-demo-mu"
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0"
+authors = ["Google LLC"]
+
+[dependencies]
+riscv-rt = "0.11.0"
+bittide-sys = { path = "../../../firmware-support/bittide-sys" }
+ufmt = "0.2.0"
+bittide-hal = { path = "../../../firmware-support/bittide-hal" }
+
+[build-dependencies]
+memmap-generate = { path = "../../../firmware-support/memmap-generate" }

--- a/firmware-binaries/demos/wire-demo-mu/build.rs
+++ b/firmware-binaries/demos/wire-demo-mu/build.rs
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: 2022 Google LLC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use memmap_generate::build_utils::standard_memmap_build;
+
+fn main() {
+    standard_memmap_build("WireDemoMu.json", "DataMemory", "InstructionMemory");
+    println!("cargo:rerun-if-changed=build.rs");
+}

--- a/firmware-binaries/demos/wire-demo-mu/src/main.rs
+++ b/firmware-binaries/demos/wire-demo-mu/src/main.rs
@@ -1,0 +1,105 @@
+#![no_std]
+#![cfg_attr(not(test), no_main)]
+
+// SPDX-FileCopyrightText: 2025 Google LLC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use bittide_hal::hals::wire_demo_mu::DeviceInstances;
+use bittide_sys::link_startup::LinkStartup;
+use bittide_sys::stability_detector::Stability;
+use core::panic::PanicInfo;
+use ufmt::uwriteln;
+
+const INSTANCES: DeviceInstances = unsafe { DeviceInstances::new() };
+
+#[cfg(not(test))]
+use riscv_rt::entry;
+
+#[cfg_attr(not(test), entry)]
+fn main() -> ! {
+    let mut uart = INSTANCES.uart;
+    let transceivers = &INSTANCES.transceivers;
+    let cc = INSTANCES.clock_control;
+
+    let elastic_buffers = [
+        &INSTANCES.elastic_buffer_0,
+        &INSTANCES.elastic_buffer_1,
+        &INSTANCES.elastic_buffer_2,
+        &INSTANCES.elastic_buffer_3,
+        &INSTANCES.elastic_buffer_4,
+        &INSTANCES.elastic_buffer_5,
+        &INSTANCES.elastic_buffer_6,
+    ];
+
+    let capture_ugns = [
+        INSTANCES.capture_ugn_0,
+        INSTANCES.capture_ugn_1,
+        INSTANCES.capture_ugn_2,
+        INSTANCES.capture_ugn_3,
+        INSTANCES.capture_ugn_4,
+        INSTANCES.capture_ugn_5,
+        INSTANCES.capture_ugn_6,
+    ];
+
+    let mut link_startups = [LinkStartup::new(); 7];
+    while !link_startups.iter().all(|ls| ls.is_done()) {
+        for (i, link_startup) in link_startups.iter_mut().enumerate() {
+            link_startup.next(
+                transceivers,
+                i,
+                elastic_buffers[i],
+                capture_ugns[i].has_captured(),
+            );
+        }
+    }
+
+    uwriteln!(uart, "Waiting for stability...").unwrap();
+    loop {
+        // We don't update the stability here, but leave that to callisto. Although
+        // we also have access to the 'links_settled' register, we don't want to
+        // flood the CC bus.
+        let stability = Stability {
+            stable: cc.links_stable()[0],
+            settled: 0,
+        };
+        let all_stable = stability.all_stable();
+        if all_stable {
+            break;
+        }
+    }
+
+    uwriteln!(uart, "Stopping auto-centering...").unwrap();
+    elastic_buffers
+        .iter()
+        .for_each(|eb| eb.set_auto_center_enable(false));
+    elastic_buffers
+        .iter()
+        .for_each(|eb| eb.wait_auto_center_idle());
+    let eb_deltas = elastic_buffers
+        .iter()
+        .map(|eb| eb.auto_center_total_adjustments());
+
+    uwriteln!(uart, "Start printing hardware UGNs").unwrap();
+    for (i, (capture_ugn, eb_delta)) in capture_ugns.iter().zip(eb_deltas).enumerate() {
+        capture_ugn.set_elastic_buffer_delta(eb_delta);
+        uwriteln!(
+            uart,
+            "Capture UGN {}: local = {}, remote = {}, eb_delta = {}",
+            i,
+            capture_ugn.local_counter(),
+            capture_ugn.remote_counter(),
+            eb_delta
+        )
+        .unwrap();
+    }
+    uwriteln!(uart, "Printed all hardware UGNs").unwrap();
+
+    #[allow(clippy::empty_loop)]
+    loop {}
+}
+
+#[panic_handler]
+fn panic_handler(_: &PanicInfo) -> ! {
+    loop {}
+}


### PR DESCRIPTION
_What (what did you do)_
Added the wire demo as a fourth demo. See the linked issue for an overview, or check out the documentation in the mdbook.

_Why (context, issues, etc.)_
Fixes #1109

_Dear reviewer (anything you'd like the reviewer to pay close attention to?)_
I've copy-pasted the Soft UGN Demo for the Wire Demo in a separate commit to make reviewing it easier. I have a few specific points I'd like you (the reviewer) to pay extra attention to:
1. I've moved some functions in the Switch Demo driver so I could reuse them for the Wire Demo. We already do this a lot in that driver, but it is not good practice. Should I move them, and if so, where to?
2. I fear my understanding of `internalDelay` in `toCounterMap` might be wrong. For the wire demo I had to set it to `1` ([here](https://github.com/bittide/bittide-hardware/blob/079ce6e1df20aa338eb4068decd53fe6fd484827/bittide-instances/src/Bittide/Instances/Hitl/WireDemo/Driver.hs#L65)), but I cannot find the additional register on the path between PEs which is not also on the `captureUgn` path.
3. Are [`generateSchedule`](https://github.com/bittide/bittide-hardware/blob/079ce6e1df20aa338eb4068decd53fe6fd484827/bittide-instances/src/Bittide/Instances/Hitl/WireDemo/Driver.hs#L94) and its documentation clear?
4. What should the PE write to the links while 'inactive'? Issue and internal documentation say 'write 0', but while debugging it was easier to use local counter.
5. I added `wireDemoTest` to `main.json` and moved both `switchDemoTest` and `switchDemoGppeTest` to nighly. Do you agree?


_AI disclaimer (heads-up for more than inline autocomplete)_
Nothing worth a heads-up

# TODO
_~~Cross-out~~ any that do not apply_

- [x] Write (regression) test 
-> Added a test for the `wireDemoPe` and the HITL test as a demo
- [x] Update documentation, including `docs/` 
-> Added docs and diagram for wire demo in mdbook
- [x] Link to existing issue
