### PR TITLE
Add `ImplicitParams` to common options, remove from source files

### DIFF
--- a/bittide/src/Bittide/MetaPeConfig.hs
+++ b/bittide/src/Bittide/MetaPeConfig.hs
@@ -1,7 +1,6 @@
 -- SPDX-FileCopyrightText: 2025 Google LLC
 --
 -- SPDX-License-Identifier: Apache-2.0
-{-# LANGUAGE ImplicitParams #-}
 
 -- | Device to store configuration data for the Switch Demo
 module Bittide.MetaPeConfig where

--- a/vivado-hs/vivado-hs.cabal
+++ b/vivado-hs/vivado-hs.cabal
@@ -28,6 +28,7 @@ common common-options
     DeriveLift
     DeriveTraversable
     DerivingStrategies
+    ImplicitParams
     InstanceSigs
     KindSignatures
     LambdaCase


### PR DESCRIPTION
_What (what did you do)_
Added `ImplicitParams` to the `common-options` of any `.cabal` file with one, and removed any language pragmas enabling it.

_Why (context, issues, etc.)_
As per request in a comment on #1246.

_Dear reviewer (anything you'd like the reviewer to pay close attention to?)_
I don't think there's anything particularly worrying about this?

_AI disclaimer (heads-up for more than inline autocomplete)_
Nope.

# TODO
_~~Cross-out~~ any that do not apply_

- [ ] ~~Write (regression) test~~
- [ ] ~~Update documentation, including `docs/`~~
- [x] Link to existing issue
