### PR TITLE
Add `Protocols.MemoryMap.Mask`

### DIFF
--- a/clash-bitpackc/src/Clash/Class/BitPackC.hs
+++ b/clash-bitpackc/src/Clash/Class/BitPackC.hs
@@ -75,7 +75,7 @@ unpackOrErrorC byteOrder bytes =
         <> " as "
         <> show (typeRep (Proxy @a))
 
-data ByteOrder = LittleEndian | BigEndian deriving (Eq, Show)
+data ByteOrder = LittleEndian | BigEndian deriving (Eq, Show, Bounded, Enum)
 
 type BitSizeInBytes a = DivRU (BitSize a) 8
 type NextPowerOfTwo a = 2 ^ CLog 2 (Max 1 a)

--- a/clash-protocols-memmap/clash-protocols-memmap.cabal
+++ b/clash-protocols-memmap/clash-protocols-memmap.cabal
@@ -150,6 +150,7 @@ library
     Protocols.MemoryMap.Check.AbsAddress
     Protocols.MemoryMap.Check.Normalized
     Protocols.MemoryMap.Json
+    Protocols.MemoryMap.Mask
     Protocols.MemoryMap.Registers.WishboneStandard
     Protocols.MemoryMap.Registers.WishboneStandard.Internal
     Protocols.MemoryMap.TypeCollect
@@ -246,6 +247,7 @@ test-suite unittests
     -with-rtsopts=-N12
 
   other-modules:
+    Tests.Protocols.MemoryMap.Mask
     Tests.Protocols.MemoryMap.Registers.WishboneStandard
 
   build-depends:

--- a/clash-protocols-memmap/src/Protocols/MemoryMap/Json.hs
+++ b/clash-protocols-memmap/src/Protocols/MemoryMap/Json.hs
@@ -143,6 +143,7 @@ generateTypeDef (Builtin b) =
           Signed -> "signed"
           Unsigned -> "unsigned"
           Index -> "index"
+          Protocols.MemoryMap.TypeDescription.Mask -> "mask"
       ]
 generateTypeDef (DataDef cons) = do
   cons1 <- mapM generateConstructor cons

--- a/clash-protocols-memmap/src/Protocols/MemoryMap/Mask.hs
+++ b/clash-protocols-memmap/src/Protocols/MemoryMap/Mask.hs
@@ -1,0 +1,123 @@
+-- SPDX-FileCopyrightText: 2026 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+{- | A bit-mask type for use in memory-mapped registers.
+
+In Clash designs we often use @'Vec' n 'Bool'@ to track per-bit enables, valid
+bits, and similar. The default 'BitPackC' representation of @'Vec' n 'Bool'@
+allocates a full byte per bit, which is wasteful when these end up in
+memory-mapped registers. Switching to a 'BitVector' is denser, but inverts the
+index correspondence: @Vec@ index @0@ maps to the MSB of the bitvector via
+Clash's standard 'pack'/'unpack', so a loop walking @0..n@ on the Haskell side
+walks the wrong direction relative to firmware that pokes individual bits.
+
+'Mask' fixes both problems: it is packed compactly (like 'BitVector'), and its
+'toVec' / 'fromVec' / 'toBitVector' / 'fromBitVector' conversions all preserve
+the @Vec@-index <-> bit-position correspondence: index @0@ is bit @0@ (the least
+significant bit).
+
+There is intentionally no usable 'BitPack' instance: 'BitPack' is conventionally
+read as \"this is the HDL-level layout\", which would be misleading for a type
+whose only purpose is to bridge the Haskell\/firmware boundary. An instance is
+provided that triggers a 'TypeError' when used, to give a better error message
+than the default \"no instance\" one.
+-}
+module Protocols.MemoryMap.Mask (
+  Mask (..),
+  toVec,
+  fromVec,
+  toBitVector,
+  fromBitVector,
+) where
+
+import Clash.Prelude
+
+import Clash.Class.BitPackC (BitPackC (..))
+import Data.Data (Proxy (..))
+
+import Protocols.MemoryMap.TypeDescription (
+  TypeArgumentDecl (TadNat),
+  TypeDefinition (Builtin),
+  TypeDescription (..),
+  TypeRef (TypeInst, TypeNat),
+  WithTypeDescription (..),
+ )
+import qualified Protocols.MemoryMap.TypeDescription as TD
+
+-- Clash doesn't handle 'newtype's properly in type families
+{-# ANN module ("HLint: ignore Use newtype instead of data" :: String) #-}
+
+{- | A bit-mask of @n@ bits.
+
+Backing storage is a 'BitVector', but the four conversion functions
+('toVec', 'fromVec', 'toBitVector', 'fromBitVector') maintain the convention
+that index @0@ corresponds to bit @0@ (the least significant bit), so indices
+stay consistent across all four representations.
+-}
+data Mask (n :: Nat)
+  = -- XXX: This is a @data@ rather than @newtype@ because Clash currently has bugs
+    --      around newtype handling.
+    Mask (BitVector n)
+  deriving (Generic, Show, Eq, NFDataX)
+
+{- | Pack @n@ booleans into a 'Mask'. Index @i@ of the input vector becomes
+bit @i@ of the result (LSB-first).
+-}
+fromVec :: (KnownNat n) => Vec n Bool -> Mask n
+fromVec = Mask . pack . reverse
+
+{- | Unpack a 'Mask' to @n@ booleans. Bit @i@ of the input becomes index @i@
+of the output (LSB-first).
+-}
+toVec :: (KnownNat n) => Mask n -> Vec n Bool
+toVec (Mask bv) = reverse (unpack bv)
+
+{- | Reinterpret a 'BitVector' as a 'Mask'. The bit at position @i@ of the
+'BitVector' (counted from the LSB) corresponds to index @i@ in
+@'toVec' . 'fromBitVector'@.
+-}
+fromBitVector :: BitVector n -> Mask n
+fromBitVector = Mask
+
+-- | Inverse of 'fromBitVector'.
+toBitVector :: Mask n -> BitVector n
+toBitVector (Mask bv) = bv
+
+instance
+  ( KnownNat n
+  , TypeError
+      ( 'Text "'Mask' intentionally has no 'BitPack' instance."
+          ':$$: 'Text "'BitPack' is conventionally read as the HDL-level layout, which"
+          ':$$: 'Text "would be misleading for a type whose only purpose is to bridge the"
+          ':$$: 'Text "Haskell/firmware boundary."
+          ':$$: 'Text ""
+          ':$$: 'Text "Use 'toBitVector' / 'fromBitVector' or 'toVec' / 'fromVec' instead."
+      )
+  ) =>
+  BitPack (Mask n)
+  where
+  type BitSize (Mask n) = n
+  pack = error "unreachable"
+  unpack = error "unreachable"
+
+instance (KnownNat n) => BitPackC (Mask n) where
+  type ConstructorSizeC (Mask n) = ConstructorSizeC (BitVector n)
+  type AlignmentBoundaryC (Mask n) = AlignmentBoundaryC (BitVector n)
+  type ByteSizeC (Mask n) = ByteSizeC (BitVector n)
+
+  packC# byteOrder (Mask bv) = packC# byteOrder bv
+  maybeUnpackC# byteOrder bytes = Mask <$> maybeUnpackC# byteOrder bytes
+
+instance (KnownNat n) => WithTypeDescription (Mask n) where
+  typeDescription Proxy =
+    TypeDescription
+      { name = ''Mask
+      , args = [TadNat ''n]
+      , definition = Builtin TD.Mask
+      }
+  dependsOn Proxy = []
+  argTypes Proxy = []
+  asTypeRef Proxy = TypeInst ''Mask [TypeNat (natToInteger @n)]

--- a/clash-protocols-memmap/src/Protocols/MemoryMap/TypeDescription/TH.hs
+++ b/clash-protocols-memmap/src/Protocols/MemoryMap/TypeDescription/TH.hs
@@ -81,6 +81,7 @@ data Builtin
   | Signed
   | Unsigned
   | Index
+  | Mask
   deriving (Show, TH.Lift)
 
 {- | Type argument

--- a/clash-protocols-memmap/tests/Tests/Protocols/MemoryMap/Mask.hs
+++ b/clash-protocols-memmap/tests/Tests/Protocols/MemoryMap/Mask.hs
@@ -1,0 +1,76 @@
+-- SPDX-FileCopyrightText: 2026 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+{-# LANGUAGE OverloadedStrings #-}
+
+module Tests.Protocols.MemoryMap.Mask where
+
+import Clash.Explicit.Prelude
+
+import Clash.Class.BitPackC (maybeUnpackC, packC)
+import Hedgehog (Property, forAll, property, (===))
+import Test.Tasty
+import Test.Tasty.Hedgehog (testPropertyNamed)
+
+import Protocols.MemoryMap.Mask (Mask, fromBitVector, fromVec, toBitVector, toVec)
+
+import qualified Clash.Hedgehog.Sized.Vector as HV
+import qualified Hedgehog.Gen as Gen
+
+prop_vecRoundTrip :: Property
+prop_vecRoundTrip = property $ do
+  bs <- forAll (HV.genVec @17 Gen.bool)
+  toVec (fromVec bs) === bs
+
+prop_bitVectorRoundTrip :: Property
+prop_bitVectorRoundTrip = property $ do
+  bv <- forAll (Gen.enumBounded @_ @(BitVector 17))
+  toBitVector (fromBitVector bv) === bv
+
+-- | Index 0 of the input 'Vec' becomes bit 0 (LSB) of the resulting 'BitVector'.
+prop_indexConvention :: Property
+prop_indexConvention = property $ do
+  let
+    v0 = True :> repeat False :: Vec 8 Bool
+    bv = toBitVector (fromVec v0)
+  bv === 0b0000_0001
+
+  let
+    v1 = repeat False :< True :: Vec 8 Bool
+    bv1 = toBitVector (fromVec v1)
+  bv1 === 0b1000_0000
+
+prop_packCRoundTrip :: Property
+prop_packCRoundTrip = property $ do
+  bv <- forAll (Gen.enumBounded @_ @(BitVector 17))
+  -- Note that byte ordering shouldn't matter as 'BitVector' isn't a numeric primitive,
+  -- but we test it anyway to snuff out issues.
+  byteOrder <- forAll Gen.enumBounded
+  let
+    m = fromBitVector bv :: Mask 17
+    packed = packC byteOrder m
+  case maybeUnpackC byteOrder packed of
+    Nothing -> fail "maybeUnpackC returned Nothing"
+    Just (m' :: Mask 17) -> toBitVector m' === bv
+
+tests :: TestTree
+tests =
+  testGroup
+    "Mask"
+    [ testPropertyNamed
+        "fromVec . toVec ≡ id (Vec 17 Bool)"
+        "prop_vecRoundTrip"
+        prop_vecRoundTrip
+    , testPropertyNamed
+        "fromBitVector . toBitVector ≡ id (BitVector 17)"
+        "prop_bitVectorRoundTrip"
+        prop_bitVectorRoundTrip
+    , testPropertyNamed
+        "Index 0 maps to LSB"
+        "prop_indexConvention"
+        prop_indexConvention
+    , testPropertyNamed
+        "BitPackC round-trip via packC/maybeUnpackC"
+        "prop_packCRoundTrip"
+        prop_packCRoundTrip
+    ]

--- a/clash-protocols-memmap/tests/UnitTests.hs
+++ b/clash-protocols-memmap/tests/UnitTests.hs
@@ -9,6 +9,7 @@ import Prelude
 import Test.Tasty
 import Test.Tasty.Hedgehog
 
+import qualified Tests.Protocols.MemoryMap.Mask
 import qualified Tests.Protocols.MemoryMap.Registers.WishboneStandard
 
 tests :: TestTree
@@ -16,6 +17,7 @@ tests =
   testGroup
     "Unittests"
     [ Tests.Protocols.MemoryMap.Registers.WishboneStandard.tests
+    , Tests.Protocols.MemoryMap.Mask.tests
     ]
 
 {- | Default number of tests is 100, which is too low for our (complicated)

--- a/firmware-support/bittide-hal/build.rs
+++ b/firmware-support/bittide-hal/build.rs
@@ -390,6 +390,11 @@ fn generate_type_ref_imports(ctx: &IrCtx, refs: &TypeReferences) -> TokenStream 
             use bittide_macros::Unsigned;
         });
     }
+    if refs.use_mask {
+        code.extend(quote! {
+            use crate::manual_additions::mask::Mask;
+        });
+    }
     for ty_ref in &refs.references {
         let name = &ctx.type_names[*ty_ref].base;
         let module = ident(IdentType::Module, name);

--- a/firmware-support/bittide-hal/src/manual_additions/mask.rs
+++ b/firmware-support/bittide-hal/src/manual_additions/mask.rs
@@ -1,0 +1,290 @@
+// SPDX-FileCopyrightText: 2026 Google LLC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! A `Mask<M, N>` type with bool-array semantics.
+//!
+//! `Mask<M, N>` is a transparent newtype around [`BitVector<M, N>`]: it has
+//! identical storage and identical bit ordering (bit `i` of the mask is bit
+//! `i` of the underlying byte array — LSB at byte 0, bit 0). The wrapper
+//! exists to provide a bool-indexed API (`get`, `set`, `from_iter`, `iter`)
+//! without re-implementing storage or size-checking. Conversion to/from
+//! `BitVector` is zero-cost.
+//!
+//! This is the Rust counterpart of the Haskell `Mask n` type from
+//! `Protocols.MemoryMap.Mask`. The Haskell side enforces the
+//! "index `i` of a `Vec n Bool` corresponds to bit `i`" convention, which is
+//! the same convention this type uses on the Rust side.
+#![deny(missing_docs)]
+
+use core::ops::Index;
+
+use crate::manual_additions::bitvector::{BitVector, BitVectorSizeCheck};
+
+/// Bit-mask of `M` bits, backed by a [`BitVector<M, N>`].
+///
+/// Bit `i` (for `i in 0..M`) is bit `i` of the underlying byte array (byte
+/// `i / 8`, bit `i % 8`). This matches the storage convention of
+/// [`BitVector<M, N>`], so converting between `Mask<M, N>` and
+/// `BitVector<M, N>` is zero-cost.
+#[derive(Clone, Copy, PartialEq, Eq)]
+#[repr(transparent)]
+pub struct Mask<const M: usize, const N: usize>(pub(crate) BitVector<M, N>);
+
+impl<const M: usize, const N: usize> Mask<M, N>
+where
+    BitVector<M, N>: BitVectorSizeCheck<Inner = [u8; N]>,
+{
+    /// Create a `Mask` with all bits cleared.
+    #[inline]
+    pub fn zero() -> Self {
+        let _: () = <BitVector<M, N> as BitVectorSizeCheck>::SIZE_CHECK;
+        // SAFETY: the all-zero byte array represents the value `0`, which is
+        // in range for any `BitVector<M, N>`.
+        Mask(unsafe { BitVector::<M, N>::new_unchecked([0u8; N]) })
+    }
+
+    /// Read bit `i`. Returns `None` if `i >= M`.
+    #[inline]
+    pub fn get(&self, i: usize) -> Option<bool> {
+        if i >= M {
+            None
+        } else {
+            // SAFETY: just bounds-checked.
+            Some(unsafe { self.get_unchecked(i) })
+        }
+    }
+
+    /// Read bit `i` without bounds-checking.
+    ///
+    /// # Safety
+    /// `i` must be `< M`.
+    #[inline]
+    pub unsafe fn get_unchecked(&self, i: usize) -> bool {
+        let _: () = <BitVector<M, N> as BitVectorSizeCheck>::SIZE_CHECK;
+        // PERFORMANCE: The `/8` and `%8` compile to `i >> 3` and `i & 7` respectively
+        let byte = self.0 .0[i / 8];
+        ((byte >> (i % 8)) & 1) == 1
+    }
+
+    /// Set bit `i` to `b`. Returns `None` if `i >= M`.
+    #[inline]
+    pub fn set(&mut self, i: usize, b: bool) -> Option<()> {
+        if i >= M {
+            return None;
+        }
+        // SAFETY: just bounds-checked.
+        unsafe { self.set_unchecked(i, b) };
+        Some(())
+    }
+
+    /// Set bit `i` to `b` without bounds-checking.
+    ///
+    /// # Safety
+    /// `i` must be `< M`.
+    #[inline]
+    pub unsafe fn set_unchecked(&mut self, i: usize, b: bool) {
+        let _: () = <BitVector<M, N> as BitVectorSizeCheck>::SIZE_CHECK;
+        // PERFORMANCE: The `/8` and `%8` compile to `i >> 3` and `i & 7` respectively
+        let bit = 1u8 << (i % 8);
+        let byte = &mut self.0 .0[i / 8];
+        if b {
+            *byte |= bit;
+        } else {
+            *byte &= !bit;
+        }
+    }
+
+    /// Iterate over the bits in order `0..M`.
+    #[inline]
+    pub fn iter(&self) -> impl DoubleEndedIterator<Item = bool> + '_ {
+        (0..M).map(|i| unsafe { self.get_unchecked(i) })
+    }
+
+    /// Unwrap to the underlying [`BitVector<M, N>`].
+    #[inline]
+    pub fn into_bitvector(self) -> BitVector<M, N> {
+        self.0
+    }
+
+    /// Construct a `Mask` from a [`BitVector<M, N>`]
+    #[inline]
+    pub fn from_bitvector(bv: BitVector<M, N>) -> Self {
+        Mask(bv)
+    }
+}
+
+impl<const M: usize, const N: usize> FromIterator<bool> for Mask<M, N>
+where
+    BitVector<M, N>: BitVectorSizeCheck<Inner = [u8; N]>,
+{
+    /// Build a `Mask` from a bool iterator. Bit `i` of the result is the
+    /// `i`-th item of the iterator. Items at index `>= M` are silently
+    /// ignored; if the iterator yields fewer than `M` items, the missing
+    /// bits are taken as `false`.
+    #[inline]
+    fn from_iter<I: IntoIterator<Item = bool>>(bools: I) -> Self {
+        let _: () = <BitVector<M, N> as BitVectorSizeCheck>::SIZE_CHECK;
+        let mut out = Self::zero();
+        for (i, b) in bools.into_iter().enumerate().take(M) {
+            // SAFETY: `take(M)` keeps `i < M`.
+            unsafe { out.set_unchecked(i, b) };
+        }
+        out
+    }
+}
+
+impl<const M: usize, const N: usize> Index<usize> for Mask<M, N>
+where
+    BitVector<M, N>: BitVectorSizeCheck<Inner = [u8; N]>,
+{
+    type Output = bool;
+
+    /// Read bit `i`. Panics if `i >= M`.
+    #[inline]
+    fn index(&self, i: usize) -> &bool {
+        match self.get(i) {
+            Some(true) => &true,
+            Some(false) => &false,
+            None => panic!("Mask index out of bounds: {i} >= {M}"),
+        }
+    }
+}
+
+impl<const M: usize, const N: usize> From<BitVector<M, N>> for Mask<M, N>
+where
+    BitVector<M, N>: BitVectorSizeCheck<Inner = [u8; N]>,
+{
+    #[inline]
+    fn from(bv: BitVector<M, N>) -> Mask<M, N> {
+        Mask(bv)
+    }
+}
+
+impl<const M: usize, const N: usize> From<Mask<M, N>> for BitVector<M, N>
+where
+    BitVector<M, N>: BitVectorSizeCheck<Inner = [u8; N]>,
+{
+    #[inline]
+    fn from(m: Mask<M, N>) -> BitVector<M, N> {
+        m.0
+    }
+}
+
+impl<const M: usize, const N: usize> core::fmt::Debug for Mask<M, N>
+where
+    BitVector<M, N>: BitVectorSizeCheck,
+{
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(fmt, "Mask<{M}>(")?;
+        <BitVector<M, N> as core::fmt::Debug>::fmt(&self.0, fmt)?;
+        write!(fmt, ")")
+    }
+}
+
+impl<const M: usize, const N: usize> ufmt::uDebug for Mask<M, N>
+where
+    BitVector<M, N>: BitVectorSizeCheck,
+{
+    fn fmt<W>(&self, fmt: &mut ufmt::Formatter<'_, W>) -> Result<(), W::Error>
+    where
+        W: ufmt::uWrite + ?Sized,
+    {
+        ufmt::uwrite!(fmt, "Mask<{}>(", M)?;
+        <BitVector<M, N> as ufmt::uDebug>::fmt(&self.0, fmt)?;
+        ufmt::uwrite!(fmt, ")")
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn from_iter_round_trip() {
+        let bs = [true, false, true, false, false, true, true, false];
+        let m: Mask<8, 1> = Mask::from_iter(bs);
+        let collected: [bool; 8] = core::array::from_fn(|i| m[i]);
+        assert_eq!(collected, bs);
+    }
+
+    #[test]
+    fn from_iter_round_trip_non_byte_multiple() {
+        let bs = [
+            true, false, true, true, false, false, false, true, true, true, false, false, true,
+        ];
+        let m: Mask<13, 2> = Mask::from_iter(bs);
+        let collected: [bool; 13] = core::array::from_fn(|i| m[i]);
+        assert_eq!(collected, bs);
+    }
+
+    #[test]
+    fn get_and_set() {
+        let mut m: Mask<10, 2> = Mask::zero();
+        assert_eq!(m.get(0), Some(false));
+        assert_eq!(m.get(9), Some(false));
+        assert_eq!(m.get(10), None);
+
+        m.set(0, true).unwrap();
+        m.set(9, true).unwrap();
+        assert_eq!(m.get(0), Some(true));
+        assert_eq!(m.get(9), Some(true));
+        assert_eq!(m.set(10, true), None);
+
+        m.set(0, false).unwrap();
+        assert_eq!(m.get(0), Some(false));
+    }
+
+    #[test]
+    fn lsb_first_layout() {
+        // Bit 0 must be the LSB of the underlying byte array.
+        let mut m: Mask<16, 2> = Mask::zero();
+        m.set(0, true).unwrap();
+        let bv: BitVector<16, 2> = m.into();
+        assert_eq!(bv.into_inner(), [0x01, 0x00]);
+
+        // Bit 8 must be bit 0 of byte 1.
+        let mut m: Mask<16, 2> = Mask::zero();
+        m.set(8, true).unwrap();
+        let bv: BitVector<16, 2> = m.into();
+        assert_eq!(bv.into_inner(), [0x00, 0x01]);
+    }
+
+    #[test]
+    fn index_round_trip() {
+        let bs = [true, false, true, false, false, true, true, false];
+        let m: Mask<8, 1> = Mask::from_iter(bs);
+        for i in 0..8 {
+            assert_eq!(m[i], bs[i]);
+        }
+    }
+
+    #[test]
+    #[should_panic]
+    fn index_out_of_bounds_panics() {
+        let m: Mask<8, 1> = Mask::zero();
+        let _ = m[8];
+    }
+
+    #[test]
+    fn iter_round_trip() {
+        let bs = [true, false, true, false, false, true, true, false];
+        let m: Mask<8, 1> = Mask::from_iter(bs);
+        let mut collected = [false; 8];
+        for (i, b) in m.iter().enumerate() {
+            collected[i] = b;
+        }
+        assert_eq!(collected, bs);
+    }
+
+    #[test]
+    fn bitvector_round_trip() {
+        // Round-trip Mask -> BitVector -> Mask preserves bits.
+        let bs = [true, false, true, true, false, true, false, false];
+        let m: Mask<8, 1> = Mask::from_iter(bs);
+        let bv: BitVector<8, 1> = m.into();
+        let m2: Mask<8, 1> = bv.into();
+        let collected: [bool; 8] = core::array::from_fn(|i| m2[i]);
+        assert_eq!(collected, bs);
+    }
+}

--- a/firmware-support/bittide-hal/src/manual_additions/mod.rs
+++ b/firmware-support/bittide-hal/src/manual_additions/mod.rs
@@ -10,6 +10,7 @@ pub mod capture_ugn;
 pub mod dna;
 pub mod elastic_buffer;
 pub mod index;
+pub mod mask;
 pub mod ring_buffer;
 pub mod scatter_gather_pe;
 pub mod si539x_spi;

--- a/firmware-support/bittide-macros/src/lib.rs
+++ b/firmware-support/bittide-macros/src/lib.rs
@@ -449,6 +449,37 @@ pub fn BitVector(toks: proc_macro::TokenStream) -> proc_macro::TokenStream {
     .into()
 }
 
+/// Macro to conveniently create a `Mask` type
+///
+/// # Example
+///
+/// ```rust,ignore
+/// # use bittide_macros::Mask;
+/// fn test(m: Mask![32]) {
+///     // ...
+/// #   _ = m;
+/// }
+/// ```
+#[proc_macro]
+#[allow(non_snake_case)]
+pub fn Mask(toks: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let n_lit = parse_macro_input!(toks as LitInt);
+
+    let n_val: usize = match n_lit.base10_parse() {
+        Err(err) => return err.into_compile_error().into(),
+        Ok(v) => v,
+    };
+
+    let size = n_val.div_ceil(8);
+
+    let prefix = get_import_prefix();
+
+    quote! {
+        #prefix::mask::Mask<#n_val, #size>
+    }
+    .into()
+}
+
 fn read_hex_literal(
     input: &LitInt,
     input_str: &str,

--- a/firmware-support/memmap-generate/src/backends/c/device_desc.rs
+++ b/firmware-support/memmap-generate/src/backends/c/device_desc.rs
@@ -75,9 +75,12 @@ fn generate_const(
     let ty = &ctx.type_refs[desc.type_ref];
 
     let variables = match ty {
-        TypeRef::BitVector(handle) | TypeRef::Unsigned(handle) | TypeRef::Signed(handle) => {
+        TypeRef::BitVector(handle)
+        | TypeRef::Unsigned(handle)
+        | TypeRef::Signed(handle)
+        | TypeRef::Mask(handle) => {
             let TypeRef::Nat(width) = &ctx.type_refs[*handle] else {
-                panic!("BitVector/Unsigned/Signed need to have constant widths")
+                panic!("BitVector/Unsigned/Signed/Mask need to have constant widths")
             };
             Some(("WIDTH", *width))
         }

--- a/firmware-support/memmap-generate/src/backends/c/mod.rs
+++ b/firmware-support/memmap-generate/src/backends/c/mod.rs
@@ -152,7 +152,17 @@ fn generate_variable_binding(
                     write!(code, "uint8_t {before_var}{variable_name}[{n}]").unwrap();
                 }
             } else {
-                panic!("Unsigned/BitVector with length not known after monomorphisation");
+                panic!("BitVector with length not known after monomorphisation");
+            }
+        }
+        TypeRef::Mask(handle) => {
+            let size = &ctx.type_refs[lookup_sub(variant, *handle)];
+
+            if let TypeRef::Nat(n) = size {
+                let n = po2_type(*n);
+                write!(code, "uint{n}_t {before_var}{variable_name}").unwrap();
+            } else {
+                panic!("Mask with length not known after monomorphisation");
             }
         }
         TypeRef::Unsigned(handle) => {
@@ -324,6 +334,10 @@ fn type_to_ident(ctx: &IrCtx, ty: Handle<TypeRef>) -> String {
         TypeRef::Index(handle) => {
             let len = type_to_ident(ctx, *handle);
             format!("i{len}")
+        }
+        TypeRef::Mask(handle) => {
+            let len = type_to_ident(ctx, *handle);
+            format!("mask{len}")
         }
         TypeRef::Bool => "bool".to_string(),
         TypeRef::Float => "f32".to_string(),

--- a/firmware-support/memmap-generate/src/backends/rust/mod.rs
+++ b/firmware-support/memmap-generate/src/backends/rust/mod.rs
@@ -81,6 +81,7 @@ pub fn generate_type_desc<'ir>(
         use_index: false,
         use_signed: false,
         use_unsigned: false,
+        use_mask: false,
     };
     let desc = &ctx.type_descs[handle];
     let type_name = &ctx.type_names[desc.name];
@@ -435,6 +436,7 @@ pub fn generate_device_desc<'ir>(
         use_index: false,
         use_signed: false,
         use_unsigned: false,
+        use_mask: false,
     };
     let desc = &ctx.device_descs[handle];
     let name = &ctx.identifiers[desc.name];
@@ -487,7 +489,10 @@ fn generate_const(
     let ty = &ctx.type_refs[desc.type_ref];
 
     let variables = match ty {
-        TypeRef::BitVector(handle) | TypeRef::Unsigned(handle) | TypeRef::Signed(handle) => {
+        TypeRef::BitVector(handle)
+        | TypeRef::Unsigned(handle)
+        | TypeRef::Signed(handle)
+        | TypeRef::Mask(handle) => {
             let width = generate_type_ref(ctx, varis, None, refs, *handle);
             Some(("WIDTH", width))
         }
@@ -673,6 +678,7 @@ pub struct TypeReferences {
     pub use_index: bool,
     pub use_signed: bool,
     pub use_unsigned: bool,
+    pub use_mask: bool,
 }
 
 fn generate_type_ref(
@@ -745,6 +751,19 @@ fn generate_type_ref(
                 quote! { Index<#n, #backer> }
             } else {
                 quote! { compile_error!("Index with length not known after monomorphisation") }
+            }
+        }
+        TypeRef::Mask(handle) => {
+            let size = &ctx.type_refs[lookup_sub(variant, *handle)];
+
+            if let &TypeRef::Nat(n) = size {
+                refs.use_mask = true;
+                let n = n as usize;
+                let len = proc_macro2::Literal::usize_unsuffixed(n.div_ceil(8));
+                let n = proc_macro2::Literal::usize_unsuffixed(n);
+                quote! { Mask<#n, #len> }
+            } else {
+                quote! { compile_error!("Mask with length not known after monomorphisation") }
             }
         }
         TypeRef::Bool => quote! { bool },
@@ -892,6 +911,10 @@ fn type_to_ident(ctx: &IrCtx, ty: Handle<TypeRef>) -> String {
         TypeRef::Index(handle) => {
             let len = type_to_ident(ctx, *handle);
             format!("i{len}")
+        }
+        TypeRef::Mask(handle) => {
+            let len = type_to_ident(ctx, *handle);
+            format!("mask{len}")
         }
         TypeRef::Bool => "bool".to_string(),
         TypeRef::Float => "f32".to_string(),

--- a/firmware-support/memmap-generate/src/input_language.rs
+++ b/firmware-support/memmap-generate/src/input_language.rs
@@ -160,6 +160,7 @@ pub enum BuiltinType {
     Signed,
     Unsigned,
     Index,
+    Mask,
 }
 
 impl TryFrom<Value> for BuiltinType {
@@ -179,6 +180,7 @@ impl TryFrom<Value> for BuiltinType {
             "signed" => Ok(BuiltinType::Signed),
             "unsigned" => Ok(BuiltinType::Unsigned),
             "index" => Ok(BuiltinType::Index),
+            "mask" => Ok(BuiltinType::Mask),
             s => Err(format!("Unsupported builin type: {s:}")),
         }
     }

--- a/firmware-support/memmap-generate/src/ir/input_to_ir.rs
+++ b/firmware-support/memmap-generate/src/ir/input_to_ir.rs
@@ -219,7 +219,8 @@ impl IrCtx {
                 TypeRef::BitVector(handle)
                 | TypeRef::Unsigned(handle)
                 | TypeRef::Signed(handle)
-                | TypeRef::Index(handle) => *handle = range.handles().next().unwrap(),
+                | TypeRef::Index(handle)
+                | TypeRef::Mask(handle) => *handle = range.handles().next().unwrap(),
                 TypeRef::Vector(size, type_ref) => {
                     let mut handles = range.handles();
                     *size = handles.next().unwrap();
@@ -341,6 +342,12 @@ impl IrCtx {
                     }
                     ("Index", "Clash.Sized.Internal.Index") => {
                         let handle = self.type_refs.push(TypeRef::Index(Handle::const_handle(0)));
+
+                        to_do_and_patch.push((handle, args));
+                        handle
+                    }
+                    ("Mask", "Protocols.MemoryMap.Mask") => {
+                        let handle = self.type_refs.push(TypeRef::Mask(Handle::const_handle(0)));
 
                         to_do_and_patch.push((handle, args));
                         handle

--- a/firmware-support/memmap-generate/src/ir/monomorph.rs
+++ b/firmware-support/memmap-generate/src/ir/monomorph.rs
@@ -271,7 +271,8 @@ impl<'ir> Monomorpher<'ir> {
             TypeRef::BitVector(arg_handle)
             | TypeRef::Unsigned(arg_handle)
             | TypeRef::Signed(arg_handle)
-            | TypeRef::Index(arg_handle) => {
+            | TypeRef::Index(arg_handle)
+            | TypeRef::Mask(arg_handle) => {
                 // shouldn't be needed to visit the args, they can only be
                 // hardcoded numbers or variables
                 self.number_primitives.insert(handle, *arg_handle);

--- a/firmware-support/memmap-generate/src/ir/types.rs
+++ b/firmware-support/memmap-generate/src/ir/types.rs
@@ -68,6 +68,7 @@ pub enum TypeRef {
     Unsigned(Handle<TypeRef>),
     Signed(Handle<TypeRef>),
     Index(Handle<TypeRef>),
+    Mask(Handle<TypeRef>),
     Bool,
     Float,
     Double,


### PR DESCRIPTION
In Clash designs we often use `Vec n Bool` to track per-bit enables, valid bits, and similar. The default `BitPackC` representation of `Vec n Bool` allocates a full byte per bit, which is wasteful when these end up in memory-mapped registers. Switching to a `BitVector` is denser, but inverts the index correspondence: `Vec` index `0` maps to the MSB of the bitvector via Clash's standard `pack`/`unpack`, so a loop walking `0..n` on the Haskell side walks the wrong direction relative to firmware that pokes individual bits.

`Mask` fixes both problems: it is packed compactly (like `BitVector`), and its `toVec` / `fromVec` / `toBitVector` / `fromBitVector` conversions all preserve the `Vec`-index <-> bit-position correspondence: index `0` is bit `0` (the least significant bit).

Lastly, it introduces a mask-focused interface on the Rust side.

**Dear reviewer**
I'm currently extending the native types `clash-protocols-memmap` and friends know about. This is because in the future I'd like to have `Mask`s operate more efficiently for tasks common to them, e.g., testing a single bit. As far as I understand, the complete structure is currently fetched, after which the bit is tested. IMO that's out of scope for this PR though.

~~Note that the type is backed by `Unsigned`. I had originally implemented backed by `BitVector`, but this requires modulo operations in software.~~ @hydrolarus pointed out that this isn't true because you can translate `%8` to `& 0b111`. 

**AI disclaimer**
You bet!

# TODO
- [X] Write (regression) test
- [X] Update documentation, including `docs/`
- [X] ~~Link to existing issue~~
- [x] Use `BitVector`-like backend in Rust
- [x] Add `Mask![n]` marcos
