### PR TITLE
Add Wishbone decrease bus width utility

### DIFF
--- a/bittide-extra/src/Protocols/Wishbone/Extra.hs
+++ b/bittide-extra/src/Protocols/Wishbone/Extra.hs
@@ -2,7 +2,11 @@
 --
 -- SPDX-License-Identifier: Apache-2.0
 
-module Protocols.Wishbone.Extra (delayWishbone, xpmCdcHandshakeWb, increaseBuswidth) where
+module Protocols.Wishbone.Extra (
+  delayWishbone,
+  xpmCdcHandshakeWb,
+  increaseBusWidth,
+) where
 
 import Clash.Cores.Xilinx.Xpm.Cdc.Extra (xpmCdcHandshakeDf)
 import Clash.Prelude
@@ -223,14 +227,14 @@ xpmCdcHandshakeWb clkM rstM clkS rstS =
 `power` bits of the address. For example, with `power = 1`, a 32-bit bus becomes a 64-bit bus,
 where even addresses access the lower 32 bits and odd addresses access the upper 32 bits.
 -}
-increaseBuswidth ::
+increaseBusWidth ::
   forall dom mode aw width power.
   (HiddenClockResetEnable dom, KnownNat aw, KnownNat width, KnownNat power, power <= aw) =>
   SNat power ->
   Circuit
     (Wishbone dom mode aw width)
     (Wishbone dom mode (aw - power) (2 ^ power * width))
-increaseBuswidth SNat = Circuit (unbundle . fmap go . bundle)
+increaseBusWidth SNat = Circuit (unbundle . fmap go . bundle)
  where
   go (m2sLeft, s2mRight) = (s2mLeft, m2sRight)
    where

--- a/bittide-extra/src/Protocols/Wishbone/Extra.hs
+++ b/bittide-extra/src/Protocols/Wishbone/Extra.hs
@@ -1,11 +1,11 @@
 -- SPDX-FileCopyrightText: 2025 Google LLC
 --
 -- SPDX-License-Identifier: Apache-2.0
-
 module Protocols.Wishbone.Extra (
   delayWishbone,
   xpmCdcHandshakeWb,
   increaseBusWidth,
+  decreaseBusWidth,
 ) where
 
 import Clash.Cores.Xilinx.Xpm.Cdc.Extra (xpmCdcHandshakeDf)
@@ -255,3 +255,106 @@ increaseBusWidth SNat = Circuit (unbundle . fmap go . bundle)
     newWriteData = pack (repeat m2sLeft.writeData)
     newBusSelect = shiftL (resize m2sLeft.busSelect) bitShift
     newReadData = resize (shiftR (s2mRight.readData) (8 * bitShift))
+
+data DecreaseBusState power width
+  = DecreaseBusState
+  { addrLsbs :: BitVector power
+  -- ^ Track the lower bits of the address to know where we are in the wider bus transaction.
+  , dataReg :: BitVector (2 ^ power * width * 8)
+  -- ^ Register to hold the read/write data as we shift it in/out over multiple cycles.
+  , maskReg :: BitVector (2 ^ power * width)
+  -- ^ Register to hold the bus select mask as we shift it out over multiple cycles.
+  }
+  deriving (Generic, NFDataX, Show, ShowX, Eq, BitPack)
+
+{- | Converts a bus of `2 ^ power * width` bytes wide to bus of `width` bytes wide based on
+the `busSelect` mask. It uses internal state to keep start at the lowest non-zero byte lane and
+then perform operations on consecutive byte lanes until the entire transaction is complete.
+
+Write operations are performed in incrementing order, meaning they start at the least significant
+byte lane and then increment the address until we reach the most significant byte lane.
+
+Read operations are performed in decrementing order, meaning they start at the highest address
+based on the busSelect, and then the address is decremented until we are at the lowest address.
+This allows us to shift the readData in our shift register while not requiring us always perform
+2^n shifts even if only the least significant byte lane is used. A single byte read now only requires at least
+1 cycle instead of at least 2^n cycles.
+
+If there are gaps in the busSelect, this component inserts idle cycles where it would otherwise start
+those transactions.
+-}
+decreaseBusWidth ::
+  forall dom mode aw width power.
+  (HiddenClockResetEnable dom, KnownNat aw, KnownNat width, KnownNat power, power <= aw, 1 <= power) =>
+  SNat power ->
+  Circuit
+    (Wishbone dom mode (aw - power) (2 ^ power * width))
+    (Wishbone dom mode aw width)
+decreaseBusWidth SNat = Circuit (unbundle . mealy go initState . bundle)
+ where
+  initState :: DecreaseBusState power width
+  initState = DecreaseBusState 0 0 0
+  go state (m2sLeft, s2mRight) = (newState1, (s2mLeft, m2sRight))
+   where
+    storedValid = state.maskReg /= 0
+    masterActive = m2sLeft.busCycle && m2sLeft.strobe
+    firstCycle = masterActive && not storedValid
+
+    nextLsbs
+      | m2sLeft.writeEnable = satSucc SatZero addrLsbs
+      | otherwise = satPred SatZero addrLsbs
+
+    nextDataReg
+      | firstCycle && m2sLeft.writeEnable =
+          resize (shiftR m2sLeft.writeData (natToNum @(width * 8)))
+      | m2sLeft.writeEnable =
+          state.dataReg `shiftR` (natToNum @(width * 8))
+      | otherwise =
+          resize (state.dataReg ++# s2mRight.readData)
+
+    nextMaskReg
+      | firstCycle = resize (shiftR m2sLeft.busSelect (natToNum @width))
+      | otherwise = state.maskReg `shiftR` (natToNum @width)
+
+    lastSubTransaction = nextMaskReg == 0
+    transactionDone = lastSubTransaction || s2mRight.err || s2mRight.retry
+
+    newState1
+      | masterActive && hasTerminateFlag s2mRight && transactionDone = initState
+      | masterActive && hasTerminateFlag s2mRight =
+          DecreaseBusState nextLsbs nextDataReg nextMaskReg
+      | masterActive = state
+      | otherwise = initState
+
+    -- wrap a vector of indices into Maybe's based on the bus select, then find the left most (highest) index.
+    combine (bv :: BitVector width) idx
+      | bv == 0 = Nothing
+      | otherwise = Just (resize $ pack idx)
+
+    lastAddress = fold (<|>) (zipWith combine (unpack m2sLeft.busSelect) (reverse indicesI) :< Nothing)
+
+    newAddress = m2sLeft.addr ++# addrLsbs
+    addrLsbs
+      | firstCycle && not m2sLeft.writeEnable = fromMaybe 0 lastAddress
+      | otherwise = state.addrLsbs
+
+    newWriteData
+      | storedValid = resize state.dataReg
+      | otherwise = resize m2sLeft.writeData
+
+    newBusSelect
+      | storedValid = resize state.maskReg
+      | otherwise = resize m2sLeft.busSelect
+
+    m2sRight =
+      m2sLeft
+        { addr = newAddress
+        , writeData = newWriteData
+        , busSelect = newBusSelect
+        }
+
+    newReadData = resize (state.dataReg ++# s2mRight.readData)
+    s2mLeft
+      | masterActive && hasTerminateFlag s2mRight && transactionDone =
+          s2mRight{readData = newReadData}
+      | otherwise = emptyWishboneS2M

--- a/bittide/src/Bittide/RingBuffer.hs
+++ b/bittide/src/Bittide/RingBuffer.hs
@@ -65,7 +65,7 @@ transmitRingBuffer ::
 transmitRingBuffer primitive SNat = circuit $ \wb -> do
   [wb0, wb1] <-
     deviceWbI (deviceConfig "TransmitRingBuffer"){registered = False}
-      <| fmapC (Wb.increaseBuswidth d1)
+      <| fmapC (Wb.increaseBusWidth d1)
       -< wb
   reqresp <- addressableBytesWb @memDepth regConfig -< wb0
   (Fwd (transmitEnable, _)) <-
@@ -139,7 +139,7 @@ receiveRingBuffer primitive SNat = circuit $ \(wb, Fwd frames) -> do
   [wb0, wb1, wb2] <-
     deviceWbI (deviceConfig "ReceiveRingBuffer"){registered = False}
       <| fmapC
-        (Wb.increaseBuswidth d1)
+        (Wb.increaseBusWidth d1)
       -< wb
   (Fwd (receiveEnable, _)) <-
     registerWbI @_ @_ @8 receiveEnableConfig False -< (wb1, Fwd (pure Nothing))

--- a/bittide/tests/Tests/Clash/Protocols/Wishbone/Extra.hs
+++ b/bittide/tests/Tests/Clash/Protocols/Wishbone/Extra.hs
@@ -20,7 +20,7 @@ import Protocols
 import Protocols.Hedgehog (ExpectOptions (eoResetCycles), defExpectOptions, eoSampleMax)
 import Protocols.MemoryMap (unMemmap)
 import Protocols.Wishbone
-import Protocols.Wishbone.Extra (increaseBuswidth, xpmCdcHandshakeWb)
+import Protocols.Wishbone.Extra (increaseBusWidth, xpmCdcHandshakeWb)
 import Protocols.Wishbone.Standard.Hedgehog (
   WishboneMasterRequest (Read, Write),
   wishbonePropWithModel,
@@ -160,7 +160,7 @@ testIncreaseBuswidth power = property $ do
         $ wbStorage "test" depth (Just (Vec (repeat 0)))
 
     dut :: Circuit (Wishbone System 'Standard (AddressWidth + power) nBytes) ()
-    dut = withClockResetEnable clk rst ena (increaseBuswidth power |> dutMem)
+    dut = withClockResetEnable clk rst ena (increaseBusWidth power |> dutMem)
 
   H.footnote [i| Depth: #{snatToInteger depth}, Last Address: #{lastAddress}|]
 
@@ -177,14 +177,14 @@ testIncreaseBuswidth power = property $ do
   rst = noReset
   ena = enableGen
 
-prop_increaseBuswidth_0 :: Property
-prop_increaseBuswidth_0 = testIncreaseBuswidth d0
+prop_increaseBusWidth_0 :: Property
+prop_increaseBusWidth_0 = testIncreaseBuswidth d0
 
-prop_increaseBuswidth_1 :: Property
-prop_increaseBuswidth_1 = testIncreaseBuswidth d1
+prop_increaseBusWidth_1 :: Property
+prop_increaseBusWidth_1 = testIncreaseBuswidth d1
 
-prop_increaseBuswidth_2 :: Property
-prop_increaseBuswidth_2 = testIncreaseBuswidth d2
+prop_increaseBusWidth_2 :: Property
+prop_increaseBusWidth_2 = testIncreaseBuswidth d2
 
 prop_memoryModel :: Property
 prop_memoryModel = property $ do

--- a/bittide/tests/Tests/Clash/Protocols/Wishbone/Extra.hs
+++ b/bittide/tests/Tests/Clash/Protocols/Wishbone/Extra.hs
@@ -1,18 +1,20 @@
 -- SPDX-FileCopyrightText: 2025 Google LLC
 --
 -- SPDX-License-Identifier: Apache-2.0
+{-# LANGUAGE MultiWayIf #-}
 {-# LANGUAGE OverloadedStrings #-}
 
-module Tests.Clash.Protocols.Wishbone.Extra (tests) where
+module Tests.Clash.Protocols.Wishbone.Extra (tests, stallStandard) where
 
 import Clash.Explicit.Prelude
+import Clash.Prelude (withClockResetEnable)
 
 import Bittide.DoubleBufferedRam (
   ContentType (Vec),
   wbStorage,
  )
 import Clash.Hedgehog.Sized.BitVector (genDefinedBitVector)
-import Clash.Prelude (withClockResetEnable)
+import Clash.Signal.Internal as S
 import Data.Map (Map)
 import Data.String.Interpolate (i)
 import Hedgehog (Gen, Property, property)
@@ -20,7 +22,7 @@ import Protocols
 import Protocols.Hedgehog (ExpectOptions (eoResetCycles), defExpectOptions, eoSampleMax)
 import Protocols.MemoryMap (unMemmap)
 import Protocols.Wishbone
-import Protocols.Wishbone.Extra (increaseBusWidth, xpmCdcHandshakeWb)
+import Protocols.Wishbone.Extra (decreaseBusWidth, increaseBusWidth, xpmCdcHandshakeWb)
 import Protocols.Wishbone.Standard.Hedgehog (
   WishboneMasterRequest (Read, Write),
   wishbonePropWithModel,
@@ -35,6 +37,7 @@ import qualified Data.Map as Map
 import qualified Hedgehog as H
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
+import qualified Protocols.Wishbone.Standard.Hedgehog as Wb
 
 type AddressWidth = 4
 
@@ -136,13 +139,13 @@ prop_xpmCdcHandshakeWb = property $ do
   genBoundedIntegral :: forall a. (Integral a, Bounded a) => Gen a
   genBoundedIntegral = Gen.integral Range.constantBounded
 
-testIncreaseBuswidth ::
+testIncreaseBusWidth ::
   forall power nBytes.
   -- \| We are restricted by our 4 byte wide `wbStorage` backend.
   (KnownNat power, (2 ^ power) * nBytes ~ 4, nBytes ~ 4 `DivRU` (2 ^ power)) =>
   SNat power ->
   Property
-testIncreaseBuswidth power = property $ do
+testIncreaseBusWidth power = property $ do
   let
     eOpts = defExpectOptions
 
@@ -178,13 +181,85 @@ testIncreaseBuswidth power = property $ do
   ena = enableGen
 
 prop_increaseBusWidth_0 :: Property
-prop_increaseBusWidth_0 = testIncreaseBuswidth d0
+prop_increaseBusWidth_0 = testIncreaseBusWidth d0
 
 prop_increaseBusWidth_1 :: Property
-prop_increaseBusWidth_1 = testIncreaseBuswidth d1
+prop_increaseBusWidth_1 = testIncreaseBusWidth d1
 
 prop_increaseBusWidth_2 :: Property
-prop_increaseBusWidth_2 = testIncreaseBuswidth d2
+prop_increaseBusWidth_2 = testIncreaseBusWidth d2
+
+testDecreaseBusWidth ::
+  forall power width.
+  -- \| We are restricted by our 4 byte wide `wbStorage` backend.
+  ( KnownNat power
+  , 1 <= power
+  , KnownNat width
+  , 1 <= width
+  , width <= 4
+  ) =>
+  SNat power ->
+  SNat width ->
+  Property
+testDecreaseBusWidth power SNat = property $ do
+  stalls <- H.forAll $ Gen.list (Range.linear 0 100) $ Gen.integral (Range.linear 0 10)
+  earlyStrobe <- H.forAll Gen.bool
+  let
+    eOpts = defExpectOptions
+
+    -- Depth is half the number of addresses to also tests error on out-of-range accesses.
+    depth = SNat @(2 ^ (AddressWidth - 2))
+    lastAddress = snatToNum $ predSNat depth
+    lastAddressSmall = lastAddress * (natToNum @(2 ^ power))
+    genAddr = Gen.integral (Range.linear 0 lastAddressSmall)
+    genInputs = Gen.list (Range.linear 1 10) (genWishboneTransfer genAddr)
+
+    dutMem :: Circuit (Wishbone System 'Standard (AddressWidth + power) width) ()
+    dutMem =
+      withClockResetEnable clk rst ena
+        $ unMemmap
+        $ wbStorage "test" depth (Just (Vec (repeat 0)))
+
+    dut :: Circuit (Wishbone System 'Standard AddressWidth (2 ^ power * width)) ()
+    dut =
+      withClockResetEnable
+        clk
+        rst
+        ena
+        (decreaseBusWidth power |> Wb.validatorCircuit |> stallStandard earlyStrobe stalls |> dutMem)
+
+  H.footnote [i| Depth: #{snatToInteger depth}, Last Address: #{lastAddress}|]
+
+  withClockResetEnable clk rst ena
+    $ wishbonePropWithModel
+      @System
+      eOpts
+      (memoryModel (fromIntegral lastAddressSmall))
+      dut
+      genInputs
+      (Map.fromList (L.zip [0 .. lastAddressSmall] (L.repeat 0)))
+ where
+  clk = clockGen
+  rst = noReset
+  ena = enableGen
+
+prop_decreaseBusWidth_1_1 :: Property
+prop_decreaseBusWidth_1_1 = testDecreaseBusWidth d1 d1
+
+prop_decreaseBusWidth_2_1 :: Property
+prop_decreaseBusWidth_2_1 = testDecreaseBusWidth d2 d1
+
+prop_decreaseBusWidth_3_1 :: Property
+prop_decreaseBusWidth_3_1 = testDecreaseBusWidth d3 d1
+
+prop_decreaseBusWidth_1_2 :: Property
+prop_decreaseBusWidth_1_2 = testDecreaseBusWidth d1 d2
+
+prop_decreaseBusWidth_2_2 :: Property
+prop_decreaseBusWidth_2_2 = testDecreaseBusWidth d2 d2
+
+prop_decreaseBusWidth_3_2 :: Property
+prop_decreaseBusWidth_3_2 = testDecreaseBusWidth d3 d2
 
 prop_memoryModel :: Property
 prop_memoryModel = property $ do

--- a/bittide/tests/Tests/Clash/Protocols/Wishbone/Extra.hs
+++ b/bittide/tests/Tests/Clash/Protocols/Wishbone/Extra.hs
@@ -210,5 +210,60 @@ prop_memoryModel = property $ do
   genAddr = Gen.integral (Range.linear 0 (lastAddress * 2))
   genInputs = Gen.list (Range.linear 1 10) (genWishboneTransfer genAddr)
 
+-- XXX: This version of stallStandard should be removed once the upstream version has been fixed.
+
+-- | Create a stalling wishbone 'Standard' circuit.
+stallStandard ::
+  forall dom addressBits dataBytes.
+  ( C.KnownNat addressBits
+  , C.KnownDomain dom
+  , C.KnownNat dataBytes
+  ) =>
+  {- | Early busCycle propagation, when 'True', the busCycle signal will always be propagated.
+  When 'False', the busCycle signal will be stalled just like the 'strobe' signal.
+  -}
+  Bool ->
+  -- | Number of cycles to stall the master for on each valid bus-cycle
+  [Int] ->
+  Circuit
+    (Wishbone dom 'Standard addressBits dataBytes)
+    (Wishbone dom 'Standard addressBits dataBytes)
+stallStandard earlyBusCycle stalls0 =
+  Circuit goS
+ where
+  goS (m2s, s2m) = (s2m, go stalls0 m2s s2m)
+  go ::
+    [Int] ->
+    Signal dom (WishboneM2S addressBits dataBytes) ->
+    Signal dom (WishboneS2M dataBytes) ->
+    Signal dom (WishboneM2S addressBits dataBytes)
+  -- Idle, waiting for a request
+  go (stall : stalls) (m :- ms) (s :- ss) = m' :- go stalls' ms ss
+   where
+    -- Only propagate the buscycle while stalling, this allows the manager to reserve the bus, but postpones the actual
+    -- transaction until the stall is over.
+    m'
+      | stall > 0 = block m
+      | otherwise = m
+    stalls' = nextStall stall stalls m s
+  go [] ms _ = ms
+
+  block m
+    | earlyBusCycle = m{strobe = False}
+    | otherwise = m{busCycle = False, strobe = False}
+
+  -- Select the correct
+  nextStall
+    | earlyBusCycle = \stall stalls m s ->
+        if
+          | m.busCycle && m.strobe && hasTerminateFlag s -> stalls
+          | m.busCycle && m.strobe && stall > 0 -> stall - 1 : stalls
+          | otherwise -> stall : stalls
+    | otherwise = \stall stalls m s ->
+        if
+          | m.busCycle && m.strobe && hasTerminateFlag s -> stalls
+          | m.busCycle && stall > 0 -> stall - 1 : stalls
+          | otherwise -> stall : stalls
+
 tests :: TestTree
 tests = $(testGroupGenerator)


### PR DESCRIPTION
_What (what did you do)_
* Renamed `increaseBuswidth` to `increaseBusWidth`.
* Add a component that reduces a bus of `(2 ^ power * width)` bytes to a bus of  `width` bytes by sequencing transactions.
This is the counterpart of `increasBusWidth`.

_Why (context, issues, etc.)_
This is useful for resizing busses.

_Dear reviewer (anything you'd like the reviewer to pay close attention to?)_
Is this the best way to reduce bus width or should we also have a plain resizer that throws an error on invalid masks?

_AI disclaimer (heads-up for more than inline autocomplete)_
Used AI for test scaffolding and debugging.

# TODO
_~~Cross-out~~ any that do not apply_

- [x] Write (regression) test
- [ ] Update documentation, including `docs/`
- [ ] Link to existing issue
