### PR TITLE
Use newer Rust version, fix warning from upgrade

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
       run:
         shell: git-nix-shell {0}
     container:
-      image: ghcr.io/clash-lang/nixos-bittide-hardware:2026-04-20
+      image: ghcr.io/clash-lang/nixos-bittide-hardware:2026-05-11
       options: --memory=11g
     steps:
     - uses: actions/checkout@v6
@@ -103,7 +103,7 @@ jobs:
         shell: git-nix-shell {0}
 
     container:
-      image: ghcr.io/clash-lang/nixos-bittide-hardware:2026-04-20
+      image: ghcr.io/clash-lang/nixos-bittide-hardware:2026-05-11
       options: --memory=11g
 
     steps:
@@ -169,7 +169,7 @@ jobs:
         shell: git-nix-shell {0} --ignore-environment
 
     container:
-      image: ghcr.io/clash-lang/nixos-bittide-hardware:2026-04-20
+      image: ghcr.io/clash-lang/nixos-bittide-hardware:2026-05-11
       options: --memory=11g
 
     steps:
@@ -222,7 +222,7 @@ jobs:
       fail-fast: false
 
     container:
-      image: ghcr.io/clash-lang/nixos-bittide-hardware:2026-04-20
+      image: ghcr.io/clash-lang/nixos-bittide-hardware:2026-05-11
       options: --memory=11g
 
     env:
@@ -285,7 +285,7 @@ jobs:
       run:
         shell: git-nix-shell {0}
     container:
-      image: ghcr.io/clash-lang/nixos-bittide-hardware:2026-04-20
+      image: ghcr.io/clash-lang/nixos-bittide-hardware:2026-05-11
       options: --memory=11g
     outputs:
       run_tests: ${{ steps.check.outputs.run_tests }}
@@ -317,7 +317,7 @@ jobs:
     if: ${{ needs.should-run-haskell-tests.outputs.run_tests == 'true' }}
 
     container:
-      image: ghcr.io/clash-lang/nixos-bittide-hardware:2026-04-20
+      image: ghcr.io/clash-lang/nixos-bittide-hardware:2026-05-11
       options: --memory=11g
       volumes:
         - /opt/tools:/opt/tools
@@ -392,7 +392,7 @@ jobs:
       run:
         shell: git-nix-shell {0} --ignore-environment
     container:
-      image: ghcr.io/clash-lang/nixos-bittide-hardware:2026-04-20
+      image: ghcr.io/clash-lang/nixos-bittide-hardware:2026-05-11
       options: --memory=11g
     needs: [build]
 
@@ -418,7 +418,7 @@ jobs:
       run:
         shell: git-nix-shell {0} --ignore-environment
     container:
-      image: ghcr.io/clash-lang/nixos-bittide-hardware:2025-12-17
+      image: ghcr.io/clash-lang/nixos-bittide-hardware:2026-05-11
       options: --memory=15g
     needs: [build]
 
@@ -446,7 +446,7 @@ jobs:
       run:
         shell: git-nix-shell {0} --ignore-environment
     container:
-      image: ghcr.io/clash-lang/nixos-bittide-hardware:2026-04-20
+      image: ghcr.io/clash-lang/nixos-bittide-hardware:2026-05-11
       options: --memory=11g
     needs: [build]
 
@@ -479,7 +479,7 @@ jobs:
       run:
         shell: git-nix-shell {0} --ignore-environment
     container:
-      image: ghcr.io/clash-lang/nixos-bittide-hardware:2026-04-20
+      image: ghcr.io/clash-lang/nixos-bittide-hardware:2026-05-11
       options: --memory=11g
     needs: [build]
 
@@ -563,7 +563,7 @@ jobs:
       fail-fast: false
 
     container:
-      image: ghcr.io/clash-lang/nixos-bittide-hardware:2026-04-20
+      image: ghcr.io/clash-lang/nixos-bittide-hardware:2026-05-11
       options: --memory=11g
 
     steps:
@@ -638,7 +638,7 @@ jobs:
       fail-fast: false
 
     container:
-      image: ghcr.io/clash-lang/nixos-bittide-hardware:2026-04-20
+      image: ghcr.io/clash-lang/nixos-bittide-hardware:2026-05-11
       volumes:
         - /opt/tools:/opt/tools
       options: --init --mac-address="6c:5a:b0:6c:13:0b" --memory=11g
@@ -734,7 +734,7 @@ jobs:
         shell: git-nix-shell {0} --ignore-environment
 
     container:
-      image: ghcr.io/clash-lang/nixos-bittide-hardware:2026-04-20
+      image: ghcr.io/clash-lang/nixos-bittide-hardware:2026-05-11
       options: --memory=11g
 
     strategy:
@@ -777,7 +777,7 @@ jobs:
       fail-fast: false
 
     container:
-      image: ghcr.io/clash-lang/nixos-bittide-hardware:2026-04-20
+      image: ghcr.io/clash-lang/nixos-bittide-hardware:2026-05-11
       volumes:
         - /opt/tools:/opt/tools
         - /dev:/dev
@@ -839,7 +839,7 @@ jobs:
       run:
         shell: git-nix-shell {0} --ignore-environment
     container:
-      image: ghcr.io/clash-lang/nixos-bittide-hardware:2026-04-20
+      image: ghcr.io/clash-lang/nixos-bittide-hardware:2026-05-11
       options: --memory=11g
     steps:
       - name: Checkout

--- a/.github/workflows/deploy-documentation.yml
+++ b/.github/workflows/deploy-documentation.yml
@@ -23,7 +23,7 @@ jobs:
       run:
         shell: git-nix-shell {0} --ignore-environment
     container:
-      image: ghcr.io/clash-lang/nixos-bittide-hardware:2026-04-20
+      image: ghcr.io/clash-lang/nixos-bittide-hardware:2026-05-11
       options: --memory=11g
     steps:
       - name: Checkout

--- a/firmware-binaries/sim-tests/elastic_buffer_wb_test/src/main.rs
+++ b/firmware-binaries/sim-tests/elastic_buffer_wb_test/src/main.rs
@@ -211,7 +211,7 @@ fn test_underflow_flag_sticky(
     uwriteln!(
         uart,
         "  Before draining: count={}, will drain {} times",
-        count_before as i8,
+        count_before,
         drains_needed
     )
     .unwrap();

--- a/firmware-support/bittide-hal/src/lib.rs
+++ b/firmware-support/bittide-hal/src/lib.rs
@@ -11,6 +11,7 @@
 // files that aren't yet generated.
 // (and if we want to style check generated files anyway?..)
 #[rustfmt::skip]
+#[allow(clippy::zero_ptr)]
 pub mod hals;
 
 pub use hals::*;

--- a/firmware-support/bittide-hal/src/manual_additions/scatter_gather_pe/scatter_gather.rs
+++ b/firmware-support/bittide-hal/src/manual_additions/scatter_gather_pe/scatter_gather.rs
@@ -13,12 +13,10 @@ impl GatherUnit {
     /// the `GatherUnit` memory.
     pub fn write_slice(&self, src: &[BitVector!(64)], offset: usize) {
         assert!(src.len() + offset <= Self::GATHER_MEMORY_LEN);
-        let mut off = offset;
-        for &val in src {
+        for (off, &val) in (offset..).zip(src.iter()) {
             unsafe {
                 self.set_gather_memory_unchecked(off, val);
             }
-            off += 1;
         }
     }
 
@@ -41,12 +39,10 @@ impl ScatterUnit {
     ///  of the `ScatterUnit`.
     pub fn read_slice(&self, dst: &mut [BitVector!(64)], offset: usize) {
         assert!(dst.len() + offset <= Self::SCATTER_MEMORY_LEN);
-        let mut off = offset;
-        for val in dst {
+        for (off, val) in (offset..).zip(dst.iter_mut()) {
             unsafe {
                 *val = self.scatter_memory_unchecked(off);
             }
-            off += 1;
         }
     }
 

--- a/firmware-support/bittide-hal/src/manual_additions/soft_ugn_demo_mu/scatter_gather.rs
+++ b/firmware-support/bittide-hal/src/manual_additions/soft_ugn_demo_mu/scatter_gather.rs
@@ -13,12 +13,10 @@ impl GatherUnit {
     /// the `GatherUnit` memory.
     pub fn write_slice(&self, src: &[BitVector!(64)], offset: usize) {
         assert!(src.len() + offset <= Self::GATHER_MEMORY_LEN);
-        let mut off = offset;
-        for &val in src {
+        for (off, &val) in (offset..).zip(src.iter()) {
             unsafe {
                 self.set_gather_memory_unchecked(off, val);
             }
-            off += 1;
         }
     }
 
@@ -41,12 +39,10 @@ impl ScatterUnit {
     ///  of the `ScatterUnit`.
     pub fn read_slice(&self, dst: &mut [BitVector!(64)], offset: usize) {
         assert!(dst.len() + offset <= Self::SCATTER_MEMORY_LEN);
-        let mut off = offset;
-        for val in dst {
+        for (off, val) in (offset..).zip(dst.iter_mut()) {
             unsafe {
                 *val = self.scatter_memory_unchecked(off);
             }
-            off += 1;
         }
     }
 

--- a/firmware-support/memmap-generate/src/ir/input_to_ir.rs
+++ b/firmware-support/memmap-generate/src/ir/input_to_ir.rs
@@ -204,11 +204,7 @@ impl IrCtx {
         mappings: &mut IrInputMapping<'input>,
         to_do_and_patch: &mut Vec<(Handle<TypeRef>, &'input [input::TypeRef])>,
     ) {
-        loop {
-            let Some((patch_handle, to_do)) = to_do_and_patch.pop() else {
-                break;
-            };
-
+        while let Some((patch_handle, to_do)) = to_do_and_patch.pop() {
             let mut range = HandleRange::build();
 
             for ty_ref in to_do {
@@ -414,11 +410,7 @@ impl IrCtx {
         let (top_handle, _top_ty_handle) =
             self.add_tree_elem(mapping, desc, tree, &mut to_do_and_patch);
 
-        loop {
-            let Some((handle, to_do)) = to_do_and_patch.pop() else {
-                break;
-            };
-
+        while let Some((handle, to_do)) = to_do_and_patch.pop() {
             let mut range = HandleRange::build();
 
             for thing in to_do {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -3,6 +3,6 @@
 # SPDX-License-Identifier: CC0-1.0
 
 [toolchain]
-channel = "nightly-2025-04-03"
+channel = "nightly-2026-04-16"
 components = ["rustfmt", "clippy", "rust-src"]
 targets = ["riscv32imc-unknown-none-elf", "x86_64-unknown-linux-gnu"]


### PR DESCRIPTION
Closes #1132

_What (what did you do)_
Updated the Rust version to `nightly-2026-04-16`.

_Why (context, issues, etc.)_
Seems we wanted to do it as per #1132, so I just went and made it happen.

_Dear reviewer (anything you'd like the reviewer to pay close attention to?)_
Nothing in particular to pay attention to, I think.

_AI disclaimer (heads-up for more than inline autocomplete)_
None.

# TODO
_~~Cross-out~~ any that do not apply_

- [ ] ~~Write (regression) test~~
- [ ] ~~Update documentation, including `docs/`~~
- [x] Link to existing issue
