### PR TITLE
Migrate `uartInterfaceWb` to `deviceWb` and `registerWb`

### DIFF
--- a/bittide-instances/src/Bittide/Instances/Pnr/Ethernet.hs
+++ b/bittide-instances/src/Bittide/Instances/Pnr/Ethernet.hs
@@ -143,7 +143,7 @@ vexRiscGmiiC sysClk sysRst rxClk rxRst txClk txRst peConfig =
       txClkEna
       rxClkEna
   macStatIf = wcre $ macStatusInterfaceWb d16
-  uart = wcre $ uartInterfaceWb d32 d2 (uartDf baud)
+  uart = withLittleEndian $ wcre $ uartInterfaceWb d32 d2 (uartDf baud)
   pe = withLittleEndian $ wcre processingElement NoDumpVcd peConfig
   wbToAxi4StreamTx' = wcre wbToAxi4StreamTx
   wbAxiRxBuffer = wcre wbAxisRxBufferCircuit (SNat @2048)

--- a/bittide/src/Bittide/Wishbone.hs
+++ b/bittide/src/Bittide/Wishbone.hs
@@ -17,7 +17,6 @@ import Clash.Cores.Xilinx.Unisim.DnaPortE2
 import Clash.Debug
 import Clash.Explicit.Prelude (noReset)
 import Clash.Functor.Extra ((<<$>>))
-import Clash.Util.Interpolate
 import Control.DeepSeq (NFData)
 import Data.Bool (bool)
 import Data.Maybe
@@ -42,7 +41,6 @@ import Bittide.SharedTypes
 import qualified Data.List as L
 import qualified Protocols.MemoryMap as Mm
 import qualified Protocols.MemoryMap.Registers.WishboneStandard as Mm
-import qualified Protocols.ToConst as ToConst
 import qualified Protocols.Vec as Vec
 import qualified Protocols.Wishbone as Wishbone
 
@@ -399,18 +397,11 @@ uartBytes = Circuit go
     ((ack, pure $ Ack True), (rxByte, txByte))
 
 {- | Wishbone accessible UART interface with configurable FIFO buffers.
-  It takes the depths of the transmit and receive buffers and the uart implementation
-  as parameters. By explicitly passing the uart implementation, the user can choose
-  to either use a 'uartDf' circuit for actual serial communication or use `uartBytes`
-  for simulation purposes. Alongside the uart interface, the component produces
-  a 'CSignal' tuple indicating the status of the transmit and receive buffers.
-
-  The register layout is as follows:
-  - Address 0 (BitVector 8): UART data register (read/write)
-  - Address 4 (BitVector 2): UART status register (read-only)
-    Relevant masks:
-    - 0b01: Transmit buffer full
-    - 0b10: Receive buffer empty
+It takes the depths of the transmit and receive buffers and the uart implementation
+as parameters. By explicitly passing the uart implementation, the user can choose
+to either use a 'uartDf' circuit for actual serial communication or use `uartBytes`
+for simulation purposes. Alongside the uart interface, the component produces
+a 'CSignal' tuple indicating the status of the transmit and receive buffers.
 -}
 uartInterfaceWb ::
   forall dom addrW nBytes transmitBufferDepth receiveBufferDepth uartIn uartOut.
@@ -421,6 +412,7 @@ uartInterfaceWb ::
   , KnownNat addrW
   , KnownNat nBytes
   , 1 <= nBytes
+  , ?byteOrder :: ByteOrder
   ) =>
   {- | Recommended value: 16. This seems to be a good balance between resource
   usage and usability.
@@ -435,136 +427,52 @@ uartInterfaceWb ::
   Circuit
     ((ToConstBwd Mm.Mm, Wishbone dom 'Standard addrW nBytes), uartIn)
     (uartOut, CSignal dom (Bool, Bool))
-uartInterfaceWb txDepth@SNat rxDepth@SNat uartImpl = circuit $ \((mm, wb), uartRx) -> do
-  (txFifoIn, uartStatus) <- wbToDf -< (wb, rxFifoOut, txFifoMeta)
-  (txFifoOut, txFifoMeta) <- fifoWithMeta txDepth -< txFifoIn
+uartInterfaceWb txDepth@SNat rxDepth@SNat uartImpl = circuit $ \(bus, uartRx) -> do
+  [dataWb, rxEmptyWb, txFullWb] <- Mm.deviceWbI (Mm.deviceConfig "Uart") -< bus
+
+  let txFifoIn = Mm.busActivityWrite <$> regOutActivity
+  (txFifoOut, Fwd txFifoMeta) <- fifoWithMeta txDepth <| unsafeToDf -< Fwd txFifoIn
+
   (rxFifoIn, uartTx) <- uartImpl -< (txFifoOut, uartRx)
+
   (rxFifoOut, _rx') <- fifoWithMeta rxDepth <| unsafeToDf -< rxFifoIn
-  ToConst.toBwd memMap -< mm
-  idC -< (uartTx, uartStatus)
- where
-  memMap =
-    SimOnly
-      $ Mm.MemoryMap
-        { tree = Mm.DeviceInstance Mm.locCaller "Uart"
-        , deviceDefs = Mm.deviceSingleton deviceDef
+  Fwd regIn <- unsafeFromDf -< (rxFifoOut, Fwd (fmap Ack busRead))
+
+  let
+    rxEmpty = fmap isNothing regIn
+    txFull = fmap (.fifoFull) txFifoMeta
+    busRead = fmap (isJust . Mm.busActivityRead) regOutActivity
+    busWrite = fmap (isJust . Mm.busActivityWrite) regOutActivity
+    regOutAck = busWrite .&&. (fmap not txFull) .||. busRead .&&. (fmap not rxEmpty)
+
+  Fwd regOutActivity <- unsafeFromDf -< (regOutActivityDf, Fwd (fmap Ack regOutAck))
+
+  (_regOut, regOutActivityDf) <-
+    Mm.registerWbDfI
+      (registerConfig "data")
+        { Mm.access = Mm.ReadWrite
+        , Mm.description = ""
         }
+      0
+      -< (dataWb, Fwd regIn)
 
-  deviceDef =
-    Mm.DeviceDefinition
-      { registers =
-          [ Mm.NamedLoc
-              { name = Mm.Name "data" ""
-              , loc = Mm.locHere
-              , value =
-                  Mm.Register
-                    { reset = Nothing
-                    , fieldType = Mm.regType @(Bytes 1)
-                    , address = 0
-                    , access = Mm.ReadWrite
-                    , tags = []
-                    }
-              }
-          , Mm.NamedLoc
-              { name = Mm.Name "status" ""
-              , loc = Mm.locHere
-              , value =
-                  Mm.Register
-                    { reset = Nothing
-                    , fieldType = Mm.regType @(Bytes 1)
-                    , address = 4
-                    , access = Mm.ReadOnly
-                    , tags = []
-                    }
-              }
-          ]
-      , deviceName =
-          Mm.Name "Uart" "Wishbone accessible UART interface with configurable FIFO buffers."
-      , definitionLoc = Mm.locHere
-      , tags = []
+  registerWbI_
+    (registerConfig "receive_buffer_empty")
+      { Mm.access = Mm.ReadOnly
+      , Mm.description = "Whether the receive buffer is empty."
       }
+    True
+    -< (rxEmptyWb, Fwd (Just <$> rxEmpty))
 
-  wbToDf ::
-    Circuit
-      ( Wishbone dom 'Standard addrW nBytes
-      , Df dom (BitVector 8)
-      , CSignal dom (FifoMeta txFifoDepth)
-      )
-      ( Df dom (BitVector 8)
-      , CSignal dom (Bool, Bool) -- (rxEmpty, txFull)
-      )
-  wbToDf = Circuit go0
-   where
-    go0 ((m2s, dfDataIn, fifoMeta), (ackIn, _)) =
-      ((s2m, ack, ()), (dfOut, status))
-     where
-      (s2m, ack, dfOut, status) = unbundle (fmap go1 (bundle (m2s, dfDataIn, fifoMeta, ackIn)))
+  registerWbI_
+    (registerConfig "transmit_buffer_full")
+      { Mm.access = Mm.ReadOnly
+      , Mm.description = "Whether the transmit buffer is full."
+      }
+    False
+    -< (txFullWb, Fwd (Just <$> txFull))
 
-    go1
-      ( WishboneM2S{addr, busCycle, strobe, writeData, writeEnable}
-        , rxData
-        , (.fifoFull) -> txFull
-        , Ack txAck
-        )
-        -- not in cycle
-        | not (busCycle && strobe) =
-            ( (emptyWishboneS2M @0){readData = invalidReq}
-            , Ack False
-            , Nothing
-            , status
-            )
-        -- illegal addr
-        | not addrLegal =
-            ( (emptyWishboneS2M @0){err = True, readData = invalidReq}
-            , Ack False
-            , Nothing
-            , status
-            )
-        -- read at 0
-        | not writeEnable && internalAddr == 0 =
-            ( (emptyWishboneS2M @0)
-                { acknowledge = True
-                , readData = resize $ fromMaybe 0 rxData
-                }
-            , Ack True
-            , Nothing
-            , status
-            )
-        -- write at 0
-        | writeEnable && internalAddr == 0 =
-            ( (emptyWishboneS2M @0)
-                { acknowledge = txAck
-                , readData = invalidReq
-                }
-            , Ack False
-            , Just $ resize writeData
-            , status
-            )
-        -- read at 1
-        | not writeEnable && internalAddr == 1 =
-            ( (emptyWishboneS2M @0)
-                { acknowledge = True
-                , readData = resize $ pack status
-                }
-            , Ack False
-            , Nothing
-            , status
-            )
-        | otherwise = (emptyWishboneS2M{err = True}, Ack False, Nothing, status)
-       where
-        internalAddr = bitCoerce $ resize addr :: Index 2
-        addrLegal = addr <= 1
-        rxEmpty = isNothing rxData
-        status = (rxEmpty, txFull)
-        invalidReq =
-          deepErrorX
-            [i|uartInterfaceWb: Invalid request.
-          BUS: {busCycle}
-          STR: {strobe}
-          ADDR: {addr}
-          WE:{writeEnable}
-          ACK:{acknowledge}
-          ERR:{err}|]
+  idC -< (uartTx, Fwd (bundle (rxEmpty, txFull)))
 
 -- | State record for the FIFO circuit.
 data FifoState depth = FifoState

--- a/bittide/tests/Tests/Wishbone.hs
+++ b/bittide/tests/Tests/Wishbone.hs
@@ -3,25 +3,26 @@
 -- SPDX-License-Identifier: Apache-2.0
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PartialTypeSignatures #-}
-{-# OPTIONS_GHC -fplugin Protocols.Plugin #-}
 
 module Tests.Wishbone (tests, simpleSlave, simpleSlave', wbRead) where
 
 import Clash.Prelude hiding (sample)
 
+import Clash.Explicit.Prelude (noReset)
 import Clash.Hedgehog.Sized.BitVector
 import Clash.Hedgehog.Sized.Vector
 import Clash.Sized.Vector (unsafeFromList)
-import Data.Bifunctor
+import Data.Maybe (fromJust)
 import Data.String
+import Data.String.Interpolate (i)
 import Hedgehog
 import Hedgehog.Range as Range
 import Protocols
 import Protocols.Hedgehog
 import Protocols.Idle (forceResetSanityGeneric)
-import Protocols.MemoryMap (ignoreMM)
+import Protocols.MemoryMap
 import Protocols.Wishbone
-import Protocols.Wishbone.Standard.Hedgehog (validatorCircuit)
+import Protocols.Wishbone.Standard.Hedgehog (validatorCircuit, wishbonePropWithModel)
 import Test.Tasty
 import Test.Tasty.Hedgehog
 
@@ -32,8 +33,12 @@ import Tests.Shared
 import Tests.Wishbone.Utils (genWishboneRequest)
 
 import qualified Data.List as L
+import qualified Data.Map as Map
 import qualified GHC.TypeNats as TN
 import qualified Hedgehog.Gen as Gen
+import qualified Protocols.Df as Df
+import qualified Protocols.Hedgehog as PH
+import qualified Protocols.Wishbone.Standard.Hedgehog as Wb
 
 tests :: TestTree
 tests =
@@ -42,90 +47,69 @@ tests =
     [ testPropertyNamed "Reading readData from slaves." "readingSlaves" readingSlaves
     , testPropertyNamed "Writing and reading from slaves." "writingSlaves" writingSlaves
     , testPropertyNamed
-        "Send and receive bytes via uartInterfaceWb"
-        "uartInterfaceWbCircuitTest"
-        uartInterfaceWbCircuitTest
+        "Loopback uartInterfaceWb through fifo with random stalls"
+        "uartInterfaceWbTest"
+        uartInterfaceWbTest
     , testPropertyNamed
         "Test the Df based wishbone master"
         "prop_dfWishboneMaster"
         prop_dfWishboneMaster
     ]
 
-data UartMachineState = ReadStatus | ReadByte | WriteByte | OutputByte (BitVector 8)
-  deriving (Generic, NFDataX, Show)
+type AddressWidth = 4
 
-{- | A `Circuit` that transforms incoming `Df` transactions into `Wishbone` transactions
-that are compatible with `Bittide.Wishbone.wbToDf`.
--}
+smallInt :: Gen Int
+smallInt = Gen.integral (Range.linear 0 10)
 
--- .It implements the following state machine:
--- 1. Check if there is incoming data available in the `wbToDf` receive fifo, if so, skip to 4.
--- 2. Check if there is space in the `wbToDf` transmit fifo. If so, skip to 6.
--- 3. Go to 1.
--- 4. Read in the incoming byte and send it to the outgoing Df interface.
--- 5. Go to 1
--- 6. If there is no data available at the incoming Df interface, go to 1.
--- 7. Write data from incoming Df interface to `wbToDf`.
-uartMachine ::
-  forall dom addrW.
-  ( HiddenClockResetEnable dom
-  , KnownNat addrW
-  ) =>
-  Circuit
-    (Df dom (BitVector 8))
-    (Wishbone dom 'Standard addrW 1, Df dom (BitVector 8))
-uartMachine = Circuit (second unbundle . mealyB go ReadStatus . second bundle)
- where
-  go ReadStatus (_, ~(s@WishboneS2M{}, _)) = (nextState, (Ack False, (wbOut, Nothing)))
-   where
-    (rxEmpty, txFull) = unpack (resize s.readData)
-    nextState = case (s.acknowledge, s.err, (rxEmpty, txFull)) of
-      (True, False, (False, _)) -> ReadByte
-      (True, False, (True, False)) -> WriteByte
-      _ -> ReadStatus
-    wbOut = (emptyWishboneM2S @30){addr = 1, busCycle = True, strobe = True}
-  go ReadByte (_, ~(s@WishboneS2M{}, _)) = (nextState, (Ack False, (wbOut, Nothing)))
-   where
-    nextState = case (s.acknowledge, s.err) of
-      (True, False) -> OutputByte (resize s.readData)
-      _ -> ReadByte
-    wbOut = (emptyWishboneM2S @30){addr = 0, busCycle = True, strobe = True}
-  go (OutputByte byte) (_, ~(_, Ack dfAck)) =
-    (nextState, (Ack False, (emptyWishboneM2S, Just byte)))
-   where
-    nextState = if dfAck then ReadStatus else (OutputByte byte)
-  go (WriteByte) (Just dfData, ~(s@WishboneS2M{}, _)) = (nextState, (Ack dfAck, (wbOut, Nothing)))
-   where
-    (nextState, dfAck) =
-      if s.acknowledge && not s.err then (ReadStatus, True) else (WriteByte, False)
-    wbOut =
-      (emptyWishboneM2S @30 @1)
-        { addr = 0
-        , busCycle = True
-        , strobe = True
-        , writeEnable = True
-        , busSelect = 1
-        , writeData = resize dfData
-        }
-  go WriteByte (Nothing, _) = (ReadStatus, (Ack False, (emptyWishboneM2S, Nothing)))
+genStalls' :: (KnownNat n) => Gen (Vec n ((StallAck, [Int])))
+genStalls' = do
+  numStalls <- smallInt
+  genVec (PH.genStalls smallInt numStalls PH.Stall)
 
--- | Check if we can combine `uartInterfaceWb` in loopback mode and `uartMachine` to create `id`.
-uartInterfaceWbCircuitTest :: Property
-uartInterfaceWbCircuitTest = do
+uartInterfaceWbTest :: Property
+uartInterfaceWbTest = property $ do
+  stallsBefore <- forAll $ genStalls'
+  stallsAfter <- forAll $ genStalls'
   let
-    dataGen = Gen.list (Range.linear 0 32) $ genDefinedBitVector @8
-    dut :: (HiddenClockResetEnable System) => Circuit (Df System Byte) (Df System Byte)
-    dut = circuit $ \dfIn -> do
-      (wb, dfOut) <- uartMachine -< dfIn
-      mm <- ignoreMM
-      (uartTx, _status) <- uartInterfaceWb @System @32 d2 d2 uartBytes -< ((mm, wb), uartTx)
-      idC -< dfOut
-    expectOptions =
-      defExpectOptions
-        { eoResetCycles = 15
-        , eoDriveEarly = True
-        }
-  idWithModel expectOptions dataGen id (wcre dut)
+    deviceName = "Uart"
+    defs = (((getMMAny dutMm).deviceDefs) Map.! deviceName)
+    dataLoc = L.find (\loc -> loc.name.name == "data") defs.registers
+    dataAddr = fromIntegral (fromJust dataLoc).value.address `div` natToNum @AddressWidth
+
+    bytes = [0 .. 7]
+    writeOps = Wb.Write dataAddr 1 <$> bytes
+    readOps = L.replicate 8 $ Wb.Read dataAddr 1
+    allOps = writeOps <> readOps
+
+    dutMm :: Circuit (ToConstBwd Mm, Wishbone XilinxSystem Standard AddressWidth 4) ()
+    dutMm =
+      withLittleEndian $ withClockResetEnable clk rst ena $ circuit $ \(mm, wb) -> do
+        -- The receive buffer needs to be large enough, otherwise bytes will be dropped.
+        (uartOut, _uartStatus) <- uartInterfaceWb d2 d16 uartBytes -< ((mm, wb), uartIn)
+        uartIn <-
+          stallC simConfig stallsAfter
+            <| Df.fifo d16
+            <| stallC simConfig stallsBefore
+            -< uartOut
+        idC -< ()
+
+    model (Wb.Write _ _ _) resp s
+      | resp.acknowledge = Right s
+      | otherwise = Left [i|Expected acknowledge for valid write, but got: #{resp}|]
+    model (Wb.Read _ _) resp (expected : rest)
+      | resp.acknowledge && resp.readData == expected = Right rest
+      | otherwise = Left [i|Expected: #{expected}, but got: #{resp}|]
+    model (Wb.Read _ _) resp [] = Left [i|Expected more read responses, but got: #{resp} |]
+
+  withClockResetEnable clk rst ena
+    $ wishbonePropWithModel eOpts model (unMemmap dutMm) (pure allOps) bytes
+ where
+  eOpts = defExpectOptions
+  simConfig = def
+
+  clk = clockGen
+  rst = noReset
+  ena = enableGen
 
 {- | Generates a 'MemoryMap' for 'singleMasterInterconnect' for a specific number
 of slaves.
@@ -134,7 +118,7 @@ genConfig ::
   forall nSlaves pfxWidth.
   (1 <= nSlaves, KnownNat pfxWidth) =>
   SNat nSlaves ->
-  Gen (MemoryMap nSlaves pfxWidth)
+  Gen (WB.MemoryMap nSlaves pfxWidth)
 genConfig nSlaves@SNat =
   unsafeFromList . L.take (snatToNum nSlaves) <$> Gen.shuffle [0 ..]
 

--- a/clash-protocols-memmap/src/Protocols/MemoryMap/Registers/WishboneStandard.hs
+++ b/clash-protocols-memmap/src/Protocols/MemoryMap/Registers/WishboneStandard.hs
@@ -29,6 +29,7 @@ module Protocols.MemoryMap.Registers.WishboneStandard (
   addressableBytesWb,
 
   -- * Supporting types and functions
+  busActivityRead,
   busActivityWrite,
   BusReadBehavior (..),
   BusActivity (..),

--- a/clash-protocols-memmap/src/Protocols/MemoryMap/Registers/WishboneStandard/Internal.hs
+++ b/clash-protocols-memmap/src/Protocols/MemoryMap/Registers/WishboneStandard/Internal.hs
@@ -57,6 +57,11 @@ busActivityWrite :: Maybe (BusActivity a) -> Maybe a
 busActivityWrite (Just (BusWrite a)) = Just a
 busActivityWrite _ = Nothing
 
+-- | Filters out only 'BusRead's, mapping any other bus activity to 'Nothing'.
+busActivityRead :: Maybe (BusActivity a) -> Maybe a
+busActivityRead (Just (BusRead a)) = Just a
+busActivityRead _ = Nothing
+
 {- | Type synonym for all the information needed to create a Wishbone register with
 auto-assigned offsets.
 -}

--- a/firmware-support/bittide-hal-c/c_src/bittide_uart.c
+++ b/firmware-support/bittide-hal-c/c_src/bittide_uart.c
@@ -5,16 +5,8 @@
 #include "bittide_uart.h"
 #include "shared_devices/uart.h"
 
-int uart_tx_full(Uart uart) {
-  return uart_get_status(uart) & UART_STATUS_TX_FULL;
-}
-
-int uart_rx_empty(Uart uart) {
-  return uart_get_status(uart) & UART_STATUS_RX_EMPTY;
-}
-
 void uart_putc(Uart uart, char c) {
-  while (uart_tx_full(uart)) {
+  while (uart_get_transmit_buffer_full(uart)) {
     // Wait for TX buffer to be ready
   }
   uart_set_data(uart, c);
@@ -27,7 +19,7 @@ void uart_puts(Uart uart, const char *s) {
 }
 
 char uart_getc(Uart uart) {
-  while (uart_rx_empty(uart)) {
+  while (uart_get_receive_buffer_empty(uart)) {
     // Wait for RX buffer to have data
   }
   return uart_get_data(uart);

--- a/firmware-support/bittide-hal-c/include/bittide_uart.h
+++ b/firmware-support/bittide-hal-c/include/bittide_uart.h
@@ -9,21 +9,8 @@
 #include <stdint.h>
 
 // ============================================================================
-// UART Status Flags
-// ============================================================================
-
-#define UART_STATUS_TX_FULL 0x01
-#define UART_STATUS_RX_EMPTY 0x02
-
-// ============================================================================
 // UART Function Declarations
 // ============================================================================
-
-/// Check if UART transmit buffer is full
-int uart_tx_full(Uart uart);
-
-/// Check if UART receive buffer is empty
-int uart_rx_empty(Uart uart);
 
 /// Put a single character to UART (blocking)
 void uart_putc(Uart uart, char c);

--- a/firmware-support/bittide-hal/src/manual_additions/uart.rs
+++ b/firmware-support/bittide-hal/src/manual_additions/uart.rs
@@ -5,31 +5,10 @@
 use crate::shared_devices::uart::Uart;
 use bittide_macros::bitvector;
 
-pub struct UartStatus {
-    pub receive_buffer_empty: bool,
-    pub transmit_buffer_full: bool,
-}
-
 pub struct TransmitBufferFull;
 pub struct ReceiveBufferEmpty;
 
 impl Uart {
-    /// UART status register output
-    pub fn read_status(&self) -> UartStatus {
-        let flags = self.status()[0];
-
-        let rx_mask = 0b10;
-        let rx_empty = flags & rx_mask;
-
-        let tx_mask = 0b01;
-        let tx_full = flags & tx_mask;
-
-        UartStatus {
-            receive_buffer_empty: rx_empty != 0,
-            transmit_buffer_full: tx_full != 0,
-        }
-    }
-
     /// The `receive` function attempts to receive data from the UART. If no
     /// data is available, it keeps looping until data is available.
     pub fn receive(&self) -> u8 {
@@ -43,7 +22,7 @@ impl Uart {
     /// The `try_receive` function attempts to receive data from the UART. If no
     /// data is available, it returns None.
     pub fn try_receive(&self) -> Result<u8, ReceiveBufferEmpty> {
-        if self.read_status().receive_buffer_empty {
+        if self.receive_buffer_empty() {
             Err(ReceiveBufferEmpty)
         } else {
             Ok(self.data()[0])
@@ -63,7 +42,7 @@ impl Uart {
     /// The `try_send` function attempts to send the given data to the UART. If
     /// the UART is unable to accept the data, it returns an error.
     pub fn try_send(&self, data: u8) -> Result<(), TransmitBufferFull> {
-        if self.read_status().transmit_buffer_full {
+        if self.transmit_buffer_full() {
             Err(TransmitBufferFull)
         } else {
             self.set_data(bitvector!([data], n = 8));


### PR DESCRIPTION
_What (what did you do)_
Migrate `uartInterfaceWb` to `deviceWb` and `registerWb`. This broke the old test, which I rewrote to also use the memorymap.

_Why (context, issues, etc.)_
Part of https://github.com/bittide/bittide-hardware/issues/965

_Dear reviewer (anything you'd like the reviewer to pay close attention to?)_
1. The 2 status registers are not tested right now. We could easily check the `receive_buffer_empty` register and verify it, but the same does not apply to the `transmit_buffer_full` register. It's hard to model the datacount in the transmit buffer as bytes are written out. Do you still want me to add a test, and if so how?
2. Are the reset values of the 2 status registers correct?

_AI disclaimer (heads-up for more than inline autocomplete)_
Not here

# TODO
_~~Cross-out~~ any that do not apply_

- [x] Write (regression) test
- [ ] ~~Update documentation, including `docs/`~~
- [x] Link to existing issue