### PR TITLE
Add `+RTS -qn4 -A128M -RTS` across project

### DIFF
--- a/bittide-instances/bittide-instances.cabal
+++ b/bittide-instances/bittide-instances.cabal
@@ -365,7 +365,10 @@ test-suite unittests
     tasty-th,
 
 executable clash
-  ghc-options: -threaded
+  ghc-options:
+    -threaded
+    "-with-rtsopts -qn4 -A128M"
+
   main-is: exe/clash/Main.hs
   build-depends:
     base,

--- a/cabal.project
+++ b/cabal.project
@@ -31,10 +31,8 @@ package bittide
 package zlib
   flags: +pkg-config
 
--- Reduces build times by ~10%, but triggers a bug in haskell-language-server:
--- https://github.com/haskell/haskell-language-server/issues/4595
---package *
---  ghc-options: +RTS -A64M -RTS
+package *
+  ghc-options: +RTS -qn4 -A128M -RTS
 semaphore: true
 jobs: $ncpus
 


### PR DESCRIPTION
_What (what did you do)_
This speeds up compilation of the whole project with ~15%. Maybe more importantly, adding it to the executable `clash` speeds op translation to HDL by about:

* 30% on my desktop
* 10% on CI

_Why (context, issues, etc.)_
Me no like waiting.

_Dear reviewer (anything you'd like the reviewer to pay close attention to?)_
Don't think so.

_AI disclaimer (heads-up for more than inline autocomplete)_
No.

# TODO

- [X] ~~Write (regression) test~~
- [X] ~~Update documentation, including `docs/`~~
- [X] ~~Link to existing issue~~
