### PR TITLE
Peel handshake from transceivers

### DIFF
--- a/bittide-instances/src/Bittide/Instances/Hitl/LinkConfiguration.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/LinkConfiguration.hs
@@ -52,11 +52,11 @@ checkData ::
   Clock dst ->
   Clock src ->
   Signal dst Bool ->
-  Signal src (Maybe (BitVector 64)) ->
+  Signal src (BitVector 64) ->
   Signal src (Maybe (Index n)) ->
   Signal dst Bool
 checkData dstClk srcClk ready rx setup =
-  ready .&&. xpmCdcSingle srcClk dstClk (match <$> rx <*> setup)
+  ready .&&. xpmCdcSingle srcClk dstClk (match <$> fmap Just rx <*> setup)
  where
   match ma mb = fromMaybe False (ma .==. (zExtend . pack <$> mb))
   zExtend = zeroExtend @_ @(BitSize (Index n)) @(64 - BitSize (Index n))
@@ -135,7 +135,9 @@ transceiversStartAndObserve refClk sysClk rst myIndex rxs rxNs rxPs spiS2M =
   , spiM2S
   )
  where
-  allReady = and <$> bundle transceivers.debugLinkReadys
+  allReady =
+    fmap and (bundle transceivers.rxDataInitDonesFree)
+      .&&. fmap and (bundle transceivers.txDataInitDonesFree)
   sysRst = rst `orReset` unsafeFromActiveLow (fmap not spiErr)
 
   -- Clock programming
@@ -175,8 +177,6 @@ transceiversStartAndObserve refClk sysClk rst myIndex rxs rxNs rxPs spiS2M =
         , rxPs
         , channelResets = repeat noReset
         , txDatas = repeat myIndexTx
-        , rxReadys = repeat $ pure True
-        , txStarts = repeat $ pure True
         }
 
   -- synchronizes the FPGA's stable index to the individual TX clock
@@ -193,7 +193,7 @@ transceiversStartAndObserve refClk sysClk rst myIndex rxs rxNs rxPs spiS2M =
       $ zipWith4
         (checkData @FpgaCount sysClk)
         transceivers.rxClocks
-        transceivers.debugLinkReadys
+        transceivers.rxDataInitDonesFree
         transceivers.rxDatas
       $ zipWith3
         (expectedTargetIndex sysClk myIndex)
@@ -245,6 +245,7 @@ linkConfigurationTest refClkDiff sysClkDiff syncIn rxs rxns rxps spiS2M =
 
   failAfterUp = isFalling sysClk testRst enableGen False allReady
   failAfterUpSticky = stickyE sysClk testRst failAfterUp
+  successSticky = stickyE sysClk testRst success
 
   -- Consider the test done if links have been up consistently for 40
   -- seconds. This is just below the test timeout of 60 seconds, so
@@ -253,7 +254,7 @@ linkConfigurationTest refClkDiff sysClkDiff syncIn rxs rxns rxps spiS2M =
   -- i.e., if all neighbors have transmitted the expected ids
   -- alltogether at least once.
   done =
-    success
+    successSticky
       .||. failAfterUpSticky
       .||. trueFor (SNat @(Seconds 40)) sysClk testRst allReady
 

--- a/bittide-instances/src/Bittide/Instances/Hitl/SoftUgnDemo/BringUp.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/SoftUgnDemo/BringUp.hs
@@ -10,7 +10,6 @@ import Clash.Prelude (HiddenClockResetEnable, withClockResetEnable)
 import Protocols
 
 import Bittide.BootPe (BootPeBusses, bootPe)
-import Bittide.CaptureUgn (sendUgnC)
 import Bittide.ClockControl
 import Bittide.Df (asciiDebugMux)
 import Bittide.Instances.Domains (
@@ -125,18 +124,10 @@ bringUp refClk refRst = withLittleEndian $ circuit $ \(memoryMaps, jtag, gths) -
       refClk
       refRst
       Transceiver.defConfig
-      -< (transceiverWb, gths, Fwd (bundle switchDataOutOrLocalCounters))
-
-  -- Send local counter the very first "user" cycle for UGN computation. Should
-  -- this be handled in 'core'?
-  Fwd switchDataOutOrLocalCounters <-
-    withBittideClockResetEnable
-      $ sendUgnC localCounter tOutputs.txSamplings
-      -< switchDataOut
+      -< (transceiverWb, gths, Fwd (bundle coreToTransceivers))
 
   ( Fwd speedChanges
-    , Fwd localCounter
-    , switchDataOut
+    , Fwd coreToTransceivers
     , sync
     , uartBytesBittide
     , muTransceiverWbBittide
@@ -145,7 +136,7 @@ bringUp refClk refRst = withLittleEndian $ circuit $ \(memoryMaps, jtag, gths) -
       (refClk, refRst)
       (bittideClk, bittideRst, enableGen)
       tOutputs.rxClocks
-      (unsafeFromActiveLow <$> tOutputs.handshakesDone)
+      (unsafeFromActiveLow <$> tOutputs.rxDataInitDones)
       -< ( coreMemoryMaps
          , otherJtagBittide
          , Fwd (pure maxBound)
@@ -157,9 +148,6 @@ bringUp refClk refRst = withLittleEndian $ circuit $ \(memoryMaps, jtag, gths) -
     withRefClockResetEnable :: forall r. ((HiddenClockResetEnable Basic125) => r) -> r
     withRefClockResetEnable = withClockResetEnable refClk refRst enableGen
 
-    withBittideClockResetEnable :: forall r. ((HiddenClockResetEnable Bittide) => r) -> r
-    withBittideClockResetEnable = withClockResetEnable bittideClk bittideRst enableGen
-
     bittideClk :: Clock Bittide
     bittideClk = tOutputs.txClock
 
@@ -167,7 +155,7 @@ bringUp refClk refRst = withLittleEndian $ circuit $ \(memoryMaps, jtag, gths) -
     bittideRst = tOutputs.txReset
 
     linksSuitableForCc :: Signal Bittide (BitVector LinkCount)
-    linksSuitableForCc = fmap pack (bundle tOutputs.handshakesDoneTx)
+    linksSuitableForCc = fmap pack (bundle tOutputs.txDataInitDones)
 
     frequencyAdjustments :: Signal Bittide (FINC, FDEC)
     frequencyAdjustments =

--- a/bittide-instances/src/Bittide/Instances/Hitl/SoftUgnDemo/Core.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/SoftUgnDemo/Core.hs
@@ -9,15 +9,24 @@ CPUs and checks that the software and hardware captured UGNs match.
 module Bittide.Instances.Hitl.SoftUgnDemo.Core (InternalCpuCount, core) where
 
 import Clash.Explicit.Prelude
-import Clash.Prelude (HiddenClockResetEnable, withClockResetEnable)
+import Clash.Prelude (
+  HiddenClock,
+  HiddenClockResetEnable,
+  HiddenReset,
+  withClock,
+  withClockResetEnable,
+  withReset,
+ )
 import Protocols
 
 import Bittide.Calendar (CalendarConfig (..), ValidEntry (..))
-import Bittide.CaptureUgn (captureUgn)
+import Bittide.CaptureUgn (captureUgn, sendUgn)
 import Bittide.ClockControl (SpeedChange)
 import Bittide.ClockControl.CallistoSw (SwcccInternalBusses, callistoSwClockControlC)
 import Bittide.DoubleBufferedRam (wbStorage)
 import Bittide.ElasticBuffer (xilinxElasticBufferWb)
+import Bittide.Extra.Maybe (toMaybe)
+import Bittide.Handshake (handshakesWb)
 import Bittide.Instances.Domains (Basic125, Bittide, GthRx)
 import Bittide.Instances.Hitl.Setup (LinkCount)
 import Bittide.Jtag (jtagChain)
@@ -35,6 +44,7 @@ import Bittide.Wishbone (readDnaPortE2WbWorker, timeWb, uartBytes, uartInterface
 import Clash.Class.BitPackC (ByteOrder)
 import Clash.Cores.Xilinx (withXilinx)
 import Clash.Cores.Xilinx.Unisim.DnaPortE2 (readDnaPortE2, simDna2)
+import Clash.Functor.Extra ((<<$>>), (<<*>>))
 import Protocols.Extra
 import Protocols.Idle (idleSink)
 import Protocols.MemoryMap (Mm)
@@ -42,6 +52,7 @@ import Protocols.Wishbone.Extra (delayWishbone)
 import VexRiscv (DumpVcd (..), Jtag)
 
 import qualified Bittide.Cpus.Riscv32imc as Riscv32imc
+import qualified Bittide.Handshake as Handshake
 import qualified Protocols.MemoryMap as Mm
 import qualified Protocols.Vec as Vec
 
@@ -71,9 +82,10 @@ type PeripheralsPerLink = 6
 
 {- External busses:
     - Transceivers
+    - Handshakes
     - Callisto
 -}
-type NmuExternalBusses = 2 + (LinkCount * PeripheralsPerLink)
+type NmuExternalBusses = 3 + (LinkCount * PeripheralsPerLink)
 type NmuRemBusWidth = RemainingBusWidth (NmuExternalBusses + NmuInternalBusses)
 
 muConfig ::
@@ -155,10 +167,9 @@ core ::
     , Jtag Bittide
     , "MASK" ::: CSignal Bittide (BitVector LinkCount)
     , "CC_SUITABLE" ::: CSignal Bittide (BitVector LinkCount)
-    , "RXS" ::: Vec LinkCount (CSignal GthRx (Maybe (BitVector 64)))
+    , "RXS" ::: Vec LinkCount (CSignal GthRx (BitVector 64))
     )
     ( CSignal Bittide (Maybe SpeedChange)
-    , "LOCAL_COUNTER" ::: CSignal Bittide (Unsigned 64)
     , "TXS" ::: Vec LinkCount (CSignal Bittide (BitVector 64))
     , Sync Bittide Basic125
     , "UARTS" ::: Vec InternalCpuCount (Df Bittide (BitVector 8))
@@ -182,7 +193,7 @@ core (refClk, refRst) (bitClk, bitRst, bitEna) rxClocks rxResets = withXilinx
     (ebWbs, muWbs2) <- Vec.split -< muWbs1
     (scatterBusses, scatterCalendarBusses, muWbs3) <- Vec.split3 -< muWbs2
     (gatherBusses, gatherCalendarBusses, muWbs4) <- Vec.split3 -< muWbs3
-    [muTransceiverBus, muCallistoBus] <- idC -< muWbs4
+    [muTransceiverBus, muCallistoBus, muHandshakeBus] <- idC -< muWbs4
     -- Stop management unit
 
     -- Start internal links
@@ -200,11 +211,30 @@ core (refClk, refRst) (bitClk, bitRst, bitEna) rxClocks rxResets = withXilinx
         <| repeatC (fmapC $ withBittideClockResetEnable delayWishbone)
         -< ebWbs
 
-    -- Use of `dflipflop` to add pipelining should be replaced by
-    -- https://github.com/bittide/bittide-hardware/pull/1134
-    Fwd rxs2 <-
+    let
+      rxs2 = dflipflop bitClk <$> rxs1
+
+    Fwd handshakesOut <-
+      withBittideClockReset handshakesWb
+        -< ( muHandshakeBus
+           , Fwd
+               ( Handshake.Inputs
+                   { fromNeighbors = rxs2
+                   , fromCores = txs1
+                   }
+               )
+           )
+
+    let
+      -- TODO: Hardware UGN capture is currently mandatory, it shouldn't be.
+      rxs3 = toMaybe <<$>> handshakesOut.toCoreDones <<*>> handshakesOut.toCores
+      rxs4 = dflipflop bitClk <$> rxs3
+
+      txs1 = withClock bitClk $ sendUgn localCounter <$> handshakesOut.fromCoreDones <*> txs0
+
+    Fwd rxs5 <-
       withBittideClockResetEnable
-        $ Vec.vecCircuits ((captureUgn localCounter . dflipflop bitClk) <$> rxs1)
+        $ Vec.vecCircuits (captureUgn localCounter <$> rxs4)
         -< ugnWbs
     -- Stop internal links
 
@@ -222,10 +252,10 @@ core (refClk, refRst) (bitClk, bitRst, bitEna) rxClocks rxResets = withXilinx
       repeatC (fmapC $ withBittideClockResetEnable delayWishbone) -< gatherCalendarBusses
 
     idleSink
-      <| Vec.vecCircuits (fmap (withBittideClockResetEnable (scatterUnitWbC scatterConfig)) rxs2)
+      <| Vec.vecCircuits (fmap (withBittideClockResetEnable (scatterUnitWbC scatterConfig)) rxs5)
       <| Vec.zip
       -< (scatterBusses, scatterCalendarBussesDelayed)
-    Fwd txs <-
+    Fwd txs0 <-
       repeatC (withBittideClockResetEnable (gatherUnitWbC gatherConfig))
         <| Vec.zip
         -< (gatherBusses, gatherCalendarBussesDelayed)
@@ -277,8 +307,7 @@ core (refClk, refRst) (bitClk, bitRst, bitEna) rxClocks rxResets = withXilinx
     -- https://github.com/bittide/bittide-hardware/pull/1134
     idC
       -< ( Fwd swCcOut1
-         , Fwd localCounter
-         , Fwd (dflipflop bitClk <$> txs)
+         , Fwd handshakesOut.toNeighbors
          , sync
          , [muUartBytesBittide, ccUartBytesBittide]
          , muTransceiverBus
@@ -286,6 +315,9 @@ core (refClk, refRst) (bitClk, bitRst, bitEna) rxClocks rxResets = withXilinx
  where
   withBittideClockResetEnable :: forall r. ((HiddenClockResetEnable Bittide) => r) -> r
   withBittideClockResetEnable = withClockResetEnable bitClk bitRst bitEna
+
+  withBittideClockReset :: forall r. ((HiddenClock Bittide, HiddenReset Bittide) => r) -> r
+  withBittideClockReset r = withClock bitClk $ withReset bitRst r
 
 uncurry4 ::
   (a -> b -> c -> d -> e) ->

--- a/bittide-instances/src/Bittide/Instances/Hitl/SoftUgnDemo/Driver.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/SoftUgnDemo/Driver.hs
@@ -168,7 +168,7 @@ driver testName targets = do
             softwareUgnsFlat <- postProcessSoftwareUgns softwareUgnsPerNode
 
             let
-              swExtraLatency = 2 -- gather read latency + extra link registers
+              swExtraLatency = 1 -- gather read latency
               mismatchedUgns =
                 findMismatchedUgnEdges
                   (fmap (addLatencyEdge swExtraLatency) hardwareUgnsFlat)

--- a/bittide-instances/src/Bittide/Instances/Hitl/Transceivers.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/Transceivers.hs
@@ -58,20 +58,22 @@ counter ::
 counter clk rst = let c = register clk rst enableGen counterStart (c + 1) in c
 
 {- | Expect a counter starting at 'counterStart' and incrementing by one on each
-cycle.
+cycle. Starts running when the received value equals 'counterStart'.
 -}
 expectCounter ::
   (KnownDomain dom) =>
   Clock dom ->
   Reset dom ->
   -- | Received data
-  Signal dom (Maybe (BitVector 64)) ->
+  Signal dom (BitVector 64) ->
   -- | Error
   Signal dom Bool
-expectCounter clk rst = stickyE clk rst . mealy clk rst enableGen go counterStart
+expectCounter clk rst = stickyE clk rst . mealy clk rst enableGen go Nothing
  where
-  go c (Just e) = (c + 1, c /= e)
-  go c Nothing = (c, False)
+  go Nothing e
+    | e == counterStart = (Just (e + 1), False)
+    | otherwise = (Nothing, False)
+  go (Just c) e = (Just (c + 1), c /= e)
 
 {- | Worker function for 'transceiversUpTest'. See module documentation for more
 information.
@@ -104,7 +106,9 @@ goTransceiversUpTest refClk sysClk rst rxs rxNs rxPs spiS2M =
   , spiM2S
   )
  where
-  allUp = and <$> bundle transceivers.debugLinkUps
+  allUp =
+    fmap and (bundle transceivers.rxDataInitDonesFree)
+      .&&. fmap and (bundle transceivers.txDataInitDonesFree)
 
   sysRst = orReset rst (unsafeFromActiveLow (fmap not spiErr))
 
@@ -127,19 +131,20 @@ goTransceiversUpTest refClk sysClk rst rxs rxNs rxPs spiS2M =
   gthAllReset = unsafeFromActiveLow spiDone
 
   txCounters =
-    counter transceivers.txClock . unsafeFromActiveLow <$> transceivers.txSamplings
+    counter transceivers.txClock . unsafeFromActiveLow <$> transceivers.txDataInitDones
+
+  rxDataResets = unsafeFromActiveLow <$> transceivers.rxDataInitDones
 
   expectCounterError =
     zipWith3
       expectCounter
       transceivers.rxClocks
-      transceivers.rxResets
+      (zipWith orReset transceivers.rxResets rxDataResets)
       transceivers.rxDatas
 
   expectCounterErrorSys =
     fmap or
       $ bundle
-      $ zipWith (.&&.) transceivers.debugLinkUps
       $ zipWith (`xpmCdcSingle` sysClk) transceivers.rxClocks expectCounterError
 
   transceivers =
@@ -162,8 +167,6 @@ goTransceiversUpTest refClk sysClk rst rxs rxNs rxPs spiS2M =
         , rxPs
         , channelResets = repeat noReset
         , txDatas = txCounters
-        , txStarts = repeat (pure True)
-        , rxReadys = repeat (pure True)
         }
 
 -- | Top entity for this test. See module documentation for more information.

--- a/bittide-instances/src/Bittide/Instances/Hitl/WireDemo/BringUp.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/WireDemo/BringUp.hs
@@ -10,7 +10,6 @@ import Clash.Prelude (HiddenClockResetEnable, withClockResetEnable)
 import Protocols
 
 import Bittide.BootPe (BootPeBusses, bootPe)
-import Bittide.CaptureUgn (sendUgnC)
 import Bittide.ClockControl
 import Bittide.Df (asciiDebugMux)
 import Bittide.Instances.Domains (
@@ -124,18 +123,10 @@ bringUp refClk refRst = withLittleEndian $ circuit $ \(memoryMaps, jtag, gths) -
       refClk
       refRst
       Transceiver.defConfig
-      -< (transceiverWb, gths, Fwd (bundle switchDataOutOrLocalCounters))
-
-  -- Send local counter the very first "user" cycle for UGN computation. Should
-  -- this be handled in 'core'?
-  Fwd switchDataOutOrLocalCounters <-
-    withBittideClockResetEnable
-      $ sendUgnC localCounter tOutputs.txSamplings
-      -< switchDataOut
+      -< (transceiverWb, gths, Fwd (bundle coreToTransceivers))
 
   ( Fwd speedChanges
-    , Fwd localCounter
-    , switchDataOut
+    , Fwd coreToTransceivers
     , sync
     , uartBytesBittide
     , muTransceiverWbBittide
@@ -144,7 +135,7 @@ bringUp refClk refRst = withLittleEndian $ circuit $ \(memoryMaps, jtag, gths) -
       (refClk, refRst)
       (bittideClk, bittideRst, enableGen)
       tOutputs.rxClocks
-      (unsafeFromActiveLow <$> tOutputs.handshakesDone)
+      (unsafeFromActiveLow <$> tOutputs.rxDataInitDones)
       -< ( coreMemoryMaps
          , otherJtagBittide
          , Fwd (pure maxBound)
@@ -156,9 +147,6 @@ bringUp refClk refRst = withLittleEndian $ circuit $ \(memoryMaps, jtag, gths) -
     withRefClockResetEnable :: forall r. ((HiddenClockResetEnable Basic125) => r) -> r
     withRefClockResetEnable = withClockResetEnable refClk refRst enableGen
 
-    withBittideClockResetEnable :: forall r. ((HiddenClockResetEnable Bittide) => r) -> r
-    withBittideClockResetEnable = withClockResetEnable bittideClk bittideRst enableGen
-
     bittideClk :: Clock Bittide
     bittideClk = tOutputs.txClock
 
@@ -166,7 +154,7 @@ bringUp refClk refRst = withLittleEndian $ circuit $ \(memoryMaps, jtag, gths) -
     bittideRst = tOutputs.txReset
 
     linksSuitableForCc :: Signal Bittide (BitVector LinkCount)
-    linksSuitableForCc = fmap pack (bundle tOutputs.handshakesDoneTx)
+    linksSuitableForCc = fmap pack (bundle tOutputs.txDataInitDones)
 
     frequencyAdjustments :: Signal Bittide (FINC, FDEC)
     frequencyAdjustments =

--- a/bittide-instances/src/Bittide/Instances/Hitl/WireDemo/Core.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/WireDemo/Core.hs
@@ -6,15 +6,24 @@
 module Bittide.Instances.Hitl.WireDemo.Core (InternalCpuCount, core) where
 
 import Clash.Explicit.Prelude
-import Clash.Prelude (HiddenClockResetEnable, withClock, withClockResetEnable)
+import Clash.Prelude (
+  HiddenClock,
+  HiddenClockResetEnable,
+  HiddenReset,
+  withClock,
+  withClockResetEnable,
+  withReset,
+ )
 import Protocols
 
 import Bittide.Calendar (CalendarConfig (..), ValidEntry (..))
-import Bittide.CaptureUgn (captureUgn)
+import Bittide.CaptureUgn (captureUgn, sendUgn)
 import Bittide.ClockControl (SpeedChange)
 import Bittide.ClockControl.CallistoSw (SwcccInternalBusses, callistoSwClockControlC)
 import Bittide.DoubleBufferedRam (wbStorage)
 import Bittide.ElasticBuffer (xilinxElasticBufferWb)
+import Bittide.Extra.Maybe (toMaybe)
+import Bittide.Handshake (handshakesWb)
 import Bittide.Instances.Domains (Basic125, Bittide, GthRx)
 import Bittide.Instances.Hitl.Setup (LinkCount)
 import Bittide.Jtag (jtagChain)
@@ -34,6 +43,7 @@ import Bittide.Wishbone (readDnaPortE2WbWorker, timeWb, uartBytes, uartInterface
 import Clash.Class.BitPackC (ByteOrder)
 import Clash.Cores.Xilinx (withXilinx)
 import Clash.Cores.Xilinx.Unisim.DnaPortE2 (readDnaPortE2, simDna2)
+import Clash.Functor.Extra ((<<$>>), (<<*>>))
 import Protocols.Extra
 import Protocols.Idle (idleSink)
 import Protocols.MemoryMap (Mm)
@@ -41,6 +51,7 @@ import Protocols.Wishbone.Extra (delayWishbone)
 import VexRiscv (DumpVcd (..), Jtag)
 
 import qualified Bittide.Cpus.Riscv32imc as Riscv32imc
+import qualified Bittide.Handshake as Handshake
 import qualified Protocols.MemoryMap as Mm
 import qualified Protocols.Vec as Vec
 
@@ -70,11 +81,12 @@ type PeripheralsPerLink = 6
 
 {- External busses:
     - Transceivers
+    - Handshakes
     - Callisto
     - Programmable mux
     - PE config
 -}
-type NmuExternalBusses = 4 + (LinkCount * PeripheralsPerLink)
+type NmuExternalBusses = 5 + (LinkCount * PeripheralsPerLink)
 type NmuRemBusWidth = RemainingBusWidth (NmuExternalBusses + NmuInternalBusses)
 
 muConfig ::
@@ -156,10 +168,9 @@ core ::
     , Jtag Bittide
     , "MASK" ::: CSignal Bittide (BitVector LinkCount)
     , "CC_SUITABLE" ::: CSignal Bittide (BitVector LinkCount)
-    , "RXS" ::: Vec LinkCount (CSignal GthRx (Maybe (BitVector 64)))
+    , "RXS" ::: Vec LinkCount (CSignal GthRx (BitVector 64))
     )
     ( CSignal Bittide (Maybe SpeedChange)
-    , "LOCAL_COUNTER" ::: CSignal Bittide (Unsigned 64)
     , "TXS" ::: Vec LinkCount (CSignal Bittide (BitVector 64))
     , Sync Bittide Basic125
     , "UARTS" ::: Vec InternalCpuCount (Df Bittide (BitVector 8))
@@ -183,6 +194,7 @@ core (refClk, refRst) (bitClk, bitRst, bitEna) rxClocks rxResets =
     (scatterBusses, scatterCalendarBusses, muWbs3) <- Vec.split3 -< muWbs2
     (gatherBusses, gatherCalendarBusses, muWbs4) <- Vec.split3 -< muWbs3
     [ muTransceiverBus
+      , muHandshakeBus
       , muCallistoBus
       , muProgrammableMuxBus
       , peConfigBus
@@ -205,11 +217,30 @@ core (refClk, refRst) (bitClk, bitRst, bitEna) rxClocks rxResets =
         <| repeatC (fmapC $ withBittideClockResetEnable delayWishbone)
         -< ebWbs
 
-    -- Use of `dflipflop` to add pipelining should be replaced by
-    -- https://github.com/bittide/bittide-hardware/pull/1134
-    Fwd rxs2 <-
+    let
+      rxs2 = dflipflop bitClk <$> rxs1
+
+    Fwd handshakesOut <-
+      withBittideClockReset handshakesWb
+        -< ( muHandshakeBus
+           , Fwd
+               ( Handshake.Inputs
+                   { fromNeighbors = rxs2
+                   , fromCores = txs1
+                   }
+               )
+           )
+
+    let
+      -- TODO: Hardware UGN capture is currently mandatory, it shouldn't be.
+      rxs3 = toMaybe <<$>> handshakesOut.toCoreDones <<*>> handshakesOut.toCores
+      rxs4 = dflipflop bitClk <$> rxs3
+
+      txs1 = withClock bitClk $ sendUgn localCounter <$> handshakesOut.fromCoreDones <*> unbundle txs
+
+    Fwd rxs5 <-
       withBittideClockResetEnable
-        $ Vec.vecCircuits ((captureUgn localCounter . dflipflop bitClk) <$> rxs1)
+        $ Vec.vecCircuits (captureUgn localCounter <$> rxs4)
         -< ugnWbs
     -- Stop internal links
 
@@ -230,7 +261,7 @@ core (refClk, refRst) (bitClk, bitRst, bitEna) rxClocks rxResets =
       repeatC (fmapC $ withBittideClockResetEnable delayWishbone) -< gatherCalendarBusses
 
     idleSink
-      <| Vec.vecCircuits (fmap (withBittideClockResetEnable (scatterUnitWbC scatterConfig)) rxs2)
+      <| Vec.vecCircuits (fmap (withBittideClockResetEnable (scatterUnitWbC scatterConfig)) rxs5)
       <| Vec.zip
       -< (scatterBusses, scatterCalendarBussesDelayed)
     Fwd txsMu <-
@@ -245,7 +276,7 @@ core (refClk, refRst) (bitClk, bitRst, bitEna) rxClocks rxResets =
     (Fwd txsBl, peWrittenData) <-
       withClock bitClk
         $ wireDemoPe businessLogicReset maybeDna localCounter
-        -< (Fwd rxs2, readLinkI, writeLinkI)
+        -< (Fwd rxs5, readLinkI, writeLinkI)
     -- Stop business logic
 
     -- Start programmable mux
@@ -306,8 +337,7 @@ core (refClk, refRst) (bitClk, bitRst, bitEna) rxClocks rxResets =
     -- https://github.com/bittide/bittide-hardware/pull/1134
     idC
       -< ( Fwd swCcOut1
-         , Fwd localCounter
-         , Fwd (dflipflop bitClk <$> (unbundle txs))
+         , Fwd handshakesOut.toNeighbors
          , sync
          , [muUartBytesBittide, ccUartBytesBittide]
          , muTransceiverBus
@@ -315,6 +345,9 @@ core (refClk, refRst) (bitClk, bitRst, bitEna) rxClocks rxResets =
  where
   withBittideClockResetEnable :: forall r. ((HiddenClockResetEnable Bittide) => r) -> r
   withBittideClockResetEnable = withClockResetEnable bitClk bitRst bitEna
+
+  withBittideClockReset :: forall r. ((HiddenClock Bittide, HiddenReset Bittide) => r) -> r
+  withBittideClockReset r = withClock bitClk $ withReset bitRst r
 
 uncurry4 ::
   (a -> b -> c -> d -> e) ->

--- a/bittide-instances/src/Bittide/Instances/Hitl/WireDemo/Driver.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/WireDemo/Driver.hs
@@ -55,11 +55,11 @@ type StartDelay = 10 -- seconds
 {- | The delay in clock cycles between 2 PEs which is not accounted for by the
 `captureUgn` component.
 
-For the wire demo this delay is 1 cycle, caused by the 'dflipflop' at the output of
-'core', which is _before_ the 'sendUgn' component and therefore not accounted for in the
-captured UGN.
+For the wire demo this delay is 0 cycles, because 'sendUgn' now sits inside 'core' so
+there are no unaccounted-for registers between 'sendUgn' and the corresponding
+'captureUgn' on the other side. If this ever changes again, this should be updated.
 -}
-type InternalDelay = 1
+type InternalDelay = 0
 
 {- | Collect the configuration for the 'wireDemoPeConfig' and the 'programmableMux' in
 a single data structure for easier schedule generation.

--- a/bittide-instances/src/Bittide/Instances/Tests/CaptureUgn.hs
+++ b/bittide-instances/src/Bittide/Instances/Tests/CaptureUgn.hs
@@ -13,7 +13,6 @@ import VexRiscv (DumpVcd (NoDumpVcd))
 
 import Bittide.CaptureUgn (captureUgn)
 import Bittide.Cpus.Riscv32imc (vexRiscv0)
-import Bittide.ElasticBuffer (ElasticBufferData (Data))
 import Bittide.Instances.Common (PeConfigElfSource (NameOnly), emptyPeConfig, peConfigFromElf)
 import Bittide.ProcessingElement (PeConfig, processingElement)
 import Bittide.SharedTypes (withLittleEndian)
@@ -30,9 +29,9 @@ dutWithMm ::
   ( HiddenClockResetEnable dom
   , 1 <= DomainPeriod dom
   ) =>
-  -- | Procesing element configuration
+  -- | Processing element configuration
   PeConfig 4 ->
-  -- | Elastic buffer
+  -- | From handshake
   Signal dom (Maybe (BitVector 64)) ->
   -- | Local sequence counter
   Signal dom (Unsigned 64) ->
@@ -41,7 +40,7 @@ dutWithMm peConfig eb localCounter = withLittleEndian $ circuit $ \(mm, _unit) -
   (uartRx, jtagIdle) <- idleSource
   [uartBus, ugnBus] <- processingElement @dom NoDumpVcd peConfig -< (mm, jtagIdle)
   (uartTx, _uartStatus) <- uartInterfaceWb d2 d2 uartBytes -< (uartBus, uartRx)
-  _bittideData <- captureUgn localCounter (Data <$> eb) -< ugnBus
+  _bittideData <- captureUgn localCounter eb -< ugnBus
   idC -< uartTx
 
 type IMemWords = DivRU (4 * 1024) 4
@@ -74,9 +73,9 @@ dut ::
   ) =>
   -- | Procesing element configuration
   PeConfig 4 ->
-  -- | Elastic buffer
+  -- | From handshake
   Signal dom (Maybe (BitVector 64)) ->
   -- | Local sequence counter
   Signal dom (Unsigned 64) ->
   Circuit () (Df dom (BitVector 8))
-dut peConfig eb localCounter = unMemmap $ dutWithMm peConfig eb localCounter
+dut peConfig handshake localCounter = unMemmap $ dutWithMm peConfig handshake localCounter

--- a/bittide-instances/tests/Tests/Bittide/Instances/Hitl/Utils/MemoryMap.hs
+++ b/bittide-instances/tests/Tests/Bittide/Instances/Hitl/Utils/MemoryMap.hs
@@ -7,7 +7,6 @@ import Clash.Explicit.Prelude
 import Clash.Prelude (withClockResetEnable)
 
 import Bittide.CaptureUgn
-import Bittide.ElasticBuffer (ElasticBufferData (Data))
 import Bittide.Instances.Hitl.Utils.MemoryMap (getPathAddress)
 import Bittide.Instances.Tests.NestedInterconnect (nestedInterconnectMm)
 import Bittide.ProcessingElement
@@ -38,7 +37,7 @@ exampleDevice =
     $ \mm -> do
       jtag <- idleSource
       peWbs <- processingElement NoDumpVcd peConfig -< (mm, jtag)
-      _ugns <- vecCircuits (captureUgn (pure 0) <$> (repeat (pure (Data Nothing)))) -< peWbs
+      _ugns <- vecCircuits (captureUgn (pure 0) <$> (repeat (pure Nothing))) -< peWbs
       guh <- idleSource
       idC -< guh
  where

--- a/bittide-instances/tests/Wishbone/CaptureUgn.hs
+++ b/bittide-instances/tests/Wishbone/CaptureUgn.hs
@@ -9,14 +9,14 @@ module Wishbone.CaptureUgn where
 import Clash.Explicit.Prelude
 import Clash.Prelude (withClockResetEnable)
 
-import Clash.Signal.Internal (Signal (..))
-import Data.Char (chr)
-import Data.Maybe (catMaybes)
-import Numeric (showHex)
-import Protocols (sampleC)
-import Test.Tasty (TestTree)
-import Test.Tasty.HUnit (Assertion, assertBool, testCase)
-import Test.Tasty.TH (testGroupGenerator)
+import Clash.Signal.Internal
+import Data.Char
+import Data.Maybe
+import Numeric
+import Protocols
+import Test.Tasty
+import Test.Tasty.HUnit
+import Test.Tasty.TH
 
 import Bittide.Instances.Tests.CaptureUgn (dut, peConfigSim)
 

--- a/bittide/src/Bittide/CaptureUgn.hs
+++ b/bittide/src/Bittide/CaptureUgn.hs
@@ -6,7 +6,6 @@ module Bittide.CaptureUgn (captureUgn, sendUgn, sendUgnC) where
 
 import Clash.Explicit.Prelude
 
-import Bittide.ElasticBuffer (ElasticBufferData (Data), fromData)
 import Bittide.SharedTypes (BitboneMm)
 import Bittide.Shutter (shutter)
 import Data.Maybe (fromJust)
@@ -55,7 +54,7 @@ captureUgn ::
   -- | Local counter
   Signal dom (Unsigned 64) ->
   -- | Data from link
-  Signal dom (ElasticBufferData (Maybe (BitVector 64))) ->
+  Signal dom (Maybe (BitVector 64)) ->
   Circuit
     (BitboneMm dom addrW)
     (CSignal dom (BitVector 64))
@@ -63,7 +62,7 @@ captureUgn localCounter (C.dflipflop -> linkIn) = circuit $ \bus -> do
   [wbLocalCounter, wbRemoteCounter, wbEbDelta, wbHasCaptured] <-
     deviceWbI (deviceConfig "CaptureUgn") -< bus
   let
-    rawLinkIn = fromJust . fromData <$> linkIn
+    rawLinkIn = fromJust <$> linkIn
     trigger = C.mealy goTrigger HasNotCaptured linkIn
   capturedLocalCounter <- shutter trigger -< Fwd localCounter
   capturedRemoteCounter <- shutter trigger -< Fwd (unpack <$> rawLinkIn)
@@ -84,9 +83,9 @@ captureUgn localCounter (C.dflipflop -> linkIn) = circuit $ \bus -> do
 
   goTrigger ::
     HasCaptured ->
-    ElasticBufferData (Maybe (BitVector 64)) ->
+    Maybe (BitVector 64) ->
     (HasCaptured, Bool)
-  goTrigger HasNotCaptured (Data (Just _)) = (HasCaptured, True)
+  goTrigger HasNotCaptured (Just _) = (HasCaptured, True)
   goTrigger s _ = (s, False)
 
 {- | Outputs the local counter when the link is *not* sampling and the very first
@@ -123,7 +122,7 @@ sendUgnC ::
   ) =>
   -- | Local counter
   Signal dom (Unsigned 64) ->
-  -- | Sampling? Typically driven by 'Bittide.Transceiver.Outputs.txSamplings'.
+  -- | Sampling? Typically driven by 'Bittide.Handshake.Output.fromCoreDone'.
   Vec n (Signal dom Bool) ->
   Circuit
     (Vec n (CSignal dom (BitVector 64)))

--- a/bittide/src/Bittide/ElasticBuffer.hs
+++ b/bittide/src/Bittide/ElasticBuffer.hs
@@ -118,7 +118,7 @@ data ElasticBufferData a
     FillCycle
   | -- | FIFO is in passthrough mode and was not empty
     Data a
-  deriving (Generic, NFDataX, Eq, Show)
+  deriving (Generic, NFDataX, Eq, Show, Functor)
 
 fromData :: ElasticBufferData a -> a
 fromData (Data dat) = dat

--- a/bittide/src/Bittide/Handshake.hs
+++ b/bittide/src/Bittide/Handshake.hs
@@ -1,22 +1,31 @@
 -- SPDX-FileCopyrightText: 2026 Google LLC
 --
 -- SPDX-License-Identifier: Apache-2.0
+
+{- | Tooling to negotiate a common "start word" in an otherwise unstructured stream of
+words.
+-}
 module Bittide.Handshake where
 
 import Clash.Prelude
 import Protocols
 
-import Bittide.ElasticBuffer (sticky)
-import Clash.Class.BitPackC (ByteOrder)
+import Bittide.ElasticBuffer (ElasticBufferData (..), fromData)
+import Clash.Class.BitPackC (BitPackC, ByteOrder)
+import Clash.Functor.Extra ((<<$>>))
+import Data.Maybe (fromMaybe)
 import GHC.Stack (HasCallStack)
 import Protocols.MemoryMap (Access (..), Mm)
+import Protocols.MemoryMap.Mask (fromBitVector, fromVec, toVec)
 import Protocols.MemoryMap.Registers.WishboneStandard (
   RegisterConfig (..),
   deviceConfig,
   deviceWbI,
   registerConfig,
   registerWbI,
+  registerWbI_,
  )
+import Protocols.MemoryMap.TypeDescription (deriveTypeDescription)
 import Protocols.Wishbone
 
 nextLfsr :: BitVector 8 -> BitVector 8
@@ -25,170 +34,427 @@ nextLfsr current
   | lsb current == 1 = (current `shiftR` 1) `xor` 0xB8
   | otherwise = current `shiftR` 1
 
-{- The handshake itself is independent of the representation of a metadata word
-in bit form. The representation itself is only relevant to `wordToMetadata` and
-`metadataToWord`. Currently, we just generate a magic constant based on a shift
-register.
+{- Magic 'BitVector' used to detect whether a handshake is currently active.
 -}
 magicConstant :: forall n. (KnownNat n) => BitVector n
 magicConstant = resize $ pack num
  where
   num = iterateI nextLfsr 0xAB :: Vec (n `DivRU` 8) (BitVector 8)
 
-{- | Meta information send along with the PRBS and alignment symbols. See
-"Bittide.Transceiver" documentation for more information.
+{- | Meta information send along with 'magicConstant'. Used to negotiate a common start
+word. In practice, this is used to allow hardware UGN capture and ring buffer alignment.
 -}
-data Meta = Meta
+data Meta a = Meta
   { readyToReceive :: Bool
   -- ^ Ready to receive user data
-  , readyToTransmit :: Bool
-  -- ^ Ready to transmit user data
-  , lastMetadataWord :: Bool
-  -- ^ Next word will be user data
-  , padding :: Unsigned 5
-  -- ^ Padding up to 1 byte (due to Meta still being used by transceiver for now)
+  , lastMetaWord :: Bool
+  -- ^ Next transceiver word will be user data, i.e., it won't contain this 'Meta' anymore
+  , softwareMeta :: a
+  -- ^ Additional information transmitted to the software
   }
-  deriving (Generic, NFDataX, BitPack, Eq, Show)
+  deriving (Generic, NFDataX, BitPack, Eq, Show, Functor)
 
-{- | Given a @BitVector n@, where @n@ is a positive multiple of @8@,
-convert it to a @Just metadata@ (or @Nothing@ if the BitVector does
-not fit the metadata format).
+emptyMeta :: a -> Meta a
+emptyMeta softwareMeta =
+  Meta
+    { readyToReceive = False
+    , lastMetaWord = False
+    , softwareMeta
+    }
+
+{- | Given a @BitVector n@, parse the least @BitSize Meta@ bits as 'Meta', but only if the
+rest of the bits correspond to 'magicConstant'.
 -}
-wordToMetadata ::
-  forall n.
-  (KnownNat n, BitSize Meta <= n) =>
+wordToMeta ::
+  forall a n.
+  (KnownNat n, BitPack (Meta a), BitSize (Meta a) <= n) =>
   BitVector n ->
-  Maybe Meta
-wordToMetadata word =
-  let (header, meta) = split @_ @(n - 8) word
-   in if (header == magicConstant)
-        then Just $ unpack meta
-        else Nothing
+  Maybe (Meta a)
+wordToMeta word
+  -- TODO: There is some worry that we'd be looking at stale data even if we do see the
+  --       magic constant. Future implementations could try and detect a sequence of
+  --       @magicConstant@ followed by @complement magicConstant@.
+  | header == magicConstant = Just $ unpack meta
+  | otherwise = Nothing
+ where
+  (header, meta) = split @_ @(n - BitSize (Meta a)) word
 
-{- | Given a @Meta@, convert it to a @BitVector n@, where @n@ is a positive
-multiple of @8@.
+{- | Given a @Meta@, convert it to a @BitVector n@. The resulting 'BitVector' will have
+its LSBs set to @Meta@, with its MSBs set to 'magicConstant'.
 -}
-metadataToWord ::
-  forall n.
-  (KnownNat n, BitSize Meta <= n) =>
-  Meta ->
+metaToWord ::
+  forall a n.
+  (KnownNat n, BitPack (Meta a), BitSize (Meta a) <= n) =>
+  Meta a ->
   BitVector n
-metadataToWord meta = magicConstant @(n - 8) ++# (pack meta)
+metaToWord meta = magicConstant @(n - BitSize (Meta a)) ++# pack meta
 
-handshake ::
-  ( KnownNat n
-  , BitSize Meta <= n
-  , HiddenClockResetEnable dom
-  ) =>
-  -- | From transceiver
-  Signal dom (BitVector n) ->
-  -- | From ugn capture
-  Signal dom (BitVector n) ->
-  -- | Read, Write enable regs
-  Signal dom (Bool, Bool) ->
-  ( -- \| To UGN capture
-    Signal dom (BitVector n)
-  , -- \| To transceiver
-    Signal dom (BitVector n)
-  , -- \| Tuple of (txLast, rxLast), which indicates to ugnCapture when to send/receive the UGN.
-    Signal dom (Bool, Bool)
-  )
-handshake rxWordIn txWordIn regs = (rxWordOut, txWordOut, bundle (txLast, rxLast))
- where
-  neighborMetadata = wordToMetadata <$> rxWordIn
+data Status
+  = -- | Negotiating transition to post-handshake data (or in reset)
+    Negotiating
+  | -- | Next word is going to be post-handshake
+    Last
+  | -- | Current word is post-handshake
+    PostHandshake
+  deriving (Generic, Show, Eq, NFDataX, BitPack, BitPackC)
+deriveTypeDescription ''Status
 
-  (metadata, rxLastS) = handshakeStateMachine neighborMetadata regs
+{- | A circuit negotiating a common "first word" boundary on an unstructured stream of
+words. In a bittide context, this typically sits behind the elastic buffer and before
+the transmit channel of a transceiver. Also in bittide context, the purpose of a "first
+word" negotiation is two-fold:
 
-  lastMetadataWordSticky = sticky $ metadata.lastMetadataWord
-  txLast = isRising False lastMetadataWordSticky
-  rxLast = isRising False $ sticky $ rxLastS
+  1. Implement a mini-protocol that states that the "first word" contains the local
+     counter of a node. This is used to construct a clock cycle to clock cycle mapping
+     from one node to another (the main thesis of bittide).
 
-  handshakeFinished = not <$> lastMetadataWordSticky
+  2. Implement hardware accelerated ring buffer alignment. For various reasons, bittide
+     systems communicate over ring buffers when in asynchronous mode. In a system that
+     has achieved syntony, the transmit buffer of one node will move in lockstep with
+     another. This is a very nice feature as it means that when a transmit buffer is
+     stable, a receive buffer will be too and read the exact same words. In this case
+     a "first word" negotiation negotiates the first clock cycle at which the ring
+     buffers start turning.
 
-  -- Words out
-  txWordOut =
-    mux
-      (register False handshakeFinished)
-      (metadataToWord <$> metadata)
-      txWordIn
-  rxWordOut = rxWordIn
-
-{- | The following properties should be observed by the state machine
-1) A txReady should only be sent after both rxReady and rxNeighborReady
+It works by detecting 'magicWord' in the words it receives and decoding a few bits of
+'Meta' information.
 -}
-handshakeStateMachine ::
-  (HiddenClockResetEnable dom) =>
-  -- | Neighbor state
-  Signal dom (Maybe Meta) ->
-  -- | txEn, rxEn regs
-  Signal dom (Bool, Bool) ->
-  -- | New state of node
-  ( Signal dom Meta
-  , Signal dom Bool
+handshake ::
+  forall a n dom.
+  ( KnownNat n
+  , BitPack a
+  , NFDataX a
+  , BitSize (Meta a) <= n
+  , HiddenClock dom
+  ) =>
+  Reset dom ->
+  -- | From neighbor
+  Signal dom (ElasticBufferData (BitVector n)) ->
+  -- | Receive OK?
+  Signal dom Bool ->
+  -- | Additional metadata to send to neighbor
+  Signal dom a ->
+  ( -- To neighbor
+    Signal dom (BitVector n)
+  , -- Receive status (neighbor to core)
+    Signal dom Status
+  , -- Transmit status (core to neighbor)
+    Signal dom Status
+  , -- Additional metadata received from neighbor
+    Signal dom (Maybe a)
   )
-handshakeStateMachine neighborState enableRegs = mooreB updateState id initState (neighborState, enableRegs)
+handshake reset wordIn receiveEnable userMeta =
+  ( wordOut
+  , neighborToCoreStatus
+  , coreToNeighborStatus
+  , (.softwareMeta) <<$>> maybeNeighborMeta
+  )
  where
-  initState = (Meta False False False 0, False)
+  withResetEnable :: ((HiddenReset dom, HiddenEnable dom) => r) -> r
+  withResetEnable r = withReset reset $ withEnable enableGen $ r
 
-  updateState hState (Nothing, _) = hState
-  updateState
-    -- \| Current state
-    (meta, rxLast)
-    -- \| Neighbor state
-    (Just neighborMeta, (txEn, rxEn)) =
-      ((Meta newRxReady newTxReady newTxLast 0), newRxLast)
-     where
-      newTxReady = meta.readyToTransmit || txEn
-      newRxReady = meta.readyToReceive || ((rxEn && txEn) && neighborMeta.readyToTransmit)
-      newTxLast = (neighborMeta.readyToReceive && rxEn) || meta.lastMetadataWord
-      newRxLast = neighborMeta.lastMetadataWord || rxLast
+  prevReceiveStatus = withResetEnable $ register Negotiating neighborToCoreStatus
+  neighborToCoreStatus = mkStatus <$> maybeNeighborMeta <*> prevReceiveStatus
 
-handshakeWb ::
-  forall dom addrW nBytes.
+  prevCoreToNeighborStatus = withResetEnable $ register Negotiating coreToNeighborStatus
+  coreToNeighborStatus = mkStatus <$> fmap Just transmitMeta <*> prevCoreToNeighborStatus
+  transmitMeta =
+    mkMeta
+      <$> neighborToCoreStatus
+      <*> maybeNeighborMeta
+      <*> userMeta
+      <*> receiveEnable
+
+  resetAsBool = unsafeToActiveHigh reset
+  wordOut = metaToWord @a <$> mux resetAsBool (emptyMeta <$> userMeta) transmitMeta
+  maybeNeighborMeta =
+    mux
+      resetAsBool
+      (pure Nothing)
+      (withReset reset $ elasticBufferWordToMeta @a wordIn)
+{-# OPAQUE handshake #-}
+
+{- | Convert each incoming 'ElasticBufferData' word to @'Maybe' ('Meta' a)@. The result is
+registered, so that on cycles where the elastic buffer does not produce valid data (or the
+word does not decode to 'Meta') the previous cycle's 'Meta' is used as a fallback via
+'<|>'.
+-}
+elasticBufferWordToMeta ::
+  forall a n dom.
+  ( KnownNat n
+  , BitPack a
+  , NFDataX a
+  , BitSize (Meta a) <= n
+  , HiddenClock dom
+  , HiddenReset dom
+  ) =>
+  Signal dom (ElasticBufferData (BitVector n)) ->
+  Signal dom (Maybe (Meta a))
+elasticBufferWordToMeta wordIn = current
+ where
+  (.<|>.) = liftA2 (<|>)
+  prev = withEnable enableGen $ register Nothing current
+  current = fmap decode wordIn .<|>. prev
+
+  decode (Data w) = wordToMeta w
+  decode _ = Nothing
+
+mkStatus ::
+  -- | Meta from neighbor or ourselves
+  Maybe (Meta a) ->
+  -- | Previous status
+  Status ->
+  -- | Updated status
+  Status
+mkStatus maybeMeta prevStatus =
+  case prevStatus of
+    Last -> PostHandshake
+    PostHandshake -> PostHandshake
+    Negotiating
+      | Just meta <- maybeMeta, meta.lastMetaWord -> Last
+      | otherwise -> Negotiating
+
+mkMeta :: Status -> Maybe (Meta a) -> a -> Bool -> Meta a
+mkMeta neighborToCoreStatus maybeNeighborMeta softwareMeta readyToReceive =
+  Meta
+    { softwareMeta
+    , readyToReceive
+    , -- Note: we don't send the last word until we're ready to receive a word ourselves. We
+      -- do this, because if we'd send the last word we'd have no way to communicate whether
+      -- we're ready anymore.
+      lastMetaWord = neighborIsReadyToReceive && readyToReceive
+    }
+ where
+  neighborIsReadyToReceive =
+    case neighborToCoreStatus of
+      Last -> True
+      PostHandshake -> True
+      _ ->
+        case maybeNeighborMeta of
+          Just neighborMeta -> neighborMeta.readyToReceive
+          Nothing -> False
+
+data Inputs dom n = Inputs
+  { fromNeighbors :: Vec n (Signal dom (ElasticBufferData (BitVector 64)))
+  , fromCores :: Vec n (Signal dom (BitVector 64))
+  }
+
+instance Protocol (Inputs dom n) where
+  type Fwd (Inputs dom n) = Inputs dom n
+  type Bwd (Inputs dom n) = ()
+
+data Outputs dom n = Outputs
+  { toNeighbors :: Vec n (Signal dom (BitVector 64))
+  -- ^ Data to be propagated to the neighbor (typically transceiver IP)
+  , toCores :: Vec n (Signal dom (BitVector 64))
+  -- ^ Data to be propagated to the core (typically UGN capture)
+  , toNeighborDones :: Vec n (Signal dom Bool)
+  -- ^ Whether the data in 'toNeighbor' is post-handshake data
+  , toCoreDones :: Vec n (Signal dom Bool)
+  -- ^ Whether the data in 'toCore' is post-handshake data
+  , fromNeighborDones :: Vec n (Signal dom Bool)
+  -- ^ Whether the data in 'Inputs.fromNeighbor' is propagated to the core as post-handshake data
+  , fromCoreDones :: Vec n (Signal dom Bool)
+  -- ^ Whether the data in 'Inputs.fromCore' is propagated to the neighbor as post-handshake data
+  }
+
+instance Protocol (Outputs dom n) where
+  type Fwd (Outputs dom n) = Outputs dom n
+  type Bwd (Outputs dom n) = ()
+
+data Mode
+  = {- | Register data from the core to the neighbor and vice versa. While this mode is
+    active, the handshake logic has its reset asserted.
+    -}
+    PassThrough
+  | -- | Handshake module engaged
+    Enabled
+  deriving (Generic, Show, Eq, NFDataX, BitPack, BitPackC)
+deriveTypeDescription ''Mode
+
+data Input dom = Input
+  { mode :: Signal dom Mode
+  , receiveReady :: Signal dom Bool
+  , softwareReady :: Signal dom Bool
+  , fromNeighbor :: Signal dom (BitVector 64)
+  , fromCore :: Signal dom (BitVector 64)
+  }
+
+data Output dom = Output
+  { toNeighbor :: Signal dom (BitVector 64)
+  , toCore :: Signal dom (BitVector 64)
+  , toNeighborDone :: Signal dom Bool
+  , toCoreDone :: Signal dom Bool
+  , fromNeighborDone :: Signal dom Bool
+  , fromCoreDone :: Signal dom Bool
+  , neighborSoftwareReady :: Signal dom Bool
+  , handshakeDone :: Signal dom Bool
+  }
+
+perChannel ::
+  (HiddenClock dom) =>
+  Signal dom Mode ->
+  Signal dom Bool ->
+  Signal dom Bool ->
+  Signal dom (ElasticBufferData (BitVector 64)) ->
+  Signal dom (BitVector 64) ->
+  Output dom
+perChannel mode receiveReady softwareReady fromNeighbor fromCore =
+  Output
+    { toNeighbor = dflipflop toNeighbor
+    , toCore = dflipflop (fromData <$> fromNeighbor)
+    , toNeighborDone = dflipflop coreToNeighborDone
+    , toCoreDone = dflipflop neighborToCoreDone
+    , -- Software only:
+      neighborSoftwareReady = dflipflop neighborSoftwareReady
+    , handshakeDone = dflipflop (neighborToCoreDone .&&. coreToNeighborDone)
+    , -- These signals relate to input signals, so we can't test for "done", because we'd
+      -- be too late if we register it. We therefore jump a cycle ahead by testing for
+      -- 'Last' too.
+      fromNeighborDone = dflipflop (neighborToCoreStatus .== Last .||. neighborToCoreDone)
+    , fromCoreDone = dflipflop (coreToNeighborStatus .== Last .||. coreToNeighborDone)
+    }
+ where
+  handshakeReset = unsafeFromActiveHigh (mode .== PassThrough)
+  (handshakeToNeighbor, neighborToCoreStatus, coreToNeighborStatus, maybeSoftwareReady) =
+    handshake
+      handshakeReset
+      fromNeighbor
+      receiveReady
+      softwareReady
+
+  neighborToCoreDone = neighborToCoreStatus .== PostHandshake
+  coreToNeighborDone = coreToNeighborStatus .== PostHandshake
+  neighborSoftwareReady = fromMaybe False <$> maybeSoftwareReady
+  toNeighbor = mux (mode .== PassThrough .||. coreToNeighborDone) fromCore handshakeToNeighbor
+
+handshakesWb ::
+  forall n dom addrW nBytes.
   ( HasCallStack
-  , HiddenClockResetEnable dom
+  , HiddenClock dom
+  , HiddenReset dom
+  , KnownNat n
   , KnownNat addrW
   , KnownNat nBytes
   , 1 <= nBytes
   , ?byteOrder :: ByteOrder
   ) =>
   Circuit
-    ( (ToConstBwd Mm, Wishbone dom 'Standard addrW nBytes)
-    , -- \| Link from transceiver
-      CSignal dom (BitVector 64)
-    , -- \| Link from UGN capture
-      CSignal dom (BitVector 64)
-    )
-    ( -- \| Link to transceiver
-      CSignal dom (BitVector 64)
-    , -- \| Link to UGN capture
-      CSignal dom (BitVector 64)
-    , -- \| `txLast` and `rxLast` signal for the UGN send/receive(?)
-      CSignal dom (Bool, Bool)
-    )
-handshakeWb = circuit $ \(bus, (Fwd rxLinkIn), (Fwd txLinkIn)) -> do
-  [txLastBus, rxLastBus] <- deviceWbI (deviceConfig "Handshake") -< bus
+    ((ToConstBwd Mm, Wishbone dom 'Standard addrW nBytes), Inputs dom n)
+    (Outputs dom n)
+handshakesWb = circuit $ \(bus, Fwd inputs) -> do
+  [ modesBus
+    , receiveReadysBus
+    , softwareReadysBus
+    , neighborSoftwareReadysBus
+    , neighborToCoreDonesBus
+    , coreToNeighborDonesBus
+    , handshakeDonesBus
+    ] <-
+    deviceWbI (deviceConfig "Handshakes") -< bus
 
-  (Fwd txLast, _txLastActivity) <-
-    registerWbI
-      ( (registerConfig "tx_en")
-          { access = WriteOnly
-          , description = "The CPU should write True once it has paused Elastic Buffer centering"
+  Fwd (modes, _) <-
+    registerWbI modesConfig (repeat PassThrough) -< (modesBus, Fwd noWrite)
+  Fwd (receiveReadys, _) <-
+    registerWbI receiveReadysConfig zeroMask -< (receiveReadysBus, Fwd noWrite)
+  Fwd (softwareReadys, _) <-
+    registerWbI softwareReadysConfig zeroMask -< (softwareReadysBus, Fwd noWrite)
+
+  registerWbI_ neighborSoftwareReadysConfig zeroMask
+    -< (neighborSoftwareReadysBus, Fwd (Just <$> neighborSoftwareReadysMask))
+  registerWbI_ neighborToCoreDonesConfig zeroMask
+    -< (neighborToCoreDonesBus, Fwd (Just <$> neighborToCoreDonesMask))
+  registerWbI_ coreToNeighborDonesConfig zeroMask
+    -< (coreToNeighborDonesBus, Fwd (Just <$> coreToNeighborDonesMask))
+  registerWbI_ handshakeDonesConfig zeroMask
+    -< (handshakeDonesBus, Fwd (Just <$> handshakeDonesMask))
+
+  let
+    modesV = unbundle modes
+    receiveReadysV = unbundle (toVec <$> receiveReadys)
+    softwareReadysV = unbundle (toVec <$> softwareReadys)
+
+    outputs =
+      zipWith5
+        perChannel
+        modesV
+        receiveReadysV
+        softwareReadysV
+        inputs.fromNeighbors
+        inputs.fromCores
+
+    toNeighbors = map (.toNeighbor) outputs
+    toCores = map (.toCore) outputs
+    toNeighborDones = map (.toNeighborDone) outputs
+    toCoreDones = map (.toCoreDone) outputs
+    fromNeighborDones = map (.fromNeighborDone) outputs
+    fromCoreDones = map (.fromCoreDone) outputs
+    neighborSoftwareReadys = map (.neighborSoftwareReady) outputs
+    handshakeDones = map (.handshakeDone) outputs
+
+    neighborSoftwareReadysMask = fromVec <$> bundle neighborSoftwareReadys
+    neighborToCoreDonesMask = fromVec <$> bundle toCoreDones
+    coreToNeighborDonesMask = fromVec <$> bundle toNeighborDones
+    handshakeDonesMask = fromVec <$> bundle handshakeDones
+
+  -- Note that all flip-flopping is done inside 'perChannel' and all signals routed outside
+  -- come directly from it. This is on purpose to trivially show that:
+  --
+  --  * All outputs are registered
+  --  * The delay through this component is always the same, enabled or not
+  idC
+    -< Fwd
+      ( Outputs
+          { toNeighbors
+          , toCores
+          , toNeighborDones
+          , toCoreDones
+          , fromNeighborDones
+          , fromCoreDones
           }
       )
-      False
-      -< (txLastBus, Fwd (pure Nothing))
-  (Fwd rxLast, _rxLastActivity) <-
-    registerWbI
-      ( (registerConfig "rx_en")
-          { access = WriteOnly
-          , description = "The CPU should write True once it is ready to receive UGN"
-          }
-      )
-      False
-      -< (rxLastBus, Fwd (pure Nothing))
+ where
+  noWrite = pure Nothing
+  zeroMask = fromBitVector 0
 
-  let txRxRegs = bundle (txLast, rxLast)
-  let (txLinkOut, rxLinkOut, txRxLast) = handshake rxLinkIn txLinkIn txRxRegs
+  modesConfig =
+    (registerConfig "modes")
+      { description =
+          "Per-channel mode. Whether to engage the handshake module or not. In both modes, this device introduces a single cycle of latency. To renegotiate post handshake, set the mode to 'PassThrough' and back to 'Enabled'. Keep in mind that you should clear the other control registers when a channel is in 'PassThrough' mode again."
+      }
 
-  idC -< (Fwd txLinkOut, Fwd rxLinkOut, Fwd txRxLast)
+  receiveReadysConfig = registerConfig "receive_readys"
+
+  softwareReadysConfig =
+    (registerConfig "software_readys")
+      { description =
+          "Per-channel extra field sent to the neighbor while negotiating to indicate whether software has reached a state where it will soon assert 'receive_readys'. In a bittide context, this means that elastic buffers aren't actively (destructively) centered anymore, making it safe to end the handshake and send over UGNs. The neighbor will send this field too, which will end up in 'neighbor_software_readys'. Once a channel's bit is asserted, it should not be deasserted anymore."
+      }
+
+  neighborSoftwareReadysConfig =
+    (registerConfig "neighbor_software_readys")
+      { access = ReadOnly
+      , description =
+          "Per-channel extra field received from the neighbor, see 'software_readys'. A channel's bit is only valid when its corresponding entry in 'modes' is set to 'Enabled'."
+      }
+
+  neighborToCoreDonesConfig =
+    (registerConfig "receive_dones")
+      { access = ReadOnly
+      , description =
+          "Per-channel state of the handshake of the receive channel. A channel's bit is only valid when its corresponding entry in 'modes' is set to 'Enabled'."
+      }
+
+  coreToNeighborDonesConfig =
+    (registerConfig "transmit_dones")
+      { access = ReadOnly
+      , description =
+          "Per-channel state of the handshake of the transmit channel. A channel's bit is only valid when its corresponding entry in 'modes' is set to 'Enabled'."
+      }
+
+  handshakeDonesConfig =
+    (registerConfig "handshake_dones")
+      { access = ReadOnly
+      , description =
+          "Per-channel indicator that both the receive and transmit channels have completed their handshake negotiation."
+      }

--- a/bittide/src/Bittide/Node.hs
+++ b/bittide/src/Bittide/Node.hs
@@ -21,8 +21,10 @@ import Protocols.Vec (vecCircuits)
 import VexRiscv
 
 import Bittide.Calendar
-import Bittide.CaptureUgn (captureUgn)
+import Bittide.CaptureUgn (captureUgn, sendUgn)
 import Bittide.ElasticBuffer (ElasticBufferData)
+import Bittide.Extra.Maybe (toMaybe)
+import Bittide.Handshake (handshakesWb)
 import Bittide.Jtag
 import Bittide.MetaPeConfig (metaPeConfig)
 import Bittide.ProcessingElement
@@ -31,6 +33,8 @@ import Bittide.SharedTypes
 import Bittide.Switch
 import Bittide.Wishbone (readDnaPortE2Wb, timeWb, uartBytes, uartInterfaceWb)
 
+import qualified Bittide.Handshake as Handshake
+import Clash.Functor.Extra ((<<$>>), (<<*>>))
 import qualified Protocols.Vec as Vec
 
 {- | Each 'gppe' results in 2 busses for the 'managementUnit', namely:
@@ -70,7 +74,7 @@ node ::
     ( ToConstBwd Mm
     , Vec gppes (ToConstBwd Mm)
     , Jtag dom
-    , Vec linkCount (CSignal dom (ElasticBufferData (Maybe (BitVector 64))))
+    , Vec linkCount (CSignal dom (ElasticBufferData (BitVector 64)))
     )
     ( Vec linkCount (CSignal dom (BitVector 64))
     , CSignal dom (Unsigned 64)
@@ -81,7 +85,7 @@ node ::
     , CSignal dom (Vec (linkCount + gppes + 1) (Index (linkCount + gppes + 2)))
     )
 node (Config muConfig switchConfig gppeConfigs) =
-  circuit $ \(muMM, gppeMMs, jtag, Fwd rxs) -> do
+  circuit $ \(muMM, gppeMMs, jtag, Fwd rxs0) -> do
     [muJtag, gppesJtagTap] <- jtagChain -< jtag
     gppesJtag <- jtagChain -< gppesJtagTap
 
@@ -89,13 +93,30 @@ node (Config muConfig switchConfig gppeConfigs) =
       , Fwd localCounter
       , (switchMM, switchWb)
       , externalMMWb
+      , handshakeMMWb
       , captureUgnsMMWb
       , scatterCalsMMWb
       , gatherCalsMMWb
       ) <-
       managementUnitC muConfig -< (muMM, nmuLinkIn, muJtag)
 
-    ugnRxs <- vecCircuits (captureUgn localCounter <$> rxs) -< captureUgnsMMWb
+    Fwd handshakesOut <-
+      handshakesWb
+        -< ( handshakeMMWb
+           , Fwd
+               ( Handshake.Inputs
+                   { fromNeighbors = rxs0
+                   , fromCores = txs1
+                   }
+               )
+           )
+
+    let
+      -- TODO: Hardware UGN capture is currently mandatory, it shouldn't be.
+      rxs1 = toMaybe <<$>> handshakesOut.toCoreDones <<*>> handshakesOut.toCores
+      txs1 = sendUgn localCounter <$> handshakesOut.fromCoreDones <*> linksOut
+
+    ugnRxs <- vecCircuits (captureUgn localCounter <$> rxs1) -< captureUgnsMMWb
 
     (Fwd peLinksOut, peUartsOut) <-
       Vec.unzip
@@ -106,10 +127,10 @@ node (Config muConfig switchConfig gppeConfigs) =
     switchIn <- Vec.append3 -< ([nmuLinkOut], Fwd peLinksOut, ugnRxs)
     (switchOut, cal) <-
       switchC @_ @_ @_ @_ @64 switchConfig -< (switchMM, (switchIn, switchWb))
-    ([nmuLinkIn], Fwd switchToGppes, linksOut) <- Vec.split3 -< switchOut
+    ([nmuLinkIn], Fwd switchToGppes, Fwd linksOut) <- Vec.split3 -< switchOut
 
     idC
-      -< ( linksOut
+      -< ( Fwd handshakesOut.toNeighbors
          , Fwd localCounter
          , externalMMWb
          , Fwd switchToGppes
@@ -221,11 +242,12 @@ Internal busses:
   * Switch
   * 'timeWb'
   * External link
+  * Handshakes
   * 'linkCount' number of 'captureUgn' components
   * 'gppes' number of Scatter calendars
   * 'gppes' number of Gather calendars
 -}
-type NmuBusses linkCount gppes = PeInternalBusses + 7 + linkCount + 2 * gppes
+type NmuBusses linkCount gppes = PeInternalBusses + 8 + linkCount + 2 * gppes
 type NmuPrefixWidth linkCount gppes = CLog 2 (NmuBusses linkCount gppes + 1)
 type NmuRemBusWidth linkCount gppes = 30 - NmuPrefixWidth linkCount gppes
 type NmuWishbone dom linkCount gppes = Bitbone dom (NmuRemBusWidth linkCount gppes)
@@ -278,6 +300,8 @@ managementUnitC ::
       (ToConstBwd Mm, NmuWishbone dom linkCount gppes)
     , -- \| External connection memory map and Wishbone bus
       (ToConstBwd Mm, NmuWishbone dom linkCount gppes)
+    , -- \| Handshake memory map and Wishbone bus
+      (ToConstBwd Mm, NmuWishbone dom linkCount gppes)
     , -- \| 'captureUgn's memory maps and Wishbone busses
       Vec
         linkCount
@@ -301,6 +325,7 @@ managementUnitC (ManagementConfig{scatterConfig, gatherConfig, peConfig, dumpVcd
         , switchMMWb
         , timeMMWb
         , externalMMWb
+        , handshakeMMWb
         ]
       , myWbRest
       ) <-
@@ -321,6 +346,7 @@ managementUnitC (ManagementConfig{scatterConfig, gatherConfig, peConfig, dumpVcd
          , localCounter
          , switchMMWb
          , externalMMWb
+         , handshakeMMWb
          , captureUgnMMWbs
          , scatterMMWbs
          , gatherMMWbs

--- a/bittide/src/Bittide/Transceiver.hs
+++ b/bittide/src/Bittide/Transceiver.hs
@@ -4,8 +4,7 @@
 
 {- | Transceiver module for the Bittide project. This module is a wrapper around
 the 'Clash.Cores.Xilinx.Gth.gthCore' function, adding additional functionality
-such as PRBS generation and checking, comma insertion, word alignment, and
-user data handshaking.
+such as PRBS generation and checking, comma insertion, and word alignment.
 
 __CAUTION__: When instantiating multiple transceivers you might want to use
 'transceiverPrbsN'. Make sure to read its documentation before proceeding.
@@ -25,11 +24,6 @@ After sending commas, we assume the receiver receives our words in a byte-aligne
 fashion. We can use this fact by reserving the MSB of each byte for an alignment
 symbol - see "Bittide.Transceiver.WordAlign".
 
-__Meta data__
-We send along meta data with each word. This meta data is used to signal to the
-neighbor that we're ready to receive user data, ready to transmit user data, or
-that the next word will be user data.
-
 __Reset manager__
 A reset manager is used as a sort of \"watchdog\" while booting the
 transceivers. It will reset the receive side of the transceiver if it doesn't
@@ -44,11 +38,10 @@ __Word format__
 An (aligned) 64 bit word is formatted as follows:
 
 > +----------+----------+----------+----------+----------+----------+----------+----------+
-> | 1mpppppp | 0mpppppp | 0mpppppp | 0mpppppp | 0mpppppp | 0mpppppp | 0mpppppp | 0mpppppp |
+> | 1ppppppp | 0ppppppp | 0ppppppp | 0ppppppp | 0ppppppp | 0ppppppp | 0ppppppp | 0ppppppp |
 > +----------+----------+----------+----------+----------+----------+----------+----------+
 
  * 1/0: alignment symbol
- * m: meta data
  * p: PRBS data
 
 __Protocol__
@@ -57,13 +50,12 @@ The protocol is as follows:
 Transmit:
 
  1. Send commas for a number of cycles
- 2. Send PRBS data with meta data
- 3. Wait for receiver to signal it has successfully decoded PRBS data for a long time
- 4. Send meta data with user supplied 'Input.rxReady' and 'Input.txStart'
- 5. Wait for 'Input.rxReady', 'Input.txStart' and its neighbor to signal it is ready to
-    receive user data.
- 6. Send meta data with 'lastPrbsWord' set to 'True'
- 7. Send user data
+ 2. Send PRBS data with word alignment bits
+ 3. Wait for receive side to signal it has successfully decoded PRBS data for such a long
+    time that we don't expect the other side to reset anymore.
+ 4. Wait for that same amount of time (+a little bit) to make sure the other side can reach
+    the same conclusion.
+ 5. Send user data
 
 Note that the reset manager might decide to reset in steps (2) and (3).
 
@@ -71,10 +63,8 @@ Receive:
 
  1. Detect alignment symbol and shift data accordingly
  2. Check PRBS data
- 3. Signal that PRBS data is OK after observing it for some time (see section
-   __Reset manager__).
- 4. Wait for 'Meta.lastPrbsWord'
- 5. Freeze alignment logic
+ 3. Signal that PRBS data is OK after observing it for some time (see section __Reset manager__).
+ 4. Freeze alignment logic
 -}
 module Bittide.Transceiver where
 
@@ -83,7 +73,7 @@ import Protocols
 
 import Bittide.Arithmetic.Time (trueForSteps)
 import Bittide.ElasticBuffer (stickyE)
-import Bittide.Handshake (Meta (..))
+import Clash.Cores.Xilinx.Xpm.Cdc.Single (xpmCdcSingle)
 import Clash.Explicit.Reset.Extra (Asserted (Asserted), delayReset, xpmResetSynchronizer)
 import Clash.Prelude (withClock)
 import Data.Maybe (fromMaybe, isNothing)
@@ -126,8 +116,6 @@ data Input tx rx tx1 rx1 ref free rxS = Input
   , clockRx1 :: Clock rx1
   , clockRx2 :: Clock rx
   , rxActive :: Signal rx (BitVector 1)
-  , transceiverIndex :: Unsigned 3
-  -- ^ Index of this transceiver, used for debugging. Can be set to 0 if not used.
   , channelName :: String
   -- ^ Channel name, example \"X0Y18\"
   , clockPath :: String
@@ -137,19 +125,7 @@ data Input tx rx tx1 rx1 ref free rxS = Input
   , rxN :: Gth.Wire rxS
   , rxP :: Gth.Wire rxS
   , txData :: Signal tx (BitVector 64)
-  {- ^ Data to transmit to the neighbor. Is first sampled one cycle after both
-  'Input.txStart' and 'Output.txReady' are asserted. Is continuously sampled
-  afterwards.
-  -}
-  , txStart :: Signal tx Bool
-  {- ^ When asserted, signal to neighbor that next word will be user data. This
-  signal is ignored until 'Output.txReady' is asserted. Can be tied
-  to 'True'.
-  -}
-  , rxReady :: Signal rx Bool
-  {- ^ When asserted, allow signalling to the neighbor that we are ready to
-  receive user data. Once asserted, it should stay asserted. Note that the
-  neighbor might decide to not send user data for a long time, even if this
+  {- ^ Data to transmit to the neighbor. This data is sampled if 'Output.txDataInitDone'
   is asserted.
   -}
   }
@@ -175,10 +151,6 @@ data Inputs tx rx ref free rxS n = Inputs
   -- ^ See 'Input.rxSim'
   , txDatas :: Vec n (Signal tx (BitVector 64))
   -- ^ See 'Input.txData'
-  , txStarts :: Vec n (Signal tx Bool)
-  -- ^ See 'Input.txStart'
-  , rxReadys :: Vec n (Signal rx Bool)
-  -- ^ See 'Input.rxReady'
   }
 
 data CInputs tx rx free n = CInputs
@@ -186,10 +158,6 @@ data CInputs tx rx free n = CInputs
   -- ^ Resets for each individual link
   , txDatas :: Vec n (Signal tx (BitVector 64))
   -- ^ See 'Input.txData'
-  , txStarts :: Vec n (Signal tx Bool)
-  -- ^ See 'Input.txStart'
-  , rxReadys :: Vec n (Signal rx Bool)
-  -- ^ See 'Input.rxReady'
   }
 
 instance Protocol (CInputs tx rx free n) where
@@ -203,16 +171,6 @@ data Output tx rx tx1 rx1 txS free = Output
   {- ^ Reset for 'Input.clockTx2'. Clock can be unstable until this reset is
   deasserted. See documentation of 'transceiverPrbsN' for more information.
   -}
-  , txReady :: Signal tx Bool
-  {- ^ Ready to signal to neighbor that next word will be user data. Waiting for
-  'Input.txStart' to be asserted before starting to send 'txData'.
-  -}
-  , txSampling :: Signal tx Bool
-  -- ^ Data is sampled from 'Input.txData'
-  , handshakeDoneTx :: Signal tx Bool
-  {- ^ Asserted when link has been established, but not necessarily handling user data.
-  This signal is native to the 'rx' domain. If you need that, use 'handshakeDone'.
-  -}
   , txP :: Gth.Wire txS
   -- ^ Transmit data (and implicitly a clock), positive
   , txN :: Gth.Wire txS
@@ -225,27 +183,24 @@ data Output tx rx tx1 rx1 txS free = Output
   {- ^ Reset signal for the receive side. Clock can be unstable until this reset
   is deasserted.
   -}
-  , rxData :: Signal rx (Maybe (BitVector 64))
-  -- ^ User data received from the neighbor
-  , handshakeDone :: Signal rx Bool
-  -- ^ Asserted when link has been established, but not necessarily handling user data.
-  , debugLinkUp :: Signal free Bool
-  {- ^ Legacy field, not yet removed because it is used by a HITL test. True if both the transmit
-  and receive side are either handling user data.
+  , rxData :: Signal rx (BitVector 64)
+  {- ^ User data received from the neighbor. Valid (but not necessary a user word) when
+  'Output.rxReset' is deasserted and 'Output.rxDataInitDone' is asserted.
   -}
-  , debugLinkReady :: Signal free Bool
-  {- ^ Legacy field, not yet removed because it is used by a HITL test. True if both the transmit
-  and receive side ready to handle user data or doing so. I.e., 'debugLinkUp' implies
-  'debugLinkReady'.
+  , rxDataInitDone :: Signal rx Bool
+  {- ^ Receive data initialization procedure done. This means that the data presented on
+  'rxData' is word aligned and coming from the neighbor. Note that you might still see
+  PRBS / initialization data coming from the other side. If you need first-word boundaries
+  you'll need to connect a handshake component.
   -}
-  , handshakeDoneFree :: Signal free Bool
-  {- ^ Asserted when link has been established, but not necessarily handling user data.
-  This signal is native to the 'rx' domain. If you need that, use 'handshakeDone'.
+  , rxDataInitDoneFree :: Signal free Bool
+  -- ^ 'rxDataInitDone', but synchronized to @free@ domain
+  , txDataInitDone :: Signal tx Bool
+  {- ^ Transmit data initialization procedure done. This mean that the data presented on
+  'Input.txData' is sampled and sent to the neighbor.
   -}
-  , neighborReceiveReady :: Signal free Bool
-  -- ^ Asserted when the neighbor has signalled it is ready to receive user data.
-  , neighborTransmitReady :: Signal free Bool
-  -- ^ Asserted when the neighbor has signalled it is ready to transmit user data.
+  , txDataInitDoneFree :: Signal free Bool
+  -- ^ 'Output.txDataInitDone' but in the free domain.
   , stats :: Signal free ResetManager.Statistics
   -- ^ Statistics exported by 'ResetManager.resetManager'. Useful for debugging.
   }
@@ -258,12 +213,6 @@ data Outputs n tx rx txS free = Outputs
   -- ^ Single transmit clock, shared by all links
   , txReset :: Reset tx
   -- ^ Reset associated with 'txClock'. Once deasserted, the clock is stable.
-  , txReadys :: Vec n (Signal tx Bool)
-  -- ^ See 'Output.txReady'
-  , txSamplings :: Vec n (Signal tx Bool)
-  -- ^ See 'Output.txSampling'
-  , handshakesDoneTx :: Vec n (Signal tx Bool)
-  -- ^ See 'Output.handshakeDoneTx'
   , txPs :: Gth.Wires txS n
   -- ^ See 'Output.txP'
   , txNs :: Gth.Wires txS n
@@ -274,20 +223,16 @@ data Outputs n tx rx txS free = Outputs
   -- ^ See 'Output.rxClock'
   , rxResets :: Vec n (Reset rx)
   -- ^ See 'Output.rxReset'
-  , rxDatas :: Vec n (Signal rx (Maybe (BitVector 64)))
+  , rxDatas :: Vec n (Signal rx (BitVector 64))
   -- ^ See 'Output.rxData'
-  , handshakesDone :: Vec n (Signal rx Bool)
-  -- ^ See 'Output.handshakeDone'
-  , debugLinkUps :: Vec n (Signal free Bool)
-  -- ^ See 'Output.debugLinkUp'
-  , debugLinkReadys :: Vec n (Signal free Bool)
-  -- ^ See 'Output.debugLinkReady'
-  , handshakesDoneFree :: Vec n (Signal free Bool)
-  -- ^ See 'Output.handshakeDoneFree'
-  , neighborReceiveReadys :: Vec n (Signal free Bool)
-  -- ^ See 'Output.neighborReceiveReady'
-  , neighborTransmitReadys :: Vec n (Signal free Bool)
-  -- ^ See 'Output.neighborTransmitReady'
+  , rxDataInitDones :: Vec n (Signal rx Bool)
+  -- ^ See 'Output.rxDataInitDone'
+  , rxDataInitDonesFree :: Vec n (Signal free Bool)
+  -- ^ See 'Output.rxDataInitDoneFree'
+  , txDataInitDones :: Vec n (Signal tx Bool)
+  -- ^ See 'Output.txDataInitDone'
+  , txDataInitDonesFree :: Vec n (Signal free Bool)
+  -- ^ See 'Output.txDataInitDoneFree'
   , stats :: Vec n (Signal free ResetManager.Statistics)
   -- ^ See 'Output.stats'
   }
@@ -300,30 +245,20 @@ data COutputs n tx rx free = COutputs
   -- ^ See 'Output.txClock'
   , txReset :: Reset tx
   -- ^ See 'Output.txReset'
-  , txReadys :: Vec n (Signal tx Bool)
-  -- ^ See 'Output.txReady'
-  , txSamplings :: Vec n (Signal tx Bool)
-  -- ^ See 'Output.txSampling'
-  , handshakesDoneTx :: Vec n (Signal tx Bool)
-  -- ^ See 'Output.handshakeDoneTx'
   , rxClocks :: Vec n (Clock rx)
   -- ^ See 'Output.rxClock'
   , rxResets :: Vec n (Reset rx)
   -- ^ See 'Output.rxReset'
-  , rxDatas :: Vec n (Signal rx (Maybe (BitVector 64)))
+  , rxDatas :: Vec n (Signal rx (BitVector 64))
   -- ^ See 'Output.rxData'
-  , handshakesDone :: Vec n (Signal rx Bool)
-  -- ^ See 'Output.handshakeDone'
-  , debugLinkUps :: Vec n (Signal free Bool)
-  -- ^ See 'Output.debugLinkUp'
-  , debugLinkReadys :: Vec n (Signal free Bool)
-  -- ^ See 'Output.debugLinkReady'
-  , handshakesDoneFree :: Vec n (Signal free Bool)
-  -- ^ See 'Output.handshakeDoneFree'
-  , neighborReceiveReadys :: Vec n (Signal free Bool)
-  -- ^ See 'Output.neighborReceiveReady'
-  , neighborTransmitReadys :: Vec n (Signal free Bool)
-  -- ^ See 'Output.neighborTransmitReady'
+  , rxDataInitDones :: Vec n (Signal rx Bool)
+  -- ^ See 'Output.rxDataInitDone'
+  , rxDataInitDonesFree :: Vec n (Signal free Bool)
+  -- ^ See 'Output.rxDataInitDoneFree'
+  , txDataInitDones :: Vec n (Signal tx Bool)
+  -- ^ See 'Output.txDataInitDone'
+  , txDataInitDonesFree :: Vec n (Signal free Bool)
+  -- ^ See 'Output.txDataInitDoneFree'
   , stats :: Vec n (Signal free ResetManager.Statistics)
   -- ^ See 'Output.stats'
   }
@@ -357,15 +292,14 @@ instance Protocol (Outputs n tx rx txS free) where
 {-
 [NOTE: duplicate tx/rx domain]
 'gthCore' and the inside of 'transceiverPrbsN' have two extra domains, tx1 and rx1,
-that aren't visible outside of transceiverPrbsN.
-To do this completely clean/safe transceiverPrbsN should have two extra
-forall arguments, two extra KnownDomain constraints.
+that aren't visible outside of transceiverPrbsN. To do this completely clean/safe
+transceiverPrbsN should have two extra forall arguments, two extra KnownDomain constraints.
 And either some Proxy arguments or we would have to enable AllowAmbiguousTypes.
 
-Because the tx1/rx1 domains aren't visible outside 'transceiverPrbsN',
-I choose to sidestep the extra complication and pretend tx1/rx1 and tx/rx are the same.
-This disables the typechecking safety we'd normally get from clash,
-but vivado should call us out when we make a mistake.
+Because the tx1/rx1 domains aren't visible outside 'transceiverPrbsN', I chose to sidestep
+the extra complication and pretend tx1/rx1 and tx/rx are the same. This disables the type
+checking safety we'd normally get from Clash, but Vivado should call us out when we make a
+mistake.
 -}
 
 {- | Clash has a very hard time translating maps with 'SimOnly' constructs,
@@ -385,18 +319,13 @@ outputsToCOutputs outputs =
   COutputs
     { txClock = outputs.txClock
     , txReset = outputs.txReset
-    , txReadys = outputs.txReadys
-    , txSamplings = outputs.txSamplings
-    , handshakesDoneTx = outputs.handshakesDoneTx
     , rxClocks = outputs.rxClocks
     , rxResets = outputs.rxResets
     , rxDatas = outputs.rxDatas
-    , handshakesDone = outputs.handshakesDone
-    , debugLinkUps = outputs.debugLinkUps
-    , debugLinkReadys = outputs.debugLinkReadys
-    , handshakesDoneFree = outputs.handshakesDoneFree
-    , neighborReceiveReadys = outputs.neighborReceiveReadys
-    , neighborTransmitReadys = outputs.neighborTransmitReadys
+    , rxDataInitDones = outputs.rxDataInitDones
+    , rxDataInitDonesFree = outputs.rxDataInitDonesFree
+    , txDataInitDones = outputs.txDataInitDones
+    , txDataInitDonesFree = outputs.txDataInitDonesFree
     , stats = outputs.stats
     }
 
@@ -459,8 +388,6 @@ transceiverPrbsNC clock reset config = Circuit go
           , rxNs
           , rxPs
           , txDatas = cInputs.txDatas
-          , txStarts = cInputs.txStarts
-          , rxReadys = cInputs.rxReadys
           }
 
 transceiverPrbsN ::
@@ -486,24 +413,19 @@ transceiverPrbsN opts inputs@Inputs{clock, reset, refClock} =
     { -- tx
       txClock
     , txReset
-    , txReadys = map (.txReady) outputs
-    , txSamplings = map (.txSampling) outputs
-    , handshakesDoneTx = map (.handshakeDoneTx) outputs
     , txSims = simOnlyHdlWorkaround (SimOnly (map (Gth.unSimOnly . (.txSim)) outputs))
+    , txDataInitDones = map (.txDataInitDone) outputs
     , -- rx
       rxClocks = rxClocks
     , rxResets = map (.rxReset) outputs
     , rxDatas = map (.rxData) outputs
-    , handshakesDone = map (.handshakeDone) outputs
+    , rxDataInitDones = map (.rxDataInitDone) outputs
     , -- transceiver
       txPs = pack <$> bundle (map (.txP) outputs)
     , txNs = pack <$> bundle (map (.txN) outputs)
     , -- free
-      debugLinkUps = map (.debugLinkUp) outputs
-    , debugLinkReadys = map (.debugLinkReady) outputs
-    , handshakesDoneFree = map (.handshakeDoneFree) outputs
-    , neighborReceiveReadys = map (.neighborReceiveReady) outputs
-    , neighborTransmitReadys = map (.neighborTransmitReady) outputs
+      txDataInitDonesFree = map (.txDataInitDoneFree) outputs
+    , rxDataInitDonesFree = map (.rxDataInitDoneFree) outputs
     , stats = map (.stats) outputs
     }
  where
@@ -513,22 +435,17 @@ transceiverPrbsN opts inputs@Inputs{clock, reset, refClock} =
   -- That breaks the instantiation of the the debug ILAs inside 'transceiverPrbs'.
   --
   -- But when the GTHs were changed to use external "user clock networks",
-  -- this zipWithN became unusably slow when using more then ~4 transceivers.
-  -- Unfortunately this means debugIla is broken now, when using more then 1 transceiver.
+  -- this zipWithN became unusably slow when using more than ~4 transceivers.
+  -- Unfortunately this means debugIla is broken now, when using more than 1 transceiver.
   outputs =
     go txClockNw
-      <$> iterateI (+ 1) 0 -- Note that the target type is only 3 bits, so this will
-      -- wrap around after 8 transceivers. This is fine, as we
-      -- only use this for debugging.
-      <*> inputs.channelNames
+      <$> inputs.channelNames
       <*> inputs.clockPaths
       <*> simOnlyHdlWorkaround (map SimOnly (Gth.unSimOnly inputs.rxSims))
       <*> unbundle (unpack <$> inputs.rxNs)
       <*> unbundle (unpack <$> inputs.rxPs)
       <*> inputs.channelResets
       <*> inputs.txDatas
-      <*> inputs.txStarts
-      <*> inputs.rxReadys
       <*> rxClockNws
 
   -- NOTE: The example project generated by gtwizard_ultrascale suggests tying tx/rxUsrClkRst
@@ -550,7 +467,7 @@ transceiverPrbsN opts inputs@Inputs{clock, reset, refClock} =
   rxClockNws = map (flip (Gth.xilinxGthUserClockNetworkRx @rx @rx) rxUsrClkRst) rxOutClks
   (_rxClk1s, rxClocks, _rxClkActives) = unzip3 rxClockNws
 
-  go (clockTx1, clockTx2, txActive) transceiverIndex channelName clockPath rxSim rxN rxP channelReset txData txStart rxReady (clockRx1, clockRx2, rxActive) =
+  go (clockTx1, clockTx2, txActive) channelName clockPath rxSim rxN rxP channelReset txData (clockRx1, clockRx2, rxActive) =
     transceiverPrbs
       opts
       Input
@@ -561,9 +478,6 @@ transceiverPrbsN opts inputs@Inputs{clock, reset, refClock} =
         , rxP
         , channelReset
         , txData
-        , txStart
-        , rxReady
-        , transceiverIndex
         , clock
         , reset
         , refClock
@@ -593,172 +507,7 @@ transceiverPrbs ::
   Config free ->
   Input tx rx tx1 rx1 ref free rxS ->
   Output tx rx tx1 rx1 txS free
-transceiverPrbs = transceiverAndHandshake Gth.gthCore
-
-transceiverAndHandshake ::
-  ( HasSynchronousReset tx
-  , HasDefinedInitialValues tx
-  , HasSynchronousReset rx
-  , HasDefinedInitialValues rx
-  , HasSynchronousReset free
-  , HasDefinedInitialValues free
-  , KnownDomain rx1
-  , KnownDomain tx1
-  , KnownDomain rxS
-  , KnownDomain txS
-  , KnownDomain ref
-  , KnownDomain free
-  ) =>
-  Gth.GthCore tx1 tx rx1 rx ref free txS rxS ->
-  Config free ->
-  Input tx rx tx1 rx1 ref free rxS ->
-  Output tx rx tx1 rx1 txS free
-transceiverAndHandshake core config input = output
- where
-  output = transceiverOutputAndHandshakeOutputToOutput transceiver handshake
-
-  transceiverInput = inputToTransceiverInput input
-  handshakeInput = inputToHandshakeInput input
-  (transceiver, handshakeInputFromTransceiver) = transceiverPrbsWith core config transceiverInput transceiverInputFromHandshake
-  (handshake, transceiverInputFromHandshake) = userDataHandshake handshakeInput handshakeInputFromTransceiver
-
-transceiverOutputAndHandshakeOutputToOutput ::
-  TransceiverOutput tx rx tx1 rx1 txS free ->
-  HandshakeOutput tx rx free ->
-  Output tx rx tx1 rx1 txS free
-transceiverOutputAndHandshakeOutputToOutput transceiver handshake = output
- where
-  output =
-    Output
-      { txSampling = handshake.txIsUserData
-      , rxData = handshake.wordToUser
-      , txReady = handshake.neighborReceiveReadyTx
-      , handshakeDoneTx = transceiver.prbsHandshakeDoneTx
-      , handshakeDone = transceiver.prbsHandshakeDone
-      , handshakeDoneFree = transceiver.prbsHandshakeDoneFree
-      , txSim = transceiver.txSim
-      , txN = transceiver.txN
-      , txP = transceiver.txP
-      , txReset = transceiver.txReset
-      , txOutClock = transceiver.txOutClock
-      , rxOutClock = transceiver.rxOutClock
-      , rxReset = transceiver.rxReset
-      , debugLinkUp = handshake.debugLinkUp
-      , debugLinkReady = handshake.debugLinkReady
-      , neighborReceiveReady = handshake.neighborReceiveReady
-      , neighborTransmitReady = handshake.neighborTransmitReady
-      , stats = transceiver.stats
-      }
-
-inputToTransceiverInput ::
-  Input tx rx tx1 rx1 ref free rxS -> TransceiverInput tx rx tx1 rx1 ref free rxS
-inputToTransceiverInput input = transceiverInput
- where
-  transceiverInput =
-    TransceiverInput
-      { clock = input.clock
-      , reset = input.reset
-      , channelReset = input.channelReset
-      , refClock = input.refClock
-      , clockTx1 = input.clockTx1
-      , clockTx2 = input.clockTx2
-      , txActive = input.txActive
-      , clockRx1 = input.clockRx1
-      , clockRx2 = input.clockRx2
-      , rxActive = input.rxActive
-      , transceiverIndex = input.transceiverIndex
-      , channelName = input.channelName
-      , clockPath = input.clockPath
-      , rxSim = input.rxSim
-      , rxN = input.rxN
-      , rxP = input.rxP
-      }
-
-inputToHandshakeInput :: Input tx rx tx1 rx1 ref free rxS -> HandshakeInput tx rx free
-inputToHandshakeInput input = handshakeInput
- where
-  handshakeInput =
-    HandshakeInput
-      { clock = input.clock
-      , reset = input.reset
-      , txClock = input.clockTx2
-      , rxClock = input.clockRx2
-      , wordFromUser = input.txData
-      , txStart = input.txStart
-      , rxReady = input.rxReady
-      }
-
-data TransceiverInput tx rx tx1 rx1 ref free rxS = TransceiverInput
-  { clock :: Clock free
-  , reset :: Reset free
-  , channelReset :: Reset free
-  , refClock :: Clock ref
-  , clockTx1 :: Clock tx1
-  , clockTx2 :: Clock tx
-  , txActive :: Signal tx (BitVector 1)
-  , clockRx1 :: Clock rx1
-  , clockRx2 :: Clock rx
-  , rxActive :: Signal rx (BitVector 1)
-  , transceiverIndex :: Unsigned 3
-  , channelName :: String
-  , clockPath :: String
-  , rxSim :: Gth.SimWire rx
-  , rxN :: Gth.Wire rxS
-  , rxP :: Gth.Wire rxS
-  }
-
-data TransceiverOutput tx rx tx1 rx1 txS free = TransceiverOutput
-  { txOutClock :: Clock tx1
-  , txReset :: Reset tx
-  , prbsHandshakeDoneTx :: Signal tx Bool
-  , txP :: Gth.Wire txS
-  , txN :: Gth.Wire txS
-  , txSim :: Gth.SimWire tx
-  , rxOutClock :: Clock rx1
-  , rxReset :: Reset rx
-  , prbsHandshakeDone :: Signal rx Bool
-  , prbsHandshakeDoneFree :: Signal free Bool
-  , stats :: Signal free ResetManager.Statistics
-  }
-
-data HandshakeInput tx rx free = HandshakeInput
-  { clock :: Clock free
-  , reset :: Reset free
-  , txClock :: Clock tx
-  , rxClock :: Clock rx
-  , wordFromUser :: Signal tx (BitVector 64)
-  , txStart :: Signal tx Bool -- Set by CPU via wishbone
-  , rxReady :: Signal rx Bool -- Set by CPU via wishbone
-  }
-
-data HandshakeOutput tx rx free = HandshakeOutput
-  { wordToTransceiver :: Signal tx (BitVector 64)
-  , wordToUser :: Signal rx (Maybe (BitVector 64))
-  , rxLast :: Signal rx Bool
-  , rxIsUserData :: Signal rx Bool
-  , txIsUserData :: Signal tx Bool
-  , debugLinkUp :: Signal free Bool
-  , debugLinkReady :: Signal free Bool
-  , neighborReceiveReady :: Signal free Bool
-  , neighborReceiveReadyTx :: Signal tx Bool
-  , neighborTransmitReady :: Signal free Bool
-  }
-
-data HandshakeInputFromTransceiver tx rx = HandshakeInputFromTransceiver
-  { txReset :: Reset tx
-  , txResetDone :: Signal tx (BitVector 1)
-  , rxReset :: Reset rx
-  , rxResetDone :: Signal rx (BitVector 1)
-  , linkHealthy :: Signal rx Bool
-  , wordFromTransceiver :: Signal rx (BitVector 64)
-  }
-
-data TransceiverInputFromHandshake tx rx free = TransceiverInputFromHandshake
-  { wordToTransceiver :: Signal tx (BitVector 64)
-  , rxLast :: Signal rx Bool
-  , rxUserData :: Signal rx Bool
-  , txUserData :: Signal tx Bool
-  }
+transceiverPrbs = transceiverPrbsWith Gth.gthCore
 
 transceiverPrbsWith ::
   forall tx rx tx1 rx1 ref free txS rxS.
@@ -777,34 +526,25 @@ transceiverPrbsWith ::
   ) =>
   Gth.GthCore tx1 tx rx1 rx ref free txS rxS ->
   Config free ->
-  TransceiverInput tx rx tx1 rx1 ref free rxS ->
-  TransceiverInputFromHandshake tx rx free ->
-  (TransceiverOutput tx rx tx1 rx1 txS free, HandshakeInputFromTransceiver tx rx)
-transceiverPrbsWith gthCore opts input (TransceiverInputFromHandshake wordToTransceiver rxLast rxUserData txUserData) = (output, handshakeInput)
+  Input tx rx tx1 rx1 ref free rxS ->
+  Output tx rx tx1 rx1 txS free
+transceiverPrbsWith gthCore opts input = output
  where
   output =
-    TransceiverOutput
-      { prbsHandshakeDoneTx = withLockRxTx prbsOkDelayed
-      , prbsHandshakeDone = prbsOkDelayed
-      , prbsHandshakeDoneFree = withLockRxFree prbsOkDelayed
-      , txSim
+    Output
+      { txSim
       , txN
       , txP
       , txReset = txDomainReset
       , txOutClock
       , rxOutClock
       , rxReset
+      , rxData = alignedRxData0
       , stats
-      }
-
-  handshakeInput =
-    HandshakeInputFromTransceiver
-      { txReset
-      , txResetDone = reset_tx_done
-      , rxReset
-      , rxResetDone = reset_rx_done
-      , linkHealthy = prbsOkDelayed
-      , wordFromTransceiver = alignedRxData0
+      , rxDataInitDone
+      , rxDataInitDoneFree
+      , txDataInitDone = txDataInitDoneTx
+      , txDataInitDoneFree
       }
 
   Gth.CoreOutput
@@ -851,7 +591,7 @@ transceiverPrbsWith gthCore opts input (TransceiverInputFromHandshake wordToTran
           , gtwizUserclkRxActiveIn = input.rxActive
           }
 
-  prbsConfig = Prbs.conf31 @48
+  prbsConfig = Prbs.conf31 @56
 
   clock = input.clock
   reset = input.reset
@@ -861,23 +601,12 @@ transceiverPrbsWith gthCore opts input (TransceiverInputFromHandshake wordToTran
   (commas, txctrl) = Comma.generator d1 txClock txReset
   commasDone = isNothing <$> commas
   prbs = Prbs.generator txClock (unsafeFromActiveLow commasDone) enableGen prbsConfig
-  -- Ideally, the transceiver would just receive a word from the handshake and send it out.
-  -- This word could be a metadata word or a user word. However, since metadata words are
-  -- padded with prbs data, we have two options: 1) setup handshake to do prbs, so that the
-  -- metadata words can be sent directly by the transceiver, or 2) take the metadata word
-  -- from handshake and have the transceiver write in the prbs info into the word. We choose
-  -- option 2, because that better decouples the handshake from the transceiver logic.
-  --
-  -- The logic below simply takes the handshake word and, if the handshake signals it's
-  -- sending metadata, rewrites the metadata word with prbs data inserted
-  metaTx = wordToMetadata <$> wordToTransceiver
-  prbsWithMeta = WordAlign.joinMsbs @8 <$> fmap pack metaTx <*> prbs
-  prbsWithMetaAndAlign = WordAlign.joinMsbs @8 WordAlign.alignSymbol <$> prbsWithMeta
+  prbsWithAlign = WordAlign.joinMsbs @8 WordAlign.alignSymbol <$> prbs
   gtwiz_userdata_tx_in =
     mux
-      txUserData
-      wordToTransceiver
-      (fromMaybe <$> prbsWithMetaAndAlign <*> commas)
+      txDataInitDoneTx
+      input.txData
+      (fromMaybe <$> prbsWithAlign <*> commas)
 
   rxReset =
     xpmResetSynchronizer Asserted rxClock rxClock
@@ -887,15 +616,12 @@ transceiverPrbsWith gthCore opts input (TransceiverInputFromHandshake wordToTran
   alignedRxData0 :: Signal rx (BitVector 64)
   alignedRxData0 =
     withClock rxClock
-      $ WordAlign.alignBytesFromMsbs @8 WordAlign.alignLsbFirst (rxUserData .||. rxLast) rx_data0
+      $ WordAlign.alignBytesFromMsbs @8 WordAlign.alignLsbFirst prbsOkDelayedSticky rx_data0
 
   (alignedAlignBits, alignedRxData1) =
     unbundle (WordAlign.splitMsbs @8 @8 <$> alignedRxData0)
 
-  (_, alignedRxData2) =
-    unbundle (WordAlign.splitMsbs @8 @7 <$> alignedRxData1)
-
-  prbsErrors = Prbs.checker rxClock rxReset enableGen prbsConfig alignedRxData2
+  prbsErrors = Prbs.checker rxClock rxReset enableGen prbsConfig alignedRxData1
   anyPrbsErrors = prbsErrors ./=. pure 0
   alignError = alignedAlignBits ./=. pure WordAlign.alignSymbol
 
@@ -910,21 +636,39 @@ transceiverPrbsWith gthCore opts input (TransceiverInputFromHandshake wordToTran
       .||. (rxCtrl2 ./=. pure 0)
       .||. (rxCtrl3 ./=. pure 0)
 
-  prbsOk =
-    rxUserData
-      .||. Prbs.tracker rxClock rxReset (anyPrbsErrors .||. alignError .||. rxCtrlOrError)
+  prbsOk = Prbs.tracker rxClock rxReset (anyPrbsErrors .||. alignError .||. rxCtrlOrError)
 
-  -- 'prbsWaitMs' is the number of milliseconds representing the worst case time
-  -- it takes for the PRBS to stabilize. I.e., after this time we can be sure the
-  -- neighbor doesn't reset its transceiver anymore. We add a single retry to
-  -- account for clock speed variations.
+  -- 'prbsWaitMs' is the number of milliseconds representing the worst case time it takes
+  -- for the PRBS to stabilize. I.e., after this time we can be sure the neighbor doesn't
+  -- reset its transceiver anymore. We add a single retry to account for clock speed
+  -- variations.
   prbsWaitMs =
     ((1 :: Index 2) `add` opts.resetManagerConfig.rxRetries)
       `mul` opts.resetManagerConfig.rxTimeoutMs
-  prbsOkDelayed = trueForSteps (Proxy @(Milliseconds 1)) prbsWaitMs rxClock rxReset prbsOk
 
-  errorAfterRxUserData :: Signal rx Bool
-  errorAfterRxUserData = mux rxUserData rxCtrlOrError (pure False)
+  -- We assume that the link is established after waiting for 'prbsWaitMs' and won't switch
+  -- out off it. Recovering for errors is handled by the 'ResetManager' after observing
+  -- encoding errors, or by the application layer.
+  prbsOkDelayed = trueForSteps (Proxy @(Milliseconds 1)) prbsWaitMs rxClock rxReset prbsOk
+  prbsOkDelayedSticky = stickyE rxClock rxReset prbsOkDelayed
+  rxDataInitDone = prbsOkDelayedSticky
+  rxDataInitDoneFree = withLockRxFree rxDataInitDone
+
+  -- After we assume the RX side is stable, we cannot be sure the other side has concluded
+  -- the same yet. We therefore wait the worst case time it takes for the PRBS to stabilize
+  -- (see 'prbsWaitMs') and add another retry to account for clock speed variations.
+  prbsWaitMsPessimistic =
+    ((2 :: Index 3) `add` opts.resetManagerConfig.rxRetries)
+      `mul` opts.resetManagerConfig.rxTimeoutMs
+  txGraceDoneSticky =
+    -- Note that this variable is sticky because 'prbsOkDelayedSticky' is
+    trueForSteps (Proxy @(Milliseconds 1)) prbsWaitMsPessimistic rxClock rxReset prbsOkDelayedSticky
+  txDataInitDone = txGraceDoneSticky
+  txDataInitDoneFree = withLockRxFree txGraceDoneSticky
+  txDataInitDoneTx = xpmCdcSingle rxClock txClock txDataInitDone
+
+  errorAfterRxInitDone :: Signal rx Bool
+  errorAfterRxInitDone = mux rxDataInitDone rxCtrlOrError (pure False)
 
   (resets, stats) =
     ResetManager.resetManager
@@ -935,8 +679,8 @@ transceiverPrbsWith gthCore opts input (TransceiverInputFromHandshake wordToTran
         { channelReset = input.channelReset
         , txInitDone = withLockTxFree (pure True) -- See note @ withLockRxFree
         , rxInitDone = withLockRxFree (pure True) -- See note @ withLockRxFree
-        , rxDataGood = withLockRxFree (prbsOk .||. rxUserData)
-        , errorAfterRxUser = withLockRxFree errorAfterRxUserData
+        , rxDataGood = withLockRxFree (prbsOk .||. prbsOkDelayedSticky)
+        , errorAfterRxUser = withLockRxFree errorAfterRxInitDone
         }
 
   -- Synchronized version of 'resets.txUser' and 'resets.txDomain'. We use
@@ -956,127 +700,5 @@ transceiverPrbsWith gthCore opts input (TransceiverInputFromHandshake wordToTran
   -- seeing stale signals, 'withLock' is employed. This means that constructs
   -- such as @withLockRxFree (pure True)@ are actually doing something!
   withLockRxFree = Cdc.withLock rxClock (unpack <$> reset_rx_done) clock reset
-  withLockRxTx = Cdc.withLock rxClock (unpack <$> reset_rx_done) txClock txReset
   withLockTxFree = Cdc.withLock txClock (unpack <$> reset_tx_done) clock reset
-
-{- | Given a bittide word, extract the metadata. This function does not check that
-the input is a metadata word, and will produce garbage if used on a user word.
--}
-wordToMetadata ::
-  BitVector 64 ->
-  Meta
-wordToMetadata word = unpack alignedMetaBits
- where
-  (_alignData, payload) = WordAlign.splitMsbs @8 @8 word
-  (alignedMetaBits, _) = WordAlign.splitMsbs @8 @7 payload
-
-{- | Given a metadata, output it formatted into a bittide word. The word is
-simply the metadata padded with 0s, such that one can later re-extract the
-metadata with `wordToMetadata`.
--}
-metadataToWord ::
-  Meta ->
-  BitVector 64
-metadataToWord meta = word
- where
-  padding = 0 :: BitVector 48
-  metaWithPadding = WordAlign.joinMsbs @8 (pack meta) padding
-  word = WordAlign.joinMsbs @8 0 metaWithPadding
-
-{- | Performs the handshake between two nodes to agree on when to switch over from
- - bittide metadata words to user data words. The handshake follows these steps:
- - 1) These two steps happen in parallel:
- -    1A) When the CPU says it is successfully booted, the handshake sends "Read Ready"
- -    metadata word to neighbor node.
- -    1B) The handshake waits to receive a "Read Ready" metadata word from the neighbor
- - 2) Once both 1A and 1B have been done, the handshake signals to the EB to pause centering.
- - 3) These two steps happen in parallel:
- -    3A) The handshake sends a "Write Ready" metadata word when the EB has paused
- -    3B) The handshake waits to receive a "Write Ready" metadata word from the neighbor
- - 4) Once both 3A and 3B have been done, the following two happen in parallel
- -    4A) The handshake sends a "Last Metadata Word" metadata word, and then switches to a pass-through mode.
- -    4B) The handshake waits for a "Last Metadat Word" metadata word, and then switches to a pass-through mode
--}
-userDataHandshake ::
-  forall rx tx free.
-  (KnownDomain rx, KnownDomain tx, KnownDomain free) =>
-  HandshakeInput tx rx free ->
-  HandshakeInputFromTransceiver tx rx ->
-  (HandshakeOutput tx rx free, TransceiverInputFromHandshake tx rx free)
-userDataHandshake input fromTransceiver = (output, transceiverInputFromHandshake)
- where
-  output =
-    HandshakeOutput
-      { wordToTransceiver
-      , wordToUser
-      , rxLast
-      , rxIsUserData
-      , txIsUserData
-      , debugLinkUp
-      , debugLinkReady
-      , neighborReceiveReady
-      , neighborReceiveReadyTx
-      , neighborTransmitReady
-      }
-
-  transceiverInputFromHandshake =
-    TransceiverInputFromHandshake
-      wordToTransceiver
-      rxLast
-      rxIsUserData
-      txIsUserData
-
-  metadata = wordToMetadata <$> fromTransceiver.wordFromTransceiver
-  validMeta = mux rxIsUserData (pure False) fromTransceiver.linkHealthy
-
-  rxMeta = mux validMeta (Just <$> metadata) (pure Nothing)
-  rxLast = maybe False (.lastMetadataWord) <$> rxMeta
-  rxReadyNeighbor = maybe False (.readyToReceive) <$> rxMeta
-  txReadyNeighbor = maybe False (.readyToTransmit) <$> rxMeta
-
-  rxIsUserData = stickyE input.rxClock fromTransceiver.rxReset rxLast
-  txIsUserData = stickyE input.txClock fromTransceiver.txReset txLast
-
-  indicateRxReady =
-    withLockRxTx
-      (fromTransceiver.linkHealthy .&&. stickyE input.rxClock fromTransceiver.rxReset input.rxReady)
-
-  rxReadyNeighborSticky = stickyE input.rxClock fromTransceiver.rxReset rxReadyNeighbor
-  txReadyNeighborSticky = stickyE input.rxClock fromTransceiver.rxReset txReadyNeighbor
-  txLast = indicateRxReady .&&. input.txStart .&&. withLockRxTx rxReadyNeighborSticky
-
-  metaTx :: Signal tx Meta
-  metaTx =
-    Meta
-      <$> indicateRxReady
-      <*> (withLockRxTx fromTransceiver.linkHealthy .&&. input.txStart)
-      <*> txLast
-      -- Padding
-      <*> pure 0
-
-  wordToTransceiver =
-    mux
-      txIsUserData
-      input.wordFromUser
-      (metadataToWord <$> metaTx)
-  wordToUser = mux rxIsUserData (Just <$> fromTransceiver.wordFromTransceiver) (pure Nothing)
-
-  debugLinkUp =
-    withLockTxFree txIsUserData
-      .&&. withLockRxFree rxIsUserData
-
-  debugLinkReady = debugLinkUp .||. withLockRxFree rxReadyNeighborSticky
-
-  neighborReceiveReady = withLockRxFree rxReadyNeighborSticky
-  neighborReceiveReadyTx = withLockRxTx rxReadyNeighborSticky
-  neighborTransmitReady = withLockRxFree txReadyNeighborSticky
-
-  -- Clock domain crossing functions
-  withLockRxFree = Cdc.withLock input.rxClock (unpack <$> fromTransceiver.rxResetDone) input.clock input.reset
-  withLockRxTx =
-    Cdc.withLock
-      input.rxClock
-      (unpack <$> fromTransceiver.rxResetDone)
-      input.txClock
-      fromTransceiver.txReset
-  withLockTxFree = Cdc.withLock input.txClock (unpack <$> fromTransceiver.txResetDone) input.clock input.reset
+{-# INLINE transceiverPrbsWith #-}

--- a/bittide/src/Bittide/Transceiver/Wishbone.hs
+++ b/bittide/src/Bittide/Transceiver/Wishbone.hs
@@ -11,7 +11,6 @@ import Bittide.Transceiver (CInputs (..), COutputs (..), Config, transceiverPrbs
 
 import Bittide.Transceiver.ResetManager (emptyStatistics)
 import Clash.Class.BitPackC (ByteOrder)
-import Clash.Cores.Xilinx.Xpm.Cdc (xpmCdcArraySingle, xpmCdcSingle)
 import GHC.Stack (HasCallStack)
 import Protocols.MemoryMap (Access (ReadOnly))
 import Protocols.MemoryMap.Registers.WishboneStandard (
@@ -52,14 +51,14 @@ transceiverPrbsNWb ::
   Reset free ->
   Config free ->
   Circuit
-    ( (BitboneMm free aw)
+    ( BitboneMm free aw
     , Gth.Gths rx rxS tx txS ref n
     , CSignal tx (Vec n (BitVector 64))
     )
     (COutputs n tx rx free)
 transceiverPrbsNWb clk rst config = circuit $ \(wb, gths, Fwd txDatas) -> do
   Fwd tOutputs <- transceiverPrbsNC clk tReset config -< (Fwd tInputs, gths)
-  [wbc0, wbc1, wbc2, wbc3, wbs0, wbs1, wbs2, wbs3] <-
+  [wbc0, wbc1, wbs0, wbs1, wbs2] <-
     deviceWb clk rst (deviceConfig "Transceivers") -< wb
 
   -- Configuration registers
@@ -67,20 +66,14 @@ transceiverPrbsNWb clk rst config = circuit $ \(wb, gths, Fwd txDatas) -> do
     registerWb clk rst transceiverEnableConfig False -< (wbc0, Fwd noWrite)
   (Fwd channelEnables, _c1) <-
     registerWb clk tReset channelEnablesConfig (repeat False) -< (wbc1, Fwd noWrite)
-  (Fwd rxReadys, _c2) <-
-    registerWb clk tReset rxReadysConfig (repeat False) -< (wbc2, Fwd noWrite)
-  (Fwd txStarts, _c3) <-
-    registerWb clk tReset txStartsConfig (repeat False) -< (wbc3, Fwd noWrite)
 
   -- Status registers
   registerWb_ clk tReset statsConfig (repeat emptyStatistics)
     -< (wbs0, Fwd (Just <$> bundle tOutputs.stats))
-  registerWb_ clk tReset handshakesDoneConfig (repeat False)
-    -< (wbs1, Fwd (Just <$> bundle tOutputs.handshakesDoneFree))
-  registerWb_ clk tReset neighborReceiveReadysConfig (repeat False)
-    -< (wbs2, Fwd (Just <$> bundle tOutputs.neighborReceiveReadys))
-  registerWb_ clk tReset neighborTransmitReadysConfig (repeat False)
-    -< (wbs3, Fwd (Just <$> bundle tOutputs.neighborTransmitReadys))
+  registerWb_ clk tReset rxDataInitDoneConfig (repeat False)
+    -< (wbs1, Fwd (Just <$> bundle tOutputs.rxDataInitDonesFree))
+  registerWb_ clk tReset txDataInitDoneConfig (repeat False)
+    -< (wbs2, Fwd (Just <$> bundle tOutputs.txDataInitDonesFree))
 
   let
     noWrite = pure Nothing
@@ -91,8 +84,6 @@ transceiverPrbsNWb clk rst config = circuit $ \(wb, gths, Fwd txDatas) -> do
       CInputs
         { channelResets = map unsafeFromActiveLow (unbundle channelEnables)
         , txDatas = unbundle txDatas
-        , txStarts = unbundle (xpmCdcArraySingle clk tOutputs.txClock txStarts)
-        , rxReadys = xpmCdcSingle clk <$> tOutputs.rxClocks <*> unbundle rxReadys
         }
 
   idC -< Fwd tOutputs
@@ -106,44 +97,23 @@ transceiverPrbsNWb clk rst config = circuit $ \(wb, gths, Fwd txDatas) -> do
   channelEnablesConfig =
     (registerConfig "channel_enables")
       { description =
-          "Enable individual channels. Enabling a channel means a link will be established, provided the other side also enables it. It does not mean (user) data will be sent or received on that channel, see 'receive_readys' and 'transmit_starts'. Conversely, disabling a channel will immediately drop the link if it was up, and no data will be sent or received on that channel."
+          "Enable individual channels. Enabling a channel means a link will be established, provided the other side also enables it. Conversely, disabling a channel will immediately drop the link if it was up, and no data will be sent or received on that channel."
       }
 
-  rxReadysConfig =
-    (registerConfig "receive_readys")
+  rxDataInitDoneConfig =
+    (registerConfig "rx_data_init_dones")
       { description =
-          "Indicate ready to receive (non-link negotiation) data. You should only set this when you are actually ready to receive data, as setting it when not ready will lead to data loss. This typically means that the elastic buffer on the receiver side has space to store incoming data. Though this can be set independently of 'channel_enables', this setting has no effect unless the corresponding channel is also enabled. Once set, you must not retract readiness until the next time the channel is disabled."
+          "Receive data initialization procedure done. This means that the data presented on 'rxData' is word aligned and coming from the neighbor."
       }
 
-  txStartsConfig =
-    (registerConfig "transmit_starts")
+  txDataInitDoneConfig =
+    (registerConfig "tx_data_init_dones")
       { description =
-          "Indicate ready to transmit (non-link negotiation) data. Note that the transceiver block will not transition to sending data until you indicate the link is also ready to receive data (see 'receive_readys'). Though this can be set independently of 'channel_enables', this setting has no effect unless the corresponding channel is also enabled. Once set, you must not retract readiness until the next time the channel is disabled."
+          "Transmit data initialization procedure done. This mean that the data presented on the block's input is sampled and sent to the neighbor."
       }
 
   statsConfig =
     (registerConfig "statistics")
       { access = ReadOnly
       , description = "Various statistics from the transceiver reset manager."
-      }
-
-  handshakesDoneConfig =
-    (registerConfig "handshakes_done")
-      { access = ReadOnly
-      , description =
-          "Indicates whether link negotiation has completed for each channel. This means that, bar catastrophic failure, the link will be able to transfer user data."
-      }
-
-  neighborReceiveReadysConfig =
-    (registerConfig "neighbor_receive_readys")
-      { access = ReadOnly
-      , description =
-          "Indicates for each neighbor whether it is ready to receive data. Implies 'handshakes_done' is also 'True' for that neighbor."
-      }
-
-  neighborTransmitReadysConfig =
-    (registerConfig "neighbor_transmit_readys")
-      { access = ReadOnly
-      , description =
-          "Indicates for each neighbor whether it is ready to transmit data. Implies 'handshakes_done' is also 'True' for that neighbor."
       }

--- a/bittide/tests/Tests/Handshake.hs
+++ b/bittide/tests/Tests/Handshake.hs
@@ -1,19 +1,22 @@
 -- SPDX-FileCopyrightText: 2026 Google LLC
 --
 -- SPDX-License-Identifier: Apache-2.0
+{-# LANGUAGE OverloadedStrings #-}
+
 module Tests.Handshake where
 
-import Clash.Prelude
-import Hedgehog
+import Clash.Prelude hiding (delayN)
 
+import Bittide.ElasticBuffer (ElasticBufferData (Data))
 import Bittide.Handshake
+import Hedgehog
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (Assertion, assertEqual, testCase)
+import Test.Tasty.Hedgehog (testPropertyNamed)
+
 import qualified Data.List as List
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
-import Test.Tasty (TestTree, testGroup)
-import Test.Tasty.HUnit (Assertion, assertEqual, testCase)
-import Test.Tasty.Hedgehog (testProperty)
-import Tests.Shared (SomeSNat (..), someSNat)
 
 {- | Number of bytes in a BittideWord. Meant to be adjustable based on expected
 workload size
@@ -48,255 +51,415 @@ genOneshotTrue minK maxK len = do
 stickyTrue :: [Bool] -> [Bool]
 stickyTrue = List.drop 1 . List.scanl (||) False
 
--- | Create @n@ registers in a row, each with initial value @a@.
-registerN ::
-  forall n a dom.
-  (KnownNat n) =>
-  (NFDataX a) =>
-  (HiddenClockResetEnable dom) =>
-  SNat n ->
+{- | Create @n@ registers in a row, each with initial value @a@. Isn't synthesizable so
+takes a hedgehog-friendly 'Natural'.
+-}
+delayN ::
+  forall a dom.
+  (NFDataX a, HiddenClock dom) =>
+  Natural ->
   a ->
   Signal dom a ->
   Signal dom a
-registerN _ initVal s = register initVal $ last $ iterateI @(n + 1) (register initVal) s
+delayN n initVal s =
+  withEnable enableGen $ List.iterate (delay initVal) s List.!! fromIntegral n
+
+data HandshakeIn dom n = HandshakeIn
+  { reset :: Reset dom
+  , fromCore :: Signal dom (BitVector n)
+  , receiveOk :: Signal dom Bool
+  }
+
+data HandshakesIn dom n = HandshakesIn
+  { a :: HandshakeIn dom n
+  , b :: HandshakeIn dom n
+  }
+
+data HandshakeOut dom n = HandshakeOut
+  { toCore :: Signal dom (BitVector n)
+  , fromCoreStatus :: Signal dom Status
+  , toCoreStatus :: Signal dom Status
+  }
+
+data HandshakesOut dom n = HandshakesOut
+  { a :: HandshakeOut dom n
+  , b :: HandshakeOut dom n
+  }
 
 {- Connect two handshake state machines together, with a variable number of cycle delay
 between the two state machines. The cycle delays need not be symmetrical.
 -}
 handshakesWithDelays ::
-  forall dom n delayAB delayBA.
-  (HiddenClockResetEnable dom) =>
-  (KnownNat delayAB, KnownNat delayBA) =>
-  (KnownNat n, BitSize Meta <= n) =>
-  SNat delayAB ->
-  SNat delayBA ->
-  Signal dom (Bool, Bool) ->
-  Signal dom (BitVector n) ->
-  Signal dom (Bool, Bool) ->
-  Signal dom (BitVector n) ->
-  ( Signal dom (BitVector n)
-  , Signal dom (Bool, Bool)
-  , Signal dom (BitVector n)
-  , Signal dom (Bool, Bool)
-  )
-handshakesWithDelays delayAtoB delayBtoA regsA wordA regsB wordB = (wordA', regsA', wordB', regsB')
+  forall dom n.
+  ( HiddenClock dom
+  , KnownNat n
+  , BitSize (Meta ()) <= n
+  ) =>
+  -- | Delay from A -> B
+  Natural ->
+  -- | Delay from B -> A
+  Natural ->
+  HandshakesIn dom n ->
+  HandshakesOut dom n
+handshakesWithDelays delayAtoB delayBtoA handshakesIn =
+  HandshakesOut
+    { a =
+        HandshakeOut
+          { toCore = wireBtoA
+          , fromCoreStatus = transmitStatusA
+          , toCoreStatus = receiveStatusA
+          }
+    , b =
+        HandshakeOut
+          { toCore = wireAtoB
+          , fromCoreStatus = transmitStatusB
+          , toCoreStatus = receiveStatusB
+          }
+    }
  where
-  (wordA', wordToB, regsA') = handshake @n wordToADelayed wordA regsA
-  (wordB', wordToA, regsB') = handshake @n wordToBDelayed wordB regsB
+  (handshakeWordA, receiveStatusA, transmitStatusA, _metaA) =
+    handshake
+      @()
+      handshakesIn.a.reset
+      (Data <$> wireBtoA)
+      handshakesIn.a.receiveOk
+      (pure ())
 
-  wordToADelayed = registerN delayBtoA initValue wordToA
-  wordToBDelayed = registerN delayAtoB initValue wordToB
-  initValue = unpack 0
+  (handshakeWordB, receiveStatusB, transmitStatusB, _metaB) =
+    handshake
+      @()
+      handshakesIn.b.reset
+      (Data <$> wireAtoB)
+      handshakesIn.b.receiveOk
+      (pure ())
 
-{- A simple state machine that starts by sending dummy data. When it receives a
-lastTx to be True, it sends out the @ugn@ value next cycle, then continuously
-sends out user data values.
+  -- XXX: In practice, these words would be sourced from 'fromCore' when the handshake
+  --      component is in reset too, because we boot up 'handshakeWb' in 'PassThrough'
+  --      mode. That doesn't really make sense for this test though.
+  wordFromA = mux (transmitStatusA .== PostHandshake) handshakesIn.a.fromCore handshakeWordA
+  wordFromB = mux (transmitStatusB .== PostHandshake) handshakesIn.b.fromCore handshakeWordB
+
+  wireAtoB :: Signal dom (BitVector n)
+  wireAtoB = delayN delayAtoB garbageWord wordFromA
+
+  wireBtoA :: Signal dom (BitVector n)
+  wireBtoA = delayN delayBtoA garbageWord wordFromB
+
+garbageWord :: (KnownNat n) => BitVector n
+garbageWord = 0xDEAD_ABBA
+
+dummyWord :: (KnownNat n) => BitVector n
+dummyWord = 0x11
+
+ugnWord :: (KnownNat n) => BitVector n
+ugnWord = 0xaa
+
+userDataWord :: (KnownNat n) => BitVector n
+userDataWord = 0xff
+
+{- | What data to send (from the core) while in various stages. See 'ugnSender'. The core
+is said to be "evil" if it sends words that are parsable as handshake data, while being
+outside of the handshake period.
+-}
+data EvilDuring = EvilDuring
+  { negotiation :: Bool
+  , last :: Bool
+  , postHandshake :: Bool
+  }
+  deriving (Show)
+
+genEvilDuring :: Gen EvilDuring
+genEvilDuring = EvilDuring <$> Gen.bool <*> Gen.bool <*> Gen.bool
+
+genMeta :: Gen (Meta ())
+genMeta = Meta <$> Gen.bool <*> Gen.bool <*> pure ()
+
+{- A simple state machine that starts by sending dummy data. When it receives a 'Last', it
+sends out 'ugnWord' value next cycle, then continuously sends out 'userDataWord'. In all
+other cycles it sends 'dummyWord'.
 -}
 ugnSender ::
   forall dom n.
-  (KnownNat n, BitSize Meta <= n) =>
-  (HiddenClockResetEnable dom) =>
-  Signal dom Bool ->
+  ( HiddenClock dom
+  , KnownNat n
+  , BitSize (Meta ()) <= n
+  ) =>
+  {- | Send parsable data during stages (see 'EvilDuring'). The idea is that the handshake
+  should be wired up in such a way that data from the core gets ignored while not
+  post-handshake. Plus, while post-handshake, the handshakes should be insensitive to any
+  incoming, parsable data.
+  -}
+  EvilDuring ->
+  -- | Evil meta to send
+  Meta () ->
+  -- | @fromCore@ status
+  Signal dom Status ->
+  -- | @fromCore@
   Signal dom (BitVector n)
-ugnSender = moore updateState outputUserData initState
+ugnSender evilDuring (metaToWord -> evilMeta) status =
+  go <$> prevStatus <*> status
  where
-  dummyWord = 0x00 :: BitVector n
-  ugnWord = 0xaa :: BitVector n
-  userDataWord = 0xff :: BitVector n
+  prevStatus = withEnable enableGen $ delay Negotiating status
 
-  initState = (False, False)
+  go prev now =
+    case (prev, now) of
+      (_, Negotiating)
+        | evilDuring.negotiation -> evilMeta
+        | otherwise -> dummyWord
+      (_, Last)
+        | evilDuring.last -> evilMeta
+        | otherwise -> dummyWord
+      (Last, _) ->
+        ugnWord
+      (_, PostHandshake)
+        | evilDuring.postHandshake -> evilMeta
+        | otherwise -> userDataWord
 
-  updateState (True, False) _ = (True, True)
-  updateState (False, False) isLast = (isLast, False)
-  updateState state _ = state
+data DutIn dom = DutIn
+  { reset :: Reset dom
+  , enable :: Enable dom
+  , delay :: Natural
+  , evilDuring :: EvilDuring
+  , evilMeta :: Meta ()
+  }
 
-  outputUserData (False, _) = dummyWord -- Output dummy data since it'll be overwritten by metadata words
-  outputUserData (True, False) = ugnWord -- Output UGN
-  outputUserData (True, True) = userDataWord -- Output user data
+data DutOut dom n = DutOut
+  { toCore :: Signal dom (BitVector n)
+  , toCoreStatus :: Signal dom Status
+  , fromCore :: Signal dom (BitVector n)
+  , fromCoreStatus :: Signal dom Status
+  }
 
--- Test the property that no handshake can transition to user data before all enables from both sides are asserted
-testEnableSafety :: Property
-testEnableSafety = property $ do
-  let testLength = 100
-  txEnA <- forAll $ genStickyTrue 0 testLength testLength
-  rxEnA <- forAll $ genStickyTrue 0 testLength testLength
-  txEnB <- forAll $ genStickyTrue 0 testLength testLength
-  rxEnB <- forAll $ genStickyTrue 0 testLength testLength
+dut ::
+  (DutIn XilinxSystem, DutIn XilinxSystem) ->
+  (DutOut XilinxSystem 64, DutOut XilinxSystem 64)
+dut (dutInA, dutInB) =
+  withClock @XilinxSystem clockGen
+    $ let
+        fromCoreA = ugnSender dutInA.evilDuring dutInA.evilMeta handshakesOut.a.fromCoreStatus
+        fromCoreB = ugnSender dutInB.evilDuring dutInB.evilMeta handshakesOut.b.fromCoreStatus
 
-  delayAtoB <- forAll $ Gen.integral (Range.linear 1 19)
-  delayBtoA <- forAll $ Gen.integral (Range.linear 1 19)
+        handshakesOut =
+          handshakesWithDelays
+            dutInA.delay
+            dutInB.delay
+            HandshakesIn
+              { a =
+                  HandshakeIn
+                    { reset = dutInA.reset
+                    , fromCore = fromCoreA
+                    , receiveOk = fromEnable dutInA.enable
+                    }
+              , b =
+                  HandshakeIn
+                    { reset = dutInB.reset
+                    , fromCore = fromCoreB
+                    , receiveOk = fromEnable dutInB.enable
+                    }
+              }
 
-  let regsA = bundle (fromList txEnA, fromList rxEnA)
-      regsB = bundle (fromList txEnB, fromList rxEnB)
-      wordA = pure 0
-      wordB = pure 0
+        dutOutA =
+          DutOut
+            { toCore = handshakesOut.a.toCore
+            , toCoreStatus = handshakesOut.a.toCoreStatus
+            , fromCore = fromCoreA
+            , fromCoreStatus = handshakesOut.a.fromCoreStatus
+            }
+        dutOutB =
+          DutOut
+            { toCore = handshakesOut.b.toCore
+            , toCoreStatus = handshakesOut.b.toCoreStatus
+            , fromCore = fromCoreB
+            , fromCoreStatus = handshakesOut.b.fromCoreStatus
+            }
+       in
+        (dutOutA, dutOutB)
 
-      -- Simulate the handshake
-      (_outA, lastTxRxA, _outB, lastTxRxB) =
-        case (someSNat delayAtoB, someSNat delayBtoA) of
-          (SomeSNat (_a@SNat :: SNat delayAtoB), SomeSNat (_b@SNat :: SNat delayBtoA)) ->
-            withClockResetEnable clockGen resetGen enableGen
-              $ handshakesWithDelays @System @BittideWordSize
-                (SNat @delayAtoB)
-                (SNat @delayBtoA)
-                regsA
-                wordA
-                regsB
-                wordB
+{- | Check that the handshake never finishes if at least one handshake is in reset,
+disabled, or both.
+-}
+prop_noHandshake :: Property
+prop_noHandshake = property $ do
+  nCycles <- forAll $ Gen.int (Range.linear 8 64)
+  -- Pick which side stays blocked for the entire simulation.
+  blockedIsA <- forAll Gen.bool
+  -- Pick how the blocked side is blocked: via reset, via disabled enable, or both.
+  blockViaReset <- forAll Gen.bool
+  blockViaDisable <- forAll $ if blockViaReset then Gen.bool else pure True
 
-      (lastTxA, lastRxA) = unbundle lastTxRxA
-      (lastTxB, lastRxB) = unbundle lastTxRxB
+  -- Free side: reset deasserts (sticky-true on "not in reset"), enable asserts
+  -- (sticky-true on "enabled") at some point. Allow them to never transition by
+  -- letting @minK@ go all the way up to @nCycles@.
+  freeReset <- forAll $ genStickyTrue 0 nCycles nCycles
+  freeEnable <- forAll $ genStickyTrue 0 nCycles nCycles
 
-      -- Declare the property that the handshake will NOT assert ANY lastTx/lastRx BEFORE (ALL txEn/rxEn have been asserted TRUE)
-      allEnablesAreTrue =
-        List.zipWith4
-          (\a b c d -> a && b && c && d)
-          (stickyTrue txEnA)
-          (stickyTrue rxEnA)
-          (stickyTrue txEnB)
-          (stickyTrue rxEnB)
-      anyTransitionToUserData =
-        List.zipWith4
-          (\a b c d -> a || b || c || d)
-          (sample lastTxA)
-          (sample lastRxA)
-          (sample lastTxB)
-          (sample lastRxB)
-      myPropertyList =
-        List.take (testLength - 10) $ List.zipWith (&&) anyTransitionToUserData (not <$> allEnablesAreTrue)
-      propertyHoldsOverWholeList = and (not <$> myPropertyList)
+  delayA <- forAll $ Gen.integral (Range.linear 1 8)
+  delayB <- forAll $ Gen.integral (Range.linear 1 8)
+  evilDuringA <- forAll genEvilDuring
+  evilDuringB <- forAll genEvilDuring
+  evilMetaA <- forAll genMeta
+  evilMetaB <- forAll genMeta
 
-  assert propertyHoldsOverWholeList
+  let
+    blockedReset = if blockViaReset then List.repeat True else List.repeat False
+    blockedEnable = if blockViaDisable then List.repeat False else List.repeat True
 
--- Test the property that after all enables are asserted, the handshake completes after a bounded number of cycles
-testHandshakeLiveness :: Property
-testHandshakeLiveness = property $ do
-  let testLength = 100
-  let enableBy = 20
-  txEnA <- forAll $ genStickyTrue 0 enableBy testLength
-  rxEnA <- forAll $ genStickyTrue 0 enableBy testLength
-  txEnB <- forAll $ genStickyTrue 0 enableBy testLength
-  rxEnB <- forAll $ genStickyTrue 0 enableBy testLength
+    -- Lists of (active-high reset, enable) per cycle, padded to infinity.
+    blockedResetList = blockedReset
+    blockedEnableList = blockedEnable
+    -- Free side: starts in reset, then deasserts at some point (or never).
+    freeResetList = List.map not freeReset List.++ List.repeat False
+    freeEnableList = freeEnable List.++ List.repeat True
 
-  delayAtoB <- forAll $ Gen.integral (Range.linear 1 19)
-  delayBtoA <- forAll $ Gen.integral (Range.linear 1 19)
+    mkDutIn resetList enableList d evilDuring evilMeta =
+      withClock @XilinxSystem clockGen
+        $ DutIn
+          { reset = unsafeFromActiveHigh (fromList resetList)
+          , enable = toEnable (fromList enableList)
+          , delay = d
+          , evilDuring
+          , evilMeta
+          }
 
-  let regsA = bundle (fromList txEnA, fromList rxEnA)
-      regsB = bundle (fromList txEnB, fromList rxEnB)
-      wordA = pure 0
-      wordB = pure 0
+    (sideA, sideB)
+      | blockedIsA =
+          ( mkDutIn blockedResetList blockedEnableList delayA evilDuringA evilMetaA
+          , mkDutIn freeResetList freeEnableList delayB evilDuringB evilMetaB
+          )
+      | otherwise =
+          ( mkDutIn freeResetList freeEnableList delayA evilDuringA evilMetaA
+          , mkDutIn blockedResetList blockedEnableList delayB evilDuringB evilMetaB
+          )
 
-      -- Simulate the handshake
-      (_outA, lastTxRxA, _outB, lastTxRxB) =
-        case (someSNat delayAtoB, someSNat delayBtoA) of
-          (SomeSNat (_a@SNat :: SNat delayAtoB), SomeSNat (_b@SNat :: SNat delayBtoA)) ->
-            withClockResetEnable clockGen resetGen enableGen
-              $ handshakesWithDelays @System @BittideWordSize
-                (SNat @delayAtoB)
-                (SNat @delayBtoA)
-                regsA
-                wordA
-                regsB
-                wordB
+    (outA, outB) = dut (sideA, sideB)
 
-      (lastTxA, lastRxA) = unbundle lastTxRxA
-      (lastTxB, lastRxB) = unbundle lastTxRxB
+    aToCoreStatus = sampleN nCycles outA.toCoreStatus
+    bToCoreStatus = sampleN nCycles outB.toCoreStatus
+    aFromCoreStatus = sampleN nCycles outA.fromCoreStatus
+    bFromCoreStatus = sampleN nCycles outB.fromCoreStatus
 
-      -- Declare the property that the handshake will assert ALL lastTx/lastRx WITHIN 90 cycles of (ALL txEn/rxEn have been asserted TRUE)
-      finiteTest = List.take (testLength - 10)
-      countNumAssertTrue = List.sum . List.map fromEnum
-      numAssertTrue =
-        ( countNumAssertTrue $ finiteTest (sample lastTxA)
-        , countNumAssertTrue $ finiteTest (sample lastRxA)
-        , countNumAssertTrue $ finiteTest (sample lastTxB)
-        , countNumAssertTrue $ finiteTest (sample lastRxB)
-        )
+  footnote ("aToCoreStatus: " <> show aToCoreStatus)
+  footnote ("bToCoreStatus: " <> show bToCoreStatus)
+  footnote ("aFromCoreStatus: " <> show aFromCoreStatus)
+  footnote ("bFromCoreStatus: " <> show bFromCoreStatus)
 
-  -- Assertions
-  numAssertTrue === (1, 1, 1, 1)
+  assert (List.all (== Negotiating) aToCoreStatus)
+  assert (List.all (== Negotiating) bToCoreStatus)
+  assert (List.all (== Negotiating) aFromCoreStatus)
+  assert (List.all (== Negotiating) bFromCoreStatus)
 
--- Test that when @lastRx@ is asserted, the next cycle will be the UGN, therefore ensuring there
--- are not timing mismatches in the handshake signals.
-testHandshakeUgnCapture :: Property
-testHandshakeUgnCapture = property $ do
-  let testLength = 100
-  let enableBy = 20
-  txEnA <- forAll $ genStickyTrue 0 enableBy testLength
-  rxEnA <- forAll $ genStickyTrue 0 enableBy testLength
-  txEnB <- forAll $ genStickyTrue 0 enableBy testLength
-  rxEnB <- forAll $ genStickyTrue 0 enableBy testLength
+{- | Status sequence must match @Negotiating+ Last PostHandshake+@ exactly: one or
+more 'Negotiating', then exactly one 'Last', then one or more 'PostHandshake'.
+-}
+isValidStatusSequence :: [Status] -> Bool
+isValidStatusSequence = goNeg
+ where
+  goNeg (Negotiating : xs) = goNeg xs
+  goNeg (Last : xs) = goPost xs
+  goNeg _ = False
+  goPost [] = True
+  goPost (PostHandshake : xs) = goPost xs
+  goPost _ = False
 
-  delayAtoB <- forAll $ Gen.integral (Range.linear 1 19)
-  delayBtoA <- forAll $ Gen.integral (Range.linear 1 19)
+{- | For the cycle where status first becomes 'PostHandshake', expect 'ugnWord' on
+@toCore@. Subsequent post-handshake cycles should carry 'userDataWord'.
+-}
+checkPostHandshakeStream ::
+  (MonadTest m) => [Status] -> [BitVector 64] -> m ()
+checkPostHandshakeStream statuses words_ =
+  case List.dropWhile ((/= PostHandshake) . fst) (List.zip statuses words_) of
+    [] -> failure
+    ((_, w0) : rest) -> do
+      w0 === ugnWord
+      List.map snd rest === List.replicate (List.length rest) userDataWord
 
-  let regsA = bundle (fromList txEnA, fromList rxEnA)
-      regsB = bundle (fromList txEnB, fromList rxEnB)
-      wordA = (withClockResetEnable clockGen resetGen enableGen $ register 0 $ ugnSender lastTxA)
-      wordB = (withClockResetEnable clockGen resetGen enableGen $ register 0 $ ugnSender lastTxB)
+{- | Check that the handshake completes when both sides are eventually unblocked. After
+the unblocking, both sides should reach 'PostHandshake' on all four status signals, the
+status sequences should be monotonic with exactly one 'Last' cycle, and the first
+post-handshake word delivered on @toCore@ should be 'ugnWord' followed by 'userDataWord'
+indefinitely.
+-}
+prop_handshake :: Property
+prop_handshake = property $ do
+  let nCycles = 96
+      transitionWindow = 8
 
-      -- Simulate the handshake
-      (outA, lastTxRxA, outB, lastTxRxB) =
-        case (someSNat delayAtoB, someSNat delayBtoA) of
-          (SomeSNat (_a@SNat :: SNat delayAtoB), SomeSNat (_b@SNat :: SNat delayBtoA)) ->
-            withClockResetEnable clockGen resetGen enableGen
-              $ handshakesWithDelays @System @BittideWordSize
-                (SNat @delayAtoB)
-                (SNat @delayBtoA)
-                regsA
-                wordA
-                regsB
-                wordB
+  resetA <- forAll $ genStickyTrue 0 transitionWindow transitionWindow
+  enableA <- forAll $ genStickyTrue 0 transitionWindow transitionWindow
+  resetB <- forAll $ genStickyTrue 0 transitionWindow transitionWindow
+  enableB <- forAll $ genStickyTrue 0 transitionWindow transitionWindow
 
-      (lastTxA, lastRxA) = unbundle lastTxRxA
-      (lastTxB, lastRxB) = unbundle lastTxRxB
+  delayA <- forAll $ Gen.integral (Range.linear 1 8)
+  delayB <- forAll $ Gen.integral (Range.linear 1 8)
 
-      -- Capture how many times the UGN and lastRx are the true on 1) BOTH cycles 2) EITHER cycles
-      capturedUgnA =
-        (outA .==. pure 0xaa)
-          .&&. (withClockResetEnable clockGen resetGen enableGen $ register False lastRxA)
-      capturedUgnA' =
-        (outA .==. pure 0xaa)
-          .||. (withClockResetEnable clockGen resetGen enableGen $ register False lastRxA)
-      capturedUgnB =
-        (outB .==. pure 0xaa)
-          .&&. (withClockResetEnable clockGen resetGen enableGen $ register False lastRxB)
-      capturedUgnB' =
-        (outB .==. pure 0xaa)
-          .||. (withClockResetEnable clockGen resetGen enableGen $ register False lastRxB)
+  -- Allow evil during negotiation/Last, but not post-handshake: after the
+  -- handshake completes, ugnSender should produce userDataWord deterministically.
+  evilDuringA <- forAll $ EvilDuring <$> Gen.bool <*> Gen.bool <*> pure False
+  evilDuringB <- forAll $ EvilDuring <$> Gen.bool <*> Gen.bool <*> pure False
+  evilMetaA <- forAll genMeta
+  evilMetaB <- forAll genMeta
 
-      finiteTest = List.take (testLength - 10)
-      countNumAssertTrue = List.sum . List.map fromEnum
-      ugnCapturedA = countNumAssertTrue $ finiteTest $ sample capturedUgnA
-      ugnCapturedA' = countNumAssertTrue $ finiteTest $ sample capturedUgnA'
-      ugnCapturedB = countNumAssertTrue $ finiteTest $ sample capturedUgnB
-      ugnCapturedB' = countNumAssertTrue $ finiteTest $ sample capturedUgnB'
+  let
+    mkResetList xs = xs <> List.repeat True -- active low
+    mkEnableList xs = xs <> List.repeat True
 
-  -- Assert that the UGN and lastRx (delayed one cycle) are both only True once,
-  -- and that they are True on the same cycle.
-  ugnCapturedA === 1
-  ugnCapturedA' === 1
-  ugnCapturedB === 1
-  ugnCapturedB' === 1
+    mkDutIn r e d evilDuring evilMeta =
+      withClock @XilinxSystem clockGen
+        $ DutIn
+          { reset = unsafeFromActiveLow (fromList (mkResetList r))
+          , enable = toEnable (fromList (mkEnableList e))
+          , delay = d
+          , evilDuring
+          , evilMeta
+          }
+
+    sideA = mkDutIn resetA enableA delayA evilDuringA evilMetaA
+    sideB = mkDutIn resetB enableB delayB evilDuringB evilMetaB
+
+    (outA, outB) = dut (sideA, sideB)
+
+    aToCoreStatus = sampleN nCycles outA.toCoreStatus
+    aFromCoreStatus = sampleN nCycles outA.fromCoreStatus
+    bToCoreStatus = sampleN nCycles outB.toCoreStatus
+    bFromCoreStatus = sampleN nCycles outB.fromCoreStatus
+    aToCore = sampleN nCycles outA.toCore
+    bToCore = sampleN nCycles outB.toCore
+
+  footnote ("aToCoreStatus: " <> show aToCoreStatus)
+  footnote ("aFromCoreStatus: " <> show aFromCoreStatus)
+  footnote ("bToCoreStatus: " <> show bToCoreStatus)
+  footnote ("bFromCoreStatus: " <> show bFromCoreStatus)
+  footnote ("aToCore: " <> show aToCore)
+  footnote ("bToCore: " <> show bToCore)
+
+  -- Eventual completion + monotonic status with exactly one Last cycle.
+  assert (isValidStatusSequence aToCoreStatus)
+  assert (isValidStatusSequence aFromCoreStatus)
+  assert (isValidStatusSequence bToCoreStatus)
+  assert (isValidStatusSequence bFromCoreStatus)
+
+  -- First PostHandshake word on toCore is ugnWord, rest are userDataWord.
+  checkPostHandshakeStream aToCoreStatus aToCore
+  checkPostHandshakeStream bToCoreStatus bToCore
 
 testMetadataParsing :: Assertion
 testMetadataParsing = do
-  let regularWord = unpack 0 :: (BitVector 64)
-  let metadataWord = unpack $ magicConstant @BittideWordSize ++# (0b1110_0000 :: BitVector 8)
-  let metadata = Meta True True True 0
+  let regularWord = 0 :: BitVector 64
+  let metadataWord = magicConstant @(BittideWordSize - 3) ++# (0b111 :: BitVector 3)
+  let metadata = Meta True True True :: Meta Bool
 
-  assertEqual "Parsing regular word returns Nothing" Nothing (wordToMetadata regularWord)
-  assertEqual "Parsing metadata word returns Just xxx" (Just metadata) (wordToMetadata metadataWord)
+  assertEqual "Parsing regular word returns Nothing" Nothing (wordToMeta @() regularWord)
+  assertEqual "Parsing metadata word returns Just xxx" (Just metadata) (wordToMeta metadataWord)
   assertEqual
     "id ~ fromWord . toWord"
     (Just metadata)
-    (wordToMetadata $ metadataToWord @BittideWordSize metadata)
+    (wordToMeta @_ @BittideWordSize $ metaToWord metadata)
 
 tests :: TestTree
 tests =
   testGroup
     "Bittide.Handshake"
     [ testCase "testMetadataParsing" testMetadataParsing
-    , testProperty "testEnableSafety" testEnableSafety
-    , testProperty "testHandshakeUgnCapture" testHandshakeUgnCapture
-    , testProperty "testHandshakeLiveness" testHandshakeLiveness
+    , testPropertyNamed "prop_noHandshake" "prop_noHandshake" prop_noHandshake
+    , testPropertyNamed "prop_handshake" "prop_handshake" prop_handshake
     ]

--- a/bittide/tests/Tests/Transceiver.hs
+++ b/bittide/tests/Tests/Transceiver.hs
@@ -7,7 +7,7 @@
 
 module Tests.Transceiver where
 
-import Clash.Explicit.Prelude hiding (PeriodToCycles)
+import Clash.Explicit.Prelude hiding (PeriodToCycles, assert)
 import Clash.Prelude (withClock)
 import Hedgehog
 
@@ -27,7 +27,6 @@ import qualified Bittide.Transceiver as Transceiver
 import qualified Bittide.Transceiver.ResetManager as ResetManager
 import qualified Bittide.Transceiver.WordAlign as WordAlign
 import qualified Clash.Cores.Xilinx.Gth as Gth
-import qualified Data.List as List
 import qualified Data.Sequence as Seq
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
@@ -164,10 +163,9 @@ gthCoreMock
     predSatZeroNatural 0 = 0
     predSatZeroNatural n = n - 1
 
-data Input tx rx = Input
+data Input tx free = Input
   { dat :: Signal tx (BitVector 64)
-  , txStart :: Signal tx Bool
-  , rxReady :: Signal rx Bool
+  , channelReset :: Reset free
   }
 
 dut ::
@@ -193,8 +191,8 @@ dut ::
   Reset freeA ->
   Clock freeB ->
   Reset freeB ->
-  Input txA txB ->
-  Input txB txA ->
+  Input txA freeA ->
+  Input txB freeB ->
   ( Transceiver.Output txA txB txA txB txA freeA
   , Transceiver.Output txB txA txB txA txB freeB
   )
@@ -212,7 +210,7 @@ dut
   inputB = (outputA, outputB)
    where
     outputA =
-      Transceiver.transceiverAndHandshake
+      Transceiver.transceiverPrbsWith
         gthCoreA
         Transceiver.defConfig{Transceiver.resetManagerConfig}
         Transceiver.Input
@@ -225,20 +223,17 @@ dut
           , clockRx1 = clockGen
           , clockRx2 = clockGen
           , rxActive = pure 1 -- TODO: a better simulation of this
-          , transceiverIndex = 0
           , channelName = "A"
           , clockPath = "A clkA"
           , rxSim = delaySeqN baDelay 0 <$> outputB.txSim
           , rxN = error "A: rxN not used in simulation"
           , rxP = error "A: rxP not used in simulation"
-          , channelReset = noReset
+          , channelReset = inputA.channelReset
           , txData = inputA.dat
-          , txStart = inputA.txStart
-          , rxReady = inputA.rxReady
           }
 
     outputB =
-      Transceiver.transceiverAndHandshake
+      Transceiver.transceiverPrbsWith
         gthCoreB
         Transceiver.defConfig{Transceiver.resetManagerConfig}
         Transceiver.Input
@@ -251,16 +246,13 @@ dut
           , clockRx1 = clockGen
           , clockRx2 = clockGen
           , rxActive = pure 1
-          , transceiverIndex = 1
           , channelName = "B"
           , clockPath = "B clkB"
           , rxSim = delaySeqN abDelay 0 <$> outputA.txSim
           , rxN = error "B: rxN not used in simulation"
           , rxP = error "B: rxP not used in simulation"
-          , channelReset = noReset
+          , channelReset = inputB.channelReset
           , txData = inputB.dat
-          , txStart = inputB.txStart
-          , rxReady = inputB.rxReady
           }
 
 type DutTestFunc txA txB free =
@@ -270,7 +262,7 @@ type DutTestFunc txA txB free =
 
 type InputFunc txA txB free =
   Transceiver.Output txA txB txA txB txA free ->
-  Input txA txB
+  Input txA free
 
 dutRandomized ::
   forall txA txB free.
@@ -343,181 +335,86 @@ dutRandomized f inputA inputB Proxy = property $ do
 
   f outputA outputB
 
-{- | Tests whether the link is up within 500 milliseconds. This also asserts that
-the handshake is done
+-- | Input with no applied 'channelReset' and arbitrary TX data.
+noResetInput :: (KnownDomain free) => InputFunc txA txB free
+noResetInput _ = Input{dat = maxBound, channelReset = noReset}
+
+{- | Observation window (in @free@-domain cycles) used by 'testUp500ms' and
+'testNeverUp500ms'. 500 ms is comfortably above the link-up latency produced
+by 'dutRandomized'.
 -}
-testUp500ms :: DutTestFunc txA txB free
+window500ms :: forall free. (KnownDomain free) => Proxy free -> Int
+window500ms Proxy =
+  fromIntegral (maxBound :: Index (PeriodToCycles free (Milliseconds 500)))
+
+-- | Input that holds 'channelReset' asserted forever.
+heldResetInput :: (KnownDomain free) => InputFunc txA txB free
+heldResetInput _ =
+  Input{dat = maxBound, channelReset = unsafeFromActiveHigh (pure True)}
+
+-- | Both sides reach @rx/txDataInitDone@ within 500 ms.
+testUp500ms ::
+  forall txA txB free. (KnownDomain free) => DutTestFunc txA txB free
 testUp500ms outputA outputB =
-  case sampledAfterStable of
-    [] -> failure
-    (List.map snd -> ups) -> do
-      let n = 100
-      List.take n ups === List.replicate n True
+  assert (or (sampleN (window500ms (Proxy @free)) allUp))
  where
-  handshakeDone = outputA.handshakeDoneFree .&&. outputB.handshakeDoneFree
-  linksUp = outputA.debugLinkUp .&&. outputB.debugLinkUp
-  nCycles = fromIntegral (maxBound :: Index (PeriodToCycles Free (Milliseconds 500)))
-  sampledLinksUp = sampleN nCycles (linksUp .&&. handshakeDone)
-  sampledAfterStable = List.dropWhile (not . snd) (List.zip [(0 :: Int) ..] sampledLinksUp)
+  allUp =
+    outputA.rxDataInitDoneFree
+      .&&. outputB.rxDataInitDoneFree
+      .&&. outputA.txDataInitDoneFree
+      .&&. outputB.txDataInitDoneFree
 
--- | Tests whether the link is up within 500 milliseconds
-testHandshakeDone500ms :: DutTestFunc txA txB free
-testHandshakeDone500ms outputA outputB =
-  case sampledAfterStable of
-    [] -> failure
-    (List.map snd -> ups) -> do
-      let n = 100
-      List.take n ups === List.replicate n True
- where
-  linksUp = outputA.handshakeDoneFree .&&. outputB.handshakeDoneFree
-  nCycles = fromIntegral (maxBound :: Index (PeriodToCycles Free (Milliseconds 500)))
-  sampledLinksUp = sampleN nCycles linksUp
-  sampledAfterStable = List.dropWhile (not . snd) (List.zip [(0 :: Int) ..] sampledLinksUp)
+-- | Neither side ever reaches @rxDataInitDone@ within 500 ms.
+testNeverUp500ms ::
+  forall txA txB free. (KnownDomain free) => DutTestFunc txA txB free
+testNeverUp500ms outputA outputB = do
+  let n = window500ms (Proxy @free)
+  assert (not (or (sampleN n outputA.rxDataInitDoneFree)))
+  assert (not (or (sampleN n outputB.rxDataInitDoneFree)))
 
--- | Test whether the link is never up within 500 milliseconds
-testNeitherUp500ms :: DutTestFunc txA txB free
-testNeitherUp500ms outputA outputB =
-  False === or (sampleN nCycles linksUp)
- where
-  linksUp = outputA.debugLinkUp .||. outputB.debugLinkUp
-  nCycles = fromIntegral (maxBound :: Index (PeriodToCycles Free (Milliseconds 500)))
-
--- | Test whether the link is never up within 500 milliseconds
-testNotBothUp500ms :: DutTestFunc txA txB free
-testNotBothUp500ms outputA outputB =
-  False === or (sampleN nCycles linksUp)
- where
-  linksUp = (outputA.debugLinkUp .==. pure True) .&&. (outputB.debugLinkUp .==. pure True)
-  nCycles = fromIntegral (maxBound :: Index (PeriodToCycles Free (Milliseconds 500)))
-
--- Input that applies no (back)pressure on the link
-noPressureInput :: InputFunc txA txB free
-noPressureInput _ = Input{dat = complement <$> 0, txStart = pure True, rxReady = pure True}
-
--- | Input that ties 'txStart' to 'txReady'
-txStartEqTxReady :: InputFunc txA txB free
-txStartEqTxReady i = (noPressureInput i){txStart = i.txReady}
-
--- Input that never sets 'txStart' to 'True'
-noTxStartInput :: InputFunc txA txB free
-noTxStartInput i = (noPressureInput i){txStart = pure False}
-
--- Input that never sets 'rxReady' to 'True'
-noRxReadyInput :: InputFunc txA txB free
-noRxReadyInput i = (noPressureInput i){rxReady = pure False}
-
--- Input that never sets 'txStart' to 'True'
-noTxStartNoRxReadyInput :: InputFunc txA txB free
-noTxStartNoRxReadyInput i = (noPressureInput i){txStart = pure False, rxReady = pure False}
-
-{- | Check whether handshake works when there is no pressure on the link,
-specialized to 'A', 'A', 'FreeSlow'.
+{- | With no 'channelReset' asserted on either side, the link must come up. This test is
+repeated for a number of other domains -- initialization should work for all of these.
+The combination of domains are left out from other tests as these tests are mighty slow
+and I suspect there isn't much more value to it.
 -}
-prop_noPressure_A_A_FreeSlow :: Property
-prop_noPressure_A_A_FreeSlow =
-  dutRandomized @A @A @FreeSlow testUp500ms noPressureInput noPressureInput Proxy
+prop_bothDeasserted_AA :: Property
+prop_bothDeasserted_AA =
+  dutRandomized @A @A @Free testUp500ms noResetInput noResetInput Proxy
 
-{- | Check whether handshake works when there is no pressure on the link,
-specialized to 'A', 'A', 'Free'.
--}
-prop_noPressure_A_A_Free :: Property
-prop_noPressure_A_A_Free =
-  dutRandomized @A @A @Free testUp500ms noPressureInput noPressureInput Proxy
+prop_bothDeasserted_AAS :: Property
+prop_bothDeasserted_AAS =
+  dutRandomized @A @A @FreeSlow testUp500ms noResetInput noResetInput Proxy
 
-{- | Check whether handshake works when there is no pressure on the link,
-specialized to 'A', 'A', 'FreeFast'.
--}
-prop_noPressure_A_A_FreeFast :: Property
-prop_noPressure_A_A_FreeFast =
-  dutRandomized @A @A @FreeFast testUp500ms noPressureInput noPressureInput Proxy
+prop_bothDeasserted_AAF :: Property
+prop_bothDeasserted_AAF =
+  dutRandomized @A @A @FreeFast testUp500ms noResetInput noResetInput Proxy
 
-{- | Check whether handshake works when there is no pressure on the link,
-specialized to 'A', 'B', 'Free'.
--}
-prop_noPressure_A_B_Free :: Property
-prop_noPressure_A_B_Free =
-  dutRandomized @A @B @Free testUp500ms noPressureInput noPressureInput Proxy
+prop_bothDeasserted_AB :: Property
+prop_bothDeasserted_AB =
+  dutRandomized @A @B @Free testUp500ms noResetInput noResetInput Proxy
 
-{- | Check whether handshake works when there is no pressure on the link,
-specialized to 'B', 'A', 'Free'.
--}
-prop_noPressure_B_A_Free :: Property
-prop_noPressure_B_A_Free =
-  dutRandomized @B @A @Free testUp500ms noPressureInput noPressureInput Proxy
+prop_bothDeasserted_ABS :: Property
+prop_bothDeasserted_ABS =
+  dutRandomized @A @B @FreeSlow testUp500ms noResetInput noResetInput Proxy
 
--- | Check whether handshake works when 'txStart' is tied to 'txReady'
-prop_txStartEqTxReady :: Property
-prop_txStartEqTxReady =
-  dutRandomized @B @A @Free testUp500ms txStartEqTxReady noPressureInput Proxy
+prop_bothDeasserted_ABF :: Property
+prop_bothDeasserted_ABF =
+  dutRandomized @A @B @FreeFast testUp500ms noResetInput noResetInput Proxy
 
--- | Check whether handshake works when 'txStart' is tied to 'txReady'
-prop_txStartEqTxReadyFlipped :: Property
-prop_txStartEqTxReadyFlipped =
-  dutRandomized @B @A @Free testUp500ms noPressureInput txStartEqTxReady Proxy
+-- | If A's 'channelReset' is held asserted forever, neither side comes up.
+prop_heldOnA :: Property
+prop_heldOnA =
+  dutRandomized @A @A @Free testNeverUp500ms heldResetInput noResetInput Proxy
 
--- | Check whether handshake works when 'txStart' is tied to 'txReady'
-prop_txStartEqTxReadyBoth :: Property
-prop_txStartEqTxReadyBoth =
-  dutRandomized @B @A @Free testUp500ms txStartEqTxReady txStartEqTxReady Proxy
+-- | If B's 'channelReset' is held asserted forever, neither side comes up.
+prop_heldOnB :: Property
+prop_heldOnB =
+  dutRandomized @A @A @Free testNeverUp500ms noResetInput heldResetInput Proxy
 
-{- | Check whether neither handshake works when one of the transceivers never
-indicates it's ready to the other.
--}
-prop_noTxReady :: Property
-prop_noTxReady =
-  dutRandomized @A @A @Free testNeitherUp500ms noPressureInput noTxStartInput Proxy
-
--- | Same as 'prop_noTxReady', but with the transceivers flipped
-prop_noTxReadyFlipped :: Property
-prop_noTxReadyFlipped =
-  dutRandomized @A @A @Free testNeitherUp500ms noTxStartInput noPressureInput Proxy
-
-{- | Check whether neither node indicates it's up, when it never transitions to
-sending user data.
--}
-prop_noRxReady :: Property
-prop_noRxReady =
-  dutRandomized @A @A @Free testNeitherUp500ms noRxReadyInput noRxReadyInput Proxy
-
-{- | Check that neither node indicates it is sending *and* receiving user data,
-when one of the nodes never indicates it's ready to receive data. The side that
-never indicates it's ready to receive data, should also never start sending user
-data, because it would lose the ability to apply backpressure. The other side
-should then naturally also not claim it is receiving user data.
--}
-prop_noRxReadyNoPressure :: Property
-prop_noRxReadyNoPressure =
-  dutRandomized @A @A @Free testNeitherUp500ms noRxReadyInput noPressureInput Proxy
-
--- | Same as 'prop_noRxReadyNoPressure', but flipped.
-prop_noPressureNoRxReady :: Property
-prop_noPressureNoRxReady =
-  dutRandomized @A @A @Free testNeitherUp500ms noPressureInput noRxReadyInput Proxy
-
-{- | Check that nodes complete their handshake, even when the users never indicate
-that they're ready to receive data.
--}
-prop_handshakeNoRxReady :: Property
-prop_handshakeNoRxReady =
-  dutRandomized @A @A @Free testHandshakeDone500ms noRxReadyInput noRxReadyInput Proxy
-
-{- | Check that nodes complete their handshake, even when the users never indicate
-that they're ready to send data.
--}
-prop_handshakeNoTxStart :: Property
-prop_handshakeNoTxStart =
-  dutRandomized @A @A @Free testHandshakeDone500ms noTxStartInput noTxStartInput Proxy
-
-{- | Check that nodes complete their handshake, even when the users never indicate
-that they're ready to receive or send data.
--}
-prop_handshakeNoTxStartNoRxReady :: Property
-prop_handshakeNoTxStartNoRxReady =
-  dutRandomized @A @A @Free
-    testHandshakeDone500ms
-    noTxStartNoRxReadyInput
-    noTxStartNoRxReadyInput
-    Proxy
+-- | If both sides hold 'channelReset' asserted forever, neither side comes up.
+prop_heldOnBoth :: Property
+prop_heldOnBoth =
+  dutRandomized @A @A @Free testNeverUp500ms heldResetInput heldResetInput Proxy
 
 -- TODO: Add tests for actual data transmission. This currently only happens in
 --       hardware, as we currently don't have the infrastructure to memory-efficiently
@@ -539,33 +436,16 @@ tests :: TestTree
 tests =
   -- XXX: The number of tests we run is very low, due to the time it takes to
   --      execute them.
-  testGroup
-    "Transceiver"
-    [ adjustOption (\_ -> HedgehogTestLimit (Just 100))
-        $ testGroup
-          "Slow tests"
-          [ testPropertyThName 'prop_noPressure_A_A_FreeSlow prop_noPressure_A_A_FreeSlow
-          , testPropertyThName 'prop_noPressure_A_A_Free prop_noPressure_A_A_Free
-          , testPropertyThName 'prop_noPressure_A_A_FreeFast prop_noPressure_A_A_FreeFast
-          , testPropertyThName 'prop_noPressure_A_B_Free prop_noPressure_A_B_Free
-          , testPropertyThName 'prop_noPressure_B_A_Free prop_noPressure_B_A_Free
-          , testPropertyThName 'prop_txStartEqTxReady prop_txStartEqTxReady
-          , testPropertyThName 'prop_txStartEqTxReadyFlipped prop_txStartEqTxReadyFlipped
-          , testPropertyThName 'prop_txStartEqTxReadyBoth prop_txStartEqTxReadyBoth
-          , testPropertyThName 'prop_handshakeNoRxReady prop_handshakeNoRxReady
-          , testPropertyThName 'prop_handshakeNoTxStart prop_handshakeNoTxStart
-          , testPropertyThName 'prop_handshakeNoTxStartNoRxReady prop_handshakeNoTxStartNoRxReady
-          ]
-    , adjustOption (\_ -> HedgehogTestLimit (Just 10))
-        $ testGroup
-          "Very slow tests"
-          -- These tests are "very slow" because they cannot exit early on some
-          -- condition. Instead, they just wait for some deadline, and if they don't
-          -- see an erroneous condition by then, they pass.
-          [ testPropertyThName 'prop_noTxReady prop_noTxReady
-          , testPropertyThName 'prop_noTxReadyFlipped prop_noTxReadyFlipped
-          , testPropertyThName 'prop_noRxReady prop_noRxReady
-          , testPropertyThName 'prop_noRxReadyNoPressure prop_noRxReadyNoPressure
-          , testPropertyThName 'prop_noPressureNoRxReady prop_noPressureNoRxReady
-          ]
-    ]
+  adjustOption (\_ -> HedgehogTestLimit (Just 10))
+    $ testGroup
+      "Transceiver"
+      [ testPropertyThName 'prop_bothDeasserted_AA prop_bothDeasserted_AA
+      , testPropertyThName 'prop_bothDeasserted_AAS prop_bothDeasserted_AAS
+      , testPropertyThName 'prop_bothDeasserted_AAF prop_bothDeasserted_AAF
+      , testPropertyThName 'prop_bothDeasserted_AB prop_bothDeasserted_AB
+      , testPropertyThName 'prop_bothDeasserted_ABS prop_bothDeasserted_ABS
+      , testPropertyThName 'prop_bothDeasserted_ABF prop_bothDeasserted_ABF
+      , testPropertyThName 'prop_heldOnA prop_heldOnA
+      , testPropertyThName 'prop_heldOnB prop_heldOnB
+      , testPropertyThName 'prop_heldOnBoth prop_heldOnBoth
+      ]

--- a/firmware-binaries/demos/soft-ugn-mu/src/main.rs
+++ b/firmware-binaries/demos/soft-ugn-mu/src/main.rs
@@ -62,6 +62,7 @@ fn initialize_calendars(uart: &mut Uart) {
 fn main() -> ! {
     let mut uart = INSTANCES.uart;
     let transceivers = &INSTANCES.transceivers;
+    let handshakes = &INSTANCES.handshakes;
     let cc = INSTANCES.clock_control;
 
     let elastic_buffers = [
@@ -87,12 +88,7 @@ fn main() -> ! {
     let mut link_startups = [LinkStartup::new(); 7];
     while !link_startups.iter().all(|ls| ls.is_done()) {
         for (i, link_startup) in link_startups.iter_mut().enumerate() {
-            link_startup.next(
-                transceivers,
-                i,
-                elastic_buffers[i],
-                capture_ugns[i].has_captured(),
-            );
+            link_startup.next(transceivers, handshakes, i, elastic_buffers[i]);
         }
     }
 

--- a/firmware-binaries/demos/wire-demo-mu/src/main.rs
+++ b/firmware-binaries/demos/wire-demo-mu/src/main.rs
@@ -20,6 +20,7 @@ use riscv_rt::entry;
 fn main() -> ! {
     let mut uart = INSTANCES.uart;
     let transceivers = &INSTANCES.transceivers;
+    let handshakes = &INSTANCES.handshakes;
     let cc = INSTANCES.clock_control;
 
     let elastic_buffers = [
@@ -45,12 +46,7 @@ fn main() -> ! {
     let mut link_startups = [LinkStartup::new(); 7];
     while !link_startups.iter().all(|ls| ls.is_done()) {
         for (i, link_startup) in link_startups.iter_mut().enumerate() {
-            link_startup.next(
-                transceivers,
-                i,
-                elastic_buffers[i],
-                capture_ugns[i].has_captured(),
-            );
+            link_startup.next(transceivers, handshakes, i, elastic_buffers[i]);
         }
     }
 

--- a/firmware-support/bittide-sys/src/link_startup.rs
+++ b/firmware-support/bittide-sys/src/link_startup.rs
@@ -2,81 +2,130 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use bittide_hal::shared_devices::{ElasticBuffer, Transceivers};
+use bittide_hal::shared_devices::{ElasticBuffer, Handshakes, Transceivers};
+use bittide_hal::types::mode::Mode;
 
 #[derive(Debug, Copy, Clone, PartialEq)]
-pub enum UgnCaptureState {
-    WaitForChannelNegotiation,
-    WaitForNeighborTransmitReady,
-    SwitchUserMode,
-    WaitForUgnCapture,
+pub enum LinkStartupState {
+    WaitForRxInitDone,
+    EnableHandshake,
+    WaitForTxInitDone,
+    SignalSoftwareReady,
+    WaitForNeighborSoftwareReady,
+    CenterElasticBuffer,
+    SignalReceiveReady,
+    WaitForReceiveDone,
+    EnableAutoCenter,
+    WaitForHandshakeDone,
     Done,
 }
 
 #[derive(Debug, Copy, Clone)]
 pub struct LinkStartup {
-    pub state: UgnCaptureState,
+    pub state: LinkStartupState,
 }
 
 impl LinkStartup {
-    /// Create a new LinkStartup
     pub fn new() -> Self {
         Self {
-            state: UgnCaptureState::WaitForChannelNegotiation,
+            state: LinkStartupState::WaitForRxInitDone,
         }
     }
 
-    /// Transition to the next state based on current conditions
     pub fn next(
         &mut self,
         transceivers: &Transceivers,
+        handshakes: &Handshakes,
         channel: usize,
         elastic_buffer: &ElasticBuffer,
-        captured_ugn: bool,
     ) {
         self.state = match self.state {
-            UgnCaptureState::WaitForChannelNegotiation => {
+            LinkStartupState::WaitForRxInitDone => {
                 if transceivers
-                    .handshakes_done(channel)
+                    .rx_data_init_dones(channel)
                     .expect("Channel out of range")
                 {
-                    transceivers.set_transmit_starts(channel, true);
-                    UgnCaptureState::WaitForNeighborTransmitReady
+                    LinkStartupState::EnableHandshake
                 } else {
                     self.state
                 }
             }
-            UgnCaptureState::WaitForNeighborTransmitReady => {
+            LinkStartupState::EnableHandshake => {
+                handshakes
+                    .set_modes(channel, Mode::Enabled)
+                    .expect("Channel out of range");
+                LinkStartupState::WaitForTxInitDone
+            }
+            LinkStartupState::WaitForTxInitDone => {
                 if transceivers
-                    .neighbor_transmit_readys(channel)
+                    .tx_data_init_dones(channel)
                     .expect("Channel out of range")
                 {
-                    UgnCaptureState::SwitchUserMode
+                    LinkStartupState::SignalSoftwareReady
                 } else {
                     self.state
                 }
             }
-            UgnCaptureState::SwitchUserMode => {
-                // Center the elastic buffer once before switching to user mode
+            LinkStartupState::SignalSoftwareReady => {
+                let mut srs = handshakes.software_readys();
+                srs.set(channel, true).expect("Channel out of range");
+                handshakes.set_software_readys(srs);
+                LinkStartupState::WaitForNeighborSoftwareReady
+            }
+            LinkStartupState::WaitForNeighborSoftwareReady => {
+                if handshakes
+                    .neighbor_software_readys()
+                    .get(channel)
+                    .expect("Channel out of range")
+                {
+                    LinkStartupState::CenterElasticBuffer
+                } else {
+                    self.state
+                }
+            }
+            LinkStartupState::CenterElasticBuffer => {
                 elastic_buffer.set_occupancy(0);
                 elastic_buffer.set_clear_status_registers(true);
-                transceivers.set_receive_readys(channel, true);
-                UgnCaptureState::WaitForUgnCapture
+                LinkStartupState::SignalReceiveReady
             }
-            UgnCaptureState::WaitForUgnCapture => {
-                if captured_ugn {
-                    elastic_buffer.set_auto_center_enable(true);
-                    UgnCaptureState::Done
+            LinkStartupState::SignalReceiveReady => {
+                let mut rrs = handshakes.receive_readys();
+                rrs.set(channel, true).expect("Channel out of range");
+                handshakes.set_receive_readys(rrs);
+                LinkStartupState::WaitForReceiveDone
+            }
+            LinkStartupState::WaitForReceiveDone => {
+                if handshakes
+                    .receive_dones()
+                    .get(channel)
+                    .expect("Channel out of range")
+                {
+                    LinkStartupState::EnableAutoCenter
                 } else {
                     self.state
                 }
             }
-            UgnCaptureState::Done => self.state,
+            LinkStartupState::EnableAutoCenter => {
+                elastic_buffer.set_auto_center_enable(true);
+                LinkStartupState::WaitForHandshakeDone
+            }
+            LinkStartupState::WaitForHandshakeDone => {
+                if handshakes
+                    .handshake_dones()
+                    .get(channel)
+                    .expect("Channel out of range")
+                {
+                    LinkStartupState::Done
+                } else {
+                    self.state
+                }
+            }
+            LinkStartupState::Done => self.state,
         };
     }
 
     pub fn is_done(&self) -> bool {
-        self.state == UgnCaptureState::Done
+        self.state == LinkStartupState::Done
     }
 }
 


### PR DESCRIPTION
Fixes #1253 
Fixes #1257

_What (what did you do)_
I moved the user data handshake out of the transceiver block and into a separate component. This makes sure we can run it after the elastic buffers.

_Why (context, issues, etc.)_
In the future we expect we'll move to platforms where we won't control anything before the elastic buffers. This PR therefore prepares us for situations like that.

_Dear reviewer (anything you'd like the reviewer to pay close attention to?)_
Not in particular.

_AI disclaimer (heads-up for more than inline autocomplete)_
No.

# TODO
_~~Cross-out~~ any that do not apply_

- [X] Write (regression) test
- [X] Update documentation, including `docs/`
- [x] Link to existing issue
- [x] ~~Test handshake for correct auto-center behavior -- I think it currently behaves erratically if it misses frames~~ I'm pretty sure this is Okay now, but for ASIC I'd like to see this in a test. Reported as issue: https://github.com/bittide/bittide-hardware/issues/1286.
- [x] Have a good hard look at the Rust code
- [x] Merge fixes from WIP branch (minor CI fixes)
- [x] Merge https://github.com/bittide/bittide-hardware/pull/1264
- [x] Write cover letter
- [X] Run `all` test: https://github.com/bittide/bittide-hardware/actions/runs/25903960537: soft UGN demo flaky, but that's a known issue.