### PR TITLE
Notify Slack on nightly failure

### DIFF
--- a/.github/scripts/all_check.py
+++ b/.github/scripts/all_check.py
@@ -17,11 +17,15 @@ import yaml
 CI_PATH = ".github/workflows/ci.yml"
 ALL_TEST = "all"
 
+# Jobs that intentionally do not gate the 'all' status check, e.g. because they
+# run *after* 'all' to react to its result.
+EXCLUDED_JOBS = {"notify-slack"}
+
 def main():
   ci_yml_fp = open(CI_PATH, "r")
   ci_yml_parsed = yaml.load(ci_yml_fp, Loader=yaml.FullLoader)
 
-  all_jobs = set(ci_yml_parsed['jobs'].keys()) - {ALL_TEST}
+  all_jobs = set(ci_yml_parsed['jobs'].keys()) - {ALL_TEST} - EXCLUDED_JOBS
   all_needs = set(ci_yml_parsed["jobs"][ALL_TEST]["needs"])
 
   if all_jobs - all_needs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -773,6 +773,26 @@ jobs:
 
       # Deployment: see .github/workflows/deploy-documentation.yml
 
+  notify-slack:
+    name: Notify Slack on scheduled failure
+    if: ${{ failure() && github.event_name == 'schedule' }}
+    needs: [all]
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Post failure notification to Slack
+        uses: slackapi/slack-github-action@v3.0.3
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: ${{ secrets.SLACK_CHANNEL_ID }}
+            text: "Nightly CI failed on `${{ github.ref_name }}`: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            blocks:
+              - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: "*Nightly CI failed* on `${{ github.ref_name }}` (commit `${{ github.sha }}`)\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>"
+
   all:
     name: All jobs finished
     if: ${{ !cancelled() }}


### PR DESCRIPTION
_What (what did you do)_
I added a job that posts to our #bittide Slack channel whenever a nightly fails.

_Why (context, issues, etc.)_
Nightly has been broken for two weeks now and we didn't notice.. See https://github.com/bittide/bittide-hardware/issues/1276.

_Dear reviewer (anything you'd like the reviewer to pay close attention to?)_
~~It currently always runs, just to test the integration.~~ No.

_AI disclaimer (heads-up for more than inline autocomplete)_
Nope.

# TODO
_~~Cross-out~~ any that do not apply_

- [X] ~~Write (regression) test~~
- [X] ~~Update documentation, including `docs/`~~
- [X] Link to existing issue
