### PR TITLE
Fix race condition in Cargo when building both debug and release

### DIFF
--- a/bittide-instances/tests/unittests.hs
+++ b/bittide-instances/tests/unittests.hs
@@ -65,8 +65,11 @@ prepareTests = do
     dependentTestGroup
       "bittide-instances"
       AllSucceed
-      [ testGroup
+      [ -- These 2 cargo build commands are not actually dependent on eachother, but they
+        -- cannot happen in parallel as it could cause a race condition in Cargo.
+        dependentTestGroup
           "Build Rust crates"
+          AllSucceed
           [ testCase "release" (run "./cargo.sh" ["build", "--release"] (Just gitRoot))
           , testCase "debug" (run "./cargo.sh" ["build"] (Just gitRoot))
           ]


### PR DESCRIPTION
_What (what did you do)_
See PR title

_Why (context, issues, etc.)_
We've observed intermittent failing unittests for bittide-instances (last 3 days: [1](https://github.com/bittide/bittide-hardware/actions/runs/25397930944/job/74489878896), [2]()https://github.com/bittide/bittide-hardware/actions/runs/25339182288/job/74292323390, [3](https://github.com/bittide/bittide-hardware/actions/runs/25288467353/job/74136610665)). Note that 3 did not even fail, whereas 1 and 2 show a different but similar error. This seems to look like a race condition in Cargo when build both debug and release builds in parallel. 

We're not entirely sure why this did not show up in unscheduled CI runs (on pushes). Our guess on why it is happening _now_ is that debug builds now take longer than before PR https://github.com/bittide/bittide-hardware/pull/1245.

_Dear reviewer (anything you'd like the reviewer to pay close attention to?)_
Nothing

_AI disclaimer (heads-up for more than inline autocomplete)_
Nothing

# TODO
_~~Cross-out~~ any that do not apply_

- [ ] ~Write (regression) test~
- [ ] ~Update documentation, including `docs/`~
- [ ] Link to existing issue 
