### PR TITLE
Bump forgotten `actions/checkout` to `v6`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -396,7 +396,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - run: cache pull cargo
       - run: cache pull build


### PR DESCRIPTION
I guess this one was missed last time around, all the others have been bumped already!
