### PR TITLE
Use `-K512M -H -I5 -T` instead of `-A128M` rtsopts

### DIFF
--- a/bittide-instances/bittide-instances.cabal
+++ b/bittide-instances/bittide-instances.cabal
@@ -369,7 +369,7 @@ test-suite unittests
 executable clash
   ghc-options:
     -threaded
-    "-with-rtsopts -qn4 -A128M"
+    "-with-rtsopts -qn4 -K512M -H -I5 -T"
 
   main-is: exe/clash/Main.hs
   build-depends:

--- a/cabal.project
+++ b/cabal.project
@@ -32,7 +32,7 @@ package zlib
   flags: +pkg-config
 
 package *
-  ghc-options: +RTS -qn4 -A128M -RTS
+  ghc-options: +RTS -qn4 -K512M -H -I5 -T -RTS
 semaphore: true
 jobs: $ncpus
 


### PR DESCRIPTION
more fast more better

See also https://github.com/clash-lang/clash-compiler/pull/3244
