### PR TITLE
Fix debug profile options for Rust builds

### DIFF
--- a/firmware-binaries/Cargo.toml
+++ b/firmware-binaries/Cargo.toml
@@ -8,8 +8,7 @@ incremental = false
 lto = true
 opt-level = "z"
 panic = "abort"
-split-debuginfo = "packed"
-strip = "symbols"
+split-debuginfo = "unpacked"
 
 [profile.release]
 codegen-units = 1

--- a/firmware-support/Cargo.toml
+++ b/firmware-support/Cargo.toml
@@ -8,8 +8,7 @@ incremental = false
 lto = true
 opt-level = "z"
 panic = "abort"
-split-debuginfo = "packed"
-strip = "symbols"
+split-debuginfo = "unpacked"
 
 [profile.release]
 codegen-units = 1


### PR DESCRIPTION
_What (what did you do)_
Removed the `strip` option from the debug profile for Rust builds. As noted [here](https://users.rust-lang.org/t/how-to-gdb-with-split-debug-files/102989/2), adding the strip option strips out the headers that the split debuginfo files use, which broke things that relied on debug headers.

_Why (context, issues, etc.)_
`VexRiscvTest` was failing.

_Dear reviewer (anything you'd like the reviewer to pay close attention to?)_
Should I consider writing up something like what user p-kraszewski has in that thread? I don't know if it would be worth the effort, but it should certainly be doable at least.

_AI disclaimer (heads-up for more than inline autocomplete)_
None.

# TODO
_~~Cross-out~~ any that do not apply_

- [ ] ~~Write (regression) test~~
- [ ] ~~Update documentation, including `docs/`~~
- [ ] ~~Link to existing issue~~
- [x] Refer to existing issue (:
