### PR TITLE
Fix SDPE firmware after HAL type wrapping change

### DIFF
--- a/firmware-binaries/Cargo.lock
+++ b/firmware-binaries/Cargo.lock
@@ -835,6 +835,7 @@ name = "switch_demo_pe_test"
 version = "0.1.0"
 dependencies = [
  "bittide-hal",
+ "bittide-macros",
  "bittide-sys",
  "log",
  "memmap-generate",

--- a/firmware-binaries/sim-tests/switch_demo_pe_test/Cargo.toml
+++ b/firmware-binaries/sim-tests/switch_demo_pe_test/Cargo.toml
@@ -17,6 +17,7 @@ workspace = true
 [dependencies]
 bittide-sys = { path = "../../../firmware-support/bittide-sys" }
 bittide-hal = { path = "../../../firmware-support/bittide-hal" }
+bittide-macros = { path = "../../../firmware-support/bittide-macros" }
 riscv-rt = "0.11.0"
 ufmt = "0.2.0"
 

--- a/firmware-binaries/sim-tests/switch_demo_pe_test/src/main.rs
+++ b/firmware-binaries/sim-tests/switch_demo_pe_test/src/main.rs
@@ -6,6 +6,7 @@
 #![feature(sync_unsafe_cell)]
 
 use bittide_hal::{hals::switch_demo_pe_test::DeviceInstances, manual_additions::timer::Duration};
+use bittide_macros::{index, unsigned};
 use bittide_sys::{switch_demo_pe::NodeIterator, uart::log::LOGGER};
 use core::fmt::Write;
 use log::{info, LevelFilter};
@@ -45,36 +46,36 @@ fn main() -> ! {
 
     info!(
         "Local counter: 0x{:X}",
-        switch_pe_a.local_clock_cycle_counter()
+        switch_pe_a.local_clock_cycle_counter().into_inner()
     );
 
-    let first_transfer_start = 0x10000;
-    let second_transfer_start = 0x10100;
+    let first_transfer_start = unsigned!(0x10000, n = 64);
+    let second_transfer_start = unsigned!(0x10100, n = 64);
 
     // A only writes its own data
     switch_pe_a.set_write_start(first_transfer_start);
-    switch_pe_a.set_write_cycles(1);
+    switch_pe_a.set_write_cycles(index!(1, n = 3));
     // B reads data from A
     switch_pe_b.set_read_start(first_transfer_start);
-    switch_pe_b.set_read_cycles(1);
+    switch_pe_b.set_read_cycles(index!(1, n = 3));
     // B writes its own data and data received from A
     switch_pe_b.set_write_start(second_transfer_start);
-    switch_pe_b.set_write_cycles(2);
+    switch_pe_b.set_write_cycles(index!(2, n = 3));
     // A reads all data from B
     switch_pe_a.set_read_start(second_transfer_start);
-    switch_pe_a.set_read_cycles(2);
+    switch_pe_a.set_read_cycles(index!(2, n = 3));
 
     timer.wait(Duration::from_micros(600));
 
-    let rs_a = switch_pe_a.read_start();
-    let rc_a = switch_pe_a.read_cycles();
-    let rs_b = switch_pe_b.read_start();
-    let rc_b = switch_pe_b.read_cycles();
+    let rs_a = switch_pe_a.read_start().into_inner();
+    let rc_a = switch_pe_a.read_cycles().into_inner();
+    let rs_b = switch_pe_b.read_start().into_inner();
+    let rc_b = switch_pe_b.read_cycles().into_inner();
     info!("A: readStart: 0x{:X}, readCycles: 0x{:X}", rs_a, rc_a);
     info!("B: readStart: 0x{:X}, readCycles: 0x{:X}", rs_b, rc_b);
     info!(
         "Local counter: 0x{:X}",
-        switch_pe_a.local_clock_cycle_counter()
+        switch_pe_a.local_clock_cycle_counter().into_inner()
     );
 
     // Write the buffer of A over UART
@@ -87,7 +88,7 @@ fn main() -> ! {
 
     info!(
         "Local counter: 0x{:X}",
-        switch_pe_a.local_clock_cycle_counter()
+        switch_pe_a.local_clock_cycle_counter().into_inner()
     );
 
     // Write the buffer of B over UART
@@ -100,7 +101,7 @@ fn main() -> ! {
 
     info!(
         "Local counter: 0x{:X}",
-        switch_pe_a.local_clock_cycle_counter()
+        switch_pe_a.local_clock_cycle_counter().into_inner()
     );
 
     writeln!(uart, "Finished").unwrap();

--- a/firmware-support/bittide-sys/src/switch_demo_pe.rs
+++ b/firmware-support/bittide-sys/src/switch_demo_pe.rs
@@ -33,9 +33,9 @@ macro_rules! impl_node_iterator {
                     INDICES
                         .into_iter()
                         .map(|idx| unsafe {
-                            let local_counter = u64::from_ne_bytes(self.buffer_unchecked(idx));
-                            let dna_lo = u64::from_ne_bytes(self.buffer_unchecked(idx + 1));
-                            let dna_hi = u64::from_ne_bytes(self.buffer_unchecked(idx + 2));
+                            let local_counter = u64::from_ne_bytes(self.buffer_unchecked(idx).into_inner());
+                            let dna_lo = u64::from_ne_bytes(self.buffer_unchecked(idx + 1).into_inner());
+                            let dna_hi = u64::from_ne_bytes(self.buffer_unchecked(idx + 2).into_inner());
                             NodeData {
                                 local_counter,
                                 dna: dna_lo as u128 | ((dna_hi as u128) << 64),


### PR DESCRIPTION
The HAL codegen now wraps register values in `Unsigned`, `Index`, and `BitVector` types rather than raw primitives, which broke `switch_demo_pe.rs` and the `switch_demo_pe_test` sim test after they were merged alongside the SDPE `deviceWb`/`registerWb` migration.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

# TODO
- [X] Write (regression) test
- [X] ~~Update documentation, including `docs/`~~
- [X] ~~Link to existing issue~~
