### PR TITLE
Lower JTAG speed to 500 KHz

### DIFF
--- a/bittide-instances/data/openocd/sipeed.tcl
+++ b/bittide-instances/data/openocd/sipeed.tcl
@@ -38,6 +38,6 @@ ftdi layout_signal nSRST -data 0x0020 -oe 0x0020
 
 # The FT2232C supports sustained data rates up to 5.6 Mbit/s
 # https://ftdichip.com/wp-content/uploads/2020/08/DS_FT2232C.pdf
-# Just to be safe we set it to 1000 kHz
-adapter speed 1000
+# Just to be safe we set it to 500 kHz
+adapter speed 500
 transport select jtag


### PR DESCRIPTION
We've been seeing random failures again seemingly related to JTAG. Perhaps setting the speed even lower helps?

_Dear reviewer (anything you'd like the reviewer to pay close attention to?)_
This has survived 10 CI jobs now:

- https://github.com/bittide/bittide-hardware/actions/runs/26450958087/attempts/1
- https://github.com/bittide/bittide-hardware/actions/runs/26450958087/attempts/2
- https://github.com/bittide/bittide-hardware/actions/runs/26450990782/attempts/1
- https://github.com/bittide/bittide-hardware/actions/runs/26450990782/attempts/2

_AI disclaimer (heads-up for more than inline autocomplete)_
No. I used my two braincells to change that number.

# TODO
_~~Cross-out~~ any that do not apply_

- [X] ~~Write (regression) test~~
- [X] ~~Update documentation, including `docs/`~~
- [X] ~~Link to existing issue~~
