### PR TITLE
Emit register descriptions for zero-width registers

### DIFF
--- a/firmware-support/memmap-generate/src/backends/rust/mod.rs
+++ b/firmware-support/memmap-generate/src/backends/rust/mod.rs
@@ -25,6 +25,8 @@ use crate::{
     storage::Handle,
 };
 
+pub mod testing_utils;
+
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum IdentType {
     Type,
@@ -576,6 +578,7 @@ fn generate_reg_get_method(
     } else if ctx.tags[reg.tags].iter().any(|tag| tag == "zero-width") {
         let ty = generate_type_ref(ctx, varis, None, refs, reg.type_ref);
         quote! {
+            #desc
             pub fn #name(&self) -> #ty {
                 let _ = unsafe {
                     self.0.add(#offset).cast::<u8>().read_volatile()
@@ -652,6 +655,7 @@ fn generate_reg_set_method(
     } else if ctx.tags[reg.tags].iter().any(|tag| tag == "zero-width") {
         let ty = generate_type_ref(ctx, varis, None, refs, reg.type_ref);
         quote! {
+            #desc
             pub fn #name(&self, _val: #ty) {
                 unsafe {
                     self.0.add(#offset).cast::<u8>().write_volatile(0)

--- a/firmware-support/memmap-generate/src/backends/rust/testing_utils.rs
+++ b/firmware-support/memmap-generate/src/backends/rust/testing_utils.rs
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: 2026 Google LLC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Helpers for exercising the Rust backend from tests.
+
+use proc_macro2::TokenStream;
+
+use crate::backends::rust::generate_device_desc;
+use crate::input_language::MemoryMapDesc;
+use crate::ir::monomorph::MonomorphVariants;
+use crate::ir::types::IrCtx;
+
+/// Generate the Rust device descriptions for a single, parsed memory map.
+///
+/// This runs the full parse-to-codegen pipeline for one HAL: it builds the IR,
+/// monomorphises every register's type (nats only, as in the production build
+/// scripts), and generates the Rust code for each device. Unlike the build
+/// scripts in `bittide-hal`, it does *not* deduplicate types or devices across
+/// multiple HALs, which makes it convenient for tests that exercise a single
+/// memory map.
+///
+/// Returns the device name and generated code for each device.
+pub fn generate_device_descs(memmap: &MemoryMapDesc) -> Vec<(String, TokenStream)> {
+    use crate::ir::input_to_ir::IrInputMapping;
+    use crate::ir::monomorph::passes::OnlyNats;
+    use crate::ir::monomorph::Monomorpher;
+
+    let mut ctx = IrCtx::new();
+    let mut input_mapping = IrInputMapping::default();
+    let hal = ctx.add_memory_map_desc(&mut input_mapping, memmap);
+
+    let mut monomorpher = Monomorpher::new(&ctx, &input_mapping);
+    let mut varis = MonomorphVariants::default();
+    let mut pass = OnlyNats;
+
+    for dev in hal.devices.handles() {
+        for reg in ctx.device_descs[dev].registers.handles() {
+            monomorpher.monomorph_toplevel_type_refs(
+                &mut varis,
+                &mut pass,
+                std::iter::once(ctx.registers[reg].type_ref),
+            );
+        }
+    }
+    monomorpher.monomorph_type_descs(&mut varis, &mut pass);
+
+    hal.devices
+        .handles()
+        .map(|dev| {
+            let (name, code, _refs) = generate_device_desc(&ctx, &varis, dev);
+            (name.to_string(), code)
+        })
+        .collect()
+}

--- a/firmware-support/memmap-generate/tests/fixtures/zero_width_with_desc.json
+++ b/firmware-support/memmap-generate/tests/fixtures/zero_width_with_desc.json
@@ -1,0 +1,90 @@
+{
+    "devices": {
+        "ZeroWidthDoc": {
+            "description": "",
+            "name": "ZeroWidthDoc",
+            "registers": [
+                {
+                    "access": "write_only",
+                    "address": 0,
+                    "description": "WO_DESCRIPTION_MARKER write a zero-width register",
+                    "name": "wo_zero",
+                    "size": 0,
+                    "src_location": 0,
+                    "tags": [
+                        "zero-width"
+                    ],
+                    "type": {
+                        "args": [],
+                        "type_reference": {
+                            "name_base": "Unit",
+                            "name_module": "GHC.Tuple",
+                            "name_package": "ghc-prim"
+                        }
+                    }
+                },
+                {
+                    "access": "read_only",
+                    "address": 4,
+                    "description": "RO_DESCRIPTION_MARKER read a zero-width register",
+                    "name": "ro_zero",
+                    "size": 0,
+                    "src_location": 0,
+                    "tags": [
+                        "zero-width"
+                    ],
+                    "type": {
+                        "args": [],
+                        "type_reference": {
+                            "name_base": "Unit",
+                            "name_module": "GHC.Tuple",
+                            "name_package": "ghc-prim"
+                        }
+                    }
+                }
+            ],
+            "src_location": 0,
+            "tags": []
+        }
+    },
+    "src_locations": [
+        {
+            "end_col": 1,
+            "end_line": 1,
+            "file": "test_fixture",
+            "module": "TestFixture",
+            "package": "stub-for-memmap-tests",
+            "start_col": 1,
+            "start_line": 1
+        }
+    ],
+    "tree": {
+        "device_instance": {
+            "absolute_address": 0,
+            "device_name": "ZeroWidthDoc",
+            "path": [
+                0
+            ],
+            "src_location": 0,
+            "tags": []
+        }
+    },
+    "types": {
+        "GHC.Tuple.Unit": {
+            "definition": {
+                "datatype": [
+                    {
+                        "name": "()",
+                        "nameless": []
+                    }
+                ]
+            },
+            "name": {
+                "name_base": "Unit",
+                "name_module": "GHC.Tuple",
+                "name_package": "ghc-prim"
+            },
+            "type_args": []
+        }
+    }
+}

--- a/firmware-support/memmap-generate/tests/fixtures/zero_width_with_desc.json.license
+++ b/firmware-support/memmap-generate/tests/fixtures/zero_width_with_desc.json.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2026 Google LLC
+
+SPDX-License-Identifier: CC0-1.0

--- a/firmware-support/memmap-generate/tests/zero_width_docs.rs
+++ b/firmware-support/memmap-generate/tests/zero_width_docs.rs
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: 2026 Google LLC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Regression test for #1182: register `description`s must reach generated
+//! Rust getter/setter functions for zero-width registers, not just for
+//! scalar and vector registers.
+
+use memmap_generate::backends::rust::testing_utils as backend_rust;
+use memmap_generate::parse;
+
+#[test]
+fn zero_width_register_descriptions_reach_rust_output() {
+    let memmap = parse(include_str!("fixtures/zero_width_with_desc.json")).expect("fixture parses");
+
+    let rendered = backend_rust::generate_device_descs(&memmap)
+        .iter()
+        .map(|(_name, code)| code.to_string())
+        .collect::<String>();
+
+    assert!(
+        rendered.contains("WO_DESCRIPTION_MARKER"),
+        "expected WriteOnly zero-width setter to carry its description; got:\n{rendered}"
+    );
+    assert!(
+        rendered.contains("RO_DESCRIPTION_MARKER"),
+        "expected ReadOnly zero-width getter to carry its description; got:\n{rendered}"
+    );
+}


### PR DESCRIPTION
The Rust backend interpolated the `#desc` doc comment into the scalar and vector register accessor branches but not the zero-width branch, so `WriteOnly`/`ReadOnly` `()`-typed registers lost their descriptions in the generated code.

Fixes #1182

_Why (context, issues, etc.)_

_Dear reviewer (anything you'd like the reviewer to pay close attention to?)_
The test is quite large, is there something more sensible?

_AI disclaimer (heads-up for more than inline autocomplete)_
Yes

# TODO
_~~Cross-out~~ any that do not apply_

- [X] Write (regression) test
- [X] Update documentation, including `docs/`
- [X] Link to existing issue
- [x] ~~Investigate whether the test can be written more compactly~~ It adds a little bit of test infra that can be reused for other tests. It is what it is?