### PR TITLE
Reset JTAG adapter before starting OpenOCD in HITL

### DIFF
--- a/bittide-instances/bittide-instances.cabal
+++ b/bittide-instances/bittide-instances.cabal
@@ -203,6 +203,7 @@ library
     Bittide.Instances.Hitl.Utils.Picocom
     Bittide.Instances.Hitl.Utils.Program
     Bittide.Instances.Hitl.Utils.Ugn
+    Bittide.Instances.Hitl.Utils.Usb
     Bittide.Instances.Hitl.Utils.Utils
     Bittide.Instances.Hitl.Utils.Vivado
     Bittide.Instances.Hitl.VexRiscv

--- a/bittide-instances/src/Bittide/Instances/Hitl/Driver/DnaOverSerial.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/Driver/DnaOverSerial.hs
@@ -11,6 +11,7 @@ import Clash.Prelude
 import Bittide.Hitl
 import Bittide.Instances.Hitl.Setup
 import Bittide.Instances.Hitl.Utils.Program
+import Bittide.Instances.Hitl.Utils.Usb (resetUsbDeviceByLocation)
 import Bittide.Instances.Hitl.Utils.Vivado
 import Control.Monad.Extra
 import Control.Monad.IO.Class
@@ -41,6 +42,9 @@ dnaOverSerialDriver ::
   [(HwTarget, DeviceInfo)] ->
   VivadoM ExitCode
 dnaOverSerialDriver _name targets = do
+  -- Reset USB adapter, see documentation of "Bittide.Instances.Hitl.Utils.Usb"
+  liftIO $ forM_ targets $ \(_, d) -> resetUsbDeviceByLocation d.usbAdapterLocation
+
   results <- brackets (liftIO <$> initPicocoms) (liftIO . snd) $ \initPicocomsData -> do
     let targetPicocoms = fst <$> initPicocomsData
 

--- a/bittide-instances/src/Bittide/Instances/Hitl/Driver/Si539xConfiguration.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/Driver/Si539xConfiguration.hs
@@ -19,6 +19,7 @@ import Bittide.Hitl
 import Bittide.Instances.Hitl.Utils.Gdb (initGdb)
 import Bittide.Instances.Hitl.Utils.OpenOcd (parseTapInfo)
 import Bittide.Instances.Hitl.Utils.Picocom (initPicocom)
+import Bittide.Instances.Hitl.Utils.Usb (resetUsbDeviceByLocation)
 import "bittide-extra" Control.Exception.Extra (brackets)
 
 import Control.Concurrent.Async (forConcurrently_, mapConcurrently_)
@@ -44,6 +45,9 @@ driverFunc _name targets = do
 
   projectDir <- liftIO $ findParentContaining "cabal.project"
   let hitlDir = projectDir </> "_build" </> "hitl"
+
+  -- Reset USB adapter, see documentation of "Bittide.Instances.Hitl.Utils.Usb"
+  liftIO $ mapM_ (\(_, d) -> resetUsbDeviceByLocation d.usbAdapterLocation) targets
 
   let
     expectedJtagIds = [0x0514C001]

--- a/bittide-instances/src/Bittide/Instances/Hitl/Driver/VexRiscv.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/Driver/VexRiscv.hs
@@ -17,6 +17,7 @@ import Vivado.VivadoM
 
 import Bittide.Hitl
 import Bittide.Instances.Hitl.Utils.Program
+import Bittide.Instances.Hitl.Utils.Usb (resetUsbDeviceByLocation)
 
 import Control.Concurrent (threadDelay)
 import Control.Monad (forM)
@@ -76,6 +77,10 @@ driverFunc _name targets = do
     -- even though this is just pre-process step, the CPU is reset until
     -- the test_start signal is asserted and cannot be accessed via GDB otherwise
     updateVio "vioHitlt" [("probe_test_start", "1")]
+
+    -- Reset USB adapter, see documentation of "Bittide.Instances.Hitl.Utils.Usb"
+    liftIO $ resetUsbDeviceByLocation deviceInfo.usbAdapterLocation
+
     liftIO $ Ocd.withOpenOcdWithEnv openocdEnv deviceInfo.usbAdapterLocation gdbPort 6666 4444 $ \ocd -> do
       -- make sure OpenOCD is started properly
       hSetBuffering ocd.stderrHandle LineBuffering

--- a/bittide-instances/src/Bittide/Instances/Hitl/Driver/VexRiscvTcp.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/Driver/VexRiscvTcp.hs
@@ -8,6 +8,7 @@ import Prelude
 
 import Bittide.Hitl
 import Bittide.Instances.Hitl.Utils.Program
+import Bittide.Instances.Hitl.Utils.Usb (resetUsbDeviceByLocation)
 
 import Control.Concurrent
 import Control.Concurrent.Async
@@ -81,6 +82,9 @@ driverFunc _name [d@(_, dI)] = do
     openocdEnv = [("OPENOCD_STDOUT_LOG", ocdOutLog), ("OPENOCD_STDERR_LOG", ocdErrLog)]
 
   D.assertProbe "probe_test_start" d
+
+  -- Reset USB adapter, see documentation of "Bittide.Instances.Hitl.Utils.Usb"
+  liftIO $ resetUsbDeviceByLocation dI.usbAdapterLocation
 
   Ocd.withOpenOcdWithEnv openocdEnv dI.usbAdapterLocation 3333 6666 4444 $ \ocd -> do
     liftIO $ do

--- a/bittide-instances/src/Bittide/Instances/Hitl/SoftUgnDemo/Driver.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/SoftUgnDemo/Driver.hs
@@ -15,6 +15,7 @@ import Bittide.Instances.Hitl.Utils.Gdb (initGdb)
 import Bittide.Instances.Hitl.Utils.OpenOcd (parseBootTapInfo, parseTapInfo)
 import Bittide.Instances.Hitl.Utils.Picocom (initPicocom)
 import Bittide.Instances.Hitl.Utils.Ugn
+import Bittide.Instances.Hitl.Utils.Usb (resetUsbDeviceByLocation)
 import Bittide.Instances.Hitl.Utils.Utils (dumpCcSamples)
 import Control.Concurrent.Async (forConcurrently_, mapConcurrently, mapConcurrently_)
 import Control.Concurrent.Async.Extra (zipWithConcurrently3_)
@@ -51,6 +52,9 @@ driver testName targets = do
   let hitlDir = projectDir </> "_build/hitl" </> testName
 
   forM_ targets (assertProbe "probe_test_start")
+
+  -- Reset USB adapter, see documentation of "Bittide.Instances.Hitl.Utils.Usb"
+  liftIO $ forM_ targets $ \(_, d) -> resetUsbDeviceByLocation d.usbAdapterLocation
 
   let
     -- BOOT / MU / CC IDs

--- a/bittide-instances/src/Bittide/Instances/Hitl/Utils/Usb.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/Utils/Usb.hs
@@ -1,0 +1,71 @@
+-- SPDX-FileCopyrightText: 2026 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+{-# LANGUAGE PackageImports #-}
+
+{- | Utilities for poking at USB devices on the HITL rig.
+
+The JTAG adapters (FT2232C) occasionally get their MPSSE engine stuck, after which OpenOCD
+hangs in @mpsse_flush()@ and never finishes initializing. The device stays fully enumerated
+at the kernel level, so only a USB-level device reset (equivalent to an unplug/replug, or
+a reboot) clears it. This module offers tools to issue such a reset by location, so the
+HITL setup can recover without operator intervention. See 'resetUsbDeviceByLocation'.
+-}
+module Bittide.Instances.Hitl.Utils.Usb (
+  resetUsbDeviceByLocation,
+) where
+
+import Prelude
+
+import Control.Exception (finally)
+import Data.String.Interpolate (i)
+import Foreign.C.Error (throwErrnoIfMinus1_)
+import Foreign.C.Types (CInt (..), CULong (..))
+import System.Posix.IO (OpenMode (WriteOnly), closeFd, defaultFileFlags, openFd)
+import System.Posix.Types (Fd (..))
+import Text.Printf (printf)
+import Text.Read (readMaybe)
+import "extra" Data.List.Extra (trim)
+
+foreign import ccall unsafe "ioctl"
+  c_ioctl :: CInt -> CULong -> CInt -> IO CInt
+
+{- | @USBDEVFS_RESET@ from @<linux/usbdevice_fs.h>@, defined as @_IO('U', 20)@.
+On Linux @_IO(type, nr) = (type << 8) | nr@, so this is @(0x55 << 8) | 20@.
+-}
+usbdevfsReset :: CULong
+usbdevfsReset = 0x5514
+
+{- | Reset the USB device at the given adapter location (e.g. @"1-5.4.1:1"@, as
+stored in 'Bittide.Hitl.DeviceInfo'). This is the same operation as @usbreset@
+or physically replugging the device, and is used to recover JTAG adapters whose
+FTDI MPSSE engine has wedged.
+
+Throws if the location can't be resolved or the reset fails (e.g. the device
+node isn't present, or we lack permission). A failed reset means we'd be about
+to start OpenOCD against an adapter we couldn't recover, so we fail loudly here
+rather than letting it manifest as an opaque OpenOCD timeout later.
+-}
+resetUsbDeviceByLocation :: String -> IO ()
+resetUsbDeviceByLocation location = do
+  busnum <- readIntFile (sysfsDir <> "/busnum")
+  devnum <- readIntFile (sysfsDir <> "/devnum")
+  let devNode = printf "/dev/bus/usb/%03d/%03d" busnum devnum :: String
+  putStrLn [i|Resetting USB device #{devNode} (location #{location})|]
+  fd <- openFd devNode WriteOnly defaultFileFlags
+  let Fd cfd = fd
+  throwErrnoIfMinus1_ "USBDEVFS_RESET" (c_ioctl cfd usbdevfsReset 0)
+    `finally` closeFd fd
+ where
+  -- The adapter location is "<sysfs-device>:<config>", e.g. "1-5.4.1:1". The
+  -- sysfs device directory we need is the part before the colon.
+  sysfsName = takeWhile (/= ':') location
+  sysfsDir = "/sys/bus/usb/devices/" <> sysfsName
+
+  readIntFile path = do
+    contents <- readFile path
+    case readMaybe (trim contents) of
+      Just n -> pure (n :: Int)
+      Nothing ->
+        ioError . userError $
+          [i|Could not parse integer from #{path}: #{show contents}|]

--- a/bittide-instances/src/Bittide/Instances/Hitl/WireDemo/Driver.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/WireDemo/Driver.hs
@@ -18,6 +18,7 @@ import Bittide.Instances.Hitl.Utils.Gdb (initGdb)
 import Bittide.Instances.Hitl.Utils.MemoryMap (getPathAddress)
 import Bittide.Instances.Hitl.Utils.OpenOcd (parseBootTapInfo, parseTapInfo)
 import Bittide.Instances.Hitl.Utils.Picocom (initPicocom)
+import Bittide.Instances.Hitl.Utils.Usb (resetUsbDeviceByLocation)
 import Bittide.Instances.Hitl.Utils.Utils (dumpCcSamples)
 import Bittide.Wishbone (TimeCmd (Capture))
 import Control.Concurrent (threadDelay)
@@ -246,6 +247,9 @@ driver testName targets = do
   let hitlDir = projectDir </> "_build/hitl" </> testName
 
   forM_ targets (assertProbe "probe_test_start")
+
+  -- Reset USB adapter, see documentation of "Bittide.Instances.Hitl.Utils.Usb"
+  liftIO $ forM_ targets $ \(_, d) -> resetUsbDeviceByLocation d.usbAdapterLocation
 
   let
     -- BOOT / MU / CC IDs


### PR DESCRIPTION
The FT2232C JTAG adapters on the HITL rig occasionally get their MPSSE engine stuck. When this happens OpenOCD hangs in `mpsse_flush()` and never prints "Initialization complete", so initOpenOcd hits its 15s timeout and the test fails. The adapter stays fully enumerated at the kernel level, so only a USB-level reset (equivalent to an unplug/replug, or a reboot) clears it.

This adds `resetUsbDeviceByLocation`, which resolves a usbAdapterLocation to its /dev/bus/usb node via sysfs and issues `USBDEVFS_RESET`, and call it from `initOpenOcd` before launching OpenOCD.

_Dear reviewer (anything you'd like the reviewer to pay close attention to?)_
No.

_AI disclaimer (heads-up for more than inline autocomplete)_
It did what I couldn't do a year ago.. :'(

# TODO
_~~Cross-out~~ any that do not apply_

- [X] ~~Write (regression) test~~ Kinda? :-)
- [X] Update documentation, including `docs/`
- [X] ~~Link to existing issue~~
- [x] Survive CI
