### PR TITLE
Stream Vivado output line-by-line to logs

### DIFF
--- a/.github/scripts/cache.py
+++ b/.github/scripts/cache.py
@@ -54,7 +54,7 @@ TOUCH_AFTER=datetime.timedelta(days=1)
 
 GLOBAL_CACHE_BUST = 26
 
-CARGO_CACHE_BUST = 2
+CARGO_CACHE_BUST = 4
 CARGO_KEY_PREFIX = f"cargo-g{GLOBAL_CACHE_BUST}-l{CARGO_CACHE_BUST}-"
 CARGO_KEY_PATTERNS = ("**/Cargo.lock", "**/Cargo.toml", "**/rust-toolchain.toml")
 CARGO_CACHE_INCLUDE_PATTERNS = ("~/.cargo",)

--- a/vivado-hs/src/Vivado/Internal.hs
+++ b/vivado-hs/src/Vivado/Internal.hs
@@ -149,10 +149,12 @@ exec v cmd = do
       puts -nonewline {#{magic} ERR }
       puts [dict get $opt_dict_#{magic} {-code}]
       puts $result_#{magic}
+      puts {#{magic} END}
     } else {
       puts {}
       puts {#{magic} OK}
       puts $result_#{magic}
+      puts {#{magic} END}
     }
   |]
 
@@ -160,8 +162,8 @@ exec v cmd = do
   (stdout :|> _, mErr) <- expectLine v True filtUntilMagic
   let stdoutS = intercalate "\n" $ toList stdout
 
-  -- The return value
-  (retVal, _) <- expectLine v False filtUntilEnd
+  -- The return value, terminated by the END sentinel which is then dropped.
+  (retVal :|> _, _) <- expectLine v False filtUntilEnd
   let retValS = intercalate "\n" $ toList retVal
 
   case mErr of
@@ -188,9 +190,9 @@ exec v cmd = do
     | otherwise = return Continue
 
   filtUntilEnd :: String -> IO Filter
-  filtUntilEnd _ = do
-    inputAvailable <- IO.hReady v.stdout
-    return $ if inputAvailable then Continue else Stop
+  filtUntilEnd line
+    | line == magic <> " END" = return Stop
+    | otherwise = return Continue
 
 {- | Execute a command in Vivado and ignore the command result.
 

--- a/vivado-hs/src/Vivado/Internal.hs
+++ b/vivado-hs/src/Vivado/Internal.hs
@@ -9,7 +9,7 @@ module Vivado.Internal where
 import Prelude
 
 import Control.Exception (Exception, finally, throwIO)
-import Control.Monad (forM_, unless, void)
+import Control.Monad (forM_, unless, void, when)
 import Data.Foldable (toList)
 import Data.List (intercalate)
 import Data.List.Extra (isPrefixOf, splitOn, trim)
@@ -97,17 +97,22 @@ successfully. If the filter returns @Stop e@, the function will return a
 expectLine ::
   (HasCallStack) =>
   VivadoHandle ->
+  {- | If 'True', also echo each line (except the magic sentinel) to host stdout
+  as it arrives, for live streaming of step output.
+  -}
+  Bool ->
   (String -> IO Filter) ->
   IO (Seq String, Maybe ErrorCode)
-expectLine v f = go mempty
+expectLine v echo f = go mempty
  where
   go :: Seq String -> IO (Seq String, Maybe ErrorCode)
   go acc = do
     line <- IO.hGetLine v.stdout
 
     IO.hPutStrLn v.logHandle line
-    unless (magic `isPrefixOf` line) $
+    unless (magic `isPrefixOf` line) $ do
       IO.hPutStrLn v.prettyLogHandle line
+      when echo $ IO.putStrLn line
 
     let lines' = acc :|> line
     f line >>= \case
@@ -152,11 +157,11 @@ exec v cmd = do
   |]
 
   -- Discard the line with the magic string at the end
-  (stdout :|> _, mErr) <- expectLine v filtUntilMagic
+  (stdout :|> _, mErr) <- expectLine v True filtUntilMagic
   let stdoutS = intercalate "\n" $ toList stdout
 
   -- The return value
-  (retVal, _) <- expectLine v filtUntilEnd
+  (retVal, _) <- expectLine v False filtUntilEnd
   let retValS = intercalate "\n" $ toList retVal
 
   case mErr of
@@ -195,28 +200,26 @@ attempt to sanitize the input.
 exec_ :: VivadoHandle -> String -> IO ()
 exec_ v cmd = void (exec v cmd)
 
-{- | Execute a command in Vivado, print the resulting standard output and return
-the command result.
+{- | Execute a command in Vivado and return the command result. Standard output
+is streamed to host stdout line-by-line as it arrives from Vivado.
+
+Kept as an alias of 'exec' for backwards compatibility; 'exec' now streams
+output unconditionally.
 
 Careful: do not use this function with unverified user input, as it does not
 attempt to sanitize the input.
 -}
 execPrint :: VivadoHandle -> String -> IO String
-execPrint v cmd = do
-  (stdout, result) <- exec v cmd
-  putStr stdout
-  return result
+execPrint v cmd = snd <$> exec v cmd
 
-{- | Execute a command in Vivado, print the resulting standard output and ignore
-the command result.
+{- | Execute a command in Vivado and ignore the command result. Standard output
+is streamed to host stdout line-by-line as it arrives from Vivado.
 
 Careful: do not use this function with unverified user input, as it does not
 attempt to sanitize the input.
 -}
 execPrint_ :: VivadoHandle -> String -> IO ()
-execPrint_ v cmd = do
-  (stdout, _) <- exec v cmd
-  putStr stdout
+execPrint_ = exec_
 
 {- | Run a block of code with a Vivado handle. Example usage:
 
@@ -241,6 +244,10 @@ with f = do
       -- do:
       ( do
           setEnv "XILINX_LOCAL_USER_DATA" "no" -- Prevents multiprocessing issues
+          -- Ensure streamed step output is flushed line-by-line even when our
+          -- own stdout is a pipe (e.g. under Shake or CI), where the default
+          -- would otherwise be block-buffered.
+          IO.hSetBuffering IO.stdout IO.LineBuffering
           withCreateProcess vivadoProc $
             \(fromJust -> stdin) (fromJust -> stdout) _stderr process -> do
               IO.hSetBuffering stdout IO.LineBuffering


### PR DESCRIPTION
_What (what did you do)_
Vivado used to buffer whole blocks of output, leaving CI logs to update only in massive chunks. This change makes it such that output is streamed line-by-line.

The other patch is something that's been living in my head forever now: the dubious use of `hReady`. I removed it :).

_Why (context, issues, etc.)_
I wasn't quite sure whether I was seeing all output while debugging a Vivado issue. This makes sure we do.

_Dear reviewer (anything you'd like the reviewer to pay close attention to?)_
No.

_AI disclaimer (heads-up for more than inline autocomplete)_
Yeah.

# TODO
_~~Cross-out~~ any that do not apply_

- [X] ~~Write (regression) test~~
- [X] ~~Update documentation, including `docs/`~~
- [X] ~~Link to existing issue~~
- [x] Survive CI
