### PR TITLE
Test components at higher clock frequencies

### DIFF
--- a/.github/synthesis/all.json
+++ b/.github/synthesis/all.json
@@ -14,8 +14,10 @@
   {"top": "freezeFast",                    "stage": "pnr",   "cc_report": false},
   {"top": "handshakesWbFast",              "stage": "pnr",   "cc_report": false},
   {"top": "programmableMuxFast",           "stage": "pnr",   "cc_report": false},
+  {"top": "receiveRingBufferFast",         "stage": "pnr",   "cc_report": false},
   {"top": "sendUgnFast",                   "stage": "pnr",   "cc_report": false},
   {"top": "timeWbFast",                    "stage": "pnr",   "cc_report": false},
+  {"top": "transmitRingBufferFast",        "stage": "pnr",   "cc_report": false},
   {"top": "uartExampleFast",               "stage": "pnr",   "cc_report": false},
 
   {"top": "vexRiscvTcpTest",               "stage": "bitstream", "cc_report": false},

--- a/.github/synthesis/all.json
+++ b/.github/synthesis/all.json
@@ -8,8 +8,10 @@
   {"top": "si5391Spi",                     "stage": "pnr",   "cc_report": false},
   {"top": "transmitRingBufferPnr",         "stage": "pnr",   "cc_report": false},
 
+  {"top": "captureUgnFast",                "stage": "pnr",   "cc_report": false},
   {"top": "domainDiffCounterFast",         "stage": "pnr",   "cc_report": false},
   {"top": "freezeFast",                    "stage": "pnr",   "cc_report": false},
+  {"top": "sendUgnFast",                   "stage": "pnr",   "cc_report": false},
 
   {"top": "vexRiscvTcpTest",               "stage": "bitstream", "cc_report": false},
 

--- a/.github/synthesis/all.json
+++ b/.github/synthesis/all.json
@@ -11,6 +11,7 @@
   {"top": "captureUgnFast",                "stage": "pnr",   "cc_report": false},
   {"top": "domainDiffCounterFast",         "stage": "pnr",   "cc_report": false},
   {"top": "freezeFast",                    "stage": "pnr",   "cc_report": false},
+  {"top": "programmableMuxFast",           "stage": "pnr",   "cc_report": false},
   {"top": "sendUgnFast",                   "stage": "pnr",   "cc_report": false},
 
   {"top": "vexRiscvTcpTest",               "stage": "bitstream", "cc_report": false},

--- a/.github/synthesis/all.json
+++ b/.github/synthesis/all.json
@@ -1,7 +1,6 @@
 [
   {"top": "asciiDebugMux",                 "stage": "hdl",   "cc_report": false},
 
-  {"top": "counterReducedPins",            "stage": "pnr",   "cc_report": false},
   {"top": "elasticBufferWb",               "stage": "pnr",   "cc_report": false},
   {"top": "freeze",                        "stage": "pnr",   "cc_report": false},
   {"top": "receiveRingBufferPnr",          "stage": "pnr",   "cc_report": false},
@@ -9,6 +8,7 @@
   {"top": "si5391Spi",                     "stage": "pnr",   "cc_report": false},
   {"top": "transmitRingBufferPnr",         "stage": "pnr",   "cc_report": false},
 
+  {"top": "domainDiffCounterFast",         "stage": "pnr",   "cc_report": false},
   {"top": "freezeFast",                    "stage": "pnr",   "cc_report": false},
 
   {"top": "vexRiscvTcpTest",               "stage": "bitstream", "cc_report": false},

--- a/.github/synthesis/all.json
+++ b/.github/synthesis/all.json
@@ -12,6 +12,7 @@
   {"top": "asciiDebugMuxFast",             "stage": "pnr",   "cc_report": false},
   {"top": "autoCenterFast",                "stage": "pnr",   "cc_report": false},
   {"top": "captureUgnFast",                "stage": "pnr",   "cc_report": false},
+  {"top": "delayWishboneFast",             "stage": "pnr",   "cc_report": false},
   {"top": "domainDiffCounterFast",         "stage": "pnr",   "cc_report": false},
   {"top": "freezeFast",                    "stage": "pnr",   "cc_report": false},
   {"top": "handshakesWbFast",              "stage": "pnr",   "cc_report": false},

--- a/.github/synthesis/all.json
+++ b/.github/synthesis/all.json
@@ -16,6 +16,7 @@
   {"top": "programmableMuxFast",           "stage": "pnr",   "cc_report": false},
   {"top": "receiveRingBufferFast",         "stage": "pnr",   "cc_report": false},
   {"top": "sendUgnFast",                   "stage": "pnr",   "cc_report": false},
+  {"top": "si5391SpiFast",                 "stage": "pnr",   "cc_report": false},
   {"top": "timeWbFast",                    "stage": "pnr",   "cc_report": false},
   {"top": "transmitRingBufferFast",        "stage": "pnr",   "cc_report": false},
   {"top": "uartExampleFast",               "stage": "pnr",   "cc_report": false},

--- a/.github/synthesis/all.json
+++ b/.github/synthesis/all.json
@@ -16,6 +16,7 @@
   {"top": "programmableMuxFast",           "stage": "pnr",   "cc_report": false},
   {"top": "sendUgnFast",                   "stage": "pnr",   "cc_report": false},
   {"top": "timeWbFast",                    "stage": "pnr",   "cc_report": false},
+  {"top": "uartExampleFast",               "stage": "pnr",   "cc_report": false},
 
   {"top": "vexRiscvTcpTest",               "stage": "bitstream", "cc_report": false},
 

--- a/.github/synthesis/all.json
+++ b/.github/synthesis/all.json
@@ -21,6 +21,7 @@
   {"top": "timeWbFast",                    "stage": "pnr",   "cc_report": false},
   {"top": "transmitRingBufferFast",        "stage": "pnr",   "cc_report": false},
   {"top": "uartExampleFast",               "stage": "pnr",   "cc_report": false},
+  {"top": "wbStorageFast",                 "stage": "pnr",   "cc_report": false},
 
   {"top": "vexRiscvTcpTest",               "stage": "bitstream", "cc_report": false},
 

--- a/.github/synthesis/all.json
+++ b/.github/synthesis/all.json
@@ -8,6 +8,7 @@
   {"top": "si5391Spi",                     "stage": "pnr",   "cc_report": false},
   {"top": "transmitRingBufferPnr",         "stage": "pnr",   "cc_report": false},
 
+  {"top": "arbiterFast",                   "stage": "pnr",   "cc_report": false},
   {"top": "asciiDebugMuxFast",             "stage": "pnr",   "cc_report": false},
   {"top": "autoCenterFast",                "stage": "pnr",   "cc_report": false},
   {"top": "captureUgnFast",                "stage": "pnr",   "cc_report": false},

--- a/.github/synthesis/all.json
+++ b/.github/synthesis/all.json
@@ -1,4 +1,6 @@
 [
+  {"top": "asciiDebugMux",                 "stage": "hdl",   "cc_report": false},
+
   {"top": "counterReducedPins",            "stage": "pnr",   "cc_report": false},
   {"top": "elasticBufferWb",               "stage": "pnr",   "cc_report": false},
   {"top": "freeze",                        "stage": "pnr",   "cc_report": false},
@@ -7,7 +9,7 @@
   {"top": "si5391Spi",                     "stage": "pnr",   "cc_report": false},
   {"top": "transmitRingBufferPnr",         "stage": "pnr",   "cc_report": false},
 
-  {"top": "asciiDebugMux",                 "stage": "hdl",   "cc_report": false},
+  {"top": "freezeFast",                    "stage": "pnr",   "cc_report": false},
 
   {"top": "vexRiscvTcpTest",               "stage": "bitstream", "cc_report": false},
 

--- a/.github/synthesis/all.json
+++ b/.github/synthesis/all.json
@@ -22,6 +22,7 @@
   {"top": "transmitRingBufferFast",        "stage": "pnr",   "cc_report": false},
   {"top": "uartExampleFast",               "stage": "pnr",   "cc_report": false},
   {"top": "wbStorageFast",                 "stage": "pnr",   "cc_report": false},
+  {"top": "wireDemoPeFast",                "stage": "pnr",   "cc_report": false},
 
   {"top": "vexRiscvTcpTest",               "stage": "bitstream", "cc_report": false},
 

--- a/.github/synthesis/all.json
+++ b/.github/synthesis/all.json
@@ -9,6 +9,7 @@
   {"top": "transmitRingBufferPnr",         "stage": "pnr",   "cc_report": false},
 
   {"top": "asciiDebugMuxFast",             "stage": "pnr",   "cc_report": false},
+  {"top": "autoCenterFast",                "stage": "pnr",   "cc_report": false},
   {"top": "captureUgnFast",                "stage": "pnr",   "cc_report": false},
   {"top": "domainDiffCounterFast",         "stage": "pnr",   "cc_report": false},
   {"top": "freezeFast",                    "stage": "pnr",   "cc_report": false},

--- a/.github/synthesis/all.json
+++ b/.github/synthesis/all.json
@@ -12,6 +12,7 @@
   {"top": "captureUgnFast",                "stage": "pnr",   "cc_report": false},
   {"top": "domainDiffCounterFast",         "stage": "pnr",   "cc_report": false},
   {"top": "freezeFast",                    "stage": "pnr",   "cc_report": false},
+  {"top": "handshakesWbFast",              "stage": "pnr",   "cc_report": false},
   {"top": "programmableMuxFast",           "stage": "pnr",   "cc_report": false},
   {"top": "sendUgnFast",                   "stage": "pnr",   "cc_report": false},
   {"top": "timeWbFast",                    "stage": "pnr",   "cc_report": false},

--- a/.github/synthesis/all.json
+++ b/.github/synthesis/all.json
@@ -8,6 +8,7 @@
   {"top": "si5391Spi",                     "stage": "pnr",   "cc_report": false},
   {"top": "transmitRingBufferPnr",         "stage": "pnr",   "cc_report": false},
 
+  {"top": "asciiDebugMuxFast",             "stage": "pnr",   "cc_report": false},
   {"top": "captureUgnFast",                "stage": "pnr",   "cc_report": false},
   {"top": "domainDiffCounterFast",         "stage": "pnr",   "cc_report": false},
   {"top": "freezeFast",                    "stage": "pnr",   "cc_report": false},

--- a/.github/synthesis/all.json
+++ b/.github/synthesis/all.json
@@ -14,6 +14,7 @@
   {"top": "freezeFast",                    "stage": "pnr",   "cc_report": false},
   {"top": "programmableMuxFast",           "stage": "pnr",   "cc_report": false},
   {"top": "sendUgnFast",                   "stage": "pnr",   "cc_report": false},
+  {"top": "timeWbFast",                    "stage": "pnr",   "cc_report": false},
 
   {"top": "vexRiscvTcpTest",               "stage": "bitstream", "cc_report": false},
 

--- a/bittide-instances/README.md
+++ b/bittide-instances/README.md
@@ -23,3 +23,43 @@ The build system automatically generates _false path_ constraints for all input 
 **Note that false path constraints are also generated for any reset lines. You therefore need to make sure to properly synchronize your resets before feeding them to a circuit.**
 
 To learn more about using these instances, go to the [`README.md` in `bittide-shake`](../bittide-shake/README.md).
+
+
+## Testing components at higher frequencies
+The Bittide demo designs currently run at 125 MHz. The table below shows how far each core component can be pushed in isolation, by testing place-and-route at 300, 350, and 400 MHz. Components that are FPGA-specific, or that add no logic, are omitted.
+
+| Name pnr target         | 300 | 350 | 400 |
+|:------------------------|:---:|:---:|:---:|
+|`arbiter`                |  X  |  X  |  X  |
+|`asciiDebugMuxFast`      |  X  |  X  |  X  |
+|`autoCenterFast`         |  X  |  X  |  X  |
+|`captureUgnFast`         |  X  |  X  |  X  |
+|`delayWishbone`          |  X  |  X  |  X  |
+|`domainDiffCounterFast`  |  X  |  X  |  X  |
+|`freezeFast`             |  X  |  X  |  X  |
+|`handshakesWbFast`       |  X  |     |     |
+|`programmableMuxFast`    |  X  |  X  |  X  |
+|`receiveRingBufferFast`  |  X  |  X  |     |
+|`sendUgnFast`            |  X  |  X  |  X  |
+|`si5391SpiFast`          |  X  |  X  |  X  |
+|`timeWbFast`             |  X  |  X  |     |
+|`transmitRingBufferFast` |  X  |  X  |     |
+|`uartExampleFast`<sup> 1 </sup> |  X  |  X  |     |
+|`wbStorageFast`          |  X  |     |     |
+|`wireDemoPeFast`         |  X  |  X  |  X  |
+
+<sup> 1 </sup> Contains: `uartInterfaceWb`, `uartBytes`, `uartDf`, `asciiDebugMux` and `dcFifoDf`
+
+Note that the table above is missing some components which are used in demos. The table below lists the missing components and the reason there is not yet a high-frequency pnr target for it.
+
+Component                 | Reason
+--------------------------|----------
+`elasticBuffer`           | Only test elastic buffer control and autocenter, not EB itself
+`readDnaPortE2`           | Did not reach 250 MHz, uses an FPGA-specific primitive
+`processingElement`       | Did not reach 200 MHz
+`callistoSwClockControlC` | Did not reach 200 MHz (contains a lot of components)
+`jtagChain`               | Doesn't add logic
+`unsafeJtagSynchronizer`  | Doesn't add logic
+`wireDemoPeConfig`        | Only wraps `deviceWb` with no other logic
+`syncInCounterC`          | To be removed in issue https://github.com/bittide/bittide-hardware/issues/1155
+`syncOutGenerateWbC`      | To be removed in issue https://github.com/bittide/bittide-hardware/issues/1155

--- a/bittide-instances/bittide-instances.cabal
+++ b/bittide-instances/bittide-instances.cabal
@@ -228,6 +228,7 @@ library
     Bittide.Instances.Pnr.Uart
     Bittide.Instances.Pnr.WbStorage
     Bittide.Instances.Pnr.WireDemoProcessingElement
+    Bittide.Instances.Pnr.Wishbone
     Bittide.Instances.Tests.AddressableBytesWb
     Bittide.Instances.Tests.CaptureUgn
     Bittide.Instances.Tests.ClockControlWb

--- a/bittide-instances/bittide-instances.cabal
+++ b/bittide-instances/bittide-instances.cabal
@@ -226,6 +226,7 @@ library
     Bittide.Instances.Pnr.Synchronizer
     Bittide.Instances.Pnr.Time
     Bittide.Instances.Pnr.Uart
+    Bittide.Instances.Pnr.WbStorage
     Bittide.Instances.Tests.AddressableBytesWb
     Bittide.Instances.Tests.CaptureUgn
     Bittide.Instances.Tests.ClockControlWb

--- a/bittide-instances/bittide-instances.cabal
+++ b/bittide-instances/bittide-instances.cabal
@@ -213,6 +213,7 @@ library
     Bittide.Instances.Hitl.WireDemo.UserCore
     Bittide.Instances.MemoryMaps
     Bittide.Instances.Pnr.AsciiDebugMux
+    Bittide.Instances.Pnr.CaptureUgn
     Bittide.Instances.Pnr.DomainDiffCounter
     Bittide.Instances.Pnr.ElasticBuffer
     Bittide.Instances.Pnr.Ethernet

--- a/bittide-instances/bittide-instances.cabal
+++ b/bittide-instances/bittide-instances.cabal
@@ -225,6 +225,7 @@ library
     Bittide.Instances.Pnr.Si539xSpi
     Bittide.Instances.Pnr.Synchronizer
     Bittide.Instances.Pnr.Time
+    Bittide.Instances.Pnr.Uart
     Bittide.Instances.Tests.AddressableBytesWb
     Bittide.Instances.Tests.CaptureUgn
     Bittide.Instances.Tests.ClockControlWb

--- a/bittide-instances/bittide-instances.cabal
+++ b/bittide-instances/bittide-instances.cabal
@@ -219,6 +219,7 @@ library
     Bittide.Instances.Pnr.Ethernet
     Bittide.Instances.Pnr.Freeze
     Bittide.Instances.Pnr.ProcessingElement
+    Bittide.Instances.Pnr.ProgrammableMux
     Bittide.Instances.Pnr.RingBuffer
     Bittide.Instances.Pnr.Si539xSpi
     Bittide.Instances.Pnr.Synchronizer

--- a/bittide-instances/bittide-instances.cabal
+++ b/bittide-instances/bittide-instances.cabal
@@ -223,6 +223,7 @@ library
     Bittide.Instances.Pnr.RingBuffer
     Bittide.Instances.Pnr.Si539xSpi
     Bittide.Instances.Pnr.Synchronizer
+    Bittide.Instances.Pnr.Time
     Bittide.Instances.Tests.AddressableBytesWb
     Bittide.Instances.Tests.CaptureUgn
     Bittide.Instances.Tests.ClockControlWb

--- a/bittide-instances/bittide-instances.cabal
+++ b/bittide-instances/bittide-instances.cabal
@@ -218,6 +218,7 @@ library
     Bittide.Instances.Pnr.ElasticBuffer
     Bittide.Instances.Pnr.Ethernet
     Bittide.Instances.Pnr.Freeze
+    Bittide.Instances.Pnr.Handshake
     Bittide.Instances.Pnr.ProcessingElement
     Bittide.Instances.Pnr.ProgrammableMux
     Bittide.Instances.Pnr.RingBuffer

--- a/bittide-instances/bittide-instances.cabal
+++ b/bittide-instances/bittide-instances.cabal
@@ -213,7 +213,7 @@ library
     Bittide.Instances.Hitl.WireDemo.UserCore
     Bittide.Instances.MemoryMaps
     Bittide.Instances.Pnr.AsciiDebugMux
-    Bittide.Instances.Pnr.Counter
+    Bittide.Instances.Pnr.DomainDiffCounter
     Bittide.Instances.Pnr.ElasticBuffer
     Bittide.Instances.Pnr.Ethernet
     Bittide.Instances.Pnr.Freeze

--- a/bittide-instances/bittide-instances.cabal
+++ b/bittide-instances/bittide-instances.cabal
@@ -227,6 +227,7 @@ library
     Bittide.Instances.Pnr.Time
     Bittide.Instances.Pnr.Uart
     Bittide.Instances.Pnr.WbStorage
+    Bittide.Instances.Pnr.WireDemoProcessingElement
     Bittide.Instances.Tests.AddressableBytesWb
     Bittide.Instances.Tests.CaptureUgn
     Bittide.Instances.Tests.ClockControlWb

--- a/bittide-instances/src/Bittide/Instances/Domains.hs
+++ b/bittide-instances/src/Bittide/Instances/Domains.hs
@@ -14,6 +14,9 @@ createDomain vXilinxSystem{vName="Basic125A", vPeriod=hzToPeriod 125e6}
 createDomain vXilinxSystem{vName="Basic125B", vPeriod=hzToPeriod 125e6}
 createDomain vXilinxSystem{vName="Basic199",  vPeriod=hzToPeriod 199e6}
 createDomain vXilinxSystem{vName="Basic200",  vPeriod=hzToPeriod 200e6}
+createDomain vXilinxSystem{vName="Basic300",  vPeriod=hzToPeriod 300e6}
+createDomain vXilinxSystem{vName="Basic350",  vPeriod=hzToPeriod 350e6}
+createDomain vXilinxSystem{vName="Basic400",  vPeriod=hzToPeriod 400e6}
 createDomain vXilinxSystem{vName="Basic625",  vPeriod=hzToPeriod 625e6, vResetKind=Asynchronous}
 
 createDomain vXilinxSystem{vName="Ext125",    vPeriod=hzToPeriod 125e6, vResetKind=Asynchronous}

--- a/bittide-instances/src/Bittide/Instances/Pnr/AsciiDebugMux.hs
+++ b/bittide-instances/src/Bittide/Instances/Pnr/AsciiDebugMux.hs
@@ -7,17 +7,38 @@ module Bittide.Instances.Pnr.AsciiDebugMux where
 import Clash.Prelude
 import Protocols
 
+import Bittide.Instances.Domains (Basic400)
+import Bittide.Instances.Hacks (reducePins)
 import Bittide.SharedTypes (Byte)
+import Data.Bifunctor (first)
 
 import qualified Bittide.Df as Df
+
+asciiDebugMuxExample ::
+  (KnownDomain dom) =>
+  Clock dom ->
+  Reset dom ->
+  Enable dom ->
+  Circuit (Vec 3 (Df dom Byte)) (Df dom Byte)
+asciiDebugMuxExample clk rst ena =
+  withClockResetEnable clk rst ena
+    $ Df.asciiDebugMux
+      (SNat @1024)
+      ((0xA :> Nil) :> (0xB :> Nil) :> (0xC :> Nil) :> Nil)
 
 asciiDebugMux ::
   Clock System ->
   Reset System ->
   Enable System ->
   Circuit (Vec 3 (Df System Byte)) (Df System Byte)
-asciiDebugMux clk rst ena =
-  withClockResetEnable @System clk rst ena
-    $ Df.asciiDebugMux
-      (SNat @1024)
-      ((0xA :> Nil) :> (0xB :> Nil) :> (0xC :> Nil) :> Nil)
+asciiDebugMux = asciiDebugMuxExample
+
+asciiDebugMuxFast :: Clock Basic400 -> Reset Basic400 -> Signal Basic400 Bit -> Signal Basic400 Bit
+asciiDebugMuxFast clk rst = withClock clk $ reducePins dut
+ where
+  dut (unbundle -> (inps, ack)) =
+    bundle
+      $ first bundle
+      $ toSignals
+        (asciiDebugMuxExample clk rst enableGen)
+        (unbundle inps, ack)

--- a/bittide-instances/src/Bittide/Instances/Pnr/CaptureUgn.hs
+++ b/bittide-instances/src/Bittide/Instances/Pnr/CaptureUgn.hs
@@ -1,0 +1,36 @@
+-- SPDX-FileCopyrightText: 2026 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+
+module Bittide.Instances.Pnr.CaptureUgn where
+
+import Clash.Prelude
+import Protocols
+
+import Bittide.Instances.Domains (Basic400)
+import Bittide.Instances.Hacks (reducePins)
+import Bittide.SharedTypes (withLittleEndian)
+import Protocols.MemoryMap (unMemmap)
+
+import qualified Bittide.CaptureUgn as Ugn
+
+captureUgnFast ::
+  Clock Basic400 -> Reset Basic400 -> Signal Basic400 Bit -> Signal Basic400 Bit
+captureUgnFast clk rst = withClock clk $ reducePins dut
+ where
+  dut (unbundle -> (localCounter, linkIn, wbIn)) =
+    bundle
+      $ toSignals
+        ( unMemmap
+            $ withLittleEndian
+            $ withClockResetEnable clk rst enableGen
+            $ Ugn.captureUgn @_ @32 localCounter linkIn
+        )
+        (wbIn, ())
+
+sendUgnFast ::
+  Clock Basic400 -> Reset Basic400 -> Signal Basic400 Bit -> Signal Basic400 Bit
+sendUgnFast clk rst = withClock clk $ reducePins dut
+ where
+  dut (unbundle -> (localCounter, sampling, linkIn)) =
+    withClockResetEnable clk rst enableGen $ Ugn.sendUgn localCounter sampling linkIn

--- a/bittide-instances/src/Bittide/Instances/Pnr/DomainDiffCounter.hs
+++ b/bittide-instances/src/Bittide/Instances/Pnr/DomainDiffCounter.hs
@@ -2,7 +2,7 @@
 --
 -- SPDX-License-Identifier: Apache-2.0
 
-module Bittide.Instances.Pnr.Counter where
+module Bittide.Instances.Pnr.DomainDiffCounter where
 
 import Clash.Explicit.Prelude
 import Clash.Prelude (withClock)
@@ -13,15 +13,16 @@ import Bittide.Instances.Hacks
 import Clash.Cores.Xilinx (withXilinx)
 
 counter ::
-  Clock Basic200 ->
-  Reset Basic200 ->
-  Clock Basic200 ->
-  Reset Basic200 ->
-  Signal Basic200 () ->
-  Signal Basic200 (Signed 32, Bool)
+  (KnownDomain dom) =>
+  Clock dom ->
+  Reset dom ->
+  Clock dom ->
+  Reset dom ->
+  Signal dom () ->
+  Signal dom (Signed 32, Bool)
 counter clk0 rst0 clk1 rst1 _ = withXilinx $ domainDiffCounter clk0 rst0 clk1 rst1
 
-counterReducedPins :: Clock Basic200 -> Signal Basic200 Bit
-counterReducedPins clk =
+domainDiffCounterFast :: Clock Basic400 -> Signal Basic400 Bit
+domainDiffCounterFast clk =
   withClock clk
     $ reducePins (counter clk noReset clk noReset) (pure 0)

--- a/bittide-instances/src/Bittide/Instances/Pnr/ElasticBuffer.hs
+++ b/bittide-instances/src/Bittide/Instances/Pnr/ElasticBuffer.hs
@@ -13,6 +13,9 @@ import Protocols.Experimental.Wishbone
 
 import Bittide.ClockControl (RelDataCount)
 import Bittide.ElasticBuffer
+import Bittide.ElasticBuffer.AutoCenter (autoCenter)
+import Bittide.Instances.Domains (Basic400)
+import Bittide.Instances.Hacks (reducePins)
 import Bittide.SharedTypes (withLittleEndian)
 
 import qualified Clash.Explicit.Prelude as E
@@ -42,3 +45,13 @@ elasticBufferWb clkRead rstRead clkWrite wbIn wdata = (wbOut, dataCount, underfl
         (((), wbIn), ((), (), (), ()))
 
 makeTopEntity 'elasticBufferWb
+
+autoCenterFast :: Clock Basic400 -> Reset Basic400 -> Signal Basic400 Bit -> Signal Basic400 Bit
+autoCenterFast clk rst = withClock clk $ reducePins dut
+ where
+  dut (unbundle -> (margin, dataCount, ack)) =
+    bundle
+      $ snd
+      $ toSignals
+        (withLittleEndian $ withClock clk $ autoCenter @_ @5 rst enableGen margin dataCount)
+        ((), (ack, (), ()))

--- a/bittide-instances/src/Bittide/Instances/Pnr/Freeze.hs
+++ b/bittide-instances/src/Bittide/Instances/Pnr/Freeze.hs
@@ -1,12 +1,13 @@
 -- SPDX-FileCopyrightText: 2025 Google LLC
 --
 -- SPDX-License-Identifier: Apache-2.0
-{-# LANGUAGE OverloadedStrings #-}
-
 module Bittide.Instances.Pnr.Freeze where
 
+import Clash.Prelude
+
+import Bittide.Instances.Domains (Basic400)
+import Bittide.Instances.Hacks (reducePins)
 import Bittide.SharedTypes (BitboneMm, withLittleEndian)
-import Clash.Explicit.Prelude
 import GHC.Stack (HasCallStack)
 import Protocols
 import Protocols.Experimental.Wishbone
@@ -64,3 +65,9 @@ freeze ::
   Signal XilinxSystem (WishboneS2M 4)
 freeze clk rst m2s =
   snd $ fst $ toSignals (freezeExample @XilinxSystem clk rst) (((), m2s), ())
+
+freezeFast ::
+  Clock Basic400 -> Reset Basic400 -> Signal Basic400 Bit -> Signal Basic400 Bit
+freezeFast clk rst = withClock clk $ reducePins dut
+ where
+  dut inp = fst $ toSignals (unMemmap (freezeExample clk rst)) (inp, ())

--- a/bittide-instances/src/Bittide/Instances/Pnr/Handshake.hs
+++ b/bittide-instances/src/Bittide/Instances/Pnr/Handshake.hs
@@ -1,0 +1,40 @@
+-- SPDX-FileCopyrightText: 2026 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+
+module Bittide.Instances.Pnr.Handshake where
+
+import Clash.Prelude
+import Protocols
+
+import Bittide.ElasticBuffer (ElasticBufferData (Data))
+import Bittide.Handshake (Inputs (..), Outputs (..), handshakesWb)
+import Bittide.Instances.Domains (Basic300)
+import Bittide.Instances.Hacks (reducePins)
+import Bittide.SharedTypes (withLittleEndian)
+
+handshakesWbFast ::
+  Clock Basic300 -> Reset Basic300 -> Signal Basic300 Bit -> Signal Basic300 Bit
+handshakesWbFast clk rst = withClock clk $ reducePins dut
+ where
+  dut (unbundle -> (wbIn, fromNeighbors, fromCores)) = bundle (wbOut, fromOutputs outputs)
+   where
+    (((_mm, wbOut), _inputs), outputs) =
+      toSignals
+        ( withLittleEndian
+            $ withClock clk
+            $ withReset rst
+            $ handshakesWb @6 @_ @32 @4
+        )
+        ((((), wbIn), inputs), units)
+
+    inputs = Inputs (unbundle (fmap (fmap Data) fromNeighbors)) (unbundle fromCores)
+    fromOutputs outs =
+      bundle
+        ( bundle outs.toNeighbors
+        , bundle outs.toCores
+        , bundle outs.toNeighborDones
+        , bundle outs.toCoreDones
+        , bundle outs.fromNeighborDones
+        , bundle outs.fromCoreDones
+        )

--- a/bittide-instances/src/Bittide/Instances/Pnr/ProgrammableMux.hs
+++ b/bittide-instances/src/Bittide/Instances/Pnr/ProgrammableMux.hs
@@ -1,0 +1,28 @@
+-- SPDX-FileCopyrightText: 2026 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+module Bittide.Instances.Pnr.ProgrammableMux where
+
+import Clash.Prelude
+
+import Bittide.Instances.Domains (Basic400)
+import Bittide.Instances.Hacks (reducePins)
+import Bittide.SharedTypes (withLittleEndian)
+import Protocols
+
+import qualified Bittide.ProgrammableMux as PM
+
+programmableMuxFast ::
+  Clock Basic400 -> Reset Basic400 -> Signal Basic400 Bit -> Signal Basic400 Bit
+programmableMuxFast clk rst = withClock clk $ reducePins dut
+ where
+  dut (unbundle -> (localCounter, wbIn, linkA, linkB)) =
+    bundle (wbOut, unsafeToActiveHigh rstOut, linkOut)
+   where
+    (((_mm, wbOut), _, _), (rstOut, linkOut)) =
+      toSignals
+        ( withLittleEndian
+            $ withClockResetEnable clk rst enableGen
+            $ PM.programmableMux @_ @32 @4 @(BitVector 64) localCounter
+        )
+        ((((), wbIn), linkA, linkB), ((), ()))

--- a/bittide-instances/src/Bittide/Instances/Pnr/RingBuffer.hs
+++ b/bittide-instances/src/Bittide/Instances/Pnr/RingBuffer.hs
@@ -12,7 +12,8 @@ import Protocols
 import Protocols.Df.Extra (tdpbramRamOp)
 import Protocols.Experimental.Wishbone
 
-import Bittide.Instances.Domains (Bittide)
+import Bittide.Instances.Domains (Basic350, Bittide)
+import Bittide.Instances.Hacks (reducePins)
 import Bittide.RingBuffer (receiveRingBuffer, transmitRingBuffer)
 import Bittide.SharedTypes (withLittleEndian)
 import Clash.Cores.Xilinx.BlockRam (tdpbram)
@@ -22,14 +23,15 @@ import qualified Clash.Explicit.Prelude as E
 type BufferDepth = 4000
 type AddressWidth = 30
 
-transmitRingBufferPnr ::
-  "clk" ::: Clock Bittide ->
-  "rst" ::: Reset Bittide ->
-  "wbIn" ::: Signal Bittide (WishboneM2S AddressWidth 4) ->
-  ( "wbOut" ::: Signal Bittide (WishboneS2M 4)
-  , "txData" ::: Signal Bittide (BitVector 64)
+transmitRingBufferExample ::
+  (KnownDomain dom) =>
+  "clk" ::: Clock dom ->
+  "rst" ::: Reset dom ->
+  "wbIn" ::: Signal dom (WishboneM2S AddressWidth 4) ->
+  ( "wbOut" ::: Signal dom (WishboneS2M 4)
+  , "txData" ::: Signal dom (BitVector 64)
   )
-transmitRingBufferPnr clk rst wbIn = (wbOut, txData)
+transmitRingBufferExample clk rst wbIn = (wbOut, txData)
  where
   txPrim = tdpbramRamOp tdpbram clk clk
   ((SimOnly _mm, wbOut), txData) =
@@ -38,15 +40,31 @@ transmitRingBufferPnr clk rst wbIn = (wbOut, txData)
         (withClockResetEnable clk rst enableGen $ transmitRingBuffer txPrim (SNat @BufferDepth))
         (((), wbIn), ())
 
-makeTopEntity 'transmitRingBufferPnr
-
-receiveRingBufferPnr ::
+transmitRingBufferPnr ::
   "clk" ::: Clock Bittide ->
   "rst" ::: Reset Bittide ->
   "wbIn" ::: Signal Bittide (WishboneM2S AddressWidth 4) ->
-  "rxData" ::: Signal Bittide (BitVector 64) ->
-  "wbOut" ::: Signal Bittide (WishboneS2M 4)
-receiveRingBufferPnr clk rst wbIn rxData = wbOut
+  ( "wbOut" ::: Signal Bittide (WishboneS2M 4)
+  , "txData" ::: Signal Bittide (BitVector 64)
+  )
+transmitRingBufferPnr = transmitRingBufferExample
+
+makeTopEntity 'transmitRingBufferPnr
+
+transmitRingBufferFast ::
+  Clock Basic350 -> Reset Basic350 -> Signal Basic350 Bit -> Signal Basic350 Bit
+transmitRingBufferFast clk rst = withClock clk $ reducePins dut
+ where
+  dut wbIn = bundle $ transmitRingBufferExample clk rst wbIn
+
+receiveRingBufferExample ::
+  (KnownDomain dom) =>
+  "clk" ::: Clock dom ->
+  "rst" ::: Reset dom ->
+  "wbIn" ::: Signal dom (WishboneM2S AddressWidth 4) ->
+  "rxData" ::: Signal dom (BitVector 64) ->
+  "wbOut" ::: Signal dom (WishboneS2M 4)
+receiveRingBufferExample clk rst wbIn rxData = wbOut
  where
   rxPrim ena = E.blockRamU clk rst ena NoClearOnReset (SNat @BufferDepth)
   (((SimOnly _mm, wbOut), ()), ()) =
@@ -57,4 +75,18 @@ receiveRingBufferPnr clk rst wbIn rxData = wbOut
         )
         ((((), wbIn), rxData), ())
 
+receiveRingBufferPnr ::
+  "clk" ::: Clock Bittide ->
+  "rst" ::: Reset Bittide ->
+  "wbIn" ::: Signal Bittide (WishboneM2S AddressWidth 4) ->
+  "rxData" ::: Signal Bittide (BitVector 64) ->
+  "wbOut" ::: Signal Bittide (WishboneS2M 4)
+receiveRingBufferPnr = receiveRingBufferExample
+
 makeTopEntity 'receiveRingBufferPnr
+
+receiveRingBufferFast ::
+  Clock Basic350 -> Reset Basic350 -> Signal Basic350 Bit -> Signal Basic350 Bit
+receiveRingBufferFast clk rst = withClock clk $ reducePins dut
+ where
+  dut (unbundle -> (wbIn, rxData)) = receiveRingBufferExample clk rst wbIn rxData

--- a/bittide-instances/src/Bittide/Instances/Pnr/Si539xSpi.hs
+++ b/bittide-instances/src/Bittide/Instances/Pnr/Si539xSpi.hs
@@ -9,10 +9,29 @@ import Clash.Annotations.TH (makeTopEntity)
 
 import Bittide.ClockControl.Si5395J
 import Bittide.ClockControl.Si539xSpi
-import Bittide.Instances.Domains
+import Bittide.Instances.Domains (Basic125, Basic400)
+import Bittide.Instances.Hacks (reducePins)
 import Bittide.SharedTypes
 
 import qualified Protocols.Spi as Spi
+
+si5391SpiExample ::
+  (KnownDomain dom) =>
+  "CLK_125MHZ_P" ::: Clock dom ->
+  "reset" ::: Reset dom ->
+  "extOp" ::: Signal dom (Maybe RegisterOperation) ->
+  Signal dom Spi.S2M ->
+  ""
+    ::: ( "readByte" ::: Signal dom (Maybe Byte)
+        , "BUSY" ::: Signal dom Busy
+        , "STATE" ::: Signal dom (ConfigState dom TestConfig6_200_on_0a_TotalRegs)
+        , "" ::: Signal dom Spi.M2S
+        )
+si5391SpiExample clk rst extOp spiS2M = (readByte, busy, state, m2s)
+ where
+  (readByte, busy, state, m2s) =
+    withClockResetEnable clk rst enableGen
+      $ si539xSpi testConfig6_200_on_0a_1ppb (SNat @50000) extOp spiS2M
 
 si5391Spi ::
   "CLK_125MHZ_P" ::: Clock Basic125 ->
@@ -25,10 +44,11 @@ si5391Spi ::
         , "STATE" ::: Signal Basic125 (ConfigState Basic125 TestConfig6_200_on_0a_TotalRegs)
         , "" ::: Signal Basic125 Spi.M2S
         )
-si5391Spi clk rst extOp spiS2M = (readByte, busy, state, m2s)
- where
-  (readByte, busy, state, m2s) =
-    withClockResetEnable clk rst enableGen
-      $ si539xSpi testConfig6_200_on_0a_1ppb (SNat @50000) extOp spiS2M
+si5391Spi = si5391SpiExample
 
 makeTopEntity 'si5391Spi
+
+si5391SpiFast :: Clock Basic400 -> Reset Basic400 -> Signal Basic400 Bit -> Signal Basic400 Bit
+si5391SpiFast clk rst = withClock clk $ reducePins dut
+ where
+  dut (unbundle -> (extOp, spiS2M)) = bundle $ si5391SpiExample clk rst extOp spiS2M

--- a/bittide-instances/src/Bittide/Instances/Pnr/Time.hs
+++ b/bittide-instances/src/Bittide/Instances/Pnr/Time.hs
@@ -1,0 +1,29 @@
+-- SPDX-FileCopyrightText: 2026 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+
+module Bittide.Instances.Pnr.Time where
+
+import Clash.Prelude
+import Protocols
+
+import Bittide.Instances.Domains (Basic350)
+import Bittide.Instances.Hacks (reducePins)
+import Bittide.SharedTypes (withLittleEndian)
+import Protocols.MemoryMap (unMemmap)
+
+import qualified Bittide.Wishbone as Wb
+
+timeWbFast ::
+  Clock Basic350 -> Reset Basic350 -> Signal Basic350 Bit -> Signal Basic350 Bit
+timeWbFast clk rst = withClock clk $ reducePins dut
+ where
+  dut (unbundle -> (lc, wbIn)) =
+    bundle
+      $ toSignals
+        ( unMemmap
+            $ withLittleEndian
+            $ withClockResetEnable clk rst enableGen
+            $ Wb.timeWb @_ @32 (Just lc)
+        )
+        (wbIn, ())

--- a/bittide-instances/src/Bittide/Instances/Pnr/Uart.hs
+++ b/bittide-instances/src/Bittide/Instances/Pnr/Uart.hs
@@ -1,0 +1,82 @@
+-- SPDX-FileCopyrightText: 2026 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+
+module Bittide.Instances.Pnr.Uart where
+
+import Clash.Prelude
+import Protocols
+
+import Bittide.Instances.Domains (Basic350)
+import Bittide.Instances.Hacks (reducePins)
+import Bittide.SharedTypes (Byte, withLittleEndian)
+import Clash.Cores.Xilinx.DcFifo (dcFifoDf)
+import Data.Char (ord)
+import Protocols.Experimental.Wishbone
+import Protocols.Extra (FunctorC (fmapC))
+import Protocols.MemoryMap
+
+import qualified Bittide.Df as Df
+import qualified Bittide.Wishbone as Wb
+
+type Baud = 921_600
+
+baud :: SNat Baud
+baud = SNat
+
+uartLabels :: Vec 3 (Vec 2 Byte)
+uartLabels =
+  fmap (fromIntegral . ord)
+    <$> ( $(listToVecTH "CC")
+            :> $(listToVecTH "BB")
+            :> $(listToVecTH "AA")
+            :> Nil
+        )
+
+{- | Instead of testing all UART components individually we test the whole chain of components
+as they are used in the demo's. This means:
+- 3x 'uartInterfaceWb' with 'uartBytes' as their uart implementation
+- For 2 uart streams a 'dcFifoDf'
+- 'asciiDebugMux'
+- 'uartDf'
+
+Note that we do not connect any 'uartRx'. This is a limitation of using 'asciiDebugMux'.
+-}
+uartExample ::
+  (HiddenClockResetEnable Basic350) =>
+  Circuit
+    ( Vec 3 (ToConstBwd Mm)
+    , Vec 3 (Wishbone Basic350 'Standard 32 4)
+    )
+    (CSignal Basic350 Bit)
+uartExample = withLittleEndian $ circuit $ \(memoryMaps, wbs) -> do
+  [mmA, mmB, mmC] <- idC -< memoryMaps
+  [wbA, wbB, wbC] <- idC -< wbs
+
+  (uartBytesA0, _uartStatusA) <-
+    Wb.uartInterfaceWb d16 d16 Wb.uartBytes -< ((mmA, wbA), Fwd (pure Nothing))
+  (uartBytesB0, _uartStatusB) <-
+    Wb.uartInterfaceWb d16 d16 Wb.uartBytes -< ((mmB, wbB), Fwd (pure Nothing))
+  (uartBytesC, _uartStatusC) <-
+    Wb.uartInterfaceWb d16 d16 Wb.uartBytes -< ((mmC, wbC), Fwd (pure Nothing))
+
+  (uartBytesA1, uartBytesB1) <-
+    fmapC
+      $ dcFifoDf d5 hasClock hasReset hasClock hasReset
+      -< (uartBytesA0, uartBytesB0)
+
+  uartTxBytes <- Df.asciiDebugMux d1024 uartLabels -< [uartBytesC, uartBytesB1, uartBytesA1]
+
+  (_uartInBytes, uartTx) <- Wb.uartDf baud -< (uartTxBytes, Fwd 0)
+
+  idC -< uartTx
+
+uartExampleFast :: Clock Basic350 -> Reset Basic350 -> Signal Basic350 Bit -> Signal Basic350 Bit
+uartExampleFast clk rst = withClock clk $ reducePins dut
+ where
+  dut (unbundle -> wbIns) = bundle (bundle wbOuts, uartTx)
+   where
+    ((_mms, wbOuts), uartTx) =
+      toSignals
+        ((withClockResetEnable clk rst enableGen $ uartExample))
+        ((units, wbIns), units)

--- a/bittide-instances/src/Bittide/Instances/Pnr/WbStorage.hs
+++ b/bittide-instances/src/Bittide/Instances/Pnr/WbStorage.hs
@@ -1,0 +1,30 @@
+-- SPDX-FileCopyrightText: 2026 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+
+module Bittide.Instances.Pnr.WbStorage where
+
+import Clash.Prelude
+import Protocols
+
+import Bittide.DoubleBufferedRam (wbStorage)
+import Bittide.Instances.Domains (Basic300)
+import Bittide.Instances.Hacks (reducePins)
+import Protocols.Experimental.Wishbone
+import Protocols.MemoryMap (Mm, unMemmap)
+
+wbStorageExample ::
+  forall dom depth.
+  (HiddenClockResetEnable dom, 1 <= depth) =>
+  SNat depth ->
+  Circuit (ToConstBwd Mm, Wishbone dom 'Standard 32 4) ()
+wbStorageExample depth = wbStorage "SampleMemory" depth Nothing
+
+wbStorageFast :: Clock Basic300 -> Reset Basic300 -> Signal Basic300 Bit -> Signal Basic300 Bit
+wbStorageFast clk rst = withClock clk $ reducePins dut
+ where
+  dut wbIn =
+    fst
+      $ toSignals
+        (unMemmap $ withClockResetEnable clk rst enableGen $ wbStorageExample (SNat @36_000))
+        (wbIn, ())

--- a/bittide-instances/src/Bittide/Instances/Pnr/WireDemoProcessingElement.hs
+++ b/bittide-instances/src/Bittide/Instances/Pnr/WireDemoProcessingElement.hs
@@ -1,0 +1,22 @@
+-- SPDX-FileCopyrightText: 2026 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+module Bittide.Instances.Pnr.WireDemoProcessingElement where
+
+import Clash.Prelude
+import Protocols
+
+import Bittide.Instances.Domains (Basic400)
+import Bittide.Instances.Hacks (reducePins)
+import Bittide.WireDemoProcessingElement (wireDemoPe)
+
+wireDemoPeFast :: Clock Basic400 -> Reset Basic400 -> Signal Basic400 Bit -> Signal Basic400 Bit
+wireDemoPeFast clk rst = withClock clk $ reducePins dut
+ where
+  dut (unbundle -> (maybeDna, localCounter, linksIn, readIndex, writeIndex)) =
+    go
+      $ toSignals
+        (withClock clk $ wireDemoPe @_ @6 @64 rst maybeDna localCounter)
+        ((unbundle linksIn, readIndex, writeIndex), (units, ()))
+   where
+    go ((_, _, _), (linksOut, writtenData)) = bundle (bundle linksOut, writtenData)

--- a/bittide-instances/src/Bittide/Instances/Pnr/Wishbone.hs
+++ b/bittide-instances/src/Bittide/Instances/Pnr/Wishbone.hs
@@ -11,6 +11,7 @@ import Bittide.Instances.Domains (Basic400)
 import Bittide.Instances.Hacks (reducePins)
 import Clash.Cores.Xilinx (withXilinx)
 import Data.Bifunctor (first)
+import Protocols.Wishbone.Extra (delayWishbone)
 
 import qualified Bittide.Wishbone as Wb
 
@@ -26,3 +27,12 @@ arbiterFast clk rst = withClock clk $ reducePins dut
             $ Wb.arbiter @_ @32 @4 @2
         )
         (unbundle wb0Ins, wb1Out)
+
+delayWishboneFast :: Clock Basic400 -> Reset Basic400 -> Signal Basic400 Bit -> Signal Basic400 Bit
+delayWishboneFast clk rst = withClock clk $ reducePins dut
+ where
+  dut (unbundle -> (wb0M2S, wb1S2M)) =
+    bundle
+      $ toSignals
+        (withClockResetEnable clk rst enableGen $ delayWishbone @_ @32 @4)
+        (wb0M2S, wb1S2M)

--- a/bittide-instances/src/Bittide/Instances/Pnr/Wishbone.hs
+++ b/bittide-instances/src/Bittide/Instances/Pnr/Wishbone.hs
@@ -1,0 +1,28 @@
+-- SPDX-FileCopyrightText: 2026 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+
+module Bittide.Instances.Pnr.Wishbone where
+
+import Clash.Prelude
+import Protocols
+
+import Bittide.Instances.Domains (Basic400)
+import Bittide.Instances.Hacks (reducePins)
+import Clash.Cores.Xilinx (withXilinx)
+import Data.Bifunctor (first)
+
+import qualified Bittide.Wishbone as Wb
+
+arbiterFast :: Clock Basic400 -> Reset Basic400 -> Signal Basic400 Bit -> Signal Basic400 Bit
+arbiterFast clk rst = withClock clk $ reducePins dut
+ where
+  dut (unbundle -> (wb0Ins, wb1Out)) =
+    bundle
+      $ first bundle
+      $ toSignals
+        ( withXilinx
+            $ withClockResetEnable clk rst enableGen
+            $ Wb.arbiter @_ @32 @4 @2
+        )
+        (unbundle wb0Ins, wb1Out)

--- a/bittide-shake/exe/Main.hs
+++ b/bittide-shake/exe/Main.hs
@@ -188,6 +188,7 @@ targets =
     , defTarget $ mkName "Bittide.Instances.Pnr.DomainDiffCounter.domainDiffCounterFast"
     , defTarget $ mkName "Bittide.Instances.Pnr.Freeze.freezeFast"
     , defTarget $ mkName "Bittide.Instances.Pnr.ProgrammableMux.programmableMuxFast"
+    , defTarget $ mkName "Bittide.Instances.Pnr.Time.timeWbFast"
     ]
       <> (testTarget <$> Bittide.Instances.Hitl.Tests.hitlTests)
 

--- a/bittide-shake/exe/Main.hs
+++ b/bittide-shake/exe/Main.hs
@@ -196,6 +196,7 @@ targets =
     , defTarget $ mkName "Bittide.Instances.Pnr.Time.timeWbFast"
     , defTarget $ mkName "Bittide.Instances.Pnr.Uart.uartExampleFast"
     , defTarget $ mkName "Bittide.Instances.Pnr.WbStorage.wbStorageFast"
+    , defTarget $ mkName "Bittide.Instances.Pnr.WireDemoProcessingElement.wireDemoPeFast"
     ]
       <> (testTarget <$> Bittide.Instances.Hitl.Tests.hitlTests)
 

--- a/bittide-shake/exe/Main.hs
+++ b/bittide-shake/exe/Main.hs
@@ -191,6 +191,7 @@ targets =
     , defTarget $ mkName "Bittide.Instances.Pnr.ProgrammableMux.programmableMuxFast"
     , defTarget $ mkName "Bittide.Instances.Pnr.RingBuffer.receiveRingBufferFast"
     , defTarget $ mkName "Bittide.Instances.Pnr.RingBuffer.transmitRingBufferFast"
+    , defTarget $ mkName "Bittide.Instances.Pnr.Si539xSpi.si5391SpiFast"
     , defTarget $ mkName "Bittide.Instances.Pnr.Time.timeWbFast"
     , defTarget $ mkName "Bittide.Instances.Pnr.Uart.uartExampleFast"
     ]

--- a/bittide-shake/exe/Main.hs
+++ b/bittide-shake/exe/Main.hs
@@ -175,7 +175,6 @@ targets =
   map enforceValidTarget $
     [ defTarget $ mkName "Bittide.Instances.Pnr.AsciiDebugMux.asciiDebugMux"
     , defTarget $ mkName "Bittide.Instances.Pnr.Freeze.freeze"
-    , defTarget $ mkName "Bittide.Instances.Pnr.Counter.counterReducedPins"
     , defTarget $ mkName "Bittide.Instances.Pnr.ElasticBuffer.elasticBufferWb"
     , defTarget $ mkName "Bittide.Instances.Pnr.ProcessingElement.vexRiscUartHello"
     , defTarget $ mkName "Bittide.Instances.Pnr.RingBuffer.transmitRingBufferPnr"
@@ -183,7 +182,8 @@ targets =
     , defTarget $ mkName "Bittide.Instances.Pnr.Si539xSpi.si5391Spi"
     , defTarget $ mkName "Bittide.Instances.Pnr.Synchronizer.safeDffSynchronizer"
     , -- High-frequency Pnr targets
-      defTarget $ mkName "Bittide.Instances.Pnr.Freeze.freezeFast"
+      defTarget $ mkName "Bittide.Instances.Pnr.DomainDiffCounter.domainDiffCounterFast"
+    , defTarget $ mkName "Bittide.Instances.Pnr.Freeze.freezeFast"
     ]
       <> (testTarget <$> Bittide.Instances.Hitl.Tests.hitlTests)
 

--- a/bittide-shake/exe/Main.hs
+++ b/bittide-shake/exe/Main.hs
@@ -187,6 +187,7 @@ targets =
     , defTarget $ mkName "Bittide.Instances.Pnr.CaptureUgn.sendUgnFast"
     , defTarget $ mkName "Bittide.Instances.Pnr.DomainDiffCounter.domainDiffCounterFast"
     , defTarget $ mkName "Bittide.Instances.Pnr.Freeze.freezeFast"
+    , defTarget $ mkName "Bittide.Instances.Pnr.Handshake.handshakesWbFast"
     , defTarget $ mkName "Bittide.Instances.Pnr.ProgrammableMux.programmableMuxFast"
     , defTarget $ mkName "Bittide.Instances.Pnr.Time.timeWbFast"
     ]

--- a/bittide-shake/exe/Main.hs
+++ b/bittide-shake/exe/Main.hs
@@ -197,6 +197,7 @@ targets =
     , defTarget $ mkName "Bittide.Instances.Pnr.Uart.uartExampleFast"
     , defTarget $ mkName "Bittide.Instances.Pnr.WbStorage.wbStorageFast"
     , defTarget $ mkName "Bittide.Instances.Pnr.WireDemoProcessingElement.wireDemoPeFast"
+    , defTarget $ mkName "Bittide.Instances.Pnr.Wishbone.arbiterFast"
     ]
       <> (testTarget <$> Bittide.Instances.Hitl.Tests.hitlTests)
 

--- a/bittide-shake/exe/Main.hs
+++ b/bittide-shake/exe/Main.hs
@@ -182,7 +182,9 @@ targets =
     , defTarget $ mkName "Bittide.Instances.Pnr.Si539xSpi.si5391Spi"
     , defTarget $ mkName "Bittide.Instances.Pnr.Synchronizer.safeDffSynchronizer"
     , -- High-frequency Pnr targets
-      defTarget $ mkName "Bittide.Instances.Pnr.DomainDiffCounter.domainDiffCounterFast"
+      defTarget $ mkName "Bittide.Instances.Pnr.CaptureUgn.captureUgnFast"
+    , defTarget $ mkName "Bittide.Instances.Pnr.CaptureUgn.sendUgnFast"
+    , defTarget $ mkName "Bittide.Instances.Pnr.DomainDiffCounter.domainDiffCounterFast"
     , defTarget $ mkName "Bittide.Instances.Pnr.Freeze.freezeFast"
     ]
       <> (testTarget <$> Bittide.Instances.Hitl.Tests.hitlTests)

--- a/bittide-shake/exe/Main.hs
+++ b/bittide-shake/exe/Main.hs
@@ -182,6 +182,8 @@ targets =
     , defTarget $ mkName "Bittide.Instances.Pnr.RingBuffer.receiveRingBufferPnr"
     , defTarget $ mkName "Bittide.Instances.Pnr.Si539xSpi.si5391Spi"
     , defTarget $ mkName "Bittide.Instances.Pnr.Synchronizer.safeDffSynchronizer"
+    , -- High-frequency Pnr targets
+      defTarget $ mkName "Bittide.Instances.Pnr.Freeze.freezeFast"
     ]
       <> (testTarget <$> Bittide.Instances.Hitl.Tests.hitlTests)
 

--- a/bittide-shake/exe/Main.hs
+++ b/bittide-shake/exe/Main.hs
@@ -198,6 +198,7 @@ targets =
     , defTarget $ mkName "Bittide.Instances.Pnr.WbStorage.wbStorageFast"
     , defTarget $ mkName "Bittide.Instances.Pnr.WireDemoProcessingElement.wireDemoPeFast"
     , defTarget $ mkName "Bittide.Instances.Pnr.Wishbone.arbiterFast"
+    , defTarget $ mkName "Bittide.Instances.Pnr.Wishbone.delayWishboneFast"
     ]
       <> (testTarget <$> Bittide.Instances.Hitl.Tests.hitlTests)
 

--- a/bittide-shake/exe/Main.hs
+++ b/bittide-shake/exe/Main.hs
@@ -189,6 +189,8 @@ targets =
     , defTarget $ mkName "Bittide.Instances.Pnr.Freeze.freezeFast"
     , defTarget $ mkName "Bittide.Instances.Pnr.Handshake.handshakesWbFast"
     , defTarget $ mkName "Bittide.Instances.Pnr.ProgrammableMux.programmableMuxFast"
+    , defTarget $ mkName "Bittide.Instances.Pnr.RingBuffer.receiveRingBufferFast"
+    , defTarget $ mkName "Bittide.Instances.Pnr.RingBuffer.transmitRingBufferFast"
     , defTarget $ mkName "Bittide.Instances.Pnr.Time.timeWbFast"
     , defTarget $ mkName "Bittide.Instances.Pnr.Uart.uartExampleFast"
     ]

--- a/bittide-shake/exe/Main.hs
+++ b/bittide-shake/exe/Main.hs
@@ -195,6 +195,7 @@ targets =
     , defTarget $ mkName "Bittide.Instances.Pnr.Si539xSpi.si5391SpiFast"
     , defTarget $ mkName "Bittide.Instances.Pnr.Time.timeWbFast"
     , defTarget $ mkName "Bittide.Instances.Pnr.Uart.uartExampleFast"
+    , defTarget $ mkName "Bittide.Instances.Pnr.WbStorage.wbStorageFast"
     ]
       <> (testTarget <$> Bittide.Instances.Hitl.Tests.hitlTests)
 

--- a/bittide-shake/exe/Main.hs
+++ b/bittide-shake/exe/Main.hs
@@ -182,7 +182,8 @@ targets =
     , defTarget $ mkName "Bittide.Instances.Pnr.Si539xSpi.si5391Spi"
     , defTarget $ mkName "Bittide.Instances.Pnr.Synchronizer.safeDffSynchronizer"
     , -- High-frequency Pnr targets
-      defTarget $ mkName "Bittide.Instances.Pnr.CaptureUgn.captureUgnFast"
+      defTarget $ mkName "Bittide.Instances.Pnr.AsciiDebugMux.asciiDebugMuxFast"
+    , defTarget $ mkName "Bittide.Instances.Pnr.CaptureUgn.captureUgnFast"
     , defTarget $ mkName "Bittide.Instances.Pnr.CaptureUgn.sendUgnFast"
     , defTarget $ mkName "Bittide.Instances.Pnr.DomainDiffCounter.domainDiffCounterFast"
     , defTarget $ mkName "Bittide.Instances.Pnr.Freeze.freezeFast"

--- a/bittide-shake/exe/Main.hs
+++ b/bittide-shake/exe/Main.hs
@@ -186,6 +186,7 @@ targets =
     , defTarget $ mkName "Bittide.Instances.Pnr.CaptureUgn.sendUgnFast"
     , defTarget $ mkName "Bittide.Instances.Pnr.DomainDiffCounter.domainDiffCounterFast"
     , defTarget $ mkName "Bittide.Instances.Pnr.Freeze.freezeFast"
+    , defTarget $ mkName "Bittide.Instances.Pnr.ProgrammableMux.programmableMuxFast"
     ]
       <> (testTarget <$> Bittide.Instances.Hitl.Tests.hitlTests)
 

--- a/bittide-shake/exe/Main.hs
+++ b/bittide-shake/exe/Main.hs
@@ -186,6 +186,7 @@ targets =
     , defTarget $ mkName "Bittide.Instances.Pnr.CaptureUgn.captureUgnFast"
     , defTarget $ mkName "Bittide.Instances.Pnr.CaptureUgn.sendUgnFast"
     , defTarget $ mkName "Bittide.Instances.Pnr.DomainDiffCounter.domainDiffCounterFast"
+    , defTarget $ mkName "Bittide.Instances.Pnr.ElasticBuffer.autoCenterFast"
     , defTarget $ mkName "Bittide.Instances.Pnr.Freeze.freezeFast"
     , defTarget $ mkName "Bittide.Instances.Pnr.Handshake.handshakesWbFast"
     , defTarget $ mkName "Bittide.Instances.Pnr.ProgrammableMux.programmableMuxFast"

--- a/bittide-shake/exe/Main.hs
+++ b/bittide-shake/exe/Main.hs
@@ -190,6 +190,7 @@ targets =
     , defTarget $ mkName "Bittide.Instances.Pnr.Handshake.handshakesWbFast"
     , defTarget $ mkName "Bittide.Instances.Pnr.ProgrammableMux.programmableMuxFast"
     , defTarget $ mkName "Bittide.Instances.Pnr.Time.timeWbFast"
+    , defTarget $ mkName "Bittide.Instances.Pnr.Uart.uartExampleFast"
     ]
       <> (testTarget <$> Bittide.Instances.Hitl.Tests.hitlTests)
 

--- a/bittide/src/Bittide/Wishbone.hs
+++ b/bittide/src/Bittide/Wishbone.hs
@@ -602,7 +602,6 @@ data TimeCmd = Capture | WaitForCmp
   deriving (Eq, Generic, Show, NFDataX, BitPack, BitPackC)
 deriveTypeDescription ''TimeCmd
 
-{- FOURMOLU_DISABLE -}
 {- | Wishbone accessible circuit that contains a free running 64 bit counter with stalling
 capabilities.
 -}
@@ -619,7 +618,8 @@ timeWb ::
     (BitboneMm dom addrW)
     (CSignal dom (Unsigned 64))
 timeWb externalCounter = circuit $ \mmWb -> do
-  [(cmdOffset, cmdConfig, cmdMeta, cmdWb0), cmpWb, scratchWb, freqWb] <- Mm.deviceWbI (Mm.deviceConfig "Timer") -< mmWb
+  [(cmdOffset, cmdConfig, cmdMeta, cmdWb0), cmpWb, scratchWb, freqWb] <-
+    Mm.deviceWbI (Mm.deviceConfig "Timer") -< mmWb
   cmdWb1 <- andAck cmdWaitAck -< cmdWb0
   cmdWb2 <- idC -< (cmdOffset, cmdConfig, cmdMeta, cmdWb1)
 
@@ -663,7 +663,6 @@ timeWb externalCounter = circuit $ \mmWb -> do
       { Mm.access = Mm.ReadOnly
       , Mm.description = "Frequency of the clock domain"
       }
-{- FOURMOLU_ENABLE -}
 
 andAck ::
   Signal dom Bool ->


### PR DESCRIPTION
_What (what did you do)_
I added place-and-route targets for (almost) all components which are used in the 2 demos. I tested each component at 300, 350 and 400 MHz and set that targets frequency to the highest it reached.

| Name pnr target         | 300 | 350 | 400 |
|:------------------------|:---:|:---:|:---:|
|`arbiter`                |  X  |  X  |  X  |
|`asciiDebugMuxFast`      |  X  |  X  |  X  |
|`autoCenterFast`         |  X  |  X  |  X  |
|`captureUgnFast`         |  X  |  X  |  X  |
|`delayWishbone`          |  X  |  X  |  X  |
|`domainDiffCounterFast`  |  X  |  X  |  X  |
|`freezeFast`             |  X  |  X  |  X  |
|`handshakesWbFast`       |  X  |     |     |
|`programmableMuxFast`    |  X  |  X  |  X  |
|`receiveRingBufferFast`  |  X  |  X  |     |
|`sendUgnFast`            |  X  |  X  |  X  |
|`si5391SpiFast`          |  X  |  X  |  X  |
|`timeWbFast`             |  X  |  X  |     |
|`transmitRingBufferFast` |  X  |  X  |     |
|`uartExampleFast`<sup> 1 </sup> |  X  |  X  |     |
|`wbStorageFast`          |  X  |     |     |
|`wireDemoPeFast`         |  X  |  X  |  X  |

<sup> 1 </sup> Contains: `uartInterfaceWb`, `uartBytes`, `uartDf`, `asciiDebugMux` and `dcFifoDf`

Note that the table above is missing some components which are used in demos. The table below lists the missing components and the reason there is not yet a high-frequency pnr target for it.

Component                 | Reason
--------------------------|----------
`elasticBuffer`           | Only test elastic buffer control and autocenter, not EB itself
`readDnaPortE2`           | Did not reach 250 MHz, uses an FPGA-specific primitive
`processingElement`       | Did not reach 200 MHz
`callistoSwClockControlC` | Did not reach 200 MHz (contains a lot of components)
`jtagChain`               | Doesn't add logic
`unsafeJtagSynchronizer`  | Doesn't add logic
`wireDemoPeConfig`        | Only wraps `deviceWb` with no other logic
`syncInCounterC`          | To be removed in issue https://github.com/bittide/bittide-hardware/issues/1155
`syncOutGenerateWbC`      | To be removed in issue https://github.com/bittide/bittide-hardware/issues/1155

_Why (context, issues, etc.)_
Fixes: #1300 

_Dear reviewer (anything you'd like the reviewer to pay close attention to?)_
1. Do you agree with the table of ignored components and their reasons?
2. Are the 2 tables complete, or did I miss a component?
3. I created new modules for most components, but now there's a lot of files. Should I merge some files?

_AI disclaimer (heads-up for more than inline autocomplete)_
No

# TODO
_~~Cross-out~~ any that do not apply_

- ~[ ] Write (regression) test~
- [x] Update documentation, including `docs/`
- [x] Link to existing issue
