### PR TITLE
Add option to repeat HITL on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,7 +227,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       REPORT_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-      REPORT_NAME: ${{ matrix.target.top }}
+      REPORT_NAME: ${{ matrix.target.top }}-${{ matrix.target.iteration }}
 
     steps:
       - name: Checkout
@@ -242,7 +242,7 @@ jobs:
 
       - name: Download HITL data
         run: |
-          gh run download ${{ github.run_id }} -p "${{ matrix.target.top }}-hitl-data"
+          gh run download ${{ github.run_id }} -p "${{ matrix.target.top }}-${{ matrix.target.iteration }}-hitl-data"
 
       - name: Generate clock control CSVs
         run: |
@@ -250,31 +250,31 @@ jobs:
           set +f
 
           # Note these aren't necessary to generate the reports, but are useful for debugging
-          cabal run bittide-instances:samples-to csv ${{ matrix.target.top }}-hitl-data/hitl/*/*.bin
-          cabal run bittide-instances:samples-to ppm-csv ${{ matrix.target.top }}-hitl-data/hitl/*/*.bin
+          cabal run bittide-instances:samples-to csv ${{ matrix.target.top }}-${{ matrix.target.iteration }}-hitl-data/hitl/*/*.bin
+          cabal run bittide-instances:samples-to ppm-csv ${{ matrix.target.top }}-${{ matrix.target.iteration }}-hitl-data/hitl/*/*.bin
 
       - name: Generate clock control reports
         run: |
-          cabal run bittide-instances:samples-to multi-report ${{ matrix.target.top }}-hitl-data/hitl
+          cabal run bittide-instances:samples-to multi-report ${{ matrix.target.top }}-${{ matrix.target.iteration }}-hitl-data/hitl
 
       - name: Upload report
         uses: actions/upload-artifact@v7
         if: always()
         with:
-          name: ${{ matrix.target.top }}-clock-report
+          name: ${{ matrix.target.top }}-${{ matrix.target.iteration }}-clock-report
           path: |
-            ${{ matrix.target.top }}-hitl-data/hitl/*.pdf
+            ${{ matrix.target.top }}-${{ matrix.target.iteration }}-hitl-data/hitl/*.pdf
           retention-days: 14
 
       - name: Upload sources
         uses: actions/upload-artifact@v7
         if: always()
         with:
-          name: ${{ matrix.target.top }}-clock-report-sources
+          name: ${{ matrix.target.top }}-${{ matrix.target.iteration }}-clock-report-sources
           path: |
-            ${{ matrix.target.top }}-hitl-data/hitl/*/*.json
-            ${{ matrix.target.top }}-hitl-data/hitl/*/*.bin
-            ${{ matrix.target.top }}-hitl-data/hitl/*/*.csv
+            ${{ matrix.target.top }}-${{ matrix.target.iteration }}-hitl-data/hitl/*/*.json
+            ${{ matrix.target.top }}-${{ matrix.target.iteration }}-hitl-data/hitl/*/*.bin
+            ${{ matrix.target.top }}-${{ matrix.target.iteration }}-hitl-data/hitl/*/*.csv
           retention-days: 14
 
   should-run-haskell-tests:
@@ -527,7 +527,11 @@ jobs:
       - name: Set HITL matrix
         id: set-hitl
         run: |
-          jq '[.[] | select(.stage=="test")]' checks.json > checks.hitl.json
+          # Expand each entry by its `repeat` field (default 1), tagging each
+          # expansion with a 1-based `iteration` so downstream jobs can give
+          # repeated runs distinct artifact names.
+          jq '[.[] | select(.stage=="test") | . as $row | ($row.repeat // 1) as $rep | ($rep | tostring | length) as $w | range($rep) | $row + {iteration: ((. + 1) | tostring | (("0" * $w) + .)[-$w:])}]' \
+            checks.json > checks.hitl.json
           cat checks.hitl.json
           echo "matrix=$(cat checks.hitl.json | tr '\n' ' ')" | tee -a "$GITHUB_OUTPUT"
 
@@ -810,7 +814,7 @@ jobs:
 
       - name: Run tests on hardware
         run: |
-          export VIVADO_HS_LOG_DIR="$(git rev-parse --show-toplevel)/_build/hitl/vivado-run/"
+          export VIVADO_HS_LOG_DIR="$(git rev-parse --show-toplevel)/_build/hitl/vivado-run-${{ matrix.target.iteration }}/"
           if [[ ! -d "${VIVADO_HS_LOG_DIR} " ]]; then
             mkdir -p "${VIVADO_HS_LOG_DIR}"
           fi
@@ -823,7 +827,7 @@ jobs:
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v7
         with:
-          name: ${{ matrix.target.top }}-hitl-data
+          name: ${{ matrix.target.top }}-${{ matrix.target.iteration }}-hitl-data
           path: |
             _build/vivado/*/ila-data
             _build/hitl/*

--- a/nix/bin/debug
+++ b/nix/bin/debug
@@ -27,12 +27,19 @@ def load_all(path: Path) -> list[dict]:
 
 
 def load_debug(path: Path) -> dict[str, dict]:
-    """Return mapping from top name to {stage, cc_report} for prefill."""
+    """Return mapping from top name to {stage, cc_report, repeat} for prefill."""
     if not path.exists():
         return {}
     with path.open() as f:
         data = json.load(f)
-    return {e["top"]: {"stage": e["stage"], "cc_report": e["cc_report"]} for e in data}
+    return {
+        e["top"]: {
+            "stage": e["stage"],
+            "cc_report": e["cc_report"],
+            "repeat": e.get("repeat", 1),
+        }
+        for e in data
+    }
 
 
 def write_debug(path: Path, entries: list[dict], all_entries: list[dict]) -> None:
@@ -49,8 +56,9 @@ def write_debug(path: Path, entries: list[dict], all_entries: list[dict]) -> Non
         stage_field = f'"{e["stage"]}",'.ljust(stage_w)
         cc = "true" if e["cc_report"] else "false"
         sep = "," if i < len(entries) - 1 else ""
+        repeat_field = f', "repeat": {e["repeat"]}' if e.get("repeat", 1) > 1 else ""
         lines.append(
-            f'  {{"top": {top_field} "stage": {stage_field} "cc_report": {cc}}}{sep}'
+            f'  {{"top": {top_field} "stage": {stage_field} "cc_report": {cc}{repeat_field}}}{sep}'
         )
     lines.append("]")
     path.write_text("\n".join(lines) + "\n")
@@ -71,6 +79,7 @@ class App:
         for e in self.all_entries:
             top = e["top"]
             max_idx = max_stage_idx(e["stage"])
+            default_repeat = e.get("repeat", 1)
             if top in prefill:
                 pre = prefill[top]
                 stage_idx = STAGES.index(pre["stage"]) if pre["stage"] in STAGES else max_idx
@@ -80,6 +89,7 @@ class App:
                     "stage_idx": stage_idx,
                     "max_stage_idx": max_idx,
                     "cc_report": pre["cc_report"],
+                    "repeat": pre.get("repeat", default_repeat),
                 })
             else:
                 self.rows.append({
@@ -87,6 +97,7 @@ class App:
                     "stage_idx": max_idx,
                     "max_stage_idx": max_idx,
                     "cc_report": e["cc_report"],
+                    "repeat": default_repeat,
                 })
         self.cursor = 0
         self.scroll = 0
@@ -111,6 +122,7 @@ class App:
                     "top": src["top"],
                     "stage": STAGES[row["stage_idx"]],
                     "cc_report": row["cc_report"],
+                    "repeat": row["repeat"],
                 })
         return out
 
@@ -149,6 +161,21 @@ class App:
             row["stage_idx"] = new_idx
             self.save()
 
+    def bump_repeat(self, delta: int) -> None:
+        idx = self.current_row_idx()
+        if idx is None:
+            return
+        row = self.rows[idx]
+        # `repeat` only affects the HITL matrix in CI, so it's only meaningful
+        # for test-stage rows.
+        if STAGES[row["stage_idx"]] != "test":
+            self.status = "repeat only applies to stage=test"
+            return
+        new_repeat = max(1, row["repeat"] + delta)
+        if new_repeat != row["repeat"]:
+            row["repeat"] = new_repeat
+            self.save()
+
     def move(self, delta: int) -> None:
         n = len(self.visible_indices())
         if n == 0:
@@ -164,7 +191,7 @@ class App:
         )
         stdscr.addnstr(0, 0, title.ljust(w), w, curses.A_REVERSE)
         help_line = (
-            " space:toggle  c:cc_report  ←/→:stage  ↑/↓:move  /:search  #<enter>:jump+toggle  q:quit "
+            " space:toggle  c:cc_report  ←/→:stage  +/-:repeat  ↑/↓:move  /:search  #<enter>:jump+toggle  q:quit "
         )
         stdscr.addnstr(1, 0, help_line[:w], w)
 
@@ -197,8 +224,10 @@ class App:
             max_stage = STAGES[row["max_stage_idx"]]
             cc = "cc" if row["cc_report"] else "  "
             stage_disp = f"{stage:<9} (max {max_stage})"
+            # `repeat` only matters for stage=test, so blank it out otherwise.
+            rep = f"x{row['repeat']}" if stage == "test" else "  "
             num = f"{idx + 1:>{num_w}}"
-            line = f" {num}  {mark}  {src['top']:<{top_w}}  {stage_disp}  {cc} "
+            line = f" {num}  {mark}  {src['top']:<{top_w}}  {stage_disp}  {cc}  {rep:<4} "
             attr = curses.A_REVERSE if vis_pos == self.cursor else curses.A_NORMAL
             if row["selected"]:
                 attr |= curses.A_BOLD | curses.color_pair(1)
@@ -311,6 +340,10 @@ class App:
                 self.cycle_stage(-1)
             elif ch in (curses.KEY_RIGHT, ord("l")):
                 self.cycle_stage(1)
+            elif ch in (ord("+"), ord("=")):
+                self.bump_repeat(1)
+            elif ch == ord("-"):
+                self.bump_repeat(-1)
 
 
 def git_change_kind(root: Path, path: Path) -> str | None:


### PR DESCRIPTION
_What (what did you do)_
Add an option "repeat" to `debug.json` (and also the other jsons, but it is unlikely we'll use that).

_Why (context, issues, etc.)_
This can be useful when investigating fragile HITL tests.

_Dear reviewer (anything you'd like the reviewer to pay close attention to?)_
Not in particular.

_AI disclaimer (heads-up for more than inline autocomplete)_
You know it.

# TODO
_~~Cross-out~~ any that do not apply_

- [X] ~~Write (regression) test~~
- [X] ~~Update documentation, including `docs/`~~
- [X] ~~Link to existing issue~~
- [X] Survive 20: https://github.com/bittide/bittide-hardware/actions/runs/26889601701
- [X] Survive 200: https://github.com/bittide/bittide-hardware/actions/runs/26896680860
- [x] Run after naming fixes:
  - [x] Once: https://github.com/bittide/bittide-hardware/actions/runs/26938310948
  - [x] Twice: https://github.com/bittide/bittide-hardware/actions/runs/26938355493
  - [x] Fifteen: https://github.com/bittide/bittide-hardware/actions/runs/26938366662
