### PR TITLE
Decrease frequency of fast pnr `transmitRingBuffer` from 350 to 340 MHz

### DIFF
--- a/bittide-instances/README.md
+++ b/bittide-instances/README.md
@@ -43,12 +43,13 @@ The Bittide demo designs currently run at 125 MHz. The table below shows how far
 |`sendUgnFast`            |  X  |  X  |  X  |
 |`si5391SpiFast`          |  X  |  X  |  X  |
 |`timeWbFast`             |  X  |  X  |     |
-|`transmitRingBufferFast` |  X  |  X  |     |
-|`uartExampleFast`<sup> 1 </sup> |  X  |  X  |     |
+|`transmitRingBufferFast` <sup> 1 </sup> |  X  |    |     |
+|`uartExampleFast`<sup> 2 </sup> |  X  |  X  |     |
 |`wbStorageFast`          |  X  |     |     |
 |`wireDemoPeFast`         |  X  |  X  |  X  |
 
-<sup> 1 </sup> Contains: `uartInterfaceWb`, `uartBytes`, `uartDf`, `asciiDebugMux` and `dcFifoDf`
+<sup> 1 </sup> Fails at 350 MHz, but does run at 340 MHz
+<sup> 2 </sup> Contains: `uartInterfaceWb`, `uartBytes`, `uartDf`, `asciiDebugMux` and `dcFifoDf`
 
 Note that the table above is missing some components which are used in demos. The table below lists the missing components and the reason there is not yet a high-frequency pnr target for it.
 

--- a/bittide-instances/src/Bittide/Instances/Domains.hs
+++ b/bittide-instances/src/Bittide/Instances/Domains.hs
@@ -15,6 +15,7 @@ createDomain vXilinxSystem{vName="Basic125B", vPeriod=hzToPeriod 125e6}
 createDomain vXilinxSystem{vName="Basic199",  vPeriod=hzToPeriod 199e6}
 createDomain vXilinxSystem{vName="Basic200",  vPeriod=hzToPeriod 200e6}
 createDomain vXilinxSystem{vName="Basic300",  vPeriod=hzToPeriod 300e6}
+createDomain vXilinxSystem{vName="Basic340",  vPeriod=hzToPeriod 340e6}
 createDomain vXilinxSystem{vName="Basic350",  vPeriod=hzToPeriod 350e6}
 createDomain vXilinxSystem{vName="Basic400",  vPeriod=hzToPeriod 400e6}
 createDomain vXilinxSystem{vName="Basic625",  vPeriod=hzToPeriod 625e6, vResetKind=Asynchronous}

--- a/bittide-instances/src/Bittide/Instances/Pnr/RingBuffer.hs
+++ b/bittide-instances/src/Bittide/Instances/Pnr/RingBuffer.hs
@@ -12,7 +12,7 @@ import Protocols
 import Protocols.Df.Extra (tdpbramRamOp)
 import Protocols.Experimental.Wishbone
 
-import Bittide.Instances.Domains (Basic350, Bittide)
+import Bittide.Instances.Domains (Basic340, Basic350, Bittide)
 import Bittide.Instances.Hacks (reducePins)
 import Bittide.RingBuffer (receiveRingBuffer, transmitRingBuffer)
 import Bittide.SharedTypes (withLittleEndian)
@@ -52,7 +52,7 @@ transmitRingBufferPnr = transmitRingBufferExample
 makeTopEntity 'transmitRingBufferPnr
 
 transmitRingBufferFast ::
-  Clock Basic350 -> Reset Basic350 -> Signal Basic350 Bit -> Signal Basic350 Bit
+  Clock Basic340 -> Reset Basic340 -> Signal Basic340 Bit -> Signal Basic340 Bit
 transmitRingBufferFast clk rst = withClock clk $ reducePins dut
  where
   dut wbIn = bundle $ transmitRingBufferExample clk rst wbIn


### PR DESCRIPTION
_What (what did you do)_
The `transmitRingBufferFast` pnr test did run at 350 MHz when it was added, but does not anymore. Instead of decreasing its frequency to 300 MHz, a step of 50 MHz like the other targets, we decrease it with 10 MHz. This is the maximum frequency this component would consistently run at (over 10 runs).

This is a temporary solution until we find why the component no longer runs at 350 MHz.

_Why (context, issues, etc.)_
The high-frequency pnr test of `transmitRingBuffer` no longer passes place and route. 

_Dear reviewer (anything you'd like the reviewer to pay close attention to?)_
Nope

_AI disclaimer (heads-up for more than inline autocomplete)_
Nope

# TODO
_~~Cross-out~~ any that do not apply_

- ~[ ] Write (regression) test~
- [x] Update documentation, including `docs/`
- ~[ ] Link to existing issue~