### PR TITLE
Bump to `all-jobs-ok@v2`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -877,8 +877,7 @@ jobs:
 
   fail-on-debug:
     name: Fail on debug
-    runs-on: ubuntu-24.04
-    if: ${{ always() }}
+    runs-on: ubuntu-slim
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -913,10 +912,11 @@ jobs:
         rust-lints,
         should-run-haskell-tests,
       ]
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v6
-      - uses: clash-lang/all-jobs-ok@v1
+      - uses: clash-lang/all-jobs-ok@v2
         with:
+          needs: ${{ toJSON(needs) }}
           exclude: |
             notify-slack


### PR DESCRIPTION
_What (what did you do)_
Bump to `all-jobs-ok@v2`.

_Why (context, issues, etc.)_
It now faithfully restores the old behavior, where the check itself also fails if any of the dependencies fail. I don't _think_ this should influence merge behavior, but its neater anyway.

It also bumps to Node 24, which will be needed after Sept 16, 2026 according to the announcement by Alphabet:

> Action Required: Node 20 actions are deprecated across GitHub and will default to Node 24 on June 16, 2026. Node 20 will be fully removed on Sept 16, 2026. Update your actions now.

_Dear reviewer (anything you'd like the reviewer to pay close attention to?)_
No.

_AI disclaimer (heads-up for more than inline autocomplete)_
No.

# TODO
_~~Cross-out~~ any that do not apply_

- [X] ~~Write (regression) test~~
- [X] ~~Update documentation, including `docs/`~~
- [X] ~~Link to existing issue~~
