### PR TITLE
Remove call to `set_ci_flags.sh` in `mdbook` job

### DIFF
--- a/.github/workflows/deploy-documentation.yml
+++ b/.github/workflows/deploy-documentation.yml
@@ -29,10 +29,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Set CI flags
-        run: |
-          .github/scripts/set_ci_flags.sh
-
       - name: Build mdBook
         run: |
           cd docs


### PR DESCRIPTION
It has been renamed, but is irrelevant for the `mdbook` job anyway
