### PR TITLE
Don't echo Vivado's protocol framing blank line

### DIFF
--- a/vivado-hs/src/Vivado/Internal.hs
+++ b/vivado-hs/src/Vivado/Internal.hs
@@ -9,7 +9,7 @@ module Vivado.Internal where
 import Prelude
 
 import Control.Exception (Exception, finally, throwIO)
-import Control.Monad (forM_, unless, void, when)
+import Control.Monad (forM_, unless, void)
 import Data.Foldable (toList)
 import Data.List (intercalate)
 import Data.List.Extra (isPrefixOf, splitOn, trim)
@@ -103,20 +103,31 @@ expectLine ::
   Bool ->
   (String -> IO Filter) ->
   IO (Seq String, Maybe ErrorCode)
-expectLine v echo f = go mempty
+expectLine v echo f = go Nothing mempty
  where
-  go :: Seq String -> IO (Seq String, Maybe ErrorCode)
-  go acc = do
+  -- We echo each line to host stdout one line behind ('pending'), so that we can recognize
+  -- and drop the empty line that 'exec' always emits ('puts {}') directly before its magic
+  -- sentinel. We do this to filter out commands that don't print anything at all -- otherwise
+  -- we'd keep printing empty lines.
+  go :: Maybe String -> Seq String -> IO (Seq String, Maybe ErrorCode)
+  go pending acc = do
     line <- IO.hGetLine v.stdout
+    let isMagic = magic `isPrefixOf` line
 
     IO.hPutStrLn v.logHandle line
-    unless (magic `isPrefixOf` line) $ do
-      IO.hPutStrLn v.prettyLogHandle line
-      when echo $ IO.putStrLn line
+    unless isMagic $ IO.hPutStrLn v.prettyLogHandle line
+
+    pending1 <-
+      if not echo
+        then pure Nothing
+        else do
+          let dropFraming = isMagic && maybe False null pending
+          unless dropFraming $ forM_ pending IO.putStrLn
+          pure (if isMagic then Nothing else Just line)
 
     let lines' = acc :|> line
     f line >>= \case
-      Continue -> go lines'
+      Continue -> go pending1 lines'
       Stop -> return (lines', Nothing)
       StopWithError code -> return (lines', Just code)
 


### PR DESCRIPTION
Since 'Stream Vivado output to stdout' (8b51b7c2), every Vivado command's stdout is echoed live. The 'exec' TCL wrapper emits a 'puts {}' empty line directly before its magic sentinel on every command (it terminates any `-nonewline` output so the sentinel lands on its own line). That blank used to be captured silently; now it is echoed, and `pollTestDone` polls ~3 commands every 1ms, flooding HITL logs with thousands of blank lines. This commit fixes that.


