### PR TITLE
Don't install git hooks in dev shell on CI

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -63,6 +63,12 @@
       in {
         devShells.default = pkgs.mkShell {
           buildInputs = [
+            # 'pre-commit' itself is normally added to PATH by
+            # 'preCommitHook.shellHook'. We skip that hook on CI (see below), but
+            # the 'format' script still needs the 'pre-commit' binary, so we add
+            # it explicitly here.
+            pkgs.pre-commit
+
             pkgs.cabal-install
             pkgs.haskellPackages.cabal-gild
             pkgs.haskellPackages.fourmolu
@@ -153,7 +159,21 @@
 
             # Allow writing 'shake ...' instead of 'cabal run shake -- ...'
             export PATH="$(git rev-parse --show-toplevel)/nix/bin:$PATH";
-            ${preCommitHook.shellHook}
+
+            # Path to the generated pre-commit config. The 'format' script uses
+            # this with 'pre-commit run --config' so it works regardless of
+            # whether the hook-installing shellHook below runs (see CI note).
+            export PRE_COMMIT_CONFIG="${preCommitHook.config.configFile}"
+
+            # Installing git hooks (and creating the .pre-commit-config.yaml
+            # symlink) is only useful for local development. On CI it is noisy
+            # and even partially fails ('nix-store: command not found') because
+            # every step re-enters the dev shell. GITHUB_SHA is set by GitHub
+            # Actions and is kept across all 'git-nix-shell' invocations, so we
+            # use it to detect a CI environment.
+            if [ -z "''${GITHUB_SHA:-}" ]; then
+              ${preCommitHook.shellHook}
+            fi
           '';
         };
       }

--- a/nix/bin/format
+++ b/nix/bin/format
@@ -5,4 +5,11 @@
 ROOT=$(git rev-parse --show-toplevel)
 cd "${ROOT}" || exit 1
 
-pre-commit run --all-files
+# Use PRE_COMMIT_CONFIG (exported by the dev shell) when set, so this works even
+# when the .pre-commit-config.yaml symlink hasn't been created (e.g. on CI, where
+# we skip the hook-installing shellHook). Fall back to the default config lookup.
+if [ -n "${PRE_COMMIT_CONFIG:-}" ]; then
+  pre-commit run --all-files --config "${PRE_COMMIT_CONFIG}"
+else
+  pre-commit run --all-files
+fi


### PR DESCRIPTION
Entering the nix dev shell via 'git-nix-shell' ran preCommitHook.shellHook on every CI step, reinstalling git hooks and printing noise (and failing with 'nix-store: command not found' where nix-store isn't on PATH).

_Dear reviewer (anything you'd like the reviewer to pay close attention to?)_
No.

_AI disclaimer (heads-up for more than inline autocomplete)_
Yeah.

# TODO
_~~Cross-out~~ any that do not apply_

- [X] ~~Write (regression) test~~
- [X] ~~Update documentation, including `docs/`~~
- [X] ~~Link to existing issue~~
