### PR TITLE
Add retry mechanism to writing clock configurations

### DIFF
--- a/firmware-support/bittide-cpus/src/boot.rs
+++ b/firmware-support/bittide-cpus/src/boot.rs
@@ -6,6 +6,14 @@ use bittide_hal::manual_additions::si539x_spi::{Config, WriteError};
 use bittide_hal::shared_devices::{Si539xSpi, Timer, Transceivers, Uart};
 use ufmt::uwriteln;
 
+/// Writing a configuration can sometimes fail, usually because a written register was not
+/// the same when not read back. This happens roughly once in 200 runs. The 'run' function
+/// therefore retries when this happens up to 'MAX_RETRIES' times.
+const MAX_RETRIES: usize = 10;
+
+/// Run the steps of a boot CPU.
+///
+/// Panics when writing a configuration fails 'MAX_RETRIES' times.
 pub fn run(
     si539x_spi: Si539xSpi,
     timer: Timer,
@@ -14,21 +22,35 @@ pub fn run(
     config: &Config<3, 590, 5>,
 ) -> ! {
     uwriteln!(uart, "Writing Si539x configuration..").unwrap();
-    match si539x_spi.write_configuration(&timer, config) {
-        Ok(()) => {
-            uwriteln!(uart, "Done.").unwrap();
-        }
-        Err(WriteError::NotConfirmed { entry, read_data }) => {
-            uwriteln!(uart, "[ERROR] failed to write Si539x configuration:").unwrap();
-            uwriteln!(
-                uart,
-                "At 0x{:02X}{:02X} wrote 0x{:02X}, but read back 0x{:02X}",
-                entry.page,
-                entry.address,
-                entry.data,
-                read_data,
-            )
-            .unwrap();
+    let mut retries = 0;
+    loop {
+        match si539x_spi.write_configuration(&timer, config) {
+            Ok(()) => {
+                uwriteln!(uart, "Done.").unwrap();
+                break;
+            }
+            Err(WriteError::NotConfirmed { entry, read_data }) => {
+                retries += 1;
+                if retries >= MAX_RETRIES {
+                    panic!(
+                        "[ERROR] failed to write Si539x configuration after {MAX_RETRIES} retries, panicking"
+                    );
+                }
+                uwriteln!(
+                    uart,
+                    "[ERROR] failed to write Si539x configuration, retrying..."
+                )
+                .unwrap();
+                uwriteln!(
+                    uart,
+                    "At 0x{:02X}{:02X} wrote 0x{:02X}, but read back 0x{:02X}",
+                    entry.page,
+                    entry.address,
+                    entry.data,
+                    read_data,
+                )
+                .unwrap();
+            }
         }
     }
 


### PR DESCRIPTION
_What (what did you do)_
Add retry mechanism to writing a clock configuration. Panics if it fails 10 times.

_Why (context, issues, etc.)_
#1343

_Dear reviewer (anything you'd like the reviewer to pay close attention to?)_
No

_AI disclaimer (heads-up for more than inline autocomplete)_
No

# TODO
_~~Cross-out~~ any that do not apply_

- ~[ ] Write (regression) test~
- [x] Update documentation, including `docs/`
- [x] Link to existing issue
