### PR TITLE
update clash-protocols-memmap, use new InstanceNames

### DIFF
--- a/.github/synthesis/debug.json
+++ b/.github/synthesis/debug.json
@@ -1,4 +1,0 @@
-[
-  {"top": "softUgnDemoTest",               "stage": "test",  "cc_report": true},
-  {"top": "wireDemoTest",                  "stage": "test",  "cc_report": true}
-]

--- a/.github/synthesis/debug.json
+++ b/.github/synthesis/debug.json
@@ -1,0 +1,4 @@
+[
+  {"top": "softUgnDemoTest",               "stage": "test",  "cc_report": true},
+  {"top": "wireDemoTest",                  "stage": "test",  "cc_report": true}
+]

--- a/cabal.project
+++ b/cabal.project
@@ -36,7 +36,7 @@ jobs: $ncpus
 source-repository-package
   type: git
   location: https://github.com/QBayLogic/clash-protocols-memmap
-  tag: ab96b206566f23889549db5c6159ccb1bcfa2d13
+  tag: 20bacc70c1ef1802cfa02228bfddbc7e8cd86f03
   subdir:
     clash-protocols-memmap
     clash-bitpackc

--- a/firmware-binaries/Cargo.lock
+++ b/firmware-binaries/Cargo.lock
@@ -106,7 +106,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -179,9 +179,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.48"
+version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c481bdbf0ed3b892f6f806287d72acd515b352a4ec27a208489b8c1bc839633a"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -196,7 +196,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 [[package]]
 name = "clash-bindings"
 version = "0.1.0"
-source = "git+https://github.com/QBayLogic/clash-protocols-memmap?rev=8624bfb4b0617ffe951a4c9c9c1c40c55f2ece11#8624bfb4b0617ffe951a4c9c9c1c40c55f2ece11"
+source = "git+https://github.com/QBayLogic/clash-protocols-memmap?rev=20bacc70c1ef1802cfa02228bfddbc7e8cd86f03#20bacc70c1ef1802cfa02228bfddbc7e8cd86f03"
 dependencies = [
  "clash-macros",
  "const_panic",
@@ -207,12 +207,12 @@ dependencies = [
 [[package]]
 name = "clash-macros"
 version = "0.1.0"
-source = "git+https://github.com/QBayLogic/clash-protocols-memmap?rev=8624bfb4b0617ffe951a4c9c9c1c40c55f2ece11#8624bfb4b0617ffe951a4c9c9c1c40c55f2ece11"
+source = "git+https://github.com/QBayLogic/clash-protocols-memmap?rev=20bacc70c1ef1802cfa02228bfddbc7e8cd86f03#20bacc70c1ef1802cfa02228bfddbc7e8cd86f03"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -278,9 +278,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "elastic_buffer_wb_test"
@@ -326,9 +326,9 @@ checksum = "784a4df722dc6267a04af36895398f59d21d07dce47232adf31ec0ff2fa45e67"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.5"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "gdb-trace"
@@ -348,9 +348,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heapless"
@@ -390,9 +390,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "lazy_static"
@@ -402,9 +402,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "log"
-version = "0.4.28"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "managed"
@@ -414,14 +414,14 @@ checksum = "0ca88d725a0a943b096803bd34e73a4437208b6077654cc4ecb2947a5f91618d"
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "memorymap-compiler"
 version = "0.1.0"
-source = "git+https://github.com/QBayLogic/clash-protocols-memmap?rev=8624bfb4b0617ffe951a4c9c9c1c40c55f2ece11#8624bfb4b0617ffe951a4c9c9c1c40c55f2ece11"
+source = "git+https://github.com/QBayLogic/clash-protocols-memmap?rev=20bacc70c1ef1802cfa02228bfddbc7e8cd86f03#20bacc70c1ef1802cfa02228bfddbc7e8cd86f03"
 dependencies = [
  "derivative",
  "heck",
@@ -435,7 +435,7 @@ dependencies = [
 [[package]]
 name = "memorymap-compiler-c"
 version = "0.1.0"
-source = "git+https://github.com/QBayLogic/clash-protocols-memmap?rev=8624bfb4b0617ffe951a4c9c9c1c40c55f2ece11#8624bfb4b0617ffe951a4c9c9c1c40c55f2ece11"
+source = "git+https://github.com/QBayLogic/clash-protocols-memmap?rev=20bacc70c1ef1802cfa02228bfddbc7e8cd86f03#20bacc70c1ef1802cfa02228bfddbc7e8cd86f03"
 dependencies = [
  "heck",
  "memorymap-compiler",
@@ -446,7 +446,7 @@ dependencies = [
 [[package]]
 name = "memorymap-compiler-rust"
 version = "0.1.0"
-source = "git+https://github.com/QBayLogic/clash-protocols-memmap?rev=8624bfb4b0617ffe951a4c9c9c1c40c55f2ece11#8624bfb4b0617ffe951a4c9c9c1c40c55f2ece11"
+source = "git+https://github.com/QBayLogic/clash-protocols-memmap?rev=20bacc70c1ef1802cfa02228bfddbc7e8cd86f03#20bacc70c1ef1802cfa02228bfddbc7e8cd86f03"
 dependencies = [
  "heck",
  "memorymap-compiler",
@@ -500,18 +500,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.103"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.42"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -524,9 +524,9 @@ checksum = "bd7a31eed1591dcbc95d92ad7161908e72f4677f8fabf2a32ca49b4237cbf211"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "rand_core",
 ]
@@ -539,9 +539,9 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "regex"
-version = "1.12.2"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -551,9 +551,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -562,9 +562,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.8"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "registerwb_test"
@@ -634,7 +634,7 @@ checksum = "f265be5d634272320a7de94cea15c22a3bfdd4eb42eb43edc528415f066a1f25"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -673,7 +673,7 @@ checksum = "30f19a85fe107b65031e0ba8ec60c34c2494069fe910d6c297f5e7cb5a6f76d0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -685,12 +685,6 @@ dependencies = [
  "lazy_static",
  "regex",
 ]
-
-[[package]]
-name = "ryu"
-version = "1.0.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "serde"
@@ -719,33 +713,33 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.145"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
  "serde_core",
+ "zmij",
 ]
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "smoltcp"
@@ -849,9 +843,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.111"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "390cc9a294ab71bdb1aa2e99d13be9c753cd2d7bd6560c77118597410c4d2e87"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -880,9 +874,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.11+spec-1.1.0"
+version = "0.25.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -901,9 +895,9 @@ dependencies = [
 
 [[package]]
 name = "typewit"
-version = "1.14.2"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8c1ae7cc0fdb8b842d65d127cb981574b0d2b249b74d1c7a2986863dc134f71"
+checksum = "214ca0b2191785cbc06209b9ca1861e048e39b5ba33574b3cedd58363d5bb5f6"
 
 [[package]]
 name = "ufmt"
@@ -934,9 +928,9 @@ checksum = "e87a2ed6b42ec5e28cc3b94c09982969e9227600b2e3dcbc1db927a84c06bd69"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "vexriscv-hello"
@@ -979,9 +973,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]
@@ -1017,3 +1011,9 @@ dependencies = [
  "riscv-rt 0.11.0",
  "ufmt",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/firmware-binaries/Cargo.toml
+++ b/firmware-binaries/Cargo.toml
@@ -56,5 +56,5 @@ print_literal = "forbid"
 uninlined_format_args = "forbid"
 
 [workspace.dependencies]
-clash-bindings = { git = "https://github.com/QBayLogic/clash-protocols-memmap", rev = "8624bfb4b0617ffe951a4c9c9c1c40c55f2ece11" }
-clash-macros = { git = "https://github.com/QBayLogic/clash-protocols-memmap", rev = "8624bfb4b0617ffe951a4c9c9c1c40c55f2ece11" }
+clash-bindings = { git = "https://github.com/QBayLogic/clash-protocols-memmap", rev = "20bacc70c1ef1802cfa02228bfddbc7e8cd86f03" }
+clash-macros = { git = "https://github.com/QBayLogic/clash-protocols-memmap", rev = "20bacc70c1ef1802cfa02228bfddbc7e8cd86f03" }

--- a/firmware-binaries/Cargo.toml
+++ b/firmware-binaries/Cargo.toml
@@ -54,3 +54,7 @@ resolver = "2"
 format_push_string = "forbid"
 print_literal = "forbid"
 uninlined_format_args = "forbid"
+
+[workspace.dependencies]
+clash-bindings = { git = "https://github.com/QBayLogic/clash-protocols-memmap", rev = "8624bfb4b0617ffe951a4c9c9c1c40c55f2ece11" }
+clash-macros = { git = "https://github.com/QBayLogic/clash-protocols-memmap", rev = "8624bfb4b0617ffe951a4c9c9c1c40c55f2ece11" }

--- a/firmware-binaries/sim-tests/addressable_bytes_wb_test/Cargo.toml
+++ b/firmware-binaries/sim-tests/addressable_bytes_wb_test/Cargo.toml
@@ -12,8 +12,8 @@ edition = "2021"
 workspace = true
 
 [dependencies]
-clash-bindings = { git = "https://github.com/QBayLogic/clash-protocols-memmap", rev = "8624bfb4b0617ffe951a4c9c9c1c40c55f2ece11" }
-clash-macros = { git = "https://github.com/QBayLogic/clash-protocols-memmap", rev = "8624bfb4b0617ffe951a4c9c9c1c40c55f2ece11" }
+clash-bindings.workspace = true
+clash-macros.workspace = true
 bittide-hal = { path = "../../../firmware-support/bittide-hal" }
 bittide-macros = { path = "../../../firmware-support/bittide-macros" }
 bittide-sys = { path = "../../../firmware-support/bittide-sys" }

--- a/firmware-binaries/sim-tests/elastic_buffer_wb_test/Cargo.toml
+++ b/firmware-binaries/sim-tests/elastic_buffer_wb_test/Cargo.toml
@@ -15,8 +15,8 @@ workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clash-bindings = { git = "https://github.com/QBayLogic/clash-protocols-memmap", rev = "8624bfb4b0617ffe951a4c9c9c1c40c55f2ece11" }
-clash-macros = { git = "https://github.com/QBayLogic/clash-protocols-memmap", rev = "8624bfb4b0617ffe951a4c9c9c1c40c55f2ece11" }
+clash-bindings.workspace = true
+clash-macros.workspace = true
 bittide-hal = { path = "../../../firmware-support/bittide-hal" }
 bittide-macros = { path = "../../../firmware-support/bittide-macros" }
 bittide-sys = { path = "../../../firmware-support/bittide-sys" }

--- a/firmware-binaries/sim-tests/nested_interconnect_test/Cargo.toml
+++ b/firmware-binaries/sim-tests/nested_interconnect_test/Cargo.toml
@@ -14,8 +14,8 @@ workspace = true
 
 [dependencies]
 heapless = "0.8.0"
-clash-bindings = { git = "https://github.com/QBayLogic/clash-protocols-memmap", rev = "8624bfb4b0617ffe951a4c9c9c1c40c55f2ece11" }
-clash-macros = { git = "https://github.com/QBayLogic/clash-protocols-memmap", rev = "8624bfb4b0617ffe951a4c9c9c1c40c55f2ece11" }
+clash-bindings.workspace = true
+clash-macros.workspace = true
 bittide-hal = { path = "../../../firmware-support/bittide-hal" }
 bittide-sys = { path = "../../../firmware-support/bittide-sys" }
 riscv-rt = "0.11.0"

--- a/firmware-binaries/sim-tests/registerwb_test/Cargo.toml
+++ b/firmware-binaries/sim-tests/registerwb_test/Cargo.toml
@@ -15,8 +15,8 @@ workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clash-bindings = { git = "https://github.com/QBayLogic/clash-protocols-memmap", rev = "8624bfb4b0617ffe951a4c9c9c1c40c55f2ece11" }
-clash-macros = { git = "https://github.com/QBayLogic/clash-protocols-memmap", rev = "8624bfb4b0617ffe951a4c9c9c1c40c55f2ece11" }
+clash-bindings.workspace = true
+clash-macros.workspace = true
 bittide-macros = { path = "../../../firmware-support/bittide-macros" }
 bittide-hal = { path = "../../../firmware-support/bittide-hal" }
 bittide-sys = { path = "../../../firmware-support/bittide-sys" }

--- a/firmware-support/Cargo.lock
+++ b/firmware-support/Cargo.lock
@@ -14,16 +14,16 @@ version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "once_cell",
  "version_check",
 ]
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "bit-set"
@@ -48,9 +48,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "bittide-build-utils"
@@ -86,7 +86,7 @@ dependencies = [
  "memorymap-compiler-rust",
  "proc-macro2",
  "quote",
- "rand 0.8.5",
+ "rand 0.8.6",
  "smoltcp 0.11.0",
  "subst_macros",
  "ufmt",
@@ -108,7 +108,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -127,7 +127,7 @@ dependencies = [
  "log",
  "object",
  "proptest",
- "rand 0.8.5",
+ "rand 0.8.6",
  "smoltcp 0.12.0",
  "tempfile",
  "test-strategy",
@@ -142,9 +142,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cc"
-version = "1.2.48"
+version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c481bdbf0ed3b892f6f806287d72acd515b352a4ec27a208489b8c1bc839633a"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -159,7 +159,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 [[package]]
 name = "clash-bindings"
 version = "0.1.0"
-source = "git+https://github.com/QBayLogic/clash-protocols-memmap?rev=8624bfb4b0617ffe951a4c9c9c1c40c55f2ece11#8624bfb4b0617ffe951a4c9c9c1c40c55f2ece11"
+source = "git+https://github.com/QBayLogic/clash-protocols-memmap?rev=20bacc70c1ef1802cfa02228bfddbc7e8cd86f03#20bacc70c1ef1802cfa02228bfddbc7e8cd86f03"
 dependencies = [
  "clash-macros",
  "const_panic",
@@ -170,12 +170,12 @@ dependencies = [
 [[package]]
 name = "clash-macros"
 version = "0.1.0"
-source = "git+https://github.com/QBayLogic/clash-protocols-memmap?rev=8624bfb4b0617ffe951a4c9c9c1c40c55f2ece11#8624bfb4b0617ffe951a4c9c9c1c40c55f2ece11"
+source = "git+https://github.com/QBayLogic/clash-protocols-memmap?rev=20bacc70c1ef1802cfa02228bfddbc7e8cd86f03#20bacc70c1ef1802cfa02228bfddbc7e8cd86f03"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -215,9 +215,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "embedded-hal"
@@ -243,9 +243,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fdt"
@@ -255,15 +255,15 @@ checksum = "784a4df722dc6267a04af36895398f59d21d07dce47232adf31ec0ff2fa45e67"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.5"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "flate2"
-version = "1.1.5"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -284,9 +284,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
  "libc",
@@ -301,8 +301,19 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
 ]
 
 [[package]]
@@ -331,9 +342,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heapless"
@@ -369,7 +380,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -383,9 +394,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "lazy_static"
@@ -395,21 +406,21 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.177"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "log"
-version = "0.4.28"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "managed"
@@ -419,14 +430,14 @@ checksum = "0ca88d725a0a943b096803bd34e73a4437208b6077654cc4ecb2947a5f91618d"
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "memorymap-compiler"
 version = "0.1.0"
-source = "git+https://github.com/QBayLogic/clash-protocols-memmap?rev=8624bfb4b0617ffe951a4c9c9c1c40c55f2ece11#8624bfb4b0617ffe951a4c9c9c1c40c55f2ece11"
+source = "git+https://github.com/QBayLogic/clash-protocols-memmap?rev=20bacc70c1ef1802cfa02228bfddbc7e8cd86f03#20bacc70c1ef1802cfa02228bfddbc7e8cd86f03"
 dependencies = [
  "derivative",
  "heck",
@@ -440,7 +451,7 @@ dependencies = [
 [[package]]
 name = "memorymap-compiler-c"
 version = "0.1.0"
-source = "git+https://github.com/QBayLogic/clash-protocols-memmap?rev=8624bfb4b0617ffe951a4c9c9c1c40c55f2ece11#8624bfb4b0617ffe951a4c9c9c1c40c55f2ece11"
+source = "git+https://github.com/QBayLogic/clash-protocols-memmap?rev=20bacc70c1ef1802cfa02228bfddbc7e8cd86f03#20bacc70c1ef1802cfa02228bfddbc7e8cd86f03"
 dependencies = [
  "heck",
  "memorymap-compiler",
@@ -451,7 +462,7 @@ dependencies = [
 [[package]]
 name = "memorymap-compiler-rust"
 version = "0.1.0"
-source = "git+https://github.com/QBayLogic/clash-protocols-memmap?rev=8624bfb4b0617ffe951a4c9c9c1c40c55f2ece11#8624bfb4b0617ffe951a4c9c9c1c40c55f2ece11"
+source = "git+https://github.com/QBayLogic/clash-protocols-memmap?rev=20bacc70c1ef1802cfa02228bfddbc7e8cd86f03#20bacc70c1ef1802cfa02228bfddbc7e8cd86f03"
 dependencies = [
  "heck",
  "memorymap-compiler",
@@ -493,9 +504,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "paste"
@@ -523,24 +534,24 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.103"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "proptest"
-version = "1.9.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee689443a2bd0a16ab0348b52ee43e3b2d1b1f931c8aa5c9f8de4c86fbe8c40"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
@@ -557,9 +568,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.42"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -571,10 +582,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
-name = "rand"
-version = "0.8.5"
+name = "r-efi"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -583,12 +600,12 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -608,7 +625,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -617,14 +634,14 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.9.3"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
@@ -635,14 +652,14 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.8"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "riscv"
@@ -665,7 +682,7 @@ checksum = "f265be5d634272320a7de94cea15c22a3bfdd4eb42eb43edc528415f066a1f25"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -676,11 +693,11 @@ checksum = "8188909339ccc0c68cfb5a04648313f09621e8b87dc03095454f1a11f6c5d436"
 
 [[package]]
 name = "rustix"
-version = "1.1.2"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -698,12 +715,6 @@ dependencies = [
  "tempfile",
  "wait-timeout",
 ]
-
-[[package]]
-name = "ryu"
-version = "1.0.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "serde"
@@ -732,39 +743,39 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.145"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
  "serde_core",
+ "zmij",
 ]
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.7"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "smoltcp"
@@ -840,9 +851,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.111"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "390cc9a294ab71bdb1aa2e99d13be9c753cd2d7bd6560c77118597410c4d2e87"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -851,12 +862,12 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.23.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys",
@@ -885,9 +896,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.11+spec-1.1.0"
+version = "0.25.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
 dependencies = [
  "indexmap 2.14.0",
  "toml_datetime",
@@ -906,9 +917,9 @@ dependencies = [
 
 [[package]]
 name = "typewit"
-version = "1.14.2"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8c1ae7cc0fdb8b842d65d127cb981574b0d2b249b74d1c7a2986863dc134f71"
+checksum = "214ca0b2191785cbc06209b9ca1861e048e39b5ba33574b3cedd58363d5bb5f6"
 
 [[package]]
 name = "ufmt"
@@ -945,9 +956,9 @@ checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "version_check"
@@ -972,9 +983,9 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.1+wasi-0.2.4"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
  "wit-bindgen",
 ]
@@ -996,35 +1007,41 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "wit-bindgen"
-version = "0.46.0"
+version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.30"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea879c944afe8a2b25fef16bb4ba234f47c694565e97383b36f3a878219065c"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.30"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf955aa904d6040f70dc8e9384444cb1030aed272ba3cb09bbc4ab9e7c1f34f5"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/firmware-support/Cargo.toml
+++ b/firmware-support/Cargo.toml
@@ -36,8 +36,8 @@ print_literal = "forbid"
 uninlined_format_args = "forbid"
 
 [workspace.dependencies]
-clash-bindings = { git = "https://github.com/QBayLogic/clash-protocols-memmap", rev = "8624bfb4b0617ffe951a4c9c9c1c40c55f2ece11" }
-clash-macros = { git = "https://github.com/QBayLogic/clash-protocols-memmap", rev = "8624bfb4b0617ffe951a4c9c9c1c40c55f2ece11" }
-memorymap-compiler = { git = "https://github.com/QBayLogic/clash-protocols-memmap", rev = "8624bfb4b0617ffe951a4c9c9c1c40c55f2ece11" }
-memorymap-compiler-c = { git = "https://github.com/QBayLogic/clash-protocols-memmap", rev = "8624bfb4b0617ffe951a4c9c9c1c40c55f2ece11" }
-memorymap-compiler-rust = { git = "https://github.com/QBayLogic/clash-protocols-memmap", rev = "8624bfb4b0617ffe951a4c9c9c1c40c55f2ece11" }
+clash-bindings = { git = "https://github.com/QBayLogic/clash-protocols-memmap", rev = "20bacc70c1ef1802cfa02228bfddbc7e8cd86f03" }
+clash-macros = { git = "https://github.com/QBayLogic/clash-protocols-memmap", rev = "20bacc70c1ef1802cfa02228bfddbc7e8cd86f03" }
+memorymap-compiler = { git = "https://github.com/QBayLogic/clash-protocols-memmap", rev = "20bacc70c1ef1802cfa02228bfddbc7e8cd86f03" }
+memorymap-compiler-c = { git = "https://github.com/QBayLogic/clash-protocols-memmap", rev = "20bacc70c1ef1802cfa02228bfddbc7e8cd86f03" }
+memorymap-compiler-rust = { git = "https://github.com/QBayLogic/clash-protocols-memmap", rev = "20bacc70c1ef1802cfa02228bfddbc7e8cd86f03" }

--- a/firmware-support/Cargo.toml
+++ b/firmware-support/Cargo.toml
@@ -34,3 +34,10 @@ resolver = "2"
 format_push_string = "forbid"
 print_literal = "forbid"
 uninlined_format_args = "forbid"
+
+[workspace.dependencies]
+clash-bindings = { git = "https://github.com/QBayLogic/clash-protocols-memmap", rev = "8624bfb4b0617ffe951a4c9c9c1c40c55f2ece11" }
+clash-macros = { git = "https://github.com/QBayLogic/clash-protocols-memmap", rev = "8624bfb4b0617ffe951a4c9c9c1c40c55f2ece11" }
+memorymap-compiler = { git = "https://github.com/QBayLogic/clash-protocols-memmap", rev = "8624bfb4b0617ffe951a4c9c9c1c40c55f2ece11" }
+memorymap-compiler-c = { git = "https://github.com/QBayLogic/clash-protocols-memmap", rev = "8624bfb4b0617ffe951a4c9c9c1c40c55f2ece11" }
+memorymap-compiler-rust = { git = "https://github.com/QBayLogic/clash-protocols-memmap", rev = "8624bfb4b0617ffe951a4c9c9c1c40c55f2ece11" }

--- a/firmware-support/bittide-build-utils/Cargo.toml
+++ b/firmware-support/bittide-build-utils/Cargo.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-memorymap-compiler = { git = "https://github.com/QBayLogic/clash-protocols-memmap", rev = "8624bfb4b0617ffe951a4c9c9c1c40c55f2ece11" }
+memorymap-compiler.workspace = true
 
 [lints]
 workspace = true

--- a/firmware-support/bittide-cpus/Cargo.toml
+++ b/firmware-support/bittide-cpus/Cargo.toml
@@ -16,7 +16,7 @@ workspace = true
 bittide-hal = { path = "../bittide-hal" }
 bittide-macros = { path = "../bittide-macros" }
 bittide-sys = { path = "../bittide-sys" }
-clash-bindings = { git = "https://github.com/QBayLogic/clash-protocols-memmap", rev = "8624bfb4b0617ffe951a4c9c9c1c40c55f2ece11" }
-clash-macros = { git = "https://github.com/QBayLogic/clash-protocols-memmap", rev = "8624bfb4b0617ffe951a4c9c9c1c40c55f2ece11" }
+clash-bindings.workspace = true
+clash-macros.workspace = true
 itertools = { version = "0.14.0", default-features = false }
 ufmt = "0.2.0"

--- a/firmware-support/bittide-hal-c/Cargo.toml
+++ b/firmware-support/bittide-hal-c/Cargo.toml
@@ -13,8 +13,8 @@ workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [build-dependencies]
-memorymap-compiler = { git = "https://github.com/QBayLogic/clash-protocols-memmap", rev = "8624bfb4b0617ffe951a4c9c9c1c40c55f2ece11" }
-memorymap-compiler-c = { git = "https://github.com/QBayLogic/clash-protocols-memmap", rev = "8624bfb4b0617ffe951a4c9c9c1c40c55f2ece11" }
+memorymap-compiler.workspace = true
+memorymap-compiler-c.workspace = true
 
 [dependencies]
 cc = "1.2"

--- a/firmware-support/bittide-hal-c/build.rs
+++ b/firmware-support/bittide-hal-c/build.rs
@@ -10,6 +10,7 @@ use std::path::{Path, PathBuf};
 use memorymap_compiler::input_language as mm_inp;
 use memorymap_compiler::ir::deduplicate::{deduplicate, deduplicate_type_names};
 use memorymap_compiler::ir::input_to_ir::IrInputMapping;
+use memorymap_compiler::ir::instance_names::{calculate_instance_names, InstanceNames};
 use memorymap_compiler::ir::monomorph::passes::All;
 use memorymap_compiler::ir::monomorph::{MonomorphVariants, Monomorpher};
 use memorymap_compiler::ir::types::IrCtx;
@@ -45,6 +46,9 @@ fn main() {
     };
 
     deduplicate_type_names(&mut ctx, &shared);
+
+    let mut instance_names = InstanceNames::default();
+    calculate_instance_names(&mut instance_names, &ctx, &deduped_hals);
 
     // monomorph
 
@@ -243,6 +247,7 @@ fn main() {
                     let code = backend_c::device_instances::generate_device_instances(
                         &ctx,
                         &shared,
+                        &instance_names,
                         hal_name,
                         deduped.tree_elem_range.handles(),
                     );

--- a/firmware-support/bittide-hal/Cargo.toml
+++ b/firmware-support/bittide-hal/Cargo.toml
@@ -17,9 +17,8 @@ const_panic = "0.2.15"
 bittide-macros = { path = "../bittide-macros" }
 log = "0.4.21"
 ufmt = "0.2.0"
-
-clash-bindings = { git = "https://github.com/QBayLogic/clash-protocols-memmap", rev = "8624bfb4b0617ffe951a4c9c9c1c40c55f2ece11" }
-clash-macros = { git = "https://github.com/QBayLogic/clash-protocols-memmap", rev = "8624bfb4b0617ffe951a4c9c9c1c40c55f2ece11" }
+clash-bindings.workspace = true
+clash-macros.workspace = true
 
 [dependencies.heapless]
 version = "0.8"
@@ -41,8 +40,8 @@ git = "https://github.com/QBayLogic/subst_macros.git"
 rev = "1273588cd7b854b8b6294cf54c7e238f77778ac4"
 
 [build-dependencies]
-memorymap-compiler = { git = "https://github.com/QBayLogic/clash-protocols-memmap", rev = "8624bfb4b0617ffe951a4c9c9c1c40c55f2ece11" }
-memorymap-compiler-rust = { git = "https://github.com/QBayLogic/clash-protocols-memmap", rev = "8624bfb4b0617ffe951a4c9c9c1c40c55f2ece11" }
+memorymap-compiler.workspace = true
+memorymap-compiler-rust.workspace = true
 quote = "1.0"
 proc-macro2 = "1.0"
 

--- a/firmware-support/bittide-hal/build.rs
+++ b/firmware-support/bittide-hal/build.rs
@@ -11,13 +11,15 @@ use memorymap_compiler::input_language as mm_inp;
 
 use memorymap_compiler::ir::deduplicate::{deduplicate, deduplicate_type_names};
 use memorymap_compiler::ir::input_to_ir::IrInputMapping;
+use memorymap_compiler::ir::instance_names::{calculate_instance_names, InstanceNames};
 use memorymap_compiler::ir::monomorph::passes::OnlyNats;
 use memorymap_compiler::ir::monomorph::{MonomorphVariants, Monomorpher};
 use memorymap_compiler::ir::types::IrCtx;
 
 use memorymap_compiler_rust::{
-    self as backend_rust, generate_device_instances, generate_type_desc, ident, IdentType,
-    TypeReferences,
+    self as backend_rust, device_desc::generate_device_desc,
+    device_instances::generate_device_instances, ident, types::generate_type_desc,
+    types::TypeReferences, IdentType,
 };
 use proc_macro2::TokenStream;
 use quote::quote;
@@ -69,6 +71,9 @@ fn main() {
     };
 
     deduplicate_type_names(&mut ctx, &shared);
+
+    let mut instance_names = InstanceNames::default();
+    calculate_instance_names(&mut instance_names, &ctx, &deduped_hals);
 
     // monomorph
 
@@ -180,7 +185,7 @@ fn main() {
                 continue;
             }
 
-            let (dev_name, code, refs) = backend_rust::generate_device_desc(&ctx, &varis, *dev);
+            let (dev_name, code, refs) = generate_device_desc(&ctx, &varis, *dev);
             let file_name = ident(IdentType::Module, dev_name);
             let file_path = shared_devices_path.join(format!("{file_name}.rs"));
             let mut file = File::create(&file_path).unwrap();
@@ -233,7 +238,7 @@ fn main() {
             {
                 continue;
             }
-            let (dev_name, code, refs) = backend_rust::generate_device_desc(&ctx, &varis, *dev);
+            let (dev_name, code, refs) = generate_device_desc(&ctx, &varis, *dev);
             let file_name = ident(IdentType::Module, dev_name);
             let file_path = hal_path.join("devices").join(format!("{file_name}.rs"));
 
@@ -252,6 +257,7 @@ fn main() {
             let code = generate_device_instances(
                 &ctx,
                 &shared,
+                &instance_names,
                 hal_name,
                 deduped.tree_elem_range.handles(),
             );

--- a/firmware-support/bittide-sys/Cargo.toml
+++ b/firmware-support/bittide-sys/Cargo.toml
@@ -19,8 +19,8 @@ workspace = true
 default = []
 
 [dependencies]
-clash-bindings = { git = "https://github.com/QBayLogic/clash-protocols-memmap", rev = "8624bfb4b0617ffe951a4c9c9c1c40c55f2ece11" }
-clash-macros = { git = "https://github.com/QBayLogic/clash-protocols-memmap", rev = "8624bfb4b0617ffe951a4c9c9c1c40c55f2ece11" }
+clash-bindings.workspace = true
+clash-macros.workspace = true
 bittide-hal = { path = "../bittide-hal" }
 bittide-macros = { path = "../bittide-macros" }
 fdt = "0.1.0"


### PR DESCRIPTION
_What (what did you do)_
This PR updates the `clash-protocols-memmap` dependency to the latest version. As part of that, it uses the new `InstanceNames` storage for more consistent names for device instances.

Also the cargo dependencies have been changed into workspace-dependencies, meaning that we can now update the git hashes in two places instead of in every single crate.

_Why (context, issues, etc.)_

The change itself doesn't seem like it's too useful, but a) internally it's simpler and b) if we need to use custom generators for bittide at some point, it's much easier to adapt than it was before this change.

_Dear reviewer (anything you'd like the reviewer to pay close attention to?)_

N/A

_AI disclaimer (heads-up for more than inline autocomplete)_

No AI used, neither for this PR or the `InstanceName` implementation in the `clash-protocols-memmap` dependency.

# TODO
_~~Cross-out~~ any that do not apply_

- [x] ~~Write (regression) test~~ All of the existing bittide-hal bindings are kind of the regression test for this :sweat_smile: 
- [x] ~~Update documentation, including `docs/`~~
- [x] Link to existing issue https://github.com/QBayLogic/clash-protocols-memmap/issues/2
