### PR TITLE
Split elastic buffers from the control/autocenter functions

### DIFF
--- a/bittide-extra/bittide-extra.cabal
+++ b/bittide-extra/bittide-extra.cabal
@@ -166,6 +166,7 @@ library
   exposed-modules:
     Bittide.Extra.Maybe
     Clash.Class.Cdc
+    Clash.Class.Cdc.Handshake
     Clash.Cores.Xilinx
     Clash.Cores.Xilinx.Xpm.Cdc.Extra
     Clash.Explicit.Signal.Delayed.Extra

--- a/bittide-extra/src/Clash/Class/Cdc.hs
+++ b/bittide-extra/src/Clash/Class/Cdc.hs
@@ -25,10 +25,7 @@ module Clash.Class.Cdc where
 
 import Clash.Prelude hiding (Bit, isRising, regEn)
 
-import Bittide.Extra.Maybe (toMaybe)
-import Clash.Explicit.Prelude (isRising, noReset, regEn)
 import Data.Data (Proxy (Proxy))
-import Data.Maybe (fromMaybe, isJust, isNothing)
 import GHC.Stack (HasCallStack)
 
 {- | Guarantees the existence of a CDC primitive for a fixed-width array of independent bits for a
@@ -700,56 +697,3 @@ withVendor ssym f = let ?vendorName = ssym in f
 -- | Implicitly creates the @SSymbol vendor@ used to call 'withVendor'
 withVendorI :: forall vendor r. (KnownSymbol vendor) => ((HiddenVendor vendor) => r) -> r
 withVendorI = withVendor (SSymbol @vendor)
-
--- | `Maybe a` based version of `handshake`.
-handshakeMaybe ::
-  forall a src dst vendor.
-  ( KnownDomain src
-  , KnownDomain dst
-  , BitPack a
-  , NFDataX a
-  , HiddenVendor vendor
-  , ValidHandshake vendor a src dst
-  ) =>
-  Clock src ->
-  Clock dst ->
-  Signal src (Maybe a) ->
-  Signal dst Bool ->
-  (Signal src Bool, Signal dst (Maybe a))
-handshakeMaybe clkSrc clkDst srcIn dstAck = (srcRcv, toMaybe <$> dstReq <*> dstOut)
- where
-  (dstOut, dstReq, srcRcv) =
-    handshake @vendor clkSrc clkDst (fromMaybe (unpack 0) <$> srcIn) (isJust <$> srcIn) dstAck
-
-{- | Reliable CDC component based on 'handshakeMaybe' without backpressure and with limited
-throughput. Data will be lost if the `src` domain provides more inputs than the circuit can handle.
-Useful for low granularity synchronization.
--}
-maybeLossy ::
-  forall a src dst vendor.
-  ( KnownDomain src
-  , KnownDomain dst
-  , BitPack a
-  , NFDataX a
-  , HiddenVendor vendor
-  , ValidHandshake vendor a src dst
-  ) =>
-  Clock src ->
-  Clock dst ->
-  Signal src (Maybe a) ->
-  Signal dst (Maybe a)
-maybeLossy clkSrc clkDst maybeInp =
-  mux (isRising clkDst noReset enableGen False dstAck) dstOut (pure Nothing)
- where
-  srcReg =
-    regEn
-      clkSrc
-      noReset
-      enableGen
-      Nothing
-      (srcRcv .||. srcRegEmpty)
-      $ mux (srcRegEmpty .&&. fmap not srcRcv) maybeInp (pure Nothing)
-
-  srcRegEmpty = isNothing <$> srcReg
-  (srcRcv, dstOut) = handshakeMaybe @a @src @dst @vendor clkSrc clkDst srcReg (isJust <$> dstOut)
-  dstAck = isJust <$> dstOut

--- a/bittide-extra/src/Clash/Class/Cdc/Handshake.hs
+++ b/bittide-extra/src/Clash/Class/Cdc/Handshake.hs
@@ -1,0 +1,170 @@
+-- SPDX-FileCopyrightText: 2026 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+module Clash.Class.Cdc.Handshake where
+
+import Clash.Explicit.Prelude
+
+import Bittide.Extra.Maybe (toMaybe)
+import Data.Maybe (fromMaybe, isJust, isNothing)
+import GHC.Stack (HasCallStack)
+import Protocols
+
+import qualified Clash.Class.Cdc as Cdc
+
+-- | `Maybe a`-based version of `handshake`.
+handshakeMaybe ::
+  forall vendor a src dst.
+  ( HasCallStack
+  , KnownDomain src
+  , KnownDomain dst
+  , BitPack a
+  , NFDataX a
+  , Cdc.HiddenVendor vendor
+  , Cdc.ValidHandshake vendor a src dst
+  ) =>
+  Clock src ->
+  Clock dst ->
+  Signal src (Maybe a) ->
+  Signal dst Bool ->
+  (Signal src Bool, Signal dst (Maybe a))
+handshakeMaybe clkSrc clkDst srcIn dstAck = (srcRcv, toMaybe <$> dstReq <*> dstOut)
+ where
+  (dstOut, dstReq, srcRcv) =
+    Cdc.handshake @vendor clkSrc clkDst (fromMaybe (unpack 0) <$> srcIn) (isJust <$> srcIn) dstAck
+
+{- | Reliable CDC component based on 'handshakeMaybe' without backpressure and with limited
+throughput. Data will be lost if the `src` domain provides more inputs than the circuit can handle.
+Useful for low granularity synchronization.
+-}
+maybeLossy ::
+  forall vendor a src dst.
+  ( HasCallStack
+  , KnownDomain src
+  , KnownDomain dst
+  , BitPack a
+  , NFDataX a
+  , Cdc.HiddenVendor vendor
+  , Cdc.ValidHandshake vendor a src dst
+  ) =>
+  Clock src ->
+  Clock dst ->
+  Signal src (Maybe a) ->
+  Signal dst (Maybe a)
+maybeLossy clkSrc clkDst maybeInp =
+  mux (isRising clkDst noReset enableGen False dstAck) dstOut (pure Nothing)
+ where
+  srcReg =
+    regEn
+      clkSrc
+      noReset
+      enableGen
+      Nothing
+      (srcRcv .||. srcRegEmpty)
+      $ mux (srcRegEmpty .&&. fmap not srcRcv) maybeInp (pure Nothing)
+
+  srcRegEmpty = isNothing <$> srcReg
+  (srcRcv, dstOut) = handshakeMaybe clkSrc clkDst srcReg (isJust <$> dstOut)
+  dstAck = isJust <$> dstOut
+
+data SafeHandshakeState
+  = InReset
+  | WaitForRising
+  | WaitForFalling
+  deriving (Generic, NFDataX)
+
+-- | State machine for the source side of a safe handshake, see 'safeXpmCdcHandshake'.
+safeHandshakeSrcFsm ::
+  forall a dom.
+  (NFDataX a, KnownDomain dom) =>
+  Clock dom ->
+  Reset dom ->
+  Signal dom (Maybe a) ->
+  "src_rcv" ::: Signal dom Bool ->
+  ( "src_send" ::: Signal dom Bool
+  , "src_in" ::: Signal dom a
+  , Signal dom Ack
+  )
+safeHandshakeSrcFsm clk rst ins srcRcvs =
+  mealyB clk rst enableGen go InReset (ins, srcRcvs)
+ where
+  go :: SafeHandshakeState -> (Maybe a, Bool) -> (SafeHandshakeState, (Bool, a, Ack))
+  go InReset _ = (WaitForRising, noInput nack)
+  go WaitForRising (Nothing, _) = (WaitForRising, noInput nack)
+  go s@WaitForRising (Just a, rcv) = (if rcv then WaitForFalling else s, input a (Ack rcv))
+  go s@WaitForFalling (_, rcv) = (if rcv then s else WaitForRising, noInput nack)
+
+  noInput :: Ack -> (Bool, a, Ack)
+  noInput acknowledge = (False, deepErrorX "no input", acknowledge)
+
+  input :: a -> Ack -> (Bool, a, Ack)
+  input a acknowledge = (True, a, acknowledge)
+
+  nack :: Ack
+  nack = Ack False
+
+{- | State machine for the destination side of a safe handshake, see
+'safeXpmCdcHandshake'.
+-}
+safeHandshakeDstFsm ::
+  (KnownDomain dom) =>
+  Clock dom ->
+  Reset dom ->
+  Signal dom Ack ->
+  "dest_out" ::: Signal dom a ->
+  "dest_req" ::: Signal dom Bool ->
+  ( "dest_ack" ::: Signal dom Bool
+  , Signal dom (Maybe a)
+  )
+safeHandshakeDstFsm clk rst acks outs reqs =
+  mealyB clk rst enableGen go InReset (acks, outs, reqs)
+ where
+  go :: SafeHandshakeState -> (Ack, a, Bool) -> (SafeHandshakeState, (Bool, Maybe a))
+  go InReset _ = (WaitForRising, (False, Nothing))
+  go s@WaitForRising (~(Ack acknowledge), a, request)
+    | request = (if acknowledge then WaitForFalling else s, (acknowledge, Just a))
+    | otherwise = (s, (False, Nothing))
+  go s@WaitForFalling (_, _, request)
+    | request = (s, (True, Nothing))
+    | otherwise = (WaitForRising, (False, Nothing))
+
+{- | A wrapper around 'xpmCdcHandshake' that implements a 'Df'-like interface:
+
+  * If a 'Just' is given as an argument it should remain stable until an Ack is
+    returned. This means that it can neither transition to 'Nothing', nor can the
+    contents inside of the 'Just' change while @'Ack' 'False'@ is returned.
+
+  * The input value (@'Maybe' a@) cannot depend combinationally on the returned
+    'Ack'.
+
+This implements the state machine necessary to safely do a handshake, as described in
+the Xilinx documentation.
+
+If either side is reset, the other should be too. Though it doesn't matter in which
+order the resets are deasserted, the resets should be asserted for long enough for the
+handshake pipeline to flush. See the Xilinx documentation for more information.
+-}
+safeHandshake ::
+  forall vendor a src dst.
+  ( HasCallStack
+  , KnownDomain src
+  , KnownDomain dst
+  , BitPack a
+  , NFDataX a
+  , Cdc.HiddenVendor vendor
+  , Cdc.ValidHandshake vendor a src dst
+  ) =>
+  Clock src ->
+  Reset src ->
+  Clock dst ->
+  Reset dst ->
+  Signal src (Maybe a) ->
+  Signal dst Ack ->
+  ( Signal src Ack
+  , Signal dst (Maybe a)
+  )
+safeHandshake clkSrc rstSrc clkDst rstDst srcData dstAck = (srcAck, dstData)
+ where
+  (srcSend, srcIn, srcAck) = safeHandshakeSrcFsm clkSrc rstSrc srcData srcRcv
+  (destAck, dstData) = safeHandshakeDstFsm clkDst rstDst dstAck destOut destReq
+  (destOut, destReq, srcRcv) = Cdc.handshake @vendor clkSrc clkDst srcIn srcSend destAck

--- a/bittide-extra/src/Clash/Cores/Xilinx/Xpm/Cdc/Extra.hs
+++ b/bittide-extra/src/Clash/Cores/Xilinx/Xpm/Cdc/Extra.hs
@@ -8,71 +8,11 @@ module Clash.Cores.Xilinx.Xpm.Cdc.Extra (
 ) where
 
 import Clash.Explicit.Prelude
-import Protocols
 
-import Clash.Cores.Xilinx.Xpm.Cdc (xpmCdcHandshake)
+import Clash.Class.Cdc.Handshake (safeHandshake)
+import Clash.Cores.Xilinx (withXilinx)
 import GHC.Stack (HasCallStack)
-
-data SafeHandshakeState
-  = InReset
-  | WaitForRising
-  | WaitForFalling
-  deriving (Generic, NFDataX)
-
--- | State machine for the source side of a safe handshake, see 'safeXpmCdcHandshake'.
-safeHandshakeSrcFsm ::
-  forall a dom.
-  (NFDataX a, KnownDomain dom) =>
-  Clock dom ->
-  Reset dom ->
-  Signal dom (Maybe a) ->
-  "src_rcv" ::: Signal dom Bool ->
-  ( "src_send" ::: Signal dom Bool
-  , "src_in" ::: Signal dom a
-  , Signal dom Ack
-  )
-safeHandshakeSrcFsm clk rst ins srcRcvs =
-  mealyB clk rst enableGen go InReset (ins, srcRcvs)
- where
-  go :: SafeHandshakeState -> (Maybe a, Bool) -> (SafeHandshakeState, (Bool, a, Ack))
-  go InReset _ = (WaitForRising, noInput nack)
-  go WaitForRising (Nothing, _) = (WaitForRising, noInput nack)
-  go s@WaitForRising (Just a, rcv) = (if rcv then WaitForFalling else s, input a (Ack rcv))
-  go s@WaitForFalling (_, rcv) = (if rcv then s else WaitForRising, noInput nack)
-
-  noInput :: Ack -> (Bool, a, Ack)
-  noInput acknowledge = (False, deepErrorX "no input", acknowledge)
-
-  input :: a -> Ack -> (Bool, a, Ack)
-  input a acknowledge = (True, a, acknowledge)
-
-  nack :: Ack
-  nack = Ack False
-
-{- | State machine for the destination side of a safe handshake, see
-'safeXpmCdcHandshake'.
--}
-safeHandshakeDstFsm ::
-  (KnownDomain dom) =>
-  Clock dom ->
-  Reset dom ->
-  Signal dom Ack ->
-  "dest_out" ::: Signal dom a ->
-  "dest_req" ::: Signal dom Bool ->
-  ( "dest_ack" ::: Signal dom Bool
-  , Signal dom (Maybe a)
-  )
-safeHandshakeDstFsm clk rst acks outs reqs =
-  mealyB clk rst enableGen go InReset (acks, outs, reqs)
- where
-  go :: SafeHandshakeState -> (Ack, a, Bool) -> (SafeHandshakeState, (Bool, Maybe a))
-  go InReset _ = (WaitForRising, (False, Nothing))
-  go s@WaitForRising (~(Ack acknowledge), a, request)
-    | request = (if acknowledge then WaitForFalling else s, (acknowledge, Just a))
-    | otherwise = (s, (False, Nothing))
-  go s@WaitForFalling (_, _, request)
-    | request = (s, (True, Nothing))
-    | otherwise = (WaitForRising, (False, Nothing))
+import Protocols
 
 {- | A wrapper around 'xpmCdcHandshake' that implements a 'Df'-like interface:
 
@@ -109,11 +49,7 @@ safeXpmCdcHandshake ::
   ( Signal src Ack
   , Signal dst (Maybe a)
   )
-safeXpmCdcHandshake clkSrc rstSrc clkDst rstDst srcData dstAck = (srcAck, dstData)
- where
-  (srcSend, srcIn, srcAck) = safeHandshakeSrcFsm clkSrc rstSrc srcData srcRcv
-  (destAck, dstData) = safeHandshakeDstFsm clkDst rstDst dstAck destOut destReq
-  (destOut, destReq, srcRcv) = xpmCdcHandshake clkSrc clkDst srcIn srcSend destAck
+safeXpmCdcHandshake = withXilinx safeHandshake
 
 {- | 'Df' version of 'xpmCdcHandshake'.
 

--- a/bittide-instances/src/Bittide/Instances/Hitl/GenericDemo/Core.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/GenericDemo/Core.hs
@@ -57,10 +57,10 @@ import Clash.Prelude (
 import Protocols
 
 import Bittide.CaptureUgn (captureUgns, sendUgn)
-import Bittide.ClockControl (SpeedChange (NoChange))
+import Bittide.ClockControl (RelDataCount, SpeedChange (NoChange))
 import Bittide.ClockControl.CallistoSw (SwcccInternalBusses, callistoSwClockControlC)
 import Bittide.DoubleBufferedRam (wbStorage)
-import Bittide.ElasticBuffer (fromData, xilinxElasticBufferWb)
+import Bittide.ElasticBuffer
 import Bittide.Extra.Maybe (toMaybe)
 import Bittide.Handshake (handshakesWb)
 import Bittide.Instances.Domains (Basic125, Bittide, GthRx)
@@ -80,6 +80,7 @@ import Bittide.Wishbone (readDnaPortE2WbWorker, timeWb, uartBytes, uartInterface
 import Clash.Class.BitPackC (ByteOrder)
 import Clash.Cores.Xilinx (withXilinx)
 import Clash.Cores.Xilinx.BlockRam (tdpbram)
+import Clash.Cores.Xilinx.ElasticBuffer (xilinxElasticBuffer)
 import Clash.Cores.Xilinx.Unisim.DnaPortE2 (readDnaPortE2, simDna2)
 import Clash.Functor.Extra ((<<$>>), (<<*>>))
 import Protocols.Df.Extra (tdpbramRamOp)
@@ -271,31 +272,36 @@ core bufferDepth mkUserCore (refClk, refRst) (bitClk, bitRst, bitEna) rxClocks r
       Vec.split -< muWbs3
     -- Stop management unit
 
-    -- Start internal links
-    (_relDatCount, _underflow, _overflow, Fwd rxs1) <-
-      unzip4Vec
-        <| ( Vec.vecCircuits
-               $ xilinxElasticBufferWb
-                 bitClk
-                 bitRst
-                 (SNat @FifoSize)
-                 localCounter
-               <$> rxClocks
-               <*> rxs0
-           )
+    let
+      controlledEbWb ::
+        Clock GthRx ->
+        Reset GthRx ->
+        Signal GthRx (BitVector 64) ->
+        Circuit
+          (BitboneMm Bittide (NmuRemBusWidth userCoreBusses))
+          ( DcFifoOutput FifoSize Bittide GthRx (BitVector 64)
+          , CSignal Bittide (RelDataCount FifoSize)
+          )
+      controlledEbWb clkWrite rstWrite wdata =
+        joinEbAndControl
+          (elasticBufferControl bitClk bitRst localCounter clkWrite rstWrite wdata)
+          (xilinxElasticBuffer bitClk clkWrite)
+
+    Fwd rxs1 <-
+      (Vec.vecCircuits $ controlledEbWb <$> rxClocks <*> rxResets <*> rxs0)
         <| repeatC (fmapC $ withBittideClockResetEnable delayWishbone)
         -< ebWbs
-
     let
-      rxs2 = dflipflop bitClk <$> rxs1
-      rxs2Raw = fmap fromData <$> rxs2
+      rxs2 = ((.fifoOut) . fst) <$> rxs1
+      rxs3 = dflipflop bitClk <$> rxs2
+      rxs3Raw = fmap fromData <$> rxs3
 
     Fwd handshakesOut <-
       withBittideClockReset handshakesWb
         -< ( muHandshakeBus
            , Fwd
                ( Handshake.Inputs
-                   { fromNeighbors = rxs2
+                   { fromNeighbors = rxs3
                    , fromCores = txs1
                    }
                )
@@ -303,14 +309,14 @@ core bufferDepth mkUserCore (refClk, refRst) (bitClk, bitRst, bitEna) rxClocks r
 
     let
       -- TODO: Hardware UGN capture is currently mandatory, it shouldn't be.
-      rxs3 = toMaybe <<$>> handshakesOut.toCoreDones <<*>> handshakesOut.toCores
-      rxs4 = dflipflop bitClk <$> rxs3
+      rxs4 = toMaybe <<$>> handshakesOut.toCoreDones <<*>> handshakesOut.toCores
+      rxs5 = dflipflop bitClk <$> rxs4
 
       txs1 = withClock bitClk $ sendUgn localCounter <$> handshakesOut.fromCoreDones <*> txs0
 
-    Fwd rxs5 <-
+    Fwd rxs6 <-
       withBittideClockResetEnable
-        $ captureUgns localCounter (bundle rxs4)
+        $ captureUgns localCounter (bundle rxs5)
         -< ugnWb
     -- Stop internal links
 
@@ -322,7 +328,7 @@ core bufferDepth mkUserCore (refClk, refRst) (bitClk, bitRst, bitEna) rxClocks r
     idleSink
       <| fmapC (withBittideClockResetEnable receiveRingBuffer rxPrim bufferDepth)
       <| Vec.zip
-      -< (rxBufferBusses, Fwd (unbundle rxs5))
+      -< (rxBufferBusses, Fwd (unbundle rxs6))
     Fwd txs0 <-
       fmapC (withBittideClockResetEnable $ transmitRingBuffer txPrim bufferDepth) -< txBufferBusses
     -- Stop ringbuffers
@@ -331,7 +337,7 @@ core bufferDepth mkUserCore (refClk, refRst) (bitClk, bitRst, bitEna) rxClocks r
     Fwd txsOut <-
       mkUserCore bitClk bitRst bitEna localCounter maybeDna
         -< ( extraMuBusses
-           , Fwd (bundle rxs2Raw)
+           , Fwd (bundle rxs3Raw)
            , Fwd (bundle handshakesOut.toNeighbors)
            )
     -- Stop user core
@@ -393,13 +399,3 @@ core bufferDepth mkUserCore (refClk, refRst) (bitClk, bitRst, bitEna) rxClocks r
 
   withBittideClockReset :: forall r. ((HiddenClock Bittide, HiddenReset Bittide) => r) -> r
   withBittideClockReset r = withClock bitClk $ withReset bitRst r
-
-uncurry4 ::
-  (a -> b -> c -> d -> e) ->
-  (a, b, c, d) ->
-  e
-uncurry4 fn (a, b, c, d) = fn a b c d
-
-unzip4Vec ::
-  Circuit (Vec n (a, b, c, d)) (Vec n a, Vec n b, Vec n c, Vec n d)
-unzip4Vec = applyC unzip4 (uncurry4 zip4)

--- a/bittide-instances/src/Bittide/Instances/Pnr/ElasticBuffer.hs
+++ b/bittide-instances/src/Bittide/Instances/Pnr/ElasticBuffer.hs
@@ -16,33 +16,45 @@ import Bittide.ElasticBuffer
 import Bittide.ElasticBuffer.AutoCenter (autoCenter)
 import Bittide.Instances.Domains (Basic400)
 import Bittide.Instances.Hacks (reducePins)
-import Bittide.SharedTypes (withLittleEndian)
+import Bittide.SharedTypes (BitboneMm, withLittleEndian)
+import Clash.Cores.Xilinx (withXilinx)
+import Clash.Cores.Xilinx.ElasticBuffer (xilinxElasticBuffer)
 
 import qualified Clash.Explicit.Prelude as E
 
 createDomain vXilinxSystem{vPeriod = hzToPeriod 201e6, vName = "Fast"}
 createDomain vXilinxSystem{vPeriod = hzToPeriod 199e6, vName = "Slow"}
 
+type FifoSize = 5
+
 elasticBufferWb ::
   "clkRead" ::: Clock Fast ->
-  "resetRead" ::: Reset Fast ->
+  "rstRead" ::: Reset Fast ->
   "clkWrite" ::: Clock Slow ->
+  "rstWrite" ::: Reset Slow ->
   "wbIn" ::: Signal Fast (WishboneM2S 30 4) ->
   "writeData" ::: Signal Slow (Unsigned 64) ->
   ( "wbOut" ::: Signal Fast (WishboneS2M 4)
-  , "dataCount" ::: Signal Fast (RelDataCount 5)
+  , "dataCount" ::: Signal Fast (RelDataCount FifoSize)
   , "underflow" ::: Signal Fast Underflow
-  , "overflow" ::: Signal Fast Overflow
+  , "overflow" ::: Signal Slow Overflow
   , "readData" ::: Signal Fast (ElasticBufferData (Unsigned 64))
   )
-elasticBufferWb clkRead rstRead clkWrite wbIn wdata = (wbOut, dataCount, underflow, overflow, readData)
+elasticBufferWb clkRead rstRead clkWrite rstWrite wbIn wdata =
+  (wbOut, dataCount, fifoOut.underflow, fifoOut.overflow, fifoOut.fifoOut)
  where
   localCounter = E.register clkRead rstRead enableGen 0 (localCounter + 1)
-  ((SimOnly _mm, wbOut), (dataCount, underflow, overflow, readData)) =
-    withLittleEndian
-      $ toSignals
-        (xilinxElasticBufferWb clkRead rstRead d5 localCounter clkWrite wdata)
-        (((), wbIn), ((), (), (), ()))
+  ebCircuit ::
+    Circuit
+      (BitboneMm Fast 30)
+      (DcFifoOutput FifoSize Fast Slow (Unsigned 64), CSignal Fast (RelDataCount FifoSize))
+  ebCircuit =
+    withXilinx
+      $ withLittleEndian
+      $ joinEbAndControl
+        (elasticBufferControl clkRead rstRead localCounter clkWrite rstWrite wdata)
+        (xilinxElasticBuffer clkRead clkWrite)
+  ((SimOnly _mm, wbOut), (fifoOut, dataCount)) = toSignals ebCircuit $ (((), wbIn), ((), ()))
 
 makeTopEntity 'elasticBufferWb
 

--- a/bittide-instances/src/Bittide/Instances/Tests/ElasticBufferWb.hs
+++ b/bittide-instances/src/Bittide/Instances/Tests/ElasticBufferWb.hs
@@ -17,6 +17,8 @@ import Bittide.Instances.Common (
 import Bittide.ProcessingElement
 import Bittide.SharedTypes (withLittleEndian)
 import Bittide.Wishbone
+import Clash.Cores.Xilinx (withXilinx)
+import Clash.Cores.Xilinx.ElasticBuffer (xilinxElasticBuffer)
 import GHC.Stack (HasCallStack)
 import Project.FilePath
 import Protocols
@@ -51,6 +53,8 @@ dutMM =
     $ dut NoDumpVcd
     $ emptyPeConfig (SNat @IMemWords) (SNat @DMemWords) d0 d0 False vexRiscv0
 
+type FifoSize = 5
+
 {- | A simulation-only instance containing VexRisc with UART and an elastic buffer
 controlled via Wishbone. The processor runs the `elastic_buffer_wb_test` program
 performing a series of tests on the elastic buffer via Wishbone and prints the
@@ -64,7 +68,8 @@ dut ::
     (ToConstBwd Mm)
     (Df XilinxSystem (BitVector 8)) -- UART output
 dut dumpVcd peConfig =
-  withLittleEndian
+  withXilinx
+    $ withLittleEndian
     $ withClockResetEnable clockGen (resetGenN d2) enableGen
     $ circuit
     $ \mm -> do
@@ -79,16 +84,20 @@ dut dumpVcd peConfig =
       -- Elastic buffer with Wishbone control and monitoring
       -- We use the same clock for both read and write domains for simplicity in testing
       _readData <-
-        xilinxElasticBufferWb
-          clockGen
-          (resetGenN d2)
-          d5
-          localCounter
-          clockGen
-          (pure () :: Signal XilinxSystem ())
+        joinEbAndControl
+          (elasticBufferControl @FifoSize clk rst localCounter clk rst unitSig)
+          (xilinxElasticBuffer clockGen clockGen)
           -< ebWbBus
 
       idC -< uartTx
+ where
+  clk :: forall dom. (KnownDomain dom) => Clock dom
+  clk = clockGen
+
+  rst :: forall dom. (KnownDomain dom) => Reset dom
+  rst = resetGenN d2
+
+  unitSig = pure () :: Signal XilinxSystem ()
 
 type IMemWords = DivRU (16 * 1024) 4
 type DMemWords = DivRU (16 * 1024) 4

--- a/bittide/bittide.cabal
+++ b/bittide/bittide.cabal
@@ -236,6 +236,7 @@ library
     Clash.Cores.Extra
     Clash.Cores.UART.Extra
     Clash.Cores.Xilinx.Ddr4
+    Clash.Cores.Xilinx.ElasticBuffer
     Clash.Cores.Xilinx.Gth
     Clash.Cores.Xilinx.Gth.Internal
     Clash.Cores.Xilinx.SystemMonitor

--- a/bittide/src/Bittide/ElasticBuffer.hs
+++ b/bittide/src/Bittide/ElasticBuffer.hs
@@ -1,7 +1,6 @@
 -- SPDX-FileCopyrightText: 2022 Google LLC
 --
 -- SPDX-License-Identifier: Apache-2.0
-
 module Bittide.ElasticBuffer where
 
 import Clash.Prelude
@@ -14,9 +13,8 @@ import Bittide.Extra.Maybe (toMaybe)
 import Bittide.SharedTypes (BitboneMm)
 import Bittide.Shutter (shutter)
 import Clash.Class.BitPackC (ByteOrder)
+import Clash.Class.Cdc.Handshake (safeHandshake)
 import Clash.Cores.Xilinx.DcFifo
-import Clash.Cores.Xilinx.Xpm.Cdc.Extra (safeXpmCdcHandshake)
-import Clash.Cores.Xilinx.Xpm.Cdc.Pulse (xpmCdcPulse)
 import Data.Maybe (isJust)
 import GHC.Stack (HasCallStack)
 import Protocols.Df (CollectMode (..), roundrobinCollect)
@@ -36,6 +34,7 @@ import Protocols.MemoryMap.Registers.WishboneStandard (
   registerWb_,
  )
 
+import qualified Clash.Class.Cdc as Cdc
 import qualified Clash.Explicit.Prelude as E
 
 {- | Elastic buffer adjustment command. Negative values drain (remove frames), positive
@@ -129,80 +128,65 @@ fromElasticBufferData :: a -> ElasticBufferData a -> a
 fromElasticBufferData _ (Data dat) = dat
 fromElasticBufferData dflt _ = dflt
 
-toElasticBufferData :: Bool -> Bool -> a -> ElasticBufferData a
-toElasticBufferData requestedReadInPreviousCycle underflow a
-  | not requestedReadInPreviousCycle = FillCycle
-  | underflow = Empty
-  | otherwise = Data a
+data DcFifoInput (readDom :: Domain) (writeDom :: Domain) (a :: Type) = DcFifoInput
+  { writeData :: Signal writeDom (Maybe a)
+  , readEnable :: Signal readDom Bool
+  }
+  deriving (Generic, NFDataX)
 
-{-# OPAQUE xilinxElasticBuffer #-}
+data DcFifoOutput (n :: Nat) (readDom :: Domain) (writeDom :: Domain) (a :: Type) = DcFifoOutput
+  { dataCount :: Signal readDom (DataCount n)
+  , underflow :: Signal readDom Underflow
+  , overflow :: Signal writeDom Overflow
+  , fifoOut :: Signal readDom (ElasticBufferData a)
+  }
+  deriving (Generic, NFDataX)
 
-{- | An elastic buffer backed by a Xilinx FIFO. It exposes all its control and
-monitor signals in its read domain.
--}
-xilinxElasticBuffer ::
-  forall n readDom writeDom a.
+instance Protocol (DcFifoOutput n readDom writeDom a) where
+  type Fwd (DcFifoOutput n readDom writeDom a) = DcFifoOutput n readDom writeDom a
+  type Bwd (DcFifoOutput _ _ _ _) = ()
+
+data DcFifoIO (n :: Nat) (readDom :: Domain) (writeDom :: Domain) (a :: Type)
+
+instance Protocol (DcFifoIO n readDom writeDom a) where
+  type Fwd (DcFifoIO n readDom writeDom a) = DcFifoInput readDom writeDom a
+  type Bwd (DcFifoIO n readDom writeDom a) = DcFifoOutput n readDom writeDom a
+
+type DcFifoC
+  (n :: Nat)
+  (readDom :: Domain)
+  (writeDom :: Domain)
+  (a :: Type) =
   ( HasCallStack
   , KnownDomain readDom
   , KnownDomain writeDom
   , NFDataX a
   , KnownNat n
-  , 4 <= n
-  , n <= 17
+  ) =>
+  Circuit (DcFifoIO n readDom writeDom a) ()
+
+elasticBufferAutoCenter ::
+  forall readDom writeDom vendor.
+  ( HasCallStack
+  , KnownDomain readDom
+  , KnownDomain writeDom
+  , Cdc.HiddenVendor vendor
+  , Cdc.ValidHandshake vendor (Unsigned 32) readDom writeDom
   ) =>
   Clock readDom ->
+  Reset readDom ->
   Clock writeDom ->
+  Reset writeDom ->
   {- | Operating mode of the elastic buffer. Must remain stable until an acknowledgement
   is received. Negative values drain, positive values fill, zero is a no-op.
   -}
   Signal readDom (Maybe EbAdjustment) ->
-  {- | Data to write into the elastic buffer. Will be ignored for a single cycle
-  when it gets a drain adjustment (negative value). Which cycle this is depends on
-  clock domain crossing.
-  -}
-  Signal writeDom a ->
-  ( Signal readDom (RelDataCount n)
-  , Signal readDom Underflow
-  , Signal writeDom Overflow
-  , Signal readDom (ElasticBufferData a)
-  , -- Acknowledgement for EbMode
-    Signal readDom Ack
-  )
-xilinxElasticBuffer clkRead clkWrite adjustment wdata =
-  ( -- Note that this is chosen to work for 'RelDataCount' either being
-    -- set to 'Signed' with 'targetDataCount' equals 0 or set to
-    -- 'Unsigned' with 'targetDataCount' equals 'shiftR maxBound 1 + 1'.
-    -- This way, the representation can be easily switched without
-    -- introducing major code changes.
-    (+ targetDataCount)
-      . bitCoerce
-      . (+ (-1 - shiftR maxBound 1))
-      <$> readCount
-  , isUnderflow
-  , isOverflow
-  , fifoOut
-  , adjustmentAck
-  )
+  (Signal writeDom Bool, Signal readDom Bool, Signal readDom Ack)
+elasticBufferAutoCenter clkRead rstRead clkWrite rstWrite adjustment =
+  (drain, readEnable, adjustmentAck)
  where
-  FifoOut{readCount, isUnderflow, isOverflow, fifoData} =
-    dcFifo
-      (defConfig @n){dcOverflow = True, dcUnderflow = True}
-      clkWrite
-      noResetWrite
-      clkRead
-      noResetRead
-      writeData
-      readEnable
-
-  -- We don't reset the Xilinx FIFO: its reset documentation is self-contradictory
-  -- and mentions situations where the FIFO can end up in an unrecoverable state.
-  noResetWrite = unsafeFromActiveHigh (pure False)
-  noResetRead = unsafeFromActiveHigh (pure False)
-
   -- Muxing between drain and fills:
   adjustmentAck = selectAck <$> adjustment <*> drainAck <*> fillAck
-  fifoOut = toElasticBufferData <$> readEnableDelayed <*> isUnderflow <*> fifoData
-  readEnableDelayed = E.register clkRead noResetRead enableGen False readEnable
   readEnable = not <$> fill
 
   selectAck :: Maybe EbAdjustment -> Ack -> Ack -> Ack
@@ -217,7 +201,7 @@ xilinxElasticBuffer clkRead clkWrite adjustment wdata =
   (fillAck, fill) =
     E.mooreB
       clkRead
-      noResetRead
+      rstRead
       enableGen
       goActState
       goActOutput
@@ -235,11 +219,10 @@ xilinxElasticBuffer clkRead clkWrite adjustment wdata =
   goActOutput (Just _) = (Ack False, True)
 
   -- Drain logic (CDC based):
-  writeData = mux drain (pure Nothing) (Just <$> wdata)
   (drainAckWrite, drain) =
-    E.mooreB clkWrite noResetWrite enableGen goActState goActOutput Nothing maybeDrainCmd
+    E.mooreB clkWrite rstWrite enableGen goActState goActOutput Nothing maybeDrainCmd
   (drainAck, maybeDrainCmd) =
-    safeXpmCdcHandshake
+    safeHandshake @vendor
       clkRead
       E.noReset
       clkWrite
@@ -247,256 +230,302 @@ xilinxElasticBuffer clkRead clkWrite adjustment wdata =
       (maybe Nothing toDrainMaybe <$> adjustment)
       drainAckWrite
 
-{-# OPAQUE xilinxElasticBufferWb #-}
-
-{- | Wishbone wrapper around 'xilinxElasticBuffer' that exposes control and monitoring
-via memory-mapped registers using the clash-protocols-memmap infrastructure.
-
-This component allows software control of the elastic buffer's buffer occupancies and
-provides monitoring capabilities. The primary use case is to enable a CPU to perform
-buffer initialization during the system startup phase.
-
-The registers provided are:
-1. Command Register (Write-Only): Adding or removing singular frames from the buffer.
-2. Data Count Register (Read-Only): Current fill level of the buffer.
-3. Underflow Register (Read-Write): Sticky flag indicating if an underflow has occurred.
-   Flag can be cleared by writing false to this register.
-4. Overflow Register (Read-Write): Sticky flag indicating if an overflow has occurred.
-   Flag can be cleared by writing false to this register.
-5. Stable Register (Write-Only): Software can set this flag to indicate that the buffer
-   is stable.
--}
-xilinxElasticBufferWb ::
-  forall n readDom writeDom addrW a.
+elasticBufferControl ::
+  forall n readDom writeDom addrW a vendor.
   ( HasCallStack
   , HasSynchronousReset readDom
   , KnownDomain readDom
   , KnownDomain writeDom
   , NFDataX a
   , KnownNat n
-  , 4 <= n
-  , n <= 17
+  , n <= 32
   , KnownNat addrW
+  , Cdc.HiddenVendor vendor
+  , Cdc.ValidPulse vendor Bool writeDom readDom
+  , Cdc.ValidHandshake vendor (Unsigned 32) readDom writeDom
   , ?byteOrder :: ByteOrder
   ) =>
   Clock readDom ->
   Reset readDom ->
-  SNat n ->
   -- | Local counter
   Signal readDom (Unsigned 64) ->
   Clock writeDom ->
+  Reset writeDom ->
   Signal writeDom a ->
   Circuit
     (BitboneMm readDom addrW)
-    ( CSignal readDom (RelDataCount n)
-    , CSignal readDom Underflow
-    , CSignal readDom Overflow
-    , CSignal readDom (ElasticBufferData a)
-    )
-xilinxElasticBufferWb clkRead rstRead SNat localCounter clkWrite wdata =
-  withClockResetEnable clkRead rstRead enableGen $ circuit $ \wb -> do
-    [ wbAdjustmentAsync
-      , wbAdjustmentWait
-      , wbDataCount
-      , wbUnderflow
-      , wbOverflow
-      , wbLocalCounterUnderflow
-      , wbLocalCounterOverflow
-      , wbClearStatusRegisters
-      , wbAutoCenterReset
-      , wbAutoCenterEnable
-      , wbAutoCenterMargin
-      , wbAutoCenterIsIdle
-      , wbAutoCenterTotalAdjustments
-      , wbMinDataCountSeen
-      , wbMaxDataCountSeen
-      ] <-
-      deviceWbI (deviceConfig "ElasticBuffer") -< wb
-
-    (_ebAdjustmentAsync, ebAdjustmentAsyncDfActivity) <-
-      registerWbDfI
-        ( registerConfig
-            "adjustment_async"
-            "Submit an adjustment. Will stall if an adjustment is still in progress."
-        )
-          { access = WriteOnly
-          }
-        (0 :: EbAdjustment)
-        -< (wbAdjustmentAsync, Fwd (pure Nothing))
-
-    (_ebAdjustmentWait, ebAdjustmentWaitDfActivity) <-
-      registerWbDfI
-        (registerConfig "adjustment_wait" "Wait until ready to (immediately) accept a new adjustment")
-          { access = WriteOnly
-          }
-        ()
-        -< (wbAdjustmentWait, Fwd (pure Nothing))
-
-    ebAdjustmentDf0 <- applyC (fmap busActivityWrite) id -< ebAdjustmentAsyncDfActivity
-
-    -- [Note Skid Buffer]
-    --
-    -- By putting a skid buffer here, we ensure that we can immediately accept a new adjustment
-    -- when writing to `adjustment_go`. We then use the 'ready' signal from the skid buffer to
-    -- implement the 'adjustment_wait' register.
-    (ebAdjustmentDf1, Fwd ebReady) <- skid -< ebAdjustmentDf0
-    ackWhen ebReady -< ebAdjustmentWaitDfActivity
-
-    -- Auto-centering state machine
-    (_autoCenterReset, Fwd autoCenterResetActivity) <-
-      registerWbI
-        ( registerConfig
-            "auto_center_reset_unchecked"
-            "Clear total adjustments. You must disable the state machine and wait for it to be idle before resetting it. After resetting, you must also wait for the state machine to become 'idle' again to make sure the registers are cleared."
-        )
-          { access = WriteOnly
-          }
-        ()
-        -< (wbAutoCenterReset, Fwd (pure Nothing))
-
-    (Fwd autoCenterEnable, _autoCenterEnableActivity) <-
-      registerWbI
-        (registerConfig "auto_center_enable" "Enable auto-centering state machine")
-          { access = ReadWrite
-          }
-        False
-        -< (wbAutoCenterEnable, Fwd (pure Nothing))
-
-    (Fwd autoCenterMargin, _autoCenterMarginActivity) <-
-      registerWbI
-        (registerConfig "auto_center_margin" "Margin for auto-centering")
-          { access = ReadWrite
-          }
-        (2 :: Unsigned 16)
-        -< (wbAutoCenterMargin, Fwd (pure Nothing))
-
-    registerWbI_
-      (registerConfig "auto_center_is_idle" "Whether the auto-centering state machine is idle")
-        { access = ReadOnly
-        }
-      False
-      -< (wbAutoCenterIsIdle, Fwd (Just <$> autoCenterIsIdle))
-
-    registerWbI_
-      ( registerConfig
-          "auto_center_total_adjustments"
-          "Total adjustments applied by the auto-centering state machine"
-      )
-        { access = ReadOnly
-        }
-      (0 :: Signed 32)
-      -< (wbAutoCenterTotalAdjustments, Fwd (Just <$> autoCenterTotalAdjustments))
-
+    (DcFifoIO n readDom writeDom a, CSignal readDom (RelDataCount n))
+elasticBufferControl clkRead rstRead localCounter clkWrite rstWrite wdata =
+  Circuit go
+ where
+  go (wbFwd, (dcFifoOut, _)) =
     let
-      autoCenterReset = unsafeFromActiveHigh (isJust . busActivityWrite <$> autoCenterResetActivity)
+      fn = toSignals goC
+      (wbBwd, dcFifoIn) = fn (wbFwd, dcFifoOut)
+     in
+      (wbBwd, (dcFifoIn, relDataCount))
+   where
+    relDataCount =
+      -- Note that this is chosen to work for 'RelDataCount' either being
+      -- set to 'Signed' with 'targetDataCount' equals 0 or set to
+      -- 'Unsigned' with 'targetDataCount' equals 'shiftR maxBound 1 + 1'.
+      -- This way, the representation can be easily switched without
+      -- introducing major code changes.
+      (+ targetDataCount)
+        . bitCoerce
+        . (+ (-1 - shiftR maxBound 1))
+        <$> dcFifoOut.dataCount
 
-      (dataCount, underflow, overflow0, readData, adjustmentAck) =
-        xilinxElasticBuffer @n clkRead clkWrite ebAdjustmentSig wdata
+    goC :: Circuit (BitboneMm readDom addrW) (DcFifoIO n readDom writeDom a)
+    goC =
+      withClockResetEnable clkRead rstRead enableGen $ circuit $ \wb -> do
+        [ wbAdjustmentAsync
+          , wbAdjustmentWait
+          , wbDataCount
+          , wbUnderflow
+          , wbOverflow
+          , wbLocalCounterUnderflow
+          , wbLocalCounterOverflow
+          , wbClearStatusRegisters
+          , wbAutoCenterReset
+          , wbAutoCenterEnable
+          , wbAutoCenterMargin
+          , wbAutoCenterIsIdle
+          , wbAutoCenterTotalAdjustments
+          , wbMinDataCountSeen
+          , wbMaxDataCountSeen
+          ] <-
+          deviceWbI (deviceConfig "ElasticBuffer") -< wb
 
-    (autoCenterAdjustmentDf, Fwd autoCenterTotalAdjustments, Fwd autoCenterIsIdle) <-
-      autoCenter
-        (autoCenterReset `E.orReset` rstRead)
-        (toEnable autoCenterEnable)
-        autoCenterMargin
-        dataCount
-        -< ()
+        (_ebAdjustmentAsync, ebAdjustmentAsyncDfActivity) <-
+          registerWbDfI @_ @_ @4
+            ( registerConfig
+                "adjustment_async"
+                "Submit an adjustment. Will stall if an adjustment is still in progress."
+            )
+              { access = WriteOnly
+              }
+            (0 :: EbAdjustment)
+            -< (wbAdjustmentAsync, Fwd (pure Nothing))
 
-    -- Multiplex manual and auto-center adjustments using round-robin collection
-    ebAdjustmentDfMuxed <-
-      roundrobinCollect @2 Parallel -< [ebAdjustmentDf1, autoCenterAdjustmentDf]
+        (_ebAdjustmentWait, ebAdjustmentWaitDfActivity) <-
+          registerWbDfI
+            ( registerConfig
+                "adjustment_wait"
+                "Wait until ready to (immediately) accept a new adjustment"
+            )
+              { access = WriteOnly
+              }
+            ()
+            -< (wbAdjustmentWait, Fwd (pure Nothing))
 
-    Fwd ebAdjustmentSig <- unsafeFromDf -< (ebAdjustmentDfMuxed, Fwd adjustmentAck)
+        ebAdjustmentDf0 <- applyC (fmap busActivityWrite) id -< ebAdjustmentAsyncDfActivity
 
-    -- Synchronize overflow pulse from write domain to read domain
-    let overflow1 = xpmCdcPulse clkWrite clkRead overflow0
+        -- [Note Skid Buffer]
+        --
+        -- By putting a skid buffer here, we ensure that we can immediately accept a new adjustment
+        -- when writing to `adjustment_go`. We then use the 'ready' signal from the skid buffer to
+        -- implement the 'adjustment_wait' register.
+        (ebAdjustmentDf1, Fwd ebReady) <- skid -< ebAdjustmentDf0
+        ackWhen ebReady -< ebAdjustmentWaitDfActivity
 
-    let
-      isFirstRising :: Signal readDom Bool -> Signal readDom Bool
-      isFirstRising = E.isRising clkRead flagsReset enableGen False . stickyE clkRead flagsReset
+        -- Auto-centering state machine
+        (_autoCenterReset, Fwd autoCenterResetActivity) <-
+          registerWbI
+            ( registerConfig
+                "auto_center_reset_unchecked"
+                "Clear total adjustments. You must disable the state machine and wait for it to be idle before resetting it. After resetting, you must also wait for the state machine to become 'idle' again to make sure the registers are cleared."
+            )
+              { access = WriteOnly
+              }
+            ()
+            -< (wbAutoCenterReset, Fwd (pure Nothing))
 
-      flagsReset :: Reset readDom
-      flagsReset = E.orReset rstRead (unsafeFromActiveHigh (clearStatusRegisters .== Just (BusWrite True)))
+        (Fwd autoCenterEnable, _autoCenterEnableActivity) <-
+          registerWbI
+            (registerConfig "auto_center_enable" "Enable auto-centering state machine")
+              { access = ReadWrite
+              }
+            False
+            -< (wbAutoCenterEnable, Fwd (pure Nothing))
 
-    localCounterUnderflow <- shutter (isFirstRising underflow) -< Fwd localCounter
-    localCounterOverflow <- shutter (isFirstRising overflow1) -< Fwd localCounter
+        (Fwd autoCenterMargin, _autoCenterMarginActivity) <-
+          registerWbI
+            (registerConfig "auto_center_margin" "Margin for auto-centering")
+              { access = ReadWrite
+              }
+            (2 :: Unsigned 16)
+            -< (wbAutoCenterMargin, Fwd (pure Nothing))
 
-    let
-      minDataCountSeen1 :: Signal readDom (RelDataCount n)
-      minDataCountSeen1 = min <$> minDataCountSeen0 <*> dataCount
+        registerWbI_
+          (registerConfig "auto_center_is_idle" "Whether the auto-centering state machine is idle")
+            { access = ReadOnly
+            }
+          False
+          -< (wbAutoCenterIsIdle, Fwd (Just <$> autoCenterIsIdle))
 
-      maxDataCountSeen1 :: Signal readDom (RelDataCount n)
-      maxDataCountSeen1 = max <$> maxDataCountSeen0 <*> dataCount
+        registerWbI_
+          ( registerConfig
+              "auto_center_total_adjustments"
+              "Total adjustments applied by the auto-centering state machine"
+          )
+            { access = ReadOnly
+            }
+          (0 :: Signed 32)
+          -< (wbAutoCenterTotalAdjustments, Fwd (Just <$> autoCenterTotalAdjustments))
 
-    (dataCountOut, _dataCountActivity) <-
-      registerWbI
-        (registerConfig "data_count" ""){access = ReadOnly}
-        0
-        -< (wbDataCount, Fwd (Just <$> dataCount))
+        let
+          autoCenterReset =
+            unsafeFromActiveHigh (isJust . busActivityWrite <$> autoCenterResetActivity)
 
-    -- Status registers
-    (underflowOut, _underflowActivity) <-
-      registerWb
-        clkRead
-        flagsReset
-        (registerConfig "underflow" "Sticky underflow flag; can be cleared by writing false")
-          { access = ReadOnly
-          }
-        False
-        -< (wbUnderflow, Fwd (flip toMaybe True <$> underflow))
+        (autoCenterAdjustmentDf, Fwd autoCenterTotalAdjustments, Fwd autoCenterIsIdle) <-
+          autoCenter
+            (autoCenterReset `E.orReset` rstRead)
+            (toEnable autoCenterEnable)
+            autoCenterMargin
+            relDataCount
+            -< ()
 
-    registerWb_
-      clkRead
-      flagsReset
-      (registerConfig "underflow_timestamp" "Local counter value when first underflow occurred")
-        { access = ReadOnly
-        }
-      0
-      -< (wbLocalCounterUnderflow, localCounterUnderflow)
+        -- Multiplex manual and auto-center adjustments using round-robin collection
+        ebAdjustmentDfMuxed <-
+          roundrobinCollect @2 Parallel -< [ebAdjustmentDf1, autoCenterAdjustmentDf]
 
-    (overflowOut, _overflowActivity) <-
-      registerWb
-        clkRead
-        flagsReset
-        (registerConfig "overflow" "Sticky overflow flag; can be cleared by writing false")
-          { access = ReadOnly
-          }
-        False
-        -< (wbOverflow, Fwd (flip toMaybe True <$> overflow1))
+        let
+          (writeEnable, readEnable, adjustmentAck) =
+            elasticBufferAutoCenter @readDom @writeDom
+              clkRead
+              rstRead
+              clkWrite
+              rstWrite
+              ebAdjustmentSig
 
-    registerWb_
-      clkRead
-      flagsReset
-      (registerConfig "overflow_timestamp" "Local counter value when first overflow occurred")
-        { access = ReadOnly
-        }
-      0
-      -< (wbLocalCounterOverflow, localCounterOverflow)
+          writeData = mux writeEnable (pure Nothing) (Just <$> wdata)
 
-    (Fwd minDataCountSeen0, _i0) <-
-      registerWb
-        clkRead
-        flagsReset
-        (registerConfig "min_data_count_seen" ""){access = ReadOnly}
-        maxBound
-        -< (wbMinDataCountSeen, Fwd (Just <$> minDataCountSeen1))
+        Fwd ebAdjustmentSig <- unsafeFromDf -< (ebAdjustmentDfMuxed, Fwd adjustmentAck)
 
-    (Fwd maxDataCountSeen0, _i1) <-
-      registerWb
-        clkRead
-        flagsReset
-        (registerConfig "max_data_count_seen" ""){access = ReadOnly}
-        minBound
-        -< (wbMaxDataCountSeen, Fwd (Just <$> maxDataCountSeen1))
+        -- Synchronize overflow pulse from write domain to read domain
+        let overflow1 = Cdc.pulse @vendor clkWrite clkRead dcFifoOut.overflow
 
-    (_cf, Fwd clearStatusRegisters) <-
-      registerWbI
-        ( registerConfig
-            "clear_status_registers"
-            "Clear the underflow and overflow sticky flags, their respective timestamps and the min/max data count seen registers."
-        )
-          { access = WriteOnly
-          }
-        False
-        -< (wbClearStatusRegisters, Fwd (pure Nothing))
+        let
+          isFirstRising :: Signal readDom Bool -> Signal readDom Bool
+          isFirstRising = E.isRising clkRead flagsReset enableGen False . stickyE clkRead flagsReset
 
-    idC -< (dataCountOut, underflowOut, overflowOut, Fwd readData)
+          flagsReset :: Reset readDom
+          flagsReset =
+            E.orReset rstRead (unsafeFromActiveHigh (clearStatusRegisters .== Just (BusWrite True)))
+
+        localCounterUnderflow <- shutter (isFirstRising dcFifoOut.underflow) -< Fwd localCounter
+        localCounterOverflow <- shutter (isFirstRising overflow1) -< Fwd localCounter
+
+        let
+          minDataCountSeen1 :: Signal readDom (RelDataCount n)
+          minDataCountSeen1 = min <$> minDataCountSeen0 <*> relDataCount
+
+          maxDataCountSeen1 :: Signal readDom (RelDataCount n)
+          maxDataCountSeen1 = max <$> maxDataCountSeen0 <*> relDataCount
+
+        registerWbI_
+          (registerConfig "data_count" ""){access = ReadOnly}
+          0
+          -< (wbDataCount, Fwd (Just <$> relDataCount))
+
+        -- Status registers
+        registerWb_
+          clkRead
+          flagsReset
+          (registerConfig "underflow" "Sticky underflow flag; can be cleared by writing false")
+            { access = ReadOnly
+            }
+          False
+          -< (wbUnderflow, Fwd (flip toMaybe True <$> dcFifoOut.underflow))
+
+        registerWb_
+          clkRead
+          flagsReset
+          (registerConfig "underflow_timestamp" "Local counter value when first underflow occurred")
+            { access = ReadOnly
+            }
+          0
+          -< (wbLocalCounterUnderflow, localCounterUnderflow)
+
+        registerWb_
+          clkRead
+          flagsReset
+          (registerConfig "overflow" "Sticky overflow flag; can be cleared by writing false")
+            { access = ReadOnly
+            }
+          False
+          -< (wbOverflow, Fwd (flip toMaybe True <$> overflow1))
+
+        registerWb_
+          clkRead
+          flagsReset
+          (registerConfig "overflow_timestamp" "Local counter value when first overflow occurred")
+            { access = ReadOnly
+            }
+          0
+          -< (wbLocalCounterOverflow, localCounterOverflow)
+
+        (Fwd minDataCountSeen0, _i0) <-
+          registerWb
+            clkRead
+            flagsReset
+            (registerConfig "min_data_count_seen" ""){access = ReadOnly}
+            maxBound
+            -< (wbMinDataCountSeen, Fwd (Just <$> minDataCountSeen1))
+
+        (Fwd maxDataCountSeen0, _i1) <-
+          registerWb
+            clkRead
+            flagsReset
+            (registerConfig "max_data_count_seen" ""){access = ReadOnly}
+            minBound
+            -< (wbMaxDataCountSeen, Fwd (Just <$> maxDataCountSeen1))
+
+        (_cf, Fwd clearStatusRegisters) <-
+          registerWbI
+            ( registerConfig
+                "clear_status_registers"
+                "Clear the underflow and overflow sticky flags, their respective timestamps and the min/max data count seen registers."
+            )
+              { access = WriteOnly
+              }
+            False
+            -< (wbClearStatusRegisters, Fwd (pure Nothing))
+
+        let
+          dcFifoIn = DcFifoInput{writeData = writeData, readEnable = readEnable}
+
+        applyC (const dcFifoIn) (const ()) -< ()
+
+joinEbAndControl ::
+  forall n readDom writeDom addrW a vendor.
+  ( HasCallStack
+  , HasSynchronousReset readDom
+  , KnownDomain readDom
+  , KnownDomain writeDom
+  , KnownNat n
+  , n <= 32
+  , NFDataX a
+  , KnownNat addrW
+  , Cdc.HiddenVendor vendor
+  , Cdc.ValidPulse vendor Bool writeDom readDom
+  , Cdc.ValidHandshake vendor (Unsigned 32) readDom writeDom
+  , ?byteOrder :: ByteOrder
+  ) =>
+  Circuit
+    (BitboneMm readDom addrW)
+    (DcFifoIO n readDom writeDom a, CSignal readDom (RelDataCount n)) ->
+  DcFifoC n readDom writeDom a ->
+  Circuit
+    (BitboneMm readDom addrW)
+    (DcFifoOutput n readDom writeDom a, CSignal readDom (RelDataCount n))
+joinEbAndControl controlC fifoC = Circuit go
+ where
+  Circuit controlFn = controlC
+  Circuit fifoFn = fifoC
+
+  go (bitboneFwd, _) = (bitboneBwd, (dcFifoOut, relDataCount))
+   where
+    (bitboneBwd, (dcFifoIn, relDataCount)) = controlFn (bitboneFwd, (dcFifoOut, ()))
+    (dcFifoOut, _) = fifoFn (dcFifoIn, ())

--- a/bittide/src/Clash/Cores/Xilinx/ElasticBuffer.hs
+++ b/bittide/src/Clash/Cores/Xilinx/ElasticBuffer.hs
@@ -1,0 +1,51 @@
+-- SPDX-FileCopyrightText: 2026 Google LLC
+--
+-- SPDX-License-Identifier: Apache-2.0
+module Clash.Cores.Xilinx.ElasticBuffer where
+
+import Clash.Explicit.Prelude
+
+import Bittide.ElasticBuffer
+import Clash.Cores.Xilinx.DcFifo
+import GHC.Stack (HasCallStack)
+import Protocols
+
+toElasticBufferData :: Bool -> Bool -> a -> ElasticBufferData a
+toElasticBufferData requestedReadInPreviousCycle underflow a
+  | not requestedReadInPreviousCycle = FillCycle
+  | underflow = Empty
+  | otherwise = Data a
+
+type XilinxEBConstraints n = (4 <= n, n <= 17)
+
+xilinxElasticBuffer ::
+  forall n readDom writeDom a.
+  (HasCallStack, XilinxEBConstraints n) =>
+  Clock readDom ->
+  Clock writeDom ->
+  DcFifoC n readDom writeDom a
+xilinxElasticBuffer clkRead clkWrite = Circuit go
+ where
+  go (input, _) = (dcFifoOutput, ())
+   where
+    dcFifoOutput =
+      DcFifoOutput
+        { dataCount = readCount
+        , underflow = isUnderflow
+        , overflow = isOverflow
+        , fifoOut = fifoOut
+        }
+
+    FifoOut{readCount, isUnderflow, isOverflow, fifoData} =
+      dcFifo @n @a @writeDom @readDom
+        (defConfig @n){dcOverflow = True, dcUnderflow = True}
+        clkWrite
+        (unsafeFromActiveHigh (pure False))
+        clkRead
+        (unsafeFromActiveHigh (pure False))
+        input.writeData
+        input.readEnable
+
+    readEnableDelayed =
+      register clkRead (unsafeFromActiveHigh (pure False)) enableGen False input.readEnable
+    fifoOut = toElasticBufferData <$> readEnableDelayed <*> isUnderflow <*> fifoData

--- a/bittide/src/Clash/Cores/Xilinx/Xpm/Cdc/Handshake/Extra.hs
+++ b/bittide/src/Clash/Cores/Xilinx/Xpm/Cdc/Handshake/Extra.hs
@@ -5,6 +5,7 @@ module Clash.Cores.Xilinx.Xpm.Cdc.Handshake.Extra where
 
 import Clash.Explicit.Prelude
 
+import Clash.Class.Cdc.Handshake (handshakeMaybe, maybeLossy)
 import Clash.Cores.Xilinx (Xilinx, withXilinx)
 
 import qualified Clash.Class.Cdc as Cdc
@@ -25,7 +26,7 @@ xpmCdcMaybeLossy ::
   Signal src (Maybe a) ->
   -- | Data in the destination domain
   Signal dst (Maybe a)
-xpmCdcMaybeLossy = withXilinx Cdc.maybeLossy
+xpmCdcMaybeLossy = withXilinx maybeLossy
 
 -- | Xilinx-specialized version of 'handshake
 xpmCdcHandshakeMaybe ::
@@ -48,4 +49,4 @@ xpmCdcHandshakeMaybe ::
   2. Data in the destination domain.
   -}
   (Signal src Bool, Signal dst (Maybe a))
-xpmCdcHandshakeMaybe = withXilinx Cdc.handshakeMaybe
+xpmCdcHandshakeMaybe = withXilinx handshakeMaybe

--- a/bittide/tests/Tests/ElasticBuffer.hs
+++ b/bittide/tests/Tests/ElasticBuffer.hs
@@ -10,7 +10,11 @@ import Clash.Prelude
 import Test.Tasty
 import Test.Tasty.HUnit
 
+import Bittide.ClockControl (RelDataCount, targetDataCount)
 import Bittide.ElasticBuffer
+import Clash.Cores.Xilinx (withXilinx)
+import Clash.Cores.Xilinx.ElasticBuffer (XilinxEBConstraints, xilinxElasticBuffer)
+import Protocols
 
 import qualified Data.List as L
 
@@ -29,6 +33,56 @@ tests =
         ]
     ]
 
+xilinxElasticBufferDut ::
+  forall n readDom writeDom.
+  ( HasCallStack
+  , HasSynchronousReset readDom
+  , KnownDomain readDom
+  , KnownDomain writeDom
+  , KnownNat n
+  , n <= 32
+  , XilinxEBConstraints n
+  ) =>
+  Clock readDom ->
+  Clock writeDom ->
+  Signal readDom (Maybe EbAdjustment) ->
+  Signal writeDom (Unsigned 8) ->
+  ( Signal readDom (RelDataCount n)
+  , Signal readDom Underflow
+  , Signal writeDom Overflow
+  , Signal readDom (ElasticBufferData (Unsigned 8))
+  , Signal readDom Ack
+  )
+xilinxElasticBufferDut clkRead clkWrite adjust dataIn =
+  ( -- Note that this is chosen to work for 'RelDataCount' either being
+    -- set to 'Signed' with 'targetDataCount' equals 0 or set to
+    -- 'Unsigned' with 'targetDataCount' equals 'shiftR maxBound 1 + 1'.
+    -- This way, the representation can be easily switched without
+    -- introducing major code changes.
+    (+ targetDataCount)
+      . bitCoerce
+      . (+ (-1 - shiftR maxBound 1))
+      <$> dcFifoOutput.dataCount
+  , dcFifoOutput.underflow
+  , dcFifoOutput.overflow
+  , dcFifoOutput.fifoOut
+  , ebAdjustAck
+  )
+ where
+  Circuit fn = xilinxElasticBuffer @n clkRead clkWrite
+
+  noReset :: forall dom. (KnownDomain dom) => Reset dom
+  noReset = unsafeFromActiveHigh (pure False)
+
+  (writeEnable, readEnable, ebAdjustAck) =
+    withXilinx $ elasticBufferAutoCenter clkRead noReset clkWrite noReset adjust
+
+  writeData = mux writeEnable (pure Nothing) (Just <$> dataIn)
+
+  dcFifoInput = DcFifoInput{writeData = writeData, readEnable = readEnable}
+
+  (dcFifoOutput, _) = fn (dcFifoInput, ())
+
 {- | When the xilinxElasticBuffer is written to more quickly than it is being read from,
 its data count should overflow.
 -}
@@ -41,13 +95,13 @@ case_xilinxElasticBufferMaxBound = do
       sampleN
         2048
         ( (\(_, under, _, _, _) -> under)
-            (xilinxElasticBuffer @6 (clockGen @Slow) (clockGen @Fast) command wData)
+            (xilinxElasticBufferDut @6 (clockGen @Slow) (clockGen @Fast) command wData)
         )
     overflows =
       sampleN
         16192
         ( (\(_, _, over, _, _) -> over)
-            (xilinxElasticBuffer @6 (clockGen @Slow) (clockGen @Fast) command wData)
+            (xilinxElasticBufferDut @6 (clockGen @Slow) (clockGen @Fast) command wData)
         )
 
     -- Ignore the first 32 samples to allow the buffer to fill up
@@ -71,13 +125,13 @@ case_xilinxElasticBufferMinBound = do
       sampleN
         2048
         ( (\(_, under, _, _, _) -> under)
-            (xilinxElasticBuffer @6 (clockGen @Fast) (clockGen @Slow) command wData)
+            (xilinxElasticBufferDut @6 (clockGen @Fast) (clockGen @Slow) command wData)
         )
     overflows =
       sampleN
         2048
         ( (\(_, _, over, _, _) -> over)
-            (xilinxElasticBuffer @6 (clockGen @Fast) (clockGen @Slow) command wData)
+            (xilinxElasticBufferDut @6 (clockGen @Fast) (clockGen @Slow) command wData)
         )
 
     -- Ignore the first 32 samples to allow the buffer to fill up
@@ -99,13 +153,13 @@ case_xilinxElasticBufferEq = do
       sampleN
         256
         ( (\(_, under, _, _, _) -> under)
-            (xilinxElasticBuffer @5 (clockGen @Slow) (clockGen @Slow) command wData)
+            (xilinxElasticBufferDut @5 (clockGen @Slow) (clockGen @Slow) command wData)
         )
     overflows =
       sampleN
         256
         ( (\(_, _, over, _, _) -> over)
-            (xilinxElasticBuffer @5 (clockGen @Slow) (clockGen @Slow) command wData)
+            (xilinxElasticBufferDut @5 (clockGen @Slow) (clockGen @Slow) command wData)
         )
 
     -- Ignore the first 32 samples to allow the buffer to fill up


### PR DESCRIPTION
_What (what did you do)_
The previous `xilinxElasticBufferWb` and `xilinxElasticBuffer` functions have been replaced by a set of new functions: `elasticBufferAutoCenter`, `elasticBufferControlWb`, and `joinEbAndControl`, as well as the `DcFifoC n readDom writeDom a vendorEbConstraints` type alias. `joinEbAndControl` joins a control circuit to any `DcFifoC` with the appropriate type parameters.

_Why (context, issues, etc.)_
Issue #1298.

_Dear reviewer (anything you'd like the reviewer to pay close attention to?)_
I'm not certain of the interface for `joinEbAndControl` at the moment. I'd like some thoughts on whether this is an appropriate degree of separation as mentioned in the linked issue, and if so, whether there's any ways that I could possibly improve the interface. At the moment it's not the neatest thing to use, but I haven't come up with a better way to do it yet.

_AI disclaimer (heads-up for more than inline autocomplete)_
None.

# TODO
_~~Cross-out~~ any that do not apply_

- [ ] ~~Write (regression) test~~
- [ ] Update documentation, including `docs/`
- [x] Link to existing issue
