### PR TITLE
Widen bounds in `temperatureMonitor` HITL test

### DIFF
--- a/bittide-instances/src/Bittide/Instances/Hitl/TemperatureMonitor.hs
+++ b/bittide-instances/src/Bittide/Instances/Hitl/TemperatureMonitor.hs
@@ -49,11 +49,16 @@ temperatureMonitor diffClk = temperatureIla `hwSeqX` bundle (testDone, testSucce
   temperature = E.regMaybe clk rst enableGen 0 temperatureMaybe
 
   testDone = trueFor (SNat @(Milliseconds 1200)) clk testRst (pure True)
+  -- This is a plausibility check on the system monitor readings, not a
+  -- constraint on lab conditions. Boards have been observed idling at 46
+  -- degrees Celcius in summer. Hence, the upper bound has generous headroom,
+  -- while staying below the 100 degrees Celcius commercial temperature grade
+  -- limit.
   testSuccess =
     trueFor (SNat @(Seconds 1)) clk testRst
-      $ 20
+      $ 10
       .<=. temperature
-      .&&. temperature .<=. 45
+      .&&. temperature .<=. 70
 
   testRst = unsafeFromActiveLow $ hitlVioBool clk testDone testSuccess
 


### PR DESCRIPTION
The test required the FPGA temperature to stay within 20-45 degrees Celcius for a full second, but two boards in the HITL rack idle at 44-46 degrees Celcius in summer, making nightlies flaky. Widen the plausibility window to 10-70 degrees Celcius.

# TODO
_~~Cross-out~~ any that do not apply_

- [X] Write (regression) test
- [X] ~~Update documentation, including `docs/`~~
- [X] ~~Link to existing issue~~
