### PR TITLE
Remove use of `Integer` in `bittide` and `bittide-extra`

### DIFF
--- a/bittide-extra/src/Protocols/Wishbone/Extra.hs
+++ b/bittide-extra/src/Protocols/Wishbone/Extra.hs
@@ -250,7 +250,10 @@ increaseBusWidth SNat = Circuit (unbundle . fmap go . bundle)
         }
 
     newAddr = addrMsbs
-    bitShift = natToNum @width * fromIntegral addrLsbs -- `shiftL` takes an `Int`
+    -- `shiftL` takes an `Int`. Note the use of `fromEnum` instead of
+    -- `fromIntegral`: `fromEnum` maps to a primitive with a black box, while
+    -- `fromIntegral` goes through `Integer`, ending up in the generated HDL.
+    bitShift = natToNum @width * fromEnum addrLsbs
     (addrMsbs, addrLsbs :: BitVector power) = bitCoerce (m2sLeft.addr)
     newWriteData = pack (repeat m2sLeft.writeData)
     newBusSelect = shiftL (resize m2sLeft.busSelect) bitShift

--- a/bittide/src/Bittide/Transceiver/WordAlign.hs
+++ b/bittide/src/Bittide/Transceiver/WordAlign.hs
@@ -175,13 +175,17 @@ dealignMsbFirst offset old new = takeLsbs $ shiftBytesR (old ++# new) offset
 alignMsbFirst :: AlignmentFn n
 alignMsbFirst offset old new = takeMsbs $ shiftBytesL (old ++# new) offset
 
+-- Note the use of 'fromEnum' instead of 'fromIntegral' in the functions
+-- below: 'fromEnum' on 'Index' maps to a primitive with a black box, while
+-- 'fromIntegral' goes through 'Integer', which ends up in the generated HDL.
+
 -- | Like 'shiftR', but for 'Bytes'
 shiftBytesR :: forall n. (KnownNat n) => Bytes (2 * n) -> Index n -> Bytes (2 * n)
-shiftBytesR bv n = shiftR bv (8 * fromIntegral n)
+shiftBytesR bv n = shiftR bv (8 * fromEnum n)
 
 -- | Like 'shiftL', but for 'Bytes'
 shiftBytesL :: forall n. (KnownNat n) => Bytes (2 * n) -> Index n -> Bytes (2 * n)
-shiftBytesL bv n = shiftL bv (8 * fromIntegral n)
+shiftBytesL bv n = shiftL bv (8 * fromEnum n)
 
 -- | Take upper bits of given 'BitVector'
 takeMsbs :: forall n. (KnownNat n) => Bytes (2 * n) -> Bytes n


### PR DESCRIPTION
_What (what did you do)_
Remove use of `fromIntegral`

_Why (context, issues, etc.)_
`fromIntegral` uses dynamically sized integers. This is okay in our context, but Clash complains about it. Use `fromEnum` to sidestep the warning.

This is part of a bigger campaign to remove the use of `Integer`s in the Clash ecosystem.

# TODO
_~~Cross-out~~ any that do not apply_

- [X] ~~Write (regression) test~~
- [X] ~~Update documentation, including `docs/`~~
- [X] ~~Link to existing issue~~
